### PR TITLE
Export Transaction fields

### DIFF
--- a/token/services/ttxcc/auditor.go
+++ b/token/services/ttxcc/auditor.go
@@ -70,7 +70,7 @@ func newAuditingViewInitiator(tx *Transaction) *AuditingViewInitiator {
 }
 
 func (a *AuditingViewInitiator) Call(context view.Context) (interface{}, error) {
-	session, err := context.GetSession(a, a.tx.opts.auditor)
+	session, err := context.GetSession(a, a.tx.Opts.auditor)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed getting session")
 	}
@@ -90,9 +90,9 @@ func (a *AuditingViewInitiator) Call(context view.Context) (interface{}, error) 
 	var msg *view.Message
 	select {
 	case msg = <-ch:
-		logger.Debug("reply received from %s", a.tx.opts.auditor)
+		logger.Debug("reply received from %s", a.tx.Opts.auditor)
 	case <-time.After(60 * time.Second):
-		return nil, errors.Errorf("Timeout from party %s", a.tx.opts.auditor)
+		return nil, errors.Errorf("Timeout from party %s", a.tx.Opts.auditor)
 	}
 	if msg.Status == view.ERROR {
 		return nil, errors.New(string(msg.Payload))
@@ -105,9 +105,9 @@ func (a *AuditingViewInitiator) Call(context view.Context) (interface{}, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed marshalling message to sign")
 	}
-	logger.Debugf("Verifying auditor signature on [%s][%s][%s]", a.tx.opts.auditor.UniqueID(), hash.Hashable(signed).String(), a.tx.ID())
+	logger.Debugf("Verifying auditor signature on [%s][%s][%s]", a.tx.Opts.auditor.UniqueID(), hash.Hashable(signed).String(), a.tx.ID())
 
-	v, err := a.tx.TokenService().SigService().GetVerifier(a.tx.opts.auditor)
+	v, err := a.tx.TokenService().SigService().GetVerifier(a.tx.Opts.auditor)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/ttxcc/endorse.go
+++ b/token/services/ttxcc/endorse.go
@@ -77,12 +77,12 @@ func (c *collectEndorsementsView) Call(context view.Context) (interface{}, error
 	distributionList = append(distributionList, parties...)
 
 	// 2. Audit
-	if !c.tx.opts.auditor.IsNone() {
+	if !c.tx.Opts.auditor.IsNone() {
 		_, err := context.RunView(newAuditingViewInitiator(c.tx))
 		if err != nil {
-			return nil, errors.WithMessagef(err, "failed requesting auditing from [%s]", c.tx.opts.auditor.String())
+			return nil, errors.WithMessagef(err, "failed requesting auditing from [%s]", c.tx.Opts.auditor.String())
 		}
-		distributionList = append(distributionList, c.tx.opts.auditor)
+		distributionList = append(distributionList, c.tx.Opts.auditor)
 	}
 
 	// 3. Endorse and return the Fabric transaction envelope

--- a/token/services/ttxcc/transaction.go
+++ b/token/services/ttxcc/transaction.go
@@ -32,8 +32,8 @@ type Payload struct {
 
 type Transaction struct {
 	*Payload
-	sp   view2.ServiceProvider
-	opts *txOptions
+	SP   view2.ServiceProvider
+	Opts *txOptions
 }
 
 // NewAnonymousTransaction returns a new anonymous token transaction customized with the passed opts
@@ -79,8 +79,8 @@ func NewTransaction(sp view.Context, signer view.Identity, opts ...TxOption) (*T
 			Namespace:      tms.Namespace(),
 			Transient:      map[string][]byte{},
 		},
-		sp:   sp,
-		opts: txOpts,
+		SP:   sp,
+		Opts: txOpts,
 	}
 	sp.OnError(tx.Release)
 	return tx, nil
@@ -93,7 +93,7 @@ func NewTransactionFromBytes(sp view.Context, network string, raw []byte) (*Tran
 			FabricEnvelope: fabric.GetFabricNetworkService(sp, network).TransactionManager().NewEnvelope(),
 			Transient:      map[string][]byte{},
 		},
-		sp: sp,
+		SP: sp,
 	}
 	err := json.Unmarshal(raw, tx.Payload)
 	if err != nil {
@@ -134,7 +134,7 @@ func ReceiveTransaction(context view.Context) (*Transaction, error) {
 
 // ID returns the ID of this transaction. It is equal to the underlying Fabric transaction's ID.
 func (t *Transaction) ID() string {
-	return fabric.GetFabricNetworkService(t.sp, t.Network()).TransactionManager().ComputeTxID(&t.Payload.Id)
+	return fabric.GetFabricNetworkService(t.SP, t.Network()).TransactionManager().ComputeTxID(&t.Payload.Id)
 }
 
 func (t *Transaction) Network() string {
@@ -214,7 +214,7 @@ func (t *Transaction) storeTransient() error {
 		return err
 	}
 
-	ch, err := fabric.GetFabricNetworkService(t.sp, t.Network()).Channel(t.Channel())
+	ch, err := fabric.GetFabricNetworkService(t.SP, t.Network()).Channel(t.Channel())
 	if err != nil {
 		return errors.Wrapf(err, "failed getting channel [%s:%s]", t.Network(), t.Channel())
 	}
@@ -263,5 +263,5 @@ func (t *Transaction) appendPayload(payload *Payload) error {
 }
 
 func (t *Transaction) TokenService() *token.ManagementService {
-	return token.GetManagementService(t.sp, token.WithChannel(t.Channel()))
+	return token.GetManagementService(t.SP, token.WithChannel(t.Channel()))
 }


### PR DESCRIPTION
To allow a consumer of the token SDK to implement new types of transaction of its own, we should consider exporting the fields of the Transaction so that the consumer can just call the fabtoken NewTransaction function and then just reference the fields if there is an need for it.


Issue: [47](https://github.com/hyperledger-labs/fabric-token-sdk/issues/47).

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>