### PR TITLE
network.fabric: support FPC

### DIFF
--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -344,14 +344,13 @@ func (n *Network) requestApprovalFPC(context view.Context, namespace string, req
 	return chaincode.NewEndorseView(
 		namespace,
 		InvokeFunction,
+		requestRaw,
 	).WithNetwork(
 		n.n.Name(),
 	).WithChannel(
 		n.ch.Name(),
 	).WithSignerIdentity(
 		signer,
-	).WithTransientEntry(
-		"token_request", requestRaw,
 	).WithTxID(
 		fabric.TxID{
 			Nonce:   txID.Nonce,


### PR DESCRIPTION
If the token chaincode is a FPC, then we must pass the token request as an input not via transient.
This, at least, until FPC supports transient: https://github.com/hyperledger/fabric-private-chaincode/issues/666

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>