### PR TITLE
fix AuditDB redeem bug

### DIFF
--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -523,7 +523,7 @@ func CheckSpending(network *integration.Infrastructure, id string, wallet string
 	Expect(err).NotTo(HaveOccurred())
 	spending, err := strconv.ParseUint(common.JSONUnmarshalString(spendingBoxed), 10, 64)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(spending).To(Equal(int(expected)))
+	Expect(spending).To(Equal(expected))
 }
 
 func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ string) *token2.IssuedTokens {

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -508,7 +508,7 @@ func CheckBalance(network *integration.Infrastructure, id string, wallet string,
 	Expect(holding).To(Equal(int(expected)))
 }
 
-func CheckSpending(network *integration.Infrastructure, id string, wallet string, typ string, expected uint64) {
+func CheckSpending(network *integration.Infrastructure, id string, wallet string, tokenType string, expected uint64) {
 	// check spending
 	// first get the enrollment id
 	eIDBoxed, err := network.Client(id).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
@@ -518,10 +518,10 @@ func CheckSpending(network *integration.Infrastructure, id string, wallet string
 	eID := common.JSONUnmarshalString(eIDBoxed)
 	spendingBoxed, err := network.Client("auditor").CallView("spending", common.JSONMarshall(&views.CurrentSpending{
 		EnrollmentID: eID,
-		TokenType:    typ,
+		TokenType:    tokenType,
 	}))
 	Expect(err).NotTo(HaveOccurred())
-	spending, err := strconv.Atoi(common.JSONUnmarshalString(spendingBoxed))
+	spending, err := strconv.ParseUint(common.JSONUnmarshalString(spendingBoxed), 10, 64)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(spending).To(Equal(int(expected)))
 }

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -179,6 +180,7 @@ func TestAll(network *integration.Infrastructure) {
 	TransferCash(network, "alice", "", "USD", 111, "bob")
 	t9 := time.Now()
 	CheckAuditedTransactions(network, TestAllTransactions[5:7], &t8, &t9)
+	CheckSpending(network, "alice", "", "USD", 111)
 	ut := ListUnspentTokens(network, "alice", "", "USD")
 	Expect(ut.Count() > 0).To(BeTrue())
 	Expect(ut.Sum(64).ToBigInt().Cmp(big.NewInt(9))).To(BeEquivalentTo(0))
@@ -195,6 +197,7 @@ func TestAll(network *integration.Infrastructure) {
 	t11 := time.Now()
 	CheckAuditedTransactions(network, TestAllTransactions[9:10], &t10, &t11)
 	CheckAuditedTransactions(network, TestAllTransactions[:], &t0, &t11)
+	CheckSpending(network, "bob", "", "USD", 11)
 
 	IssueCash(network, "", "USD", 1, "alice")
 
@@ -210,9 +213,12 @@ func TestAll(network *integration.Infrastructure) {
 	CheckBalance(network, "alice", "", "EUR", 10)
 	CheckBalance(network, "bob", "", "EUR", 20)
 	CheckBalance(network, "bob", "", "USD", 120)
+	CheckSpending(network, "alice", "", "USD", 121)
+	CheckSpending(network, "bob", "", "EUR", 10)
 
 	RedeemCash(network, "bob", "", "USD", 10)
 	CheckBalance(network, "bob", "", "USD", 110)
+	CheckSpending(network, "bob", "", "USD", 21)
 
 	// Check self endpoints
 	IssueCash(network, "", "USD", 110, "issuer")
@@ -261,6 +267,7 @@ func TestAll(network *integration.Infrastructure) {
 	CheckBalance(network, "manager", "manager.id3", "USD", 10)
 
 	TransferCash(network, "manager", "manager.id1", "USD", 10, "manager.id2")
+	CheckSpending(network, "manager", "manager.id1", "USD", 10)
 	CheckBalance(network, "manager", "", "USD", 20)
 	CheckBalance(network, "manager", "manager.id1", "USD", 0)
 	CheckBalance(network, "manager", "manager.id2", "USD", 20)
@@ -296,6 +303,8 @@ func TestAll(network *integration.Infrastructure) {
 	CheckBalance(network, "alice", "", "EUR", 2210)
 	CheckBalance(network, "charlie", "", "EUR", 2000)
 	TransferCash(network, "alice", "", "EUR", 210, "bob", "payment limit reached", "alice", "[EUR][210]")
+	CheckBalance(network, "bob", "", "USD", 110)
+	CheckBalance(network, "bob", "", "EUR", 20)
 
 	TransferCash(network, "alice", "", "EUR", 200, "bob")
 	TransferCash(network, "alice", "", "EUR", 200, "bob")
@@ -306,12 +315,15 @@ func TestAll(network *integration.Infrastructure) {
 	TransferCash(network, "alice", "", "EUR", 200, "bob")
 	TransferCash(network, "alice", "", "EUR", 200, "bob")
 	TransferCash(network, "alice", "", "EUR", 200, "bob")
+	CheckBalance(network, "bob", "", "EUR", 1820)
+	CheckSpending(network, "alice", "", "EUR", 1800)
 	TransferCash(network, "alice", "", "EUR", 200, "bob", "cumulative payment limit reached", "alice", "[EUR][2000]")
 	TransferCash(network, "charlie", "", "EUR", 200, "bob")
 	TransferCash(network, "charlie", "", "EUR", 200, "bob")
 	TransferCash(network, "charlie", "", "EUR", 200, "bob")
 	TransferCash(network, "charlie", "", "EUR", 200, "bob")
 	TransferCash(network, "charlie", "", "EUR", 200, "bob")
+	CheckBalance(network, "bob", "", "EUR", 2820)
 	TransferCash(network, "charlie", "", "EUR", 200, "bob", "holding limit reached", "bob", "[EUR][3020]")
 	CheckBalance(network, "bob", "", "EUR", 2820)
 
@@ -469,6 +481,7 @@ func CheckAuditedTransactions(network *integration.Infrastructure, expected []*a
 }
 
 func CheckBalance(network *integration.Infrastructure, id string, wallet string, typ string, expected uint64) {
+	// check balance
 	b, err := query.NewClient(network.Client(id)).WalletBalance(wallet, typ)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(len(b)).To(BeEquivalentTo(1))
@@ -477,6 +490,40 @@ func CheckBalance(network *integration.Infrastructure, id string, wallet string,
 	Expect(err).NotTo(HaveOccurred())
 	expectedQ := token2.NewQuantityFromUInt64(expected)
 	Expect(expectedQ.Cmp(q)).To(BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
+
+	// check holding, it must be equal to the balance
+	// first get the enrollment id
+	eIDBoxed, err := network.Client(id).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
+		Wallet: wallet,
+	}))
+	Expect(err).NotTo(HaveOccurred())
+	eID := common.JSONUnmarshalString(eIDBoxed)
+	holdingBoxed, err := network.Client("auditor").CallView("holding", common.JSONMarshall(&views.CurrentHolding{
+		EnrollmentID: eID,
+		TokenType:    typ,
+	}))
+	Expect(err).NotTo(HaveOccurred())
+	holding, err := strconv.Atoi(common.JSONUnmarshalString(holdingBoxed))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(holding).To(Equal(int(expected)))
+}
+
+func CheckSpending(network *integration.Infrastructure, id string, wallet string, typ string, expected uint64) {
+	// check spending
+	// first get the enrollment id
+	eIDBoxed, err := network.Client(id).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
+		Wallet: wallet,
+	}))
+	Expect(err).NotTo(HaveOccurred())
+	eID := common.JSONUnmarshalString(eIDBoxed)
+	spendingBoxed, err := network.Client("auditor").CallView("spending", common.JSONMarshall(&views.CurrentSpending{
+		EnrollmentID: eID,
+		TokenType:    typ,
+	}))
+	Expect(err).NotTo(HaveOccurred())
+	spending, err := strconv.Atoi(common.JSONUnmarshalString(spendingBoxed))
+	Expect(err).NotTo(HaveOccurred())
+	Expect(spending).To(Equal(int(expected)))
 }
 
 func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ string) *token2.IssuedTokens {

--- a/integration/token/fungible/topology.go
+++ b/integration/token/fungible/topology.go
@@ -54,6 +54,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	issuer.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
 	issuer.RegisterViewFactory("history", &views.ListIssuedTokensViewFactory{})
 	issuer.RegisterViewFactory("issuedTokenQuery", &views.ListIssuedTokensViewFactory{})
+	issuer.RegisterViewFactory("GetEnrollmentID", &views.GetEnrollmentIDViewFactory{})
 
 	auditor := fscTopology.AddNodeByName("auditor").AddOptions(
 		fabric.WithOrganization("Org1"),
@@ -63,6 +64,8 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	)
 	auditor.RegisterViewFactory("register", &views.RegisterAuditorViewFactory{})
 	auditor.RegisterViewFactory("history", &views.ListAuditedTransactionsViewFactory{})
+	auditor.RegisterViewFactory("holding", &views.CurrentHoldingViewFactory{})
+	auditor.RegisterViewFactory("spending", &views.CurrentSpendingViewFactory{})
 
 	alice := fscTopology.AddNodeByName("alice").AddOptions(
 		fabric.WithOrganization("Org2"),
@@ -78,6 +81,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	alice.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
 	alice.RegisterViewFactory("swap", &views.SwapInitiatorViewFactory{})
 	alice.RegisterViewFactory("history", &views.ListUnspentTokensViewFactory{})
+	alice.RegisterViewFactory("GetEnrollmentID", &views.GetEnrollmentIDViewFactory{})
 
 	bob := fscTopology.AddNodeByName("bob").AddOptions(
 		fabric.WithOrganization("Org2"),
@@ -95,6 +99,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	bob.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
 	bob.RegisterViewFactory("swap", &views.SwapInitiatorViewFactory{})
 	bob.RegisterViewFactory("history", &views.ListUnspentTokensViewFactory{})
+	bob.RegisterViewFactory("GetEnrollmentID", &views.GetEnrollmentIDViewFactory{})
 
 	charlie := fscTopology.AddNodeByName("charlie").AddOptions(
 		fabric.WithOrganization("Org2"),
@@ -112,6 +117,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	charlie.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
 	charlie.RegisterViewFactory("swap", &views.SwapInitiatorViewFactory{})
 	charlie.RegisterViewFactory("history", &views.ListUnspentTokensViewFactory{})
+	charlie.RegisterViewFactory("GetEnrollmentID", &views.GetEnrollmentIDViewFactory{})
 
 	manager := fscTopology.AddNodeByName("manager").AddOptions(
 		fabric.WithOrganization("Org2"),
@@ -130,6 +136,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	manager.RegisterViewFactory("swap", &views.SwapInitiatorViewFactory{})
 	manager.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
 	manager.RegisterViewFactory("history", &views.ListUnspentTokensViewFactory{})
+	manager.RegisterViewFactory("GetEnrollmentID", &views.GetEnrollmentIDViewFactory{})
 
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetDefaultSDK(fscTopology)

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -173,7 +173,7 @@ func (r *CurrentHoldingView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "failed retrieving holding for [%s][%s]", r.EnrollmentID, r.TokenType)
 	currentHolding := filter.Sum()
 	decimal := currentHolding.Decimal()
-	logger.Infof("Current Holding: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
+	logger.Debugf("Current Holding: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
 
 	return decimal, nil
 }
@@ -211,7 +211,7 @@ func (r *CurrentSpendingView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "failed retrieving spending for [%s][%s]", r.EnrollmentID, r.TokenType)
 	currentSpending := filter.Sum()
 	decimal := currentSpending.Decimal()
-	logger.Infof("Current Spending: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
+	logger.Debugf("Current Spending: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
 
 	return decimal, nil
 }

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -3,15 +3,16 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package views
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
@@ -146,5 +147,81 @@ type RegisterAuditorViewFactory struct{}
 
 func (p *RegisterAuditorViewFactory) NewView(in []byte) (view.View, error) {
 	f := &RegisterAuditorView{}
+	return f, nil
+}
+
+type CurrentHolding struct {
+	EnrollmentID string `json:"enrollment_id"`
+	TokenType    string `json:"token_type"`
+}
+
+// CurrentHoldingView is used to retrieve the current holding of token type of the passed enrollment id
+type CurrentHoldingView struct {
+	*CurrentHolding
+}
+
+func (r *CurrentHoldingView) Call(context view.Context) (interface{}, error) {
+	w := ttx.MyAuditorWallet(context)
+	assert.NotNil(w, "failed getting default auditor wallet")
+
+	auditor := ttx.NewAuditor(context, w)
+
+	aqe := auditor.NewQueryExecutor()
+	defer aqe.Done()
+
+	filter, err := aqe.Holdings().ByEnrollmentId(r.EnrollmentID).ByType(r.TokenType).Execute()
+	assert.NoError(err, "failed retrieving holding for [%s][%s]", r.EnrollmentID, r.TokenType)
+	currentHolding := filter.Sum()
+	decimal := currentHolding.Decimal()
+	logger.Infof("Current Holding: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
+
+	return decimal, nil
+}
+
+type CurrentHoldingViewFactory struct{}
+
+func (p *CurrentHoldingViewFactory) NewView(in []byte) (view.View, error) {
+	f := &CurrentHoldingView{CurrentHolding: &CurrentHolding{}}
+	err := json.Unmarshal(in, f.CurrentHolding)
+	assert.NoError(err, "failed unmarshalling input")
+
+	return f, nil
+}
+
+type CurrentSpending struct {
+	EnrollmentID string `json:"enrollment_id"`
+	TokenType    string `json:"token_type"`
+}
+
+// CurrentSpendingView is used to retrieve the current spending of token type of the passed enrollment id
+type CurrentSpendingView struct {
+	*CurrentSpending
+}
+
+func (r *CurrentSpendingView) Call(context view.Context) (interface{}, error) {
+	w := ttx.MyAuditorWallet(context)
+	assert.NotNil(w, "failed getting default auditor wallet")
+
+	auditor := ttx.NewAuditor(context, w)
+
+	aqe := auditor.NewQueryExecutor()
+	defer aqe.Done()
+
+	filter, err := aqe.Payments().ByEnrollmentId(r.EnrollmentID).ByType(r.TokenType).Execute()
+	assert.NoError(err, "failed retrieving spending for [%s][%s]", r.EnrollmentID, r.TokenType)
+	currentSpending := filter.Sum()
+	decimal := currentSpending.Decimal()
+	logger.Infof("Current Spending: [%s][%s][%s]", r.EnrollmentID, r.TokenType, decimal)
+
+	return decimal, nil
+}
+
+type CurrentSpendingViewFactory struct{}
+
+func (p *CurrentSpendingViewFactory) NewView(in []byte) (view.View, error) {
+	f := &CurrentSpendingView{CurrentSpending: &CurrentSpending{}}
+	err := json.Unmarshal(in, f.CurrentSpending)
+	assert.NoError(err, "failed unmarshalling input")
+
 	return f, nil
 }

--- a/integration/token/fungible/views/info.go
+++ b/integration/token/fungible/views/info.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package views
+
+import (
+	"encoding/json"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+)
+
+type GetEnrollmentID struct {
+	Wallet string `json:"wallet"`
+}
+
+// GetEnrollmentIDView is a view that returns the enrollment ID of a wallet.
+type GetEnrollmentIDView struct {
+	*GetEnrollmentID
+}
+
+func (r *GetEnrollmentIDView) Call(context view.Context) (interface{}, error) {
+	w := ttx.GetWallet(context, r.Wallet)
+	assert.NotNil(w, "failed getting default auditor wallet")
+
+	return w.EnrollmentID(), nil
+}
+
+type GetEnrollmentIDViewFactory struct{}
+
+func (p *GetEnrollmentIDViewFactory) NewView(in []byte) (view.View, error) {
+	f := &GetEnrollmentIDView{GetEnrollmentID: &GetEnrollmentID{}}
+	err := json.Unmarshal(in, f.GetEnrollmentID)
+	assert.NoError(err, "failed unmarshalling input")
+
+	return f, nil
+}

--- a/integration/token/fungible/views/logger.go
+++ b/integration/token/fungible/views/logger.go
@@ -1,0 +1,11 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package views
+
+import "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+
+var logger = flogging.MustGetLogger("fungible.views")

--- a/token/core/fabtoken/wallet.go
+++ b/token/core/fabtoken/wallet.go
@@ -98,7 +98,7 @@ func (s *Service) OwnerWalletByID(id interface{}) driver.OwnerWallet {
 			panic(err)
 		}
 
-		w := newOwnerWallet(s, id, wrappedID, wID)
+		w := newOwnerWallet(s, id, wrappedID, wID, idInfo)
 		s.OwnerWallets = append(s.OwnerWallets, w)
 		logger.Debugf("created owner wallet [%s:%s]", idInfo.ID, walletID)
 		return w
@@ -207,16 +207,18 @@ func (s *Service) walletID(id string) string {
 type ownerWallet struct {
 	tokenService *Service
 	id           string
+	identityInfo *driver.IdentityInfo
 	identity     view.Identity
 	wrappedID    view.Identity
 }
 
-func newOwnerWallet(tokenService *Service, identity, wrappedID view.Identity, id string) *ownerWallet {
+func newOwnerWallet(tokenService *Service, identity, wrappedID view.Identity, id string, identityInfo *driver.IdentityInfo) *ownerWallet {
 	return &ownerWallet{
 		tokenService: tokenService,
 		id:           id,
 		identity:     identity,
 		wrappedID:    wrappedID,
+		identityInfo: identityInfo,
 	}
 }
 
@@ -281,6 +283,10 @@ func (w *ownerWallet) ListTokens(opts *driver.ListTokensOptions) (*token.Unspent
 	logger.Debugf("wallet: list tokens done, found [%d] unspent tokens", len(unspentTokens.Tokens))
 
 	return unspentTokens, nil
+}
+
+func (w *ownerWallet) EnrollmentID() string {
+	return w.identityInfo.EnrollmentID
 }
 
 type issuerWallet struct {

--- a/token/core/zkatdlog/nogh/wallet.go
+++ b/token/core/zkatdlog/nogh/wallet.go
@@ -279,6 +279,10 @@ func (w *wallet) GetTokenMetadata(id view.Identity) ([]byte, error) {
 	return nil, nil
 }
 
+func (w *wallet) EnrollmentID() string {
+	return w.identityInfo.EnrollmentID
+}
+
 func (w *wallet) GetSigner(identity view.Identity) (api2.Signer, error) {
 	if !w.Contains(identity) {
 		return nil, errors.Errorf("identity [%s] does not belong to this wallet [%s]", identity, w.ID())

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -49,6 +49,9 @@ type OwnerWallet interface {
 
 	// GetTokenMetadata returns any information needed to implement the transfer
 	GetTokenMetadata(id view.Identity) ([]byte, error)
+
+	// EnrollmentID returns the enrollment ID of the owner wallet
+	EnrollmentID() string
 }
 
 // IssuerWallet models the wallet of an issuer as a container of issuer identities.

--- a/token/services/auditor/auditdb/auditdb.go
+++ b/token/services/auditor/auditdb/auditdb.go
@@ -333,8 +333,13 @@ func (db *AuditDB) Unlock(eIDs ...string) {
 func (db *AuditDB) appendSendMovements(record *token.AuditRecord) error {
 	inputs := record.Inputs
 	outputs := record.Outputs
-	eIDs := outputs.EnrollmentIDs()
+	// we need to consider both inputs and outputs enrollment IDs because the record can refer to a redeem
+	iEIDs := inputs.EnrollmentIDs()
+	oEIDs := outputs.EnrollmentIDs()
+	eIDs := append(iEIDs, oEIDs...)
+	eIDs = deduplicate(eIDs)
 	tokenTypes := outputs.TokenTypes()
+
 	for _, eID := range eIDs {
 		for _, tokenType := range tokenTypes {
 			sent := inputs.ByEnrollmentID(eID).ByType(tokenType).Sum().ToBigInt()
@@ -366,8 +371,13 @@ func (db *AuditDB) appendSendMovements(record *token.AuditRecord) error {
 func (db *AuditDB) appendReceivedMovements(record *token.AuditRecord) error {
 	inputs := record.Inputs
 	outputs := record.Outputs
-	eIDs := outputs.EnrollmentIDs()
+	// we need to consider both inputs and outputs enrollment IDs because the record can refer to a redeem
+	iEIDs := inputs.EnrollmentIDs()
+	oEIDs := outputs.EnrollmentIDs()
+	eIDs := append(iEIDs, oEIDs...)
+	eIDs = deduplicate(eIDs)
 	tokenTypes := outputs.TokenTypes()
+
 	for _, eID := range eIDs {
 		for _, tokenType := range tokenTypes {
 			received := outputs.ByEnrollmentID(eID).ByType(tokenType).Sum().ToBigInt()

--- a/token/services/auditor/auditdb/auditdb.go
+++ b/token/services/auditor/auditdb/auditdb.go
@@ -334,10 +334,7 @@ func (db *AuditDB) appendSendMovements(record *token.AuditRecord) error {
 	inputs := record.Inputs
 	outputs := record.Outputs
 	// we need to consider both inputs and outputs enrollment IDs because the record can refer to a redeem
-	iEIDs := inputs.EnrollmentIDs()
-	oEIDs := outputs.EnrollmentIDs()
-	eIDs := append(iEIDs, oEIDs...)
-	eIDs = deduplicate(eIDs)
+	eIDs := joinIOEIDs(record)
 	tokenTypes := outputs.TokenTypes()
 
 	for _, eID := range eIDs {
@@ -372,10 +369,7 @@ func (db *AuditDB) appendReceivedMovements(record *token.AuditRecord) error {
 	inputs := record.Inputs
 	outputs := record.Outputs
 	// we need to consider both inputs and outputs enrollment IDs because the record can refer to a redeem
-	iEIDs := inputs.EnrollmentIDs()
-	oEIDs := outputs.EnrollmentIDs()
-	eIDs := append(iEIDs, oEIDs...)
-	eIDs = deduplicate(eIDs)
+	eIDs := joinIOEIDs(record)
 	tokenTypes := outputs.TokenTypes()
 
 	for _, eID := range eIDs {
@@ -548,6 +542,16 @@ func GetAuditDB(sp view2.ServiceProvider, w *token.AuditorWallet) *AuditDB {
 	return c
 }
 
+// joinIOEIDs joins enrollment IDs of inputs and outputs
+func joinIOEIDs(record *token.AuditRecord) []string {
+	iEIDs := record.Inputs.EnrollmentIDs()
+	oEIDs := record.Outputs.EnrollmentIDs()
+	eIDs := append(iEIDs, oEIDs...)
+	eIDs = deduplicate(eIDs)
+	return eIDs
+}
+
+// deduplicate removes duplicate entries from a slice
 func deduplicate(source []string) []string {
 	support := make(map[string]bool)
 	var res []string

--- a/token/services/auditor/auditdb/db/badger/badger.go
+++ b/token/services/auditor/auditdb/db/badger/badger.go
@@ -126,6 +126,7 @@ func (db *Persistence) Discard() error {
 }
 
 func (db *Persistence) AddMovement(record *driver.MovementRecord) error {
+	logger.Debugf("Adding movement record [%s:%s:%s:%s]", record.TxID, record.TokenType, record.EnrollmentID, record.Amount)
 	next, key, err := db.movementKey(record.TxID)
 	if err != nil {
 		return errors.Wrapf(err, "could not get key for movement %s", record.TxID)

--- a/token/services/auditor/auditdb/db/memory/memory.go
+++ b/token/services/auditor/auditdb/db/memory/memory.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package memory
 
 import (
@@ -18,11 +19,11 @@ type Persistence struct {
 	transactionRecords []*driver.TransactionRecord
 }
 
-func (p *Persistence) QueryMovements(ids []string, types []string, status []driver.TxStatus, direction driver.SearchDirection, value driver.MovementDirection, numRecords int) ([]*driver.MovementRecord, error) {
+func (p *Persistence) QueryMovements(enrollmentIDs []string, tokenTypes []string, txStatuses []driver.TxStatus, searchDirection driver.SearchDirection, movementDirection driver.MovementDirection, numRecords int) ([]*driver.MovementRecord, error) {
 	var res []*driver.MovementRecord
 
 	var cursor int
-	switch direction {
+	switch searchDirection {
 	case driver.FromBeginning:
 		cursor = -1
 	case driver.FromLast:
@@ -32,7 +33,7 @@ func (p *Persistence) QueryMovements(ids []string, types []string, status []driv
 	}
 	counter := 0
 	for {
-		switch direction {
+		switch searchDirection {
 		case driver.FromBeginning:
 			cursor++
 		case driver.FromLast:
@@ -43,9 +44,9 @@ func (p *Persistence) QueryMovements(ids []string, types []string, status []driv
 		}
 
 		record := p.movementRecords[cursor]
-		if len(ids) != 0 {
+		if len(enrollmentIDs) != 0 {
 			found := false
-			for _, id := range ids {
+			for _, id := range enrollmentIDs {
 				if record.EnrollmentID == id {
 					found = true
 					break
@@ -55,9 +56,9 @@ func (p *Persistence) QueryMovements(ids []string, types []string, status []driv
 				continue
 			}
 		}
-		if len(types) != 0 {
+		if len(tokenTypes) != 0 {
 			found := false
-			for _, typ := range types {
+			for _, typ := range tokenTypes {
 				if record.TokenType == typ {
 					found = true
 					break
@@ -67,9 +68,9 @@ func (p *Persistence) QueryMovements(ids []string, types []string, status []driv
 				continue
 			}
 		}
-		if len(status) != 0 {
+		if len(txStatuses) != 0 {
 			found := false
-			for _, st := range status {
+			for _, st := range txStatuses {
 				if record.Status == st {
 					found = true
 					break
@@ -89,10 +90,10 @@ func (p *Persistence) QueryMovements(ids []string, types []string, status []driv
 			break
 		}
 
-		if value == driver.Sent && record.Amount.Sign() > 0 {
+		if movementDirection == driver.Sent && record.Amount.Sign() > 0 {
 			continue
 		}
-		if value == driver.Received && record.Amount.Sign() < 0 {
+		if movementDirection == driver.Received && record.Amount.Sign() < 0 {
 			continue
 		}
 

--- a/token/services/auditor/auditdb/db/memory/memory_test.go
+++ b/token/services/auditor/auditdb/db/memory/memory_test.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package memory
 
 import (

--- a/token/services/auditor/auditdb/filter.go
+++ b/token/services/auditor/auditdb/filter.go
@@ -39,7 +39,14 @@ func (f *PaymentsFilter) Last(num int) *PaymentsFilter {
 }
 
 func (f *PaymentsFilter) Execute() (*PaymentsFilter, error) {
-	records, err := f.db.db.QueryMovements(f.EnrollmentIds, f.Types, []driver.TxStatus{driver.Pending, driver.Confirmed}, driver.FromLast, driver.Sent, f.LastNumRecords)
+	records, err := f.db.db.QueryMovements(
+		f.EnrollmentIds,
+		f.Types,
+		[]driver.TxStatus{driver.Pending, driver.Confirmed},
+		driver.FromLast,
+		driver.Sent,
+		f.LastNumRecords,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -270,6 +270,10 @@ func (o *OwnerWallet) ListUnspentTokens(opts ...ListTokensOption) (*token2.Unspe
 	return o.w.ListTokens(compiledOpts)
 }
 
+func (o *OwnerWallet) EnrollmentID() string {
+	return o.w.EnrollmentID()
+}
+
 // IssuerWallet models the wallet of an issuer
 type IssuerWallet struct {
 	w api2.IssuerWallet


### PR DESCRIPTION
Currently, AuditDB fails to record redeem transactions because it does consider only the enrollment IDs of the outputs.
In a redeem, the output has no enrollment ID.
To make sure the fix works, we augment the CheckBalance function in the integration test to enforce that the holding of the party, at the auditor, is the same as the balance at the party.
We also introduce additional checks for the current spending.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>