### PR TITLE
Remove GetCachedStateRangeScanIterator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728084009-5211e445c2e3
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304
 	github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c
 	github.com/hyperledger-labs/orion-server v0.2.1
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20220128025611-fad7f691a967
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.7.1-0.20210116013205-6990a05d54c2
-	github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00
+	github.com/tedsuo/ifrit v0.0.0-20220120221754-dd274de71113
 	github.com/test-go/testify v1.1.4
 	github.com/thedevsaddam/gojsonq v2.3.0+incompatible
 	go.uber.org/atomic v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728084009-5211e445c2e3 h1:q7nQxqvQ38gCAcerBhlc0B98u21WR2yhoYVIZg5MGBo=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728084009-5211e445c2e3/go.mod h1:lHxLvBxx7U4eniJ6xHGEvqfGuM3KhkWBGlNc7L/XYqU=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304 h1:c82DVFhyvvOXtBW8rHTylhZbpYTnuft+X7Vl4R9EC7I=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304/go.mod h1:lHxLvBxx7U4eniJ6xHGEvqfGuM3KhkWBGlNc7L/XYqU=
 github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c h1:niolJc7rAbxKB1aJQH9aDvu4WteX6V2bZA/hFc2u8YE=
 github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c/go.mod h1:VDuSI17SlxWJCs+p/WYzXRT8g9FhOuL96C15zt+9Pw0=
 github.com/hyperledger-labs/orion-server v0.2.1 h1:uLhuSprg5EWWLs047+54f2ZGuhbZrMa/c38rqpj2FKQ=
@@ -1588,8 +1588,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKk
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
-github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00 h1:mujcChM89zOHwgZBBNr5WZ77mBXP1yR+gLThGCYZgAg=
-github.com/tedsuo/ifrit v0.0.0-20191009134036-9a97d0632f00/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
+github.com/tedsuo/ifrit v0.0.0-20220120221754-dd274de71113 h1:PnxSSxsUvOqMh7nslHscii/GV/Y9ZflmkZ2oEEEIGj4=
+github.com/tedsuo/ifrit v0.0.0-20220120221754-dd274de71113/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
 github.com/thedevsaddam/gojsonq v2.3.0+incompatible h1:i2lFTvGY4LvoZ2VUzedsFlRiyaWcJm3Uh6cQ9+HyQA8=

--- a/token/services/network/fabric/vault.go
+++ b/token/services/network/fabric/vault.go
@@ -56,14 +56,6 @@ func (e *Executor) GetStateRangeScanIterator(namespace string, start string, end
 	return &Iterator{it: it}, nil
 }
 
-func (e *Executor) GetCachedStateRangeScanIterator(namespace string, start string, end string) (driver.Iterator, error) {
-	it, err := e.qe.GetCachedStateRangeScanIterator(namespace, start, end)
-	if err != nil {
-		return nil, err
-	}
-	return &Iterator{it: it}, nil
-}
-
 func (e *Executor) GetStateMetadata(namespace string, id string) (map[string][]byte, error) {
 	r, _, _, err := e.qe.GetStateMetadata(namespace, id)
 	return r, err

--- a/token/services/network/orion/vault.go
+++ b/token/services/network/orion/vault.go
@@ -55,14 +55,6 @@ func (e *Executor) GetStateRangeScanIterator(namespace string, start string, end
 	return &Iterator{it: it}, nil
 }
 
-func (e *Executor) GetCachedStateRangeScanIterator(namespace string, start string, end string) (driver.Iterator, error) {
-	it, err := e.qe.GetStateRangeScanIterator(namespace, start, end)
-	if err != nil {
-		return nil, err
-	}
-	return &Iterator{it: it}, nil
-}
-
 func (e *Executor) GetStateMetadata(namespace string, id string) (map[string][]byte, error) {
 	r, _, _, err := e.qe.GetStateMetadata(namespace, id)
 	return r, err

--- a/token/services/vault/driver/driver.go
+++ b/token/services/vault/driver/driver.go
@@ -28,7 +28,6 @@ type Executor interface {
 	Done()
 	GetState(namespace string, key string) ([]byte, error)
 	GetStateRangeScanIterator(namespace string, s string, e string) (Iterator, error)
-	GetCachedStateRangeScanIterator(namespace string, s string, e string) (Iterator, error)
 	GetStateMetadata(namespace string, id string) (map[string][]byte, error)
 }
 

--- a/token/services/vault/query/query.go
+++ b/token/services/vault/query/query.go
@@ -85,7 +85,7 @@ func (e *Engine) UnspentTokensIteratorBy(id, typ string) (driver2.UnspentTokensI
 	defer qe.Done()
 
 	logger.Debugf("Get range query scan iterator... [%s,%s]", startKey, endKey)
-	iterator, err := qe.GetCachedStateRangeScanIterator(e.namespace, startKey, endKey)
+	iterator, err := qe.GetStateRangeScanIterator(e.namespace, startKey, endKey)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (e *Engine) UnspentTokensIterator() (driver2.UnspentTokensIterator, error) 
 	defer qe.Done()
 
 	logger.Debugf("Get range query scan iterator... [%s,%s]", startKey, endKey)
-	iterator, err := qe.GetCachedStateRangeScanIterator(e.namespace, startKey, endKey)
+	iterator, err := qe.GetStateRangeScanIterator(e.namespace, startKey, endKey)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (e *Engine) ListUnspentTokens() (*token.UnspentTokens, error) {
 	defer qe.Done()
 
 	logger.Debugf("Get range query scan iterator... [%s,%s]", startKey, endKey)
-	iterator, err := qe.GetCachedStateRangeScanIterator(e.namespace, startKey, endKey)
+	iterator, err := qe.GetStateRangeScanIterator(e.namespace, startKey, endKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We are going to remove the cached iterators from the DB in https://github.com/hyperledger-labs/fabric-smart-client/pull/323

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>