### PR TITLE
Namespace is always zkat even if it was changed in the node config #256

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,5 +39,7 @@ require (
 	github.com/thedevsaddam/gojsonq v2.3.0+incompatible
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.18.1
+	golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 // indirect
+	golang.org/x/tools v0.1.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1425,8 +1425,9 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1582,8 +1583,9 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098 h1:PgOr27OhUx2IRqGJ2RxAWI4dJQ7bi9cSrB82uzFzfUA=
+golang.org/x/sys v0.0.0-20220614162138-6c1b26c55098/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1653,8 +1655,9 @@ golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
 golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
+golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/integration/nwo/token/topology.go
+++ b/integration/nwo/token/topology.go
@@ -74,6 +74,7 @@ func (t *Topology) AddTMS(backend BackedTopology, channel string, driver string)
 		Driver:          driver,
 		Certifiers:      []string{},
 		BackendParams:   map[string]interface{}{},
+		TokenTopology:   t,
 	}
 	t.TMSs = append(t.TMSs, tms)
 	return tms
@@ -87,4 +88,8 @@ func (t *Topology) SetSDK(fscTopology *fsc2.Topology, sdk api.SDK) {
 	for _, node := range fscTopology.Nodes {
 		node.AddSDK(sdk)
 	}
+}
+
+func (t *Topology) GetTMSs() []*topology2.TMS {
+	return t.TMSs
 }

--- a/integration/nwo/token/topology/topology.go
+++ b/integration/nwo/token/topology/topology.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
+	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 )
 
@@ -91,9 +92,7 @@ func (t *TMS) SetNamespace(namespace string) *TMS {
 	// Check if another namespace already exists in the same <network,channel>
 	for _, tms := range t.TokenTopology.GetTMSs() {
 		if tms.Network == t.Network && tms.Channel == t.Channel {
-			if tms.Namespace == namespace {
-				panic(fmt.Sprintf("Namespace [%s] already exists", namespace))
-			}
+			Expect(tms.Namespace).To(Not(Equal(namespace)), "Namespace [%s] already exists", namespace)
 		}
 	}
 

--- a/integration/token/fungible/topology.go
+++ b/integration/token/fungible/topology.go
@@ -141,7 +141,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetDefaultSDK(fscTopology)
 	tms := tokenTopology.AddTMS(backendNetwork, backendChannel, tokenSDKDriver)
-	tms.Namespace = "token-chaincode"
+	tms.SetNamespace("token-chaincode")
 	tms.SetTokenGenPublicParams("100", "2")
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {

--- a/integration/token/fungible/topology.go
+++ b/integration/token/fungible/topology.go
@@ -141,6 +141,7 @@ func Topology(backend string, tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetDefaultSDK(fscTopology)
 	tms := tokenTopology.AddTMS(backendNetwork, backendChannel, tokenSDKDriver)
+	tms.Namespace = "token-chaincode"
 	tms.SetTokenGenPublicParams("100", "2")
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {

--- a/token/config.go
+++ b/token/config.go
@@ -6,11 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 
 package token
 
-import "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+import (
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+)
 
 // ConfigManager manages the configuration of the token-sdk
 type ConfigManager struct {
-	cm driver.ConfigManager
+	cm config.Manager
 }
 
 // Certifiers returns the list of certifier ids.

--- a/token/core/config/config.go
+++ b/token/core/config/config.go
@@ -16,13 +16,16 @@ type configProvider interface {
 	TranslatePath(path string) string
 }
 
-type Manager struct {
+// TMSProvider is a config provider for a specific TMS
+type TMSProvider struct {
 	cp    configProvider
 	tms   *driver.TMS
 	index int
 }
 
-func NewManager(cp configProvider, network, channel, namespace string) (*Manager, error) {
+// NewTMSProvider creates a new TMSProvider for a specific TMS.
+// If no matching configuration is found, an error is returned.
+func NewTMSProvider(cp configProvider, network, channel, namespace string) (*TMSProvider, error) {
 	var tmsConfigs []*driver.TMS
 	if err := cp.UnmarshalKey("token.tms", &tmsConfigs); err != nil {
 		return nil, errors.WithMessagef(err, "cannot load token-sdk configuration")
@@ -30,7 +33,7 @@ func NewManager(cp configProvider, network, channel, namespace string) (*Manager
 
 	for i, config := range tmsConfigs {
 		if config.Network == network && config.Channel == channel && config.Namespace == namespace {
-			return &Manager{
+			return &TMSProvider{
 				tms:   config,
 				index: i,
 				cp:    cp,
@@ -41,10 +44,51 @@ func NewManager(cp configProvider, network, channel, namespace string) (*Manager
 	return nil, errors.Errorf("no token-sdk configuration for network %s, channel %s, namespace %s", network, channel, namespace)
 }
 
-func (m *Manager) TMS() *driver.TMS {
+// TMS returns the TMS configuration this provider is associated with.
+func (m *TMSProvider) TMS() *driver.TMS {
 	return m.tms
 }
 
-func (m *Manager) TranslatePath(path string) string {
+// TranslatePath translates the passed path relative to the config path
+func (m *TMSProvider) TranslatePath(path string) string {
 	return m.cp.TranslatePath(path)
+}
+
+// Manager manages the configuration of the token-sdk.
+type Manager struct {
+	cp configProvider
+}
+
+// NewManager creates a new Manager.
+func NewManager(cp configProvider) (*Manager, error) {
+	var tmsConfigs []*driver.TMS
+	if err := cp.UnmarshalKey("token.tms", &tmsConfigs); err != nil {
+		return nil, errors.WithMessagef(err, "cannot load token-sdk configuration")
+	}
+	return &Manager{cp: cp}, nil
+}
+
+// SearchTMS searches for a TMS configuration that matches the given network and channel, and
+// return its namespace.
+// If no matching configuration is found, an error is returned.
+// If multiple matching configurations are found, an error is returned.
+func (m *Manager) SearchTMS(network, channel string) (string, error) {
+	var tmsConfigs []*driver.TMS
+	if err := m.cp.UnmarshalKey("token.tms", &tmsConfigs); err != nil {
+		return "", errors.WithMessagef(err, "cannot load token-sdk configuration")
+	}
+
+	var hits []*driver.TMS
+	for _, config := range tmsConfigs {
+		if config.Network == network && config.Channel == channel {
+			hits = append(hits, config)
+		}
+	}
+	if len(hits) == 1 {
+		return hits[0].Namespace, nil
+	}
+	if len(hits) == 0 {
+		return "", errors.Errorf("no token-sdk configuration for network %s, channel %s", network, channel)
+	}
+	return "", errors.Errorf("multiple token-sdk configurations for network %s, channel %s", network, channel)
 }

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -45,7 +45,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	qe := v.TokenVault().QueryEngine()
 	lm := n.LocalMembership()
 
-	cm, err := config.NewManager(view2.GetConfigService(sp), networkID, channel, namespace)
+	cm, err := config.NewTMSProvider(view2.GetConfigService(sp), networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")
 	}

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -45,7 +45,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	qe := v.TokenVault().QueryEngine()
 	lm := n.LocalMembership()
 
-	cm, err := config.NewTMSProvider(view2.GetConfigService(sp), networkID, channel, namespace)
+	cm, err := config.NewTokenSDK(view2.GetConfigService(sp)).GetTMS(networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")
 	}

--- a/token/core/fabtoken/service.go
+++ b/token/core/fabtoken/service.go
@@ -9,10 +9,9 @@ package fabtoken
 import (
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 

--- a/token/core/fabtoken/service.go
+++ b/token/core/fabtoken/service.go
@@ -9,6 +9,8 @@ package fabtoken
 import (
 	"sync"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -43,7 +45,7 @@ type Service struct {
 	PPM         PublicParametersManager
 	TokenLoader TokenLoader
 	QE          QueryEngine
-	CM          driver.ConfigManager
+	CM          config.Manager
 
 	IP             driver.IdentityProvider
 	Deserializer   driver.Deserializer
@@ -62,7 +64,7 @@ func NewService(
 	qe QueryEngine,
 	identityProvider driver.IdentityProvider,
 	deserializer driver.Deserializer,
-	cm driver.ConfigManager,
+	cm config.Manager,
 ) *Service {
 	s := &Service{
 		SP:           sp,
@@ -90,6 +92,6 @@ func (s *Service) PublicParamsManager() driver.PublicParamsManager {
 	return s.PPM
 }
 
-func (s *Service) ConfigManager() driver.ConfigManager {
+func (s *Service) ConfigManager() config.Manager {
 	return s.CM
 }

--- a/token/core/identity/tms/wm.go
+++ b/token/core/identity/tms/wm.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+
 	math3 "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
@@ -75,7 +77,7 @@ type EnrollmentService interface {
 
 type WalletManager struct {
 	sp              view2.ServiceProvider
-	cm              driver.ConfigManager
+	cm              config.Manager
 	empty           bool
 	defaultIdentity view.Identity
 	signerService   SignerService
@@ -86,7 +88,7 @@ type WalletManager struct {
 	auditors *LocalMembership
 }
 
-func NewWalletManager(sp view2.ServiceProvider, cm driver.ConfigManager, defaultIdentity view.Identity, signerService SignerService, binderService BinderService) *WalletManager {
+func NewWalletManager(sp view2.ServiceProvider, cm config.Manager, defaultIdentity view.Identity, signerService SignerService, binderService BinderService) *WalletManager {
 	return &WalletManager{
 		sp:              sp,
 		cm:              cm,
@@ -154,7 +156,7 @@ func (l *WalletManager) Auditors() *LocalMembership {
 
 type LocalMembership struct {
 	sp                 view2.ServiceProvider
-	cm                 driver.ConfigManager
+	cm                 config.Manager
 	defaultFSCIdentity view.Identity
 	signerService      SignerService
 	binderService      BinderService
@@ -167,7 +169,7 @@ type LocalMembership struct {
 	bccspResolversByIdentity map[string]*Resolver
 }
 
-func NewLocalMembership(sp view2.ServiceProvider, cm driver.ConfigManager, defaultFSCIdentity view.Identity, signerService SignerService, binderService BinderService) *LocalMembership {
+func NewLocalMembership(sp view2.ServiceProvider, cm config.Manager, defaultFSCIdentity view.Identity, signerService SignerService, binderService BinderService) *LocalMembership {
 	return &LocalMembership{
 		sp:                       sp,
 		cm:                       cm,
@@ -181,7 +183,7 @@ func NewLocalMembership(sp view2.ServiceProvider, cm driver.ConfigManager, defau
 	}
 }
 
-func (lm *LocalMembership) Load(identities []*driver.Identity) error {
+func (lm *LocalMembership) Load(identities []*config.Identity) error {
 	logger.Debugf("loadWallets: %+v", identities)
 
 	type Provider interface {

--- a/token/core/identity/tms/wm.go
+++ b/token/core/identity/tms/wm.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
-
 	math3 "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
@@ -26,12 +24,12 @@ import (
 	sig2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger/fabric/msp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 )
 
 var logger = flogging.MustGetLogger("token-sdk.driver.identity.tms")
@@ -77,7 +75,7 @@ type EnrollmentService interface {
 
 type WalletManager struct {
 	sp              view2.ServiceProvider
-	cm              config.Manager
+	configManager   config.Manager
 	empty           bool
 	defaultIdentity view.Identity
 	signerService   SignerService
@@ -88,10 +86,10 @@ type WalletManager struct {
 	auditors *LocalMembership
 }
 
-func NewWalletManager(sp view2.ServiceProvider, cm config.Manager, defaultIdentity view.Identity, signerService SignerService, binderService BinderService) *WalletManager {
+func NewWalletManager(sp view2.ServiceProvider, configManager config.Manager, defaultIdentity view.Identity, signerService SignerService, binderService BinderService) *WalletManager {
 	return &WalletManager{
 		sp:              sp,
-		cm:              cm,
+		configManager:   configManager,
 		empty:           true,
 		defaultIdentity: defaultIdentity,
 		signerService:   signerService,
@@ -102,31 +100,31 @@ func NewWalletManager(sp view2.ServiceProvider, cm config.Manager, defaultIdenti
 func (l *WalletManager) Load() error {
 	logger.Debugf("load wallets...")
 	defer logger.Debugf("load wallets...done")
-	if l.cm.TMS().Wallets == nil {
+	if l.configManager.TMS().Wallets == nil {
 		logger.Warnf("No wallets found in config")
 		return nil
 	}
 	empty := true
-	owners := NewLocalMembership(l.sp, l.cm, l.defaultIdentity, l.signerService, l.binderService)
-	if len(l.cm.TMS().Wallets.Owners) != 0 {
+	owners := NewLocalMembership(l.sp, l.configManager, l.defaultIdentity, l.signerService, l.binderService)
+	if len(l.configManager.TMS().Wallets.Owners) != 0 {
 		empty = false
-		if err := owners.Load(l.cm.TMS().Wallets.Owners); err != nil {
+		if err := owners.Load(l.configManager.TMS().Wallets.Owners); err != nil {
 			return errors.WithMessage(err, "failed to load owners")
 		}
 	}
 
-	issuers := NewLocalMembership(l.sp, l.cm, l.defaultIdentity, l.signerService, l.binderService)
-	if len(l.cm.TMS().Wallets.Issuers) != 0 {
+	issuers := NewLocalMembership(l.sp, l.configManager, l.defaultIdentity, l.signerService, l.binderService)
+	if len(l.configManager.TMS().Wallets.Issuers) != 0 {
 		empty = false
-		if err := issuers.Load(l.cm.TMS().Wallets.Issuers); err != nil {
+		if err := issuers.Load(l.configManager.TMS().Wallets.Issuers); err != nil {
 			return errors.WithMessage(err, "failed to load issuers")
 		}
 	}
 
-	auditors := NewLocalMembership(l.sp, l.cm, l.defaultIdentity, l.signerService, l.binderService)
-	if len(l.cm.TMS().Wallets.Auditors) != 0 {
+	auditors := NewLocalMembership(l.sp, l.configManager, l.defaultIdentity, l.signerService, l.binderService)
+	if len(l.configManager.TMS().Wallets.Auditors) != 0 {
 		empty = false
-		if err := auditors.Load(l.cm.TMS().Wallets.Auditors); err != nil {
+		if err := auditors.Load(l.configManager.TMS().Wallets.Auditors); err != nil {
 			return errors.WithMessage(err, "failed to load auditors")
 		}
 	}
@@ -156,7 +154,7 @@ func (l *WalletManager) Auditors() *LocalMembership {
 
 type LocalMembership struct {
 	sp                 view2.ServiceProvider
-	cm                 config.Manager
+	configManager      config.Manager
 	defaultFSCIdentity view.Identity
 	signerService      SignerService
 	binderService      BinderService
@@ -169,10 +167,10 @@ type LocalMembership struct {
 	bccspResolversByIdentity map[string]*Resolver
 }
 
-func NewLocalMembership(sp view2.ServiceProvider, cm config.Manager, defaultFSCIdentity view.Identity, signerService SignerService, binderService BinderService) *LocalMembership {
+func NewLocalMembership(sp view2.ServiceProvider, configManager config.Manager, defaultFSCIdentity view.Identity, signerService SignerService, binderService BinderService) *LocalMembership {
 	return &LocalMembership{
 		sp:                       sp,
-		cm:                       cm,
+		configManager:            configManager,
 		defaultFSCIdentity:       defaultFSCIdentity,
 		signerService:            signerService,
 		binderService:            binderService,
@@ -295,13 +293,13 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 	switch typeAndMspID[0] {
 	case IdemixMSP:
 		conf, err := msp.GetLocalMspConfigWithType(
-			lm.cm.TranslatePath(path),
+			lm.configManager.TranslatePath(path),
 			nil,
 			typeAndMspID[1],
 			IdemixMSP,
 		)
 		if err != nil {
-			return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", lm.cm.TranslatePath(path))
+			return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", lm.configManager.TranslatePath(path))
 		}
 		curveID, err := StringToCurveID(typeAndMspID[2])
 		if err != nil {
@@ -309,7 +307,7 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 		}
 		provider, err := idemix2.NewAnyProviderWithCurve(conf, lm.sp, curveID)
 		if err != nil {
-			return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", lm.cm.TranslatePath(path))
+			return errors.Wrapf(err, "failed instantiating idemix msp provider from [%s]", lm.configManager.TranslatePath(path))
 		}
 		dm.AddDeserializer(provider)
 		lm.addResolver(
@@ -321,16 +319,16 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 		)
 		logger.Debugf("added %s resolver for id %s with cache of size %d", IdemixMSP, id+"@"+provider.EnrollmentID(), DefaultCacheSize)
 	case BccspMSP:
-		provider, err := x509.NewProvider(lm.cm.TranslatePath(path), typeAndMspID[1], lm.signerService)
+		provider, err := x509.NewProvider(lm.configManager.TranslatePath(path), typeAndMspID[1], lm.signerService)
 		if err != nil {
-			return errors.Wrapf(err, "failed instantiating x509 msp provider from [%s]", lm.cm.TranslatePath(path))
+			return errors.Wrapf(err, "failed instantiating x509 msp provider from [%s]", lm.configManager.TranslatePath(path))
 		}
 		dm.AddDeserializer(provider)
 		lm.addResolver(id, BccspMSP, provider.EnrollmentID(), setDefault, provider.Identity)
 	case IdemixMSPFolder:
-		entries, err := ioutil.ReadDir(lm.cm.TranslatePath(path))
+		entries, err := ioutil.ReadDir(lm.configManager.TranslatePath(path))
 		if err != nil {
-			logger.Warnf("failed reading from [%s]: [%s]", lm.cm.TranslatePath(path), err)
+			logger.Warnf("failed reading from [%s]: [%s]", lm.configManager.TranslatePath(path), err)
 			return nil
 		}
 		for _, entry := range entries {
@@ -339,13 +337,13 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 			}
 			id := entry.Name()
 			conf, err := msp.GetLocalMspConfigWithType(
-				filepath.Join(lm.cm.TranslatePath(path), id),
+				filepath.Join(lm.configManager.TranslatePath(path), id),
 				nil,
 				typeAndMspID[1],
 				IdemixMSP,
 			)
 			if err != nil {
-				logger.Warnf("failed reading idemix msp configuration from [%s]: [%s]", filepath.Join(lm.cm.TranslatePath(path), id), err)
+				logger.Warnf("failed reading idemix msp configuration from [%s]: [%s]", filepath.Join(lm.configManager.TranslatePath(path), id), err)
 				continue
 			}
 			curveID, err := StringToCurveID(typeAndMspID[2])
@@ -354,7 +352,7 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 			}
 			provider, err := idemix2.NewAnyProviderWithCurve(conf, lm.sp, curveID)
 			if err != nil {
-				logger.Warnf("failed instantiating idemix msp configuration from [%s]: [%s]", filepath.Join(lm.cm.TranslatePath(path), id), err)
+				logger.Warnf("failed instantiating idemix msp configuration from [%s]: [%s]", filepath.Join(lm.configManager.TranslatePath(path), id), err)
 				continue
 			}
 			logger.Debugf("Adding resolver [%s:%s]", id, provider.EnrollmentID())
@@ -369,9 +367,9 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 			logger.Debugf("added %s resolver for id %s with cache of size %d", IdemixMSP, id+"@"+provider.EnrollmentID(), DefaultCacheSize)
 		}
 	case BccspMSPFolder:
-		entries, err := ioutil.ReadDir(lm.cm.TranslatePath(path))
+		entries, err := ioutil.ReadDir(lm.configManager.TranslatePath(path))
 		if err != nil {
-			logger.Warnf("failed reading from [%s]: [%s]", lm.cm.TranslatePath(path), err)
+			logger.Warnf("failed reading from [%s]: [%s]", lm.configManager.TranslatePath(path), err)
 			return nil
 		}
 		for _, entry := range entries {
@@ -382,22 +380,22 @@ func (lm *LocalMembership) registerIdentity(id string, typ string, path string, 
 
 			// Try without "msp"
 			provider, err := x509.NewProvider(
-				filepath.Join(lm.cm.TranslatePath(path), id),
+				filepath.Join(lm.configManager.TranslatePath(path), id),
 				typeAndMspID[1],
 				lm.signerService,
 			)
 			if err != nil {
-				logger.Debugf("failed reading bccsp msp configuration from [%s]: [%s]", filepath.Join(lm.cm.TranslatePath(path), id), err)
+				logger.Debugf("failed reading bccsp msp configuration from [%s]: [%s]", filepath.Join(lm.configManager.TranslatePath(path), id), err)
 				// Try with "msp"
 				provider, err = x509.NewProvider(
-					filepath.Join(lm.cm.TranslatePath(path), id, "msp"),
+					filepath.Join(lm.configManager.TranslatePath(path), id, "msp"),
 					typeAndMspID[1],
 					lm.signerService,
 				)
 				if err != nil {
 					logger.Warnf("failed reading bccsp msp configuration from [%s and %s]: [%s]",
-						filepath.Join(lm.cm.TranslatePath(path),
-							filepath.Join(lm.cm.TranslatePath(path), id, "msp")), err,
+						filepath.Join(lm.configManager.TranslatePath(path),
+							filepath.Join(lm.configManager.TranslatePath(path), id, "msp")), err,
 					)
 					continue
 				}

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -48,7 +48,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	}
 	qe := v.TokenVault().QueryEngine()
 
-	cm, err := config.NewTokenSDK(view2.GetConfigService(sp)).GetTMS(networkID, channel, namespace)
+	tmsConfig, err := config.NewTokenSDK(view2.GetConfigService(sp)).GetTMS(networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")
 	}
@@ -57,7 +57,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	// Otherwise, resort to network local membership
 	nodeIdentity := view2.GetIdentityProvider(sp).DefaultIdentity()
 	mappers := identity.NewMappers()
-	tmsWalletManager := tms.NewWalletManager(sp, cm, lm.DefaultIdentity(), tms.NewSigService(view2.GetSigService(sp)), view2.GetEndpointService(sp))
+	tmsWalletManager := tms.NewWalletManager(sp, tmsConfig, lm.DefaultIdentity(), tms.NewSigService(view2.GetSigService(sp)), view2.GetEndpointService(sp))
 	if err := tmsWalletManager.Load(); err != nil {
 		return nil, errors.WithMessage(err, "failed to load wallet")
 	}
@@ -93,7 +93,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 		identity.NewProvider(sp, eidDeserializer, mappers),
 		desProvider.Deserialize,
 		crypto.DLogPublicParameters,
-		cm,
+		tmsConfig,
 	)
 	if err != nil {
 		return nil, err

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -48,7 +48,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	}
 	qe := v.TokenVault().QueryEngine()
 
-	cm, err := config.NewTMSProvider(view2.GetConfigService(sp), networkID, channel, namespace)
+	cm, err := config.NewTokenSDK(view2.GetConfigService(sp)).GetTMS(networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")
 	}

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -48,7 +48,7 @@ func (d *Driver) NewTokenService(sp view2.ServiceProvider, publicParamsFetcher d
 	}
 	qe := v.TokenVault().QueryEngine()
 
-	cm, err := config.NewManager(view2.GetConfigService(sp), networkID, channel, namespace)
+	cm, err := config.NewTMSProvider(view2.GetConfigService(sp), networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")
 	}

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -8,6 +8,8 @@ package nogh
 import (
 	"sync"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 
@@ -52,7 +54,7 @@ type Service struct {
 	TokenCommitmentLoader TokenCommitmentLoader
 	QE                    QueryEngine
 	DeserializerProvider  DeserializerProviderFunc
-	CM                    api3.ConfigManager
+	CM                    config.Manager
 
 	identityProvider api3.IdentityProvider
 	OwnerWallets     []*wallet
@@ -72,7 +74,7 @@ func NewTokenService(
 	identityProvider api3.IdentityProvider,
 	deserializerProvider DeserializerProviderFunc,
 	ppLabel string,
-	cm api3.ConfigManager,
+	cm config.Manager,
 ) (*Service, error) {
 	s := &Service{
 		Channel:               channel,
@@ -129,7 +131,7 @@ func (s *Service) PublicParamsManager() api3.PublicParamsManager {
 	return s.PPM
 }
 
-func (s *Service) ConfigManager() api3.ConfigManager {
+func (s *Service) ConfigManager() config.Manager {
 	return s.CM
 }
 

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -3,20 +3,19 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package nogh
 
 import (
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/validator"
 	api3 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
 	token3 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
@@ -54,7 +53,7 @@ type Service struct {
 	TokenCommitmentLoader TokenCommitmentLoader
 	QE                    QueryEngine
 	DeserializerProvider  DeserializerProviderFunc
-	CM                    config.Manager
+	configManager         config.Manager
 
 	identityProvider api3.IdentityProvider
 	OwnerWallets     []*wallet
@@ -74,7 +73,7 @@ func NewTokenService(
 	identityProvider api3.IdentityProvider,
 	deserializerProvider DeserializerProviderFunc,
 	ppLabel string,
-	cm config.Manager,
+	configManager config.Manager,
 ) (*Service, error) {
 	s := &Service{
 		Channel:               channel,
@@ -87,7 +86,7 @@ func NewTokenService(
 		identityProvider:      identityProvider,
 		DeserializerProvider:  deserializerProvider,
 		PPLabel:               ppLabel,
-		CM:                    cm,
+		configManager:         configManager,
 	}
 	return s, nil
 }
@@ -132,7 +131,7 @@ func (s *Service) PublicParamsManager() api3.PublicParamsManager {
 }
 
 func (s *Service) ConfigManager() config.Manager {
-	return s.CM
+	return s.configManager
 }
 
 func (s *Service) PublicParams() *crypto.PublicParams {

--- a/token/driver/config/config.go
+++ b/token/driver/config/config.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package driver
+package config
 
 type InteractiveCertification struct {
 	IDs []string `yaml:"ids,omitempty"`
@@ -41,7 +41,7 @@ type Token struct {
 	TMS     []*TMS `yaml:"tms,omitempty"`
 }
 
-type ConfigManager interface {
+type Manager interface {
 	TMS() *TMS
 	TranslatePath(path string) string
 }

--- a/token/driver/tms.go
+++ b/token/driver/tms.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import "github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+
 type TokenManagerService interface {
 	IssueService
 	TransferService
@@ -18,7 +20,7 @@ type TokenManagerService interface {
 	IdentityProvider() IdentityProvider
 	Validator() Validator
 	PublicParamsManager() PublicParamsManager
-	ConfigManager() ConfigManager
+	ConfigManager() config.Manager
 }
 
 type TokenManagerServiceProvider interface {

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
 	_ "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/driver"
 	_ "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/driver"
 	network2 "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/network"
@@ -64,10 +65,12 @@ func (p *SDK) Install() error {
 	)
 	assert.NoError(p.registry.RegisterService(tmsProvider))
 
+	tmsConfigManager, err := config.NewManager(configProvider)
+	assert.NoError(err, "Failed to create TMS config manager")
 	assert.NoError(p.registry.RegisterService(token.NewManagementServiceProvider(
 		p.registry,
 		tmsProvider,
-		network2.NewNormalizer(p.registry),
+		network2.NewNormalizer(tmsConfigManager, p.registry),
 		vault.NewVaultProvider(p.registry),
 		network2.NewCertificationClientProvider(p.registry),
 		selector.NewProvider(

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -65,12 +65,11 @@ func (p *SDK) Install() error {
 	)
 	assert.NoError(p.registry.RegisterService(tmsProvider))
 
-	tmsConfigManager, err := config.NewManager(configProvider)
-	assert.NoError(err, "Failed to create TMS config manager")
+	// Register the token management service provider
 	assert.NoError(p.registry.RegisterService(token.NewManagementServiceProvider(
 		p.registry,
 		tmsProvider,
-		network2.NewNormalizer(tmsConfigManager, p.registry),
+		network2.NewNormalizer(config.NewTokenSDK(configProvider), p.registry),
 		vault.NewVaultProvider(p.registry),
 		network2.NewCertificationClientProvider(p.registry),
 		selector.NewProvider(

--- a/token/services/network/orion/config.go
+++ b/token/services/network/orion/config.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package orion
 
 import (
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
 	"github.com/pkg/errors"
 )
 
@@ -18,12 +18,12 @@ type configProvider interface {
 
 type Manager struct {
 	cp    configProvider
-	tms   *driver.TMS
+	tms   *config.TMS
 	index int
 }
 
 func NewManager(cp configProvider, network, channel, namespace string) (*Manager, error) {
-	var tmsConfigs []*driver.TMS
+	var tmsConfigs []*config.TMS
 	if err := cp.UnmarshalKey("token.tms", &tmsConfigs); err != nil {
 		return nil, errors.WithMessagef(err, "cannot load token-sdk configuration")
 	}
@@ -41,7 +41,7 @@ func NewManager(cp configProvider, network, channel, namespace string) (*Manager
 	return nil, errors.Errorf("no token-sdk configuration for network %s, channel %s, namespace %s", network, channel, namespace)
 }
 
-func (m *Manager) TMS() *driver.TMS {
+func (m *Manager) TMS() *config.TMS {
 	return m.tms
 }
 


### PR DESCRIPTION
When invoking token.GetManagementService() without any additional option, the token-api tries to load the default TMS. What does this mean? The token-api checks if there is a default fabric or orion network configuration, if yes it consider that the default. For the channel, it is the same. For the namespace, the issue is that there can be multiple token namespaces in the same <network, channel>. So, the code currently uses the default namespace zkat.

So, the solution we can put forth is the following: The code checks the configuration and if there is a unique tuple <network, channel, namespace>, the code will use that one, otherwise it will return an error.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>