### PR TITLE
Test the token transaction release function

### DIFF
--- a/integration/token/tcc/basic/tests.go
+++ b/integration/token/tcc/basic/tests.go
@@ -274,7 +274,9 @@ func TestAll(network *integration.Infrastructure) {
 
 	// Transfer by IDs
 	txID := issueCash(network, "", "CHF", 17, "alice")
-	txID = transferCashByIDs(network, "alice", "", []*token2.ID{{TxId: txID, Index: 0}}, 17, "bob")
+	transferCashByIDs(network, "alice", "", []*token2.ID{{TxId: txID, Index: 0}}, 17, "bob", true, "test release")
+	// the previous call should not keep the token locked if release is successful
+	txID = transferCashByIDs(network, "alice", "", []*token2.ID{{TxId: txID, Index: 0}}, 17, "bob", false)
 	redeemCashByIDs(network, "bob", "", []*token2.ID{{TxId: txID, Index: 0}}, 17)
 }
 
@@ -350,13 +352,14 @@ func transferCash(network *integration.Infrastructure, id string, wallet string,
 	}
 }
 
-func transferCashByIDs(network *integration.Infrastructure, id string, wallet string, ids []*token2.ID, amount uint64, receiver string, errorMsgs ...string) string {
+func transferCashByIDs(network *integration.Infrastructure, id string, wallet string, ids []*token2.ID, amount uint64, receiver string, failToRelease bool, errorMsgs ...string) string {
 	txid, err := network.Client(id).CallView("transfer", common.JSONMarshall(&views.Transfer{
-		Wallet:    wallet,
-		Type:      "",
-		TokenIDs:  ids,
-		Amount:    amount,
-		Recipient: network.Identity(receiver),
+		Wallet:        wallet,
+		Type:          "",
+		TokenIDs:      ids,
+		Amount:        amount,
+		Recipient:     network.Identity(receiver),
+		FailToRelease: failToRelease,
 	}))
 	if len(errorMsgs) == 0 {
 		Expect(err).NotTo(HaveOccurred())

--- a/integration/token/tcc/basic/views/transfer.go
+++ b/integration/token/tcc/basic/views/transfer.go
@@ -34,6 +34,8 @@ type Transfer struct {
 	Recipient view.Identity
 	// Retry tells if a retry must happen in case of a failure
 	Retry bool
+	// FailToRelease if true, it fails after transfer to trigger the Release function on the token transaction
+	FailToRelease bool
 }
 
 type TransferView struct {
@@ -78,6 +80,12 @@ func (t *TransferView) Call(context view.Context) (interface{}, error) {
 		token2.WithTokenIDs(t.TokenIDs...),
 	)
 	assert.NoError(err, "failed adding new tokens")
+
+	if t.FailToRelease {
+		// return an error to trigger the Release function on the token transaction
+		// The Release function is called when the context is canceled due to a panic or an error.
+		return nil, errors.New("test release")
+	}
 
 	// The sender is ready to collect all the required signatures.
 	// In this case, the sender's and the auditor's signatures.


### PR DESCRIPTION
This PR tests the token transaction release function that is triggered
when a context is cancelled due to a panic or an error returned by a view.
The test first locks a token and trigger the release, then
it tries to relock again the same token. The latter operation should succeed.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>