### PR TITLE
Reduce staticcheck warnings (ST1001)

### DIFF
--- a/integration/nwo/token/fabric/fabric.go
+++ b/integration/nwo/token/fabric/fabric.go
@@ -30,7 +30,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/generators"
 	topology2 "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/gexec"
 )
 
 var logger = flogging.MustGetLogger("integration.token.fabric")
@@ -50,7 +50,7 @@ type fabricPlatform interface {
 }
 
 type tokenPlatform interface {
-	TokenGen(keygen common.Command) (*Session, error)
+	TokenGen(keygen common.Command) (*gexec.Session, error)
 	PublicParametersFile(tms *topology2.TMS) string
 	GetContext() api2.Context
 	PublicParameters(tms *topology2.TMS) []byte

--- a/integration/nwo/token/orion/orion.go
+++ b/integration/nwo/token/orion/orion.go
@@ -29,13 +29,13 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/translator"
 	"github.com/hyperledger-labs/orion-sdk-go/pkg/bcdb"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/gexec"
 )
 
 var logger = flogging.MustGetLogger("integration.token.orion")
 
 type tokenPlatform interface {
-	TokenGen(keygen common.Command) (*Session, error)
+	TokenGen(keygen common.Command) (*gexec.Session, error)
 	PublicParametersFile(tms *topology2.TMS) string
 	GetContext() api2.Context
 	PublicParameters(tms *topology2.TMS) []byte

--- a/integration/nwo/token/platform.go
+++ b/integration/nwo/token/platform.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/ifrit/grouper"
 
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
@@ -143,7 +143,7 @@ func (p *Platform) GetBuilder() api2.Builder {
 	return p.Builder
 }
 
-func (p *Platform) TokenGen(command common.Command) (*Session, error) {
+func (p *Platform) TokenGen(command common.Command) (*gexec.Session, error) {
 	cmd := common.NewCommand(p.Builder.Build(p.TokenGenPath), command)
 	return p.StartSession(cmd, command.SessionName())
 }
@@ -201,7 +201,7 @@ func (p *Platform) GenerateExtension(node *sfcnode.Node) {
 	p.Context.AddExtension(node.Name, TopologyName, ext.String())
 }
 
-func (p *Platform) StartSession(cmd *exec.Cmd, name string) (*Session, error) {
+func (p *Platform) StartSession(cmd *exec.Cmd, name string) (*gexec.Session, error) {
 	ansiColorCode := p.nextColor()
 	fmt.Fprintf(
 		ginkgo.GinkgoWriter,
@@ -211,13 +211,13 @@ func (p *Platform) StartSession(cmd *exec.Cmd, name string) (*Session, error) {
 		filepath.Base(cmd.Args[0]),
 		strings.Join(cmd.Args[1:], " "),
 	)
-	return Start(
+	return gexec.Start(
 		cmd,
-		NewPrefixedWriter(
+		gexec.NewPrefixedWriter(
 			fmt.Sprintf("\x1b[32m[o]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
 			ginkgo.GinkgoWriter,
 		),
-		NewPrefixedWriter(
+		gexec.NewPrefixedWriter(
 			fmt.Sprintf("\x1b[91m[e]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
 			ginkgo.GinkgoWriter,
 		),

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# onsi/gomega is used only for testing purposes (in test files and in the integration-test logic)
+dot_import_whitelist=["github.com/onsi/gomega"]


### PR DESCRIPTION
As part of issue https://github.com/hyperledger-labs/fabric-token-sdk/issues/317, removed warnings related to:
* ST1001: removed dot imports and silenced warnings relevant to assertions