### PR TITLE
Optimize Idemix pre-provision cache

### DIFF
--- a/token/core/identity/msp/idemix/cache.go
+++ b/token/core/identity/msp/idemix/cache.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package idemix
 
 import (
+	"runtime"
+	"sync"
 	"time"
 
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
@@ -24,43 +26,83 @@ type identityCacheEntry struct {
 }
 
 type IdentityCache struct {
-	backed  IdentityCacheBackendFunc
-	ch      chan identityCacheEntry
-	timeout time.Duration
+	once   sync.Once
+	backed IdentityCacheBackendFunc
+	cache  chan identityCacheEntry
 }
 
 func NewIdentityCache(backed IdentityCacheBackendFunc, size int) *IdentityCache {
 	ci := &IdentityCache{
-		backed:  backed,
-		ch:      make(chan identityCacheEntry, size),
-		timeout: time.Millisecond * 100,
+		backed: backed,
+		cache:  make(chan identityCacheEntry, size),
 	}
-	go ci.run()
 
 	return ci
 }
 
 func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
-	if opts.EIDExtension && len(opts.AuditInfo) == 0 {
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("fetch identity from producer channel...")
+	if !opts.EIDExtension || len(opts.AuditInfo) != 0 {
+		return c.fetchIdentityFromBackend(opts)
+	}
+
+	c.once.Do(func() {
+		// Spin up as many background goroutines as we need to prepare identities in the background.
+		for i := 0; i < runtime.NumCPU(); i++ {
+			go c.provisionIdentities()
 		}
-		select {
-		case entry := <-c.ch:
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("fetch identity from producer channel done [%s][%d]", entry.Identity, len(entry.Audit))
-			}
-			return entry.Identity, entry.Audit, nil
-		case <-time.After(c.timeout):
-			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("fetch identity from producer channel timeout")
-			}
-			return c.backed(opts)
+	})
+
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("fetching identity from cache...")
+	}
+
+	return c.fetchIdentityFromCache(opts)
+
+}
+
+func (c *IdentityCache) fetchIdentityFromCache(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
+	var identity view.Identity
+	var audit []byte
+
+	var start time.Time
+
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		start = time.Now()
+	}
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	select {
+
+	case entry := <-c.cache:
+		identity = entry.Identity
+		audit = entry.Audit
+
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("fetching identity from cache [%s][%d] took %v", identity, len(audit), time.Since(start))
 		}
 
+	case <-timeout.C:
+		id, a, err := c.backed(opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		identity = id
+		audit = a
+
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("fetching identity from backend after a timeout [%s][%d] took %v", identity, len(audit), time.Since(start))
+		}
 	}
+
+	return identity, audit, nil
+
+}
+
+func (c *IdentityCache) fetchIdentityFromBackend(opts *driver2.IdentityOptions) (view.Identity, []byte, error) {
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("fetch identity from backend...")
+		logger.Debugf("fetching identity from backend")
 	}
 	id, audit, err := c.backed(opts)
 	if err != nil {
@@ -69,16 +111,17 @@ func (c *IdentityCache) Identity(opts *driver2.IdentityOptions) (view.Identity, 
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
 		logger.Debugf("fetch identity from backend done [%s][%d]", id, len(audit))
 	}
+
 	return id, audit, nil
 }
 
-func (c *IdentityCache) run() {
+func (c *IdentityCache) provisionIdentities() {
 	for {
 		id, audit, err := c.backed(&driver2.IdentityOptions{EIDExtension: true})
 		if err != nil {
 			continue
 		}
-		c.ch <- identityCacheEntry{Identity: id, Audit: audit}
+		c.cache <- identityCacheEntry{Identity: id, Audit: audit}
 	}
 }
 


### PR DESCRIPTION
This commit:

- Replaces time.After() with time.NewTimer()
- Only provisions the background workers if needed
- Provisions runtime.NumCPU() background workers
  to reduce waiting time in case of high bursts

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>