### PR TITLE
Resolve data races in ZKAT-DLOG transfers

### DIFF
--- a/token/core/zkatdlog/crypto/token/token.go
+++ b/token/core/zkatdlog/crypto/token/token.go
@@ -8,7 +8,7 @@ package token
 import (
 	"encoding/json"
 
-	"github.com/IBM/mathlib"
+	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -108,4 +108,12 @@ type TokenDataWitness struct {
 	Type           string
 	Value          *math.Zr
 	BlindingFactor *math.Zr
+}
+
+func (tdw *TokenDataWitness) Clone() *TokenDataWitness {
+	return &TokenDataWitness{
+		Type:           tdw.Type,
+		Value:          tdw.Value.Copy(),
+		BlindingFactor: tdw.BlindingFactor.Copy(),
+	}
 }

--- a/token/core/zkatdlog/crypto/transfer/transfer.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer.go
@@ -8,7 +8,7 @@ package transfer
 import (
 	"encoding/json"
 
-	"github.com/IBM/mathlib"
+	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	rangeproof "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/range"
@@ -35,11 +35,21 @@ type Prover struct {
 }
 
 func NewProver(inputwitness, outputwitness []*token.TokenDataWitness, inputs, outputs []*math.G1, pp *crypto.PublicParams) *Prover {
-
 	p := &Prover{}
 
-	p.RangeCorrectness = rangeproof.NewProver(outputwitness, outputs, pp.RangeProofParams.SignedValues, pp.RangeProofParams.Exponent, pp.ZKATPedParams, pp.RangeProofParams.SignPK, pp.P, pp.RangeProofParams.Q, math.Curves[pp.Curve])
-	wfw := NewWellFormednessWitness(inputwitness, outputwitness)
+	inW := make([]*token.TokenDataWitness, len(inputwitness))
+	outW := make([]*token.TokenDataWitness, len(outputwitness))
+
+	for i := 0; i < len(inputwitness); i++ {
+		inW[i] = inputwitness[i].Clone()
+	}
+
+	for i := 0; i < len(outputwitness); i++ {
+		outW[i] = outputwitness[i].Clone()
+	}
+
+	p.RangeCorrectness = rangeproof.NewProver(outW, outputs, pp.RangeProofParams.SignedValues, pp.RangeProofParams.Exponent, pp.ZKATPedParams, pp.RangeProofParams.SignPK, pp.P, pp.RangeProofParams.Q, math.Curves[pp.Curve])
+	wfw := NewWellFormednessWitness(inW, outW)
 	p.WellFormedness = NewWellFormednessProver(wfw, pp.ZKATPedParams, inputs, outputs, math.Curves[pp.Curve])
 	return p
 }


### PR DESCRIPTION
This commit resolves data races in the ZKAT-DLOG transfers via refactoring the code to use local variables instead of field variables, hence making local variables reference-able only from the goroutine that created them and not shared across goroutines.

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>