### PR TITLE
Reduce staticcheck warnings (S1011)

### DIFF
--- a/integration/nwo/token/orion/orion.go
+++ b/integration/nwo/token/orion/orion.go
@@ -207,9 +207,7 @@ func (p *NetworkHandler) GenerateCryptoMaterial(cmGenerator generators.CryptoMat
 
 		ids := cmGenerator.GenerateIssuerIdentities(tms, node, issuers...)
 		if len(ids) > 0 {
-			for _, id := range ids {
-				wallet.Issuers = append(wallet.Issuers, id)
-			}
+			wallet.Issuers = append(wallet.Issuers, ids...)
 			wallet.Issuers[index].Default = true
 		}
 	}
@@ -233,9 +231,7 @@ func (p *NetworkHandler) GenerateCryptoMaterial(cmGenerator generators.CryptoMat
 		}
 		ids := cmGenerator.GenerateOwnerIdentities(tms, node, owners...)
 		if len(ids) > 0 {
-			for _, id := range ids {
-				wallet.Owners = append(wallet.Owners, id)
-			}
+			wallet.Owners = append(wallet.Owners, ids...)
 			wallet.Owners[index].Default = true
 		}
 	}
@@ -244,9 +240,7 @@ func (p *NetworkHandler) GenerateCryptoMaterial(cmGenerator generators.CryptoMat
 	if opts.Auditor() {
 		ids := cmGenerator.GenerateAuditorIdentities(tms, node, node.Name)
 		if len(ids) > 0 {
-			for _, id := range ids {
-				wallet.Auditors = append(wallet.Auditors, id)
-			}
+			wallet.Auditors = append(wallet.Auditors, ids...)
 			wallet.Auditors[len(wallet.Auditors)-1].Default = true
 		}
 	}
@@ -255,9 +249,7 @@ func (p *NetworkHandler) GenerateCryptoMaterial(cmGenerator generators.CryptoMat
 	if opts.Certifier() {
 		ids := cmGenerator.GenerateCertifierIdentities(tms, node, node.Name)
 		if len(ids) > 0 {
-			for _, id := range ids {
-				wallet.Certifiers = append(wallet.Certifiers, id)
-			}
+			wallet.Certifiers = append(wallet.Certifiers, ids...)
 			wallet.Certifiers[len(wallet.Certifiers)-1].Default = true
 		}
 	}

--- a/token/request.go
+++ b/token/request.go
@@ -815,18 +815,10 @@ func (r *Request) Import(request *Request) error {
 		r.Metadata = &driver.TokenRequestMetadata{}
 	}
 
-	for _, issue := range request.Actions.Issues {
-		r.Actions.Issues = append(r.Actions.Issues, issue)
-	}
-	for _, transfer := range request.Actions.Transfers {
-		r.Actions.Transfers = append(r.Actions.Transfers, transfer)
-	}
-	for _, issue := range request.Metadata.Issues {
-		r.Metadata.Issues = append(r.Metadata.Issues, issue)
-	}
-	for _, transfer := range request.Metadata.Transfers {
-		r.Metadata.Transfers = append(r.Metadata.Transfers, transfer)
-	}
+	r.Actions.Issues = append(r.Actions.Issues, request.Actions.Issues...)
+	r.Actions.Transfers = append(r.Actions.Transfers, request.Actions.Transfers...)
+	r.Metadata.Issues = append(r.Metadata.Issues, request.Metadata.Issues...)
+	r.Metadata.Transfers = append(r.Metadata.Transfers, request.Metadata.Transfers...)
 	return nil
 }
 

--- a/token/validator.go
+++ b/token/validator.go
@@ -29,9 +29,7 @@ func (c *Validator) UnmarshallAndVerify(ledger Ledger, binding string, raw []byt
 		return nil, err
 	}
 
-	var res []interface{}
-	for _, action := range actions {
-		res = append(res, action)
-	}
+	res := make([]interface{}, len(actions))
+	copy(res, actions)
 	return res, nil
 }


### PR DESCRIPTION
As part of issue https://github.com/hyperledger-labs/fabric-token-sdk/issues/317, removed warnings related to:
* S1011: replaced redundant loops by simple append invocation