### PR TITLE
Add token request extractor to TCC

### DIFF
--- a/token/services/tcc/main/main.go
+++ b/token/services/tcc/main/main.go
@@ -61,8 +61,9 @@ func main() {
 				TokenServicesFactory: func(bytes []byte) (tcc.PublicParametersManager, tcc.Validator, error) {
 					return token.NewServicesFromPublicParams(bytes)
 				},
-				MetricsEnabled: config.MetricsEnabled,
-				MetricsServer:  config.MetricsServer,
+				ExtractTokenRequest: tcc.ExtractTokenRequestFromTransient,
+				MetricsEnabled:      config.MetricsEnabled,
+				MetricsServer:       config.MetricsServer,
 			},
 		)
 		if err != nil {
@@ -80,9 +81,10 @@ func main() {
 				TokenServicesFactory: func(bytes []byte) (tcc.PublicParametersManager, tcc.Validator, error) {
 					return token.NewServicesFromPublicParams(bytes)
 				},
-				LogLevel:       config.LogLevel,
-				MetricsEnabled: config.MetricsEnabled,
-				MetricsServer:  config.MetricsServer,
+				ExtractTokenRequest: tcc.ExtractTokenRequestFromTransient,
+				LogLevel:            config.LogLevel,
+				MetricsEnabled:      config.MetricsEnabled,
+				MetricsServer:       config.MetricsServer,
 			},
 			TLSProps: shim.TLSProperties{
 				// TODO : enable TLS

--- a/token/services/tcc/request.go
+++ b/token/services/tcc/request.go
@@ -1,0 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tcc
+
+import (
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/pkg/errors"
+)
+
+type ExtractTokenRequestFunc func(stub shim.ChaincodeStubInterface) ([]byte, error)
+
+func ExtractTokenRequestFromTransient(stub shim.ChaincodeStubInterface) ([]byte, error) {
+	args := stub.GetArgs()
+	if len(args) != 1 {
+		return nil, errors.New("empty token request")
+	}
+	// extract token request from transient
+	t, err := stub.GetTransient()
+	if err != nil {
+		return nil, errors.New("failed getting transient")
+	}
+	tokenRequest, ok := t["token_request"]
+	if !ok {
+		return nil, errors.New("failed getting token request, entry not found")
+	}
+
+	return tokenRequest, nil
+}

--- a/token/services/tcc/tcc.go
+++ b/token/services/tcc/tcc.go
@@ -73,6 +73,7 @@ type TokenChaincode struct {
 	initOnce                sync.Once
 	LogLevel                string
 	Validator               Validator
+	ExtractTokenRequest     ExtractTokenRequestFunc
 	PublicParametersManager PublicParametersManager
 
 	PPDigest             []byte
@@ -150,17 +151,9 @@ func (cc *TokenChaincode) Invoke(stub shim.ChaincodeStubInterface) (res pb.Respo
 		logger.Infof("running function [%s]", string(args[0]))
 		switch f := string(args[0]); f {
 		case InvokeFunction:
-			if len(args) != 1 {
-				return shim.Error("empty token request")
-			}
-			// extract token request from transient
-			t, err := stub.GetTransient()
+			tokenRequest, err := cc.ExtractTokenRequest(stub)
 			if err != nil {
-				return shim.Error("failed getting transient")
-			}
-			tokenRequest, ok := t["token_request"]
-			if !ok {
-				return shim.Error("failed getting token request, entry not found")
+				return shim.Error(err.Error())
 			}
 			return cc.ProcessRequest(tokenRequest, stub)
 		case QueryPublicParamsFunction:

--- a/token/services/tcc/tcc_test.go
+++ b/token/services/tcc/tcc_test.go
@@ -30,6 +30,7 @@ var _ = Describe("ccvalidator", func() {
 			TokenServicesFactory: func(i []byte) (chaincode2.PublicParametersManager, chaincode2.Validator, error) {
 				return fakePPM, fakeValidator, nil
 			},
+			ExtractTokenRequest: chaincode2.ExtractTokenRequestFromTransient,
 		}
 
 		pp := base64.StdEncoding.EncodeToString([]byte("public parameters"))


### PR DESCRIPTION
Refactor TCC that the tokenRequest extract logic can be injected. This
allows to use alternativ implmentations of the extracting logic other
than the default transient-based logic. A use case for this is, the
FPC-TCC. Currently, FPC does not support transient data, so the
tokenRequest must be provided via function args.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>