### PR TITLE
Various fixes

### DIFF
--- a/integration/nwo/token/platform.go
+++ b/integration/nwo/token/platform.go
@@ -267,7 +267,7 @@ func (p *Platform) FSCCertifierCryptoMaterialDir(tms *TMS, peer *sfcnode.Node) s
 		peer.ID(),
 		"wallets",
 		"certifier",
-		fmt.Sprintf("%s_%s_%s", tms.Channel, tms.Namespace, tms.Driver),
+		fmt.Sprintf("%s_%s_%s_%s", tms.Network, tms.Channel, tms.Namespace, tms.Driver),
 	)
 }
 
@@ -286,7 +286,7 @@ func (p *Platform) PublicParametersFile(tms *TMS) string {
 		"token",
 		"crypto",
 		"pp",
-		fmt.Sprintf("%s_%s_%s.pp", tms.Channel, tms.Namespace, tms.Driver),
+		fmt.Sprintf("%s_%s_%s_%s", tms.Network, tms.Channel, tms.Namespace, tms.Driver),
 	)
 }
 

--- a/integration/nwo/token/tcc.go
+++ b/integration/nwo/token/tcc.go
@@ -28,6 +28,7 @@ import (
 
 func (p *Platform) tccSetup(tms *TMS, cc *topology.ChannelChaincode) (*topology.ChannelChaincode, uint16) {
 	// Load public parameters
+	fmt.Printf("tcc setup, reading public parameters from [%s]\n", p.PublicParametersFile(tms))
 	ppRaw, err := ioutil.ReadFile(p.PublicParametersFile(tms))
 	Expect(err).ToNot(HaveOccurred())
 
@@ -37,6 +38,7 @@ func (p *Platform) tccSetup(tms *TMS, cc *topology.ChannelChaincode) (*topology.
 		"token",
 		"chaincodes",
 		"tcc",
+		tms.Network,
 		tms.Channel,
 		tms.Namespace,
 	)

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -185,7 +185,7 @@ func (v *Validator) verifyTransfers(ledger driver.Ledger, transferActions []driv
 		var inputTokens [][]byte
 		inputs, err := t.GetInputs()
 		if err != nil {
-			errors.Wrapf(err, "failed to retrieve inputs to spend")
+			return errors.Wrapf(err, "failed to retrieve inputs to spend")
 		}
 		for _, in := range inputs {
 			logger.Debugf("load token [%d][%s]", i, in)


### PR DESCRIPTION
- [x] NWO.Token now takes in account the network name when storing
data. This avoids confusion when multiple networks are used.
- [x] DLog Driver, missing return

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>