### PR TITLE
Reduce staticcheck warnings (S1023)

### DIFF
--- a/integration/nwo/token/orion/rwset.go
+++ b/integration/nwo/token/orion/rwset.go
@@ -49,7 +49,6 @@ func (r *RWSWrapper) Bytes() ([]byte, error) {
 }
 
 func (r *RWSWrapper) Done() {
-	return
 }
 
 func (r *RWSWrapper) Equals(right interface{}, namespace string) error {

--- a/token/request.go
+++ b/token/request.go
@@ -711,13 +711,11 @@ func (r *Request) FromBytes(request []byte) error {
 // AddAuditorSignature adds an auditor signature to the request.
 func (r *Request) AddAuditorSignature(sigma []byte) {
 	r.Actions.AuditorSignatures = append(r.Actions.AuditorSignatures, sigma)
-	return
 }
 
 // AppendSignature appends a signature to the request.
 func (r *Request) AppendSignature(sigma []byte) {
 	r.Actions.Signatures = append(r.Actions.Signatures, sigma)
-	return
 }
 
 // SetTokenService sets the token service.

--- a/token/services/network/fabric/tcc/rwset.go
+++ b/token/services/network/fabric/tcc/rwset.go
@@ -30,7 +30,6 @@ func (rwset *rwsWrapper) Bytes() ([]byte, error) {
 }
 
 func (rwset *rwsWrapper) Done() {
-	return
 }
 
 func (rwset *rwsWrapper) Equals(r interface{}, namespace string) error {

--- a/token/services/network/orion/rwset.go
+++ b/token/services/network/orion/rwset.go
@@ -85,7 +85,6 @@ func (r *TxRWSWrapper) Bytes() ([]byte, error) {
 }
 
 func (r *TxRWSWrapper) Done() {
-	return
 }
 
 func (r *TxRWSWrapper) Equals(right interface{}, namespace string) error {


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* S1023: removed redundant return statements

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>