### PR TITLE
use time.NewTimer instead of time.After

### DIFF
--- a/token/core/identity/msp/idemix/cache.go
+++ b/token/core/identity/msp/idemix/cache.go
@@ -102,13 +102,16 @@ func NewWalletIdentityCache(backed WalletIdentityCacheBackendFunc, size int) *Wa
 }
 
 func (c *WalletIdentityCache) Identity() (view.Identity, error) {
+	timeout := time.NewTimer(c.timeout)
+	defer timeout.Stop()
+
 	select {
 	case entry := <-c.ch:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("fetch identity from producer channel done [%s][%d]", entry)
 		}
 		return entry, nil
-	case <-time.After(c.timeout):
+	case <-timeout.C:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("fetch identity from producer channel timeout")
 		}

--- a/token/services/ttx/collect.go
+++ b/token/services/ttx/collect.go
@@ -108,6 +108,9 @@ func (c *collectActionsView) collectRemote(context view.Context, actionTransfer 
 	assert.NoError(session.Send(marshalOrPanic(c.actions)), "failed sending actions")
 	assert.NoError(session.Send(marshalOrPanic(actionTransfer)), "failed sending transfer action")
 
+	timeout := time.NewTimer(time.Minute)
+	defer timeout.Stop()
+
 	// Wait to receive a content back
 	ch := session.Receive()
 	var msg *view.Message
@@ -116,7 +119,7 @@ func (c *collectActionsView) collectRemote(context view.Context, actionTransfer 
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("collect actions: reply received from [%s]", party)
 		}
-	case <-time.After(60 * time.Second):
+	case <-timeout.C:
 		return errors.Errorf("Timeout from party %s", party)
 	}
 	if msg.Status == view.ERROR {

--- a/token/services/ttx/recipients.go
+++ b/token/services/ttx/recipients.go
@@ -139,12 +139,16 @@ func (f *RequestRecipientIdentityView) Call(context view.Context) (interface{}, 
 		// Wait to receive a view identity
 		ch := session.Receive()
 		var payload []byte
+
+		timeout := time.NewTimer(time.Minute)
+		defer timeout.Stop()
+
 		select {
 		case msg := <-ch:
 			payload = msg.Payload
 			agent.EmitKey(0, "ttx", "received", "responseRecipientIdentity", session.Info().ID)
-		case <-time.After(60 * time.Second):
-			return nil, errors.New("time out reached")
+		case <-timeout.C:
+			return nil, errors.New("timeout reached")
 		}
 
 		recipientData := &RecipientData{}


### PR DESCRIPTION
Using time.After enqueues an entry in Go's runtime scheduler and doesn't garbage collect it even if the function the timer was fired from terminates.
As a result, there can be a temporary high memory pressure and it degrades performance.

Replaced all places where time.After was used except in places where we use it for timing periodical processes.

Signed-off-by: Yacov Manevich <yacovm@il.ibm.com>