### PR TITLE
various improvements #67

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/consensys/gurvy v0.3.9-0.20210209011448-37644c45f955
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/golang/protobuf v1.5.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716064650-0cf5eab4064a
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200424173110-d7076418f212

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/consensys/gurvy v0.3.9-0.20210209011448-37644c45f955
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/golang/protobuf v1.5.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210713054710-12682c606677
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200424173110-d7076418f212

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210713054710-12682c606677 h1:QvbY+r6g9U3p408BndbmOzLYVJCRYJ+WbqoTAkPdZHU=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210713054710-12682c606677/go.mod h1:fWkzSz/BXHPyIpIDiVNH6liCzCT+alFszD8hP+EZuyI=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0 h1:T1iJ9b2p7a8dFTIgYCUJcdNDtBXvAFJ3oYwLfvDZna8=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0/go.mod h1:vSGfRhrlkNMI56iwzcnk3HzXU25KP9YVZVstPJGf2Nc=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252 h1:lQq/yygTbHWPfjFZ1VgINd1TJY7rOJ/zglcl9nE/s9Q=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252/go.mod h1:+kicKDn5xa88tOpOY/o6/7iB/RD7oOs2INzwVg2ARmM=
 github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
@@ -936,8 +936,8 @@ golang.org/x/tools v0.0.0-20200131233409-575de47986ce/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20201105001634-bc3cf281b174/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.4 h1:cVngSRcfgyZCzys3KYOpCFa+4dqX/Oub9tAq00ttGVs=
-golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0 h1:T1iJ9b2p7a8dFTIgYCUJcdNDtBXvAFJ3oYwLfvDZna8=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716034317-f57c564a4bb0/go.mod h1:vSGfRhrlkNMI56iwzcnk3HzXU25KP9YVZVstPJGf2Nc=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716064650-0cf5eab4064a h1:x8KtvIRqTF6nTYwR05FfAzAlA8yiLm+fqb5l8vb+RMQ=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20210716064650-0cf5eab4064a/go.mod h1:vSGfRhrlkNMI56iwzcnk3HzXU25KP9YVZVstPJGf2Nc=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252 h1:lQq/yygTbHWPfjFZ1VgINd1TJY7rOJ/zglcl9nE/s9Q=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20200930182727-344fda602252/go.mod h1:+kicKDn5xa88tOpOY/o6/7iB/RD7oOs2INzwVg2ARmM=
 github.com/hyperledger/fabric-amcl v0.0.0-20200128223036-d1aa2665426a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=

--- a/integration/nwo/token/topology.go
+++ b/integration/nwo/token/topology.go
@@ -84,7 +84,7 @@ func (t *Topology) AddTMS(fabric *topology.Topology, driver string) *TMS {
 
 	tms := &TMS{
 		Fabric:         fabric,
-		Network:        fabric.TopologyName,
+		Network:        fabric.Name(),
 		Channel:        fabric.Channels[0].Name,
 		Namespace:      "zkat",
 		Driver:         driver,

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -61,9 +61,9 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 		identity.NewProvider(
 			sp,
 			map[driver.IdentityUsage]identity.Mapper{
-				driver.IssuerRole:  fabric.NewMapper(fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
-				driver.AuditorRole: fabric.NewMapper(fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
-				driver.OwnerRole:   fabric.NewMapper(fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.IssuerRole:  fabric.NewMapper(network, fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.AuditorRole: fabric.NewMapper(network, fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.OwnerRole:   fabric.NewMapper(network, fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
 			},
 		),
 		fabtoken.NewDeserializer(),

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -43,9 +43,9 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 		identity.NewProvider(
 			sp,
 			map[driver.IdentityUsage]identity.Mapper{
-				driver.IssuerRole:  fabric.NewMapper(fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
-				driver.AuditorRole: fabric.NewMapper(fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
-				driver.OwnerRole:   fabric.NewMapper(fabric.IdemixMSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.IssuerRole:  fabric.NewMapper(network, fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.AuditorRole: fabric.NewMapper(network, fabric.X509MSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
+				driver.OwnerRole:   fabric.NewMapper(network, fabric.IdemixMSPIdentity, nodeIdentity, fabric2.GetFabricNetworkService(sp, network).LocalMembership()),
 			},
 		),
 	)

--- a/token/provider.go
+++ b/token/provider.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package token
 
 import (
@@ -61,7 +62,7 @@ func NewManagementServiceProvider(
 }
 
 func (p *ManagementServiceProvider) GetManagementService(opts ...ServiceOption) *ManagementService {
-	opt, err := compileServiceOptions(opts...)
+	opt, err := CompileServiceOptions(opts...)
 	if err != nil {
 		panic(err)
 	}

--- a/token/sdk/fabric/np.go
+++ b/token/sdk/fabric/np.go
@@ -1,0 +1,31 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/pkg/errors"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
+)
+
+type NetworkProvider struct {
+	sp view.ServiceProvider
+}
+
+func NewNetworkProvider(sp view.ServiceProvider) *NetworkProvider {
+	return &NetworkProvider{sp: sp}
+}
+
+func (n *NetworkProvider) Network(networkID string) (core.Network, error) {
+	fns := fabric.GetFabricNetworkService(n.sp, networkID)
+	if fns == nil {
+		return nil, errors.Errorf("network [%s] not found", networkID)
+	}
+	return fns, nil
+}

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -60,10 +60,10 @@ func (p *SDK) Install() error {
 	}
 	logger.Infof("Token platform enabled, installing...")
 
-	logger.Infof("Set Token Service")
-	fabricNetwork := fabric.GetDefaultFNS(p.registry)
-
-	tmsProvider := core.NewTMSProvider(fabricNetwork, p.registry,
+	logger.Infof("Set TMS Provider")
+	tmsProvider := core.NewTMSProvider(
+		fabric2.NewNetworkProvider(p.registry),
+		p.registry,
 		func(network, channel, namespace string) error {
 			n := fabric.GetFabricNetworkService(p.registry, network)
 			if err := n.ProcessorManager().AddProcessor(
@@ -73,6 +73,7 @@ func (p *SDK) Install() error {
 					namespace,
 					p.registry,
 					processor.NewOwnershipMultiplexer(&processor.WalletOwnership{}),
+					processor.NewIssuedMultiplexer(&processor.WalletIssued{}),
 				),
 			); err != nil {
 				return errors.Wrapf(err, "failed adding transaction processors")

--- a/token/services/tcc/fetcher/chaincode.go
+++ b/token/services/tcc/fetcher/chaincode.go
@@ -32,7 +32,7 @@ func NewPublicParamsFetcher(sp view.ServiceProvider, network string, channel str
 }
 
 func (c *publicParamsFetcher) Fetch() ([]byte, error) {
-	logger.Debugf("retrieve public params for [%s:%s]", c.channel, c.namespace)
+	logger.Debugf("retrieve public params for [%s:%s:%s]", c.network, c.channel, c.namespace)
 
 	ppBoxed, err := view.GetManager(c.sp).InitiateView(
 		chaincode.NewQueryView(

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package ttx
 
 import (
@@ -10,12 +11,14 @@ import (
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tcc"
 
 	"github.com/pkg/errors"
 
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditor"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditor/auditdb"
@@ -44,9 +47,7 @@ func (a *txAuditor) NewQueryExecutor() *auditor.QueryExecutor {
 }
 
 type RegisterAuditorView struct {
-	Network   string
-	Channel   string
-	Namespace string
+	TMSID     token.TMSID
 	Id        view.Identity
 	AuditView view.View
 }
@@ -58,7 +59,7 @@ func NewRegisterAuditorView(id view.Identity, auditView view.View) *RegisterAudi
 func (r *RegisterAuditorView) Call(context view.Context) (interface{}, error) {
 	view2.GetRegistry(context).RegisterResponder(r.AuditView, &AuditingViewInitiator{})
 
-	return context.RunView(tcc.NewRegisterAuditorView(r.Network, r.Channel, r.Namespace, r.Id))
+	return context.RunView(tcc.NewRegisterAuditorView(r.TMSID, r.Id))
 }
 
 func NewCollectAuditorEndorsement(tx *Transaction) *AuditingViewInitiator {

--- a/token/services/ttxcc/auditor.go
+++ b/token/services/ttxcc/auditor.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package ttxcc
 
 import (
@@ -44,21 +45,27 @@ func (a *txAuditor) NewQueryExecutor() *auditor.QueryExecutor {
 }
 
 type RegisterAuditorView struct {
-	Network   string
-	Channel   string
-	Namespace string
+	TMDIS     token.TMSID
 	Id        view.Identity
 	AuditView view.View
 }
 
-func NewRegisterAuditorView(id view.Identity, auditView view.View) *RegisterAuditorView {
-	return &RegisterAuditorView{Id: id, AuditView: auditView}
+func NewRegisterAuditorView(id view.Identity, auditView view.View, opts ...token.ServiceOption) *RegisterAuditorView {
+	options, err := token.CompileServiceOptions(opts...)
+	if err != nil {
+		return nil
+	}
+	return &RegisterAuditorView{
+		Id:        id,
+		AuditView: auditView,
+		TMDIS:     options.TMSID(),
+	}
 }
 
 func (r *RegisterAuditorView) Call(context view.Context) (interface{}, error) {
 	view2.GetRegistry(context).RegisterResponder(r.AuditView, &AuditingViewInitiator{})
 
-	return context.RunView(tcc.NewRegisterAuditorView(r.Network, r.Channel, r.Namespace, r.Id))
+	return context.RunView(tcc.NewRegisterAuditorView(r.TMDIS, r.Id))
 }
 
 type AuditingViewInitiator struct {

--- a/token/services/ttxcc/opts.go
+++ b/token/services/ttxcc/opts.go
@@ -5,7 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 */
 package ttxcc
 
-import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+)
 
 type txOptions struct {
 	auditor   view.Identity
@@ -50,6 +54,26 @@ func WithChannel(channel string) TxOption {
 func WithNamespace(namespace string) TxOption {
 	return func(o *txOptions) error {
 		o.namespace = namespace
+		return nil
+	}
+}
+
+// WithTMS filters by network, channel and namespace. Each of them can be empty
+func WithTMS(network, channel, namespace string) TxOption {
+	return func(o *txOptions) error {
+		o.network = network
+		o.channel = channel
+		o.namespace = namespace
+		return nil
+	}
+}
+
+// WithTMSID filters by TMS identifier
+func WithTMSID(id token.TMSID) TxOption {
+	return func(o *txOptions) error {
+		o.network = id.Network
+		o.channel = id.Channel
+		o.namespace = id.Namespace
 		return nil
 	}
 }

--- a/token/services/ttxcc/ordering.go
+++ b/token/services/ttxcc/ordering.go
@@ -8,6 +8,7 @@ package ttxcc
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/pkg/errors"
 )
 
 type orderingView struct {
@@ -25,7 +26,7 @@ func NewOrderingView(tx *Transaction) *orderingView {
 // The view does the following:
 // 1. It broadcasts the token token transaction to the proper Fabric ordering service.
 func (o *orderingView) Call(context view.Context) (interface{}, error) {
-	if err := fabric.GetDefaultFNS(context).Ordering().Broadcast(o.tx.Payload.FabricEnvelope); err != nil {
+	if err := fabric.GetFabricNetworkService(context, o.tx.Network()).Ordering().Broadcast(o.tx.Payload.FabricEnvelope); err != nil {
 		return nil, err
 	}
 	return nil, nil
@@ -50,8 +51,17 @@ func NewOrderingAndFinalityView(tx *Transaction) *orderingAndFinalityView {
 // 2. It waits for finality of the token transaction by listening to delivery events from one of the
 // Fabric peer nodes trusted by the FSC node.
 func (o *orderingAndFinalityView) Call(context view.Context) (interface{}, error) {
-	if err := fabric.GetDefaultFNS(context).Ordering().Broadcast(o.tx.Payload.FabricEnvelope); err != nil {
+	fns := fabric.GetFabricNetworkService(context, o.tx.Network())
+	if fns == nil {
+		return nil, errors.Errorf("network [%s] not found", o.tx.Network())
+	}
+	ch, err := fns.Channel(o.tx.Channel())
+	if err != nil {
+		return nil, errors.Errorf("channel [%s:%s] not found", o.tx.Network(), o.tx.Channel())
+	}
+	if err := fns.Ordering().Broadcast(o.tx.Payload.FabricEnvelope); err != nil {
 		return nil, err
 	}
-	return nil, fabric.GetChannel(context, o.tx.Network(), o.tx.Channel()).Finality().IsFinal(o.tx.ID())
+
+	return nil, ch.Finality().IsFinal(o.tx.ID())
 }

--- a/token/services/ttxcc/transaction.go
+++ b/token/services/ttxcc/transaction.go
@@ -219,7 +219,7 @@ func (t *Transaction) storeTransient() error {
 		return errors.Wrapf(err, "failed getting channel [%s:%s]", t.Network(), t.Channel())
 	}
 
-	return ch.Vault().StoreTransient(t.ID(), fabric.TransientMap(t.Payload.Transient))
+	return ch.Vault().StoreTransient(t.ID(), t.Payload.Transient)
 }
 
 func (t *Transaction) setEnvelope(envelope *fabric.Envelope) error {
@@ -263,5 +263,10 @@ func (t *Transaction) appendPayload(payload *Payload) error {
 }
 
 func (t *Transaction) TokenService() *token.ManagementService {
-	return token.GetManagementService(t.SP, token.WithChannel(t.Channel()))
+	return token.GetManagementService(
+		t.SP,
+		token.WithNetwork(t.Network()),
+		token.WithChannel(t.Channel()),
+		token.WithNamespace(t.Namespace()),
+	)
 }

--- a/token/services/vault/processor/issued.go
+++ b/token/services/vault/processor/issued.go
@@ -1,0 +1,42 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package processor
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
+
+// WalletIssued is an owner wallet-based Issued checker
+type WalletIssued struct{}
+
+// Issued returns true if the passed issuer issued the passed token
+func (w *WalletIssued) Issued(tms *token.ManagementService, issuer view.Identity, tok *token2.Token) bool {
+	return tms.WalletManager().IssuerWalletByIdentity(issuer) != nil
+}
+
+// IssuedMultiplexer iterates over multiple Issued checker
+type IssuedMultiplexer struct {
+	Checkers []Issued
+}
+
+// NewIssuedMultiplexer returns a new IssuedMultiplexer for the passed Issued checkers
+func NewIssuedMultiplexer(checkers ...Issued) *IssuedMultiplexer {
+	return &IssuedMultiplexer{Checkers: checkers}
+}
+
+// Issued returns true if the passed issuer issued the passed token
+func (o *IssuedMultiplexer) Issued(tms *token.ManagementService, issuer view.Identity, tok *token2.Token) bool {
+	for _, Issued := range o.Checkers {
+		if Issued.Issued(tms, issuer, tok) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- [x] NWO token topology: use Fabric topology's name when adding a new TMS.
- [x] Introduce TMS Identifier
- [x] Vault/Query: multi network support
- [x] TCC/Auditor: multi network support
- [x] Vault/Processor: multi network support and extendable token issued recognition
- [x] TTX and TTXCC:  multi network support
- [x] Core/TMS: multi network support

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>