### PR TITLE
Remove the need to specify the MSP-ID

### DIFF
--- a/cmd/tokengen/README.md
+++ b/cmd/tokengen/README.md
@@ -58,10 +58,10 @@ Usage:
   tokengen gen fabtoken [flags]
 
 Flags:
-  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>
+  -a, --auditors strings   list of auditor MSP directories containing the corresponding auditor certificate
       --cc                 generate chaincode package
   -h, --help               help for fabtoken
-  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>
+  -s, --issuers strings    list of issuer MSP directories containing the corresponding issuer certificate
   -o, --output string      output folder (default ".")
 
 ```
@@ -75,13 +75,13 @@ Usage:
   tokengen gen dlog [flags]
 
 Flags:
-  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>
+  -a, --auditors strings   list of auditor MSP directories containing the corresponding auditor certificate
   -b, --base int           base is used to define the maximum quantity a token can contain as Base^Exponent (default 100)
       --cc                 generate chaincode package
   -e, --exponent int       exponent is used to define the maximum quantity a token can contain as Base^Exponent (default 2)
   -h, --help               help for dlog
   -i, --idemix string      idemix msp dir
-  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>
+  -s, --issuers strings    list of issuer MSP directories containing the corresponding issuer certificate
   -o, --output string      output folder (default ".")
 ``` 
 

--- a/cmd/tokengen/README.md
+++ b/cmd/tokengen/README.md
@@ -58,10 +58,10 @@ Usage:
   tokengen gen fabtoken [flags]
 
 Flags:
-  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>:<MSP-ID>
+  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>
       --cc                 generate chaincode package
   -h, --help               help for fabtoken
-  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>:<MSP-ID>
+  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>
   -o, --output string      output folder (default ".")
 
 ```
@@ -75,13 +75,13 @@ Usage:
   tokengen gen dlog [flags]
 
 Flags:
-  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>:<MSP-ID>
+  -a, --auditors strings   list of auditor keys in the form of <MSP-Dir>
   -b, --base int           base is used to define the maximum quantity a token can contain as Base^Exponent (default 100)
       --cc                 generate chaincode package
   -e, --exponent int       exponent is used to define the maximum quantity a token can contain as Base^Exponent (default 2)
   -h, --help               help for dlog
   -i, --idemix string      idemix msp dir
-  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>:<MSP-ID>
+  -s, --issuers strings    list of issuer keys in the form of <MSP-Dir>
   -o, --output string      output folder (default ".")
 ``` 
 

--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -53,7 +53,7 @@ func TestGen(t *testing.T) {
 					driver,
 					"--auditors", "aOrg1MSP,b:Org2MSP",
 				},
-				ErrMsg: "Error: failed to generate public parameters: failed to get auditor identity [aOrg1MSP]: invalid input [aOrg1MSP]",
+				ErrMsg: "Error: failed to generate public parameters: failed to get auditor identity [aOrg1MSP]: failed to create x509 provider for [aOrg1MSP]: could not load a valid signer certificate from directory aOrg1MSP/signcerts: stat aOrg1MSP/signcerts: no such file or directory",
 			},
 			{
 				Args: []string{
@@ -69,7 +69,7 @@ func TestGen(t *testing.T) {
 					driver,
 					"--issuers", "aOrg1MSP,b:Org2MSP",
 				},
-				ErrMsg: "Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: invalid input [aOrg1MSP]",
+				ErrMsg: "Error: failed to generate public parameters: failed to get issuer identity [aOrg1MSP]: failed to create x509 provider for [aOrg1MSP]: could not load a valid signer certificate from directory aOrg1MSP/signcerts: stat aOrg1MSP/signcerts: no such file or directory",
 			},
 		}...,
 		)

--- a/token/core/cmd/pp/dlog/gen.go
+++ b/token/core/cmd/pp/dlog/gen.go
@@ -28,10 +28,10 @@ type GeneratorArgs struct {
 	// GenerateCCPackage is whether to generate the chaincode package
 	GenerateCCPackage bool
 	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each issuer should be specified in the form of <MSP-Dir>
 	Issuers []string
 	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each auditor should be specified in the form of <MSP-Dir>
 	Auditors []string
 	// Base is a dlog driver related parameter
 	Base int64
@@ -47,10 +47,10 @@ var (
 	// GenerateCCPackage is whether to generate the chaincode package
 	GenerateCCPackage bool
 	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each issuer should be specified in the form of <MSP-Dir>
 	Issuers []string
 	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each auditor should be specified in the form of <MSP-Dir>
 	Auditors []string
 	// Base is a dlog driver related parameter.
 	// It is used to define the maximum quantity a token can contain as Base^Exponent
@@ -66,8 +66,8 @@ func Cmd() *cobra.Command {
 	flags := cobraCommand.Flags()
 	flags.StringVarP(&OutputDir, "output", "o", ".", "output folder")
 	flags.BoolVarP(&GenerateCCPackage, "cc", "", false, "generate chaincode package")
-	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>:<MSP-ID>")
-	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>:<MSP-ID>")
+	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>")
+	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>")
 	flags.StringVarP(&IdemixMSPDir, "idemix", "i", "", "idemix msp dir")
 	flags.Int64VarP(&Base, "base", "b", 100, "base is used to define the maximum quantity a token can contain as Base^Exponent")
 	flags.IntVarP(&Exponent, "exponent", "e", 2, "exponent is used to define the maximum quantity a token can contain as Base^Exponent")

--- a/token/core/cmd/pp/dlog/gen.go
+++ b/token/core/cmd/pp/dlog/gen.go
@@ -25,13 +25,11 @@ type GeneratorArgs struct {
 	IdemixMSPDir string
 	// OutputDir is the directory to output the generated files
 	OutputDir string
-	// GenerateCCPackage is whether to generate the chaincode package
+	// GenerateCCPackage indicates whether to generate the chaincode package
 	GenerateCCPackage bool
-	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>
+	// Issuers is the list of issuer MSP directories containing the corresponding issuer certificate
 	Issuers []string
-	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>
+	// Auditors is the list of auditor MSP directories containing the corresponding auditor certificate
 	Auditors []string
 	// Base is a dlog driver related parameter
 	Base int64
@@ -44,13 +42,11 @@ var (
 	IdemixMSPDir string
 	// OutputDir is the directory to output the generated files
 	OutputDir string
-	// GenerateCCPackage is whether to generate the chaincode package
+	// GenerateCCPackage indicates whether to generate the chaincode package
 	GenerateCCPackage bool
-	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>
+	// Issuers is the list of issuer MSP directories containing the corresponding issuer certificate
 	Issuers []string
-	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>
+	// Auditors is the list of auditor MSP directories containing the corresponding auditor certificate
 	Auditors []string
 	// Base is a dlog driver related parameter.
 	// It is used to define the maximum quantity a token can contain as Base^Exponent
@@ -66,8 +62,8 @@ func Cmd() *cobra.Command {
 	flags := cobraCommand.Flags()
 	flags.StringVarP(&OutputDir, "output", "o", ".", "output folder")
 	flags.BoolVarP(&GenerateCCPackage, "cc", "", false, "generate chaincode package")
-	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>")
-	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>")
+	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor MSP directories containing the corresponding auditor certificate")
+	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer MSP directories containing the corresponding issuer certificate")
 	flags.StringVarP(&IdemixMSPDir, "idemix", "i", "", "idemix msp dir")
 	flags.Int64VarP(&Base, "base", "b", 100, "base is used to define the maximum quantity a token can contain as Base^Exponent")
 	flags.IntVarP(&Exponent, "exponent", "e", 2, "exponent is used to define the maximum quantity a token can contain as Base^Exponent")

--- a/token/core/cmd/pp/fabtoken/gen.go
+++ b/token/core/cmd/pp/fabtoken/gen.go
@@ -23,13 +23,11 @@ var (
 	Driver string
 	// OutputDir is the directory to output the generated files
 	OutputDir string
-	// GenerateCCPackage is whether to generate the chaincode package
+	// GenerateCCPackage indicates whether to generate the chaincode package
 	GenerateCCPackage bool
-	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>
+	// Issuers is the list of issuer MSP directories containing the corresponding issuer certificate
 	Issuers []string
-	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>
+	// Auditors is the list of auditor MSP directories containing the corresponding auditor certificate
 	Auditors []string
 )
 
@@ -39,8 +37,8 @@ func Cmd() *cobra.Command {
 	flags := cobraCommand.Flags()
 	flags.StringVarP(&OutputDir, "output", "o", ".", "output folder")
 	flags.BoolVarP(&GenerateCCPackage, "cc", "", false, "generate chaincode package")
-	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>")
-	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>")
+	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor MSP directories containing the corresponding auditor certificate")
+	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer MSP directories containing the corresponding issuer certificate")
 	return cobraCommand
 }
 
@@ -77,13 +75,11 @@ var cobraCommand = &cobra.Command{
 type GeneratorArgs struct {
 	// OutputDir is the directory to output the generated files
 	OutputDir string
-	// GenerateCCPackage is whether to generate the chaincode package
+	// GenerateCCPackage indicates whether to generate the chaincode package
 	GenerateCCPackage bool
-	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>
+	// Issuers is the list of issuer MSP directories containing the corresponding issuer certificate
 	Issuers []string
-	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>
+	// Auditors is the list of auditor MSP directories containing the corresponding auditor certificate
 	Auditors []string
 }
 

--- a/token/core/cmd/pp/fabtoken/gen.go
+++ b/token/core/cmd/pp/fabtoken/gen.go
@@ -26,10 +26,10 @@ var (
 	// GenerateCCPackage is whether to generate the chaincode package
 	GenerateCCPackage bool
 	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each issuer should be specified in the form of <MSP-Dir>
 	Issuers []string
 	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each auditor should be specified in the form of <MSP-Dir>
 	Auditors []string
 )
 
@@ -39,8 +39,8 @@ func Cmd() *cobra.Command {
 	flags := cobraCommand.Flags()
 	flags.StringVarP(&OutputDir, "output", "o", ".", "output folder")
 	flags.BoolVarP(&GenerateCCPackage, "cc", "", false, "generate chaincode package")
-	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>:<MSP-ID>")
-	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>:<MSP-ID>")
+	flags.StringSliceVarP(&Auditors, "auditors", "a", nil, "list of auditor keys in the form of <MSP-Dir>")
+	flags.StringSliceVarP(&Issuers, "issuers", "s", nil, "list of issuer keys in the form of <MSP-Dir>")
 	return cobraCommand
 }
 
@@ -80,10 +80,10 @@ type GeneratorArgs struct {
 	// GenerateCCPackage is whether to generate the chaincode package
 	GenerateCCPackage bool
 	// Issuers is the list of issuers to include in the public parameters.
-	// Each issuer should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each issuer should be specified in the form of <MSP-Dir>
 	Issuers []string
 	// Auditors is the list of auditors to include in the public parameters.
-	// Each auditor should be specified in the form of <MSP-Dir>:<MSP-ID>
+	// Each auditor should be specified in the form of <MSP-Dir>
 	Auditors []string
 }
 


### PR DESCRIPTION
Currently, when generating the public params with tokegen,
tokengen requires the MSP-ID for audtiors and issuers.
This information is not needed anymore because it is
a decision of the driver

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>