### PR TITLE
Reduce staticcheck warnings (S1039)

### DIFF
--- a/integration/nwo/token/fabric/tcc.go
+++ b/integration/nwo/token/fabric/tcc.go
@@ -101,7 +101,7 @@ func (p *NetworkHandler) tccSetup(tms *topology3.TMS, cc *topology.ChannelChainc
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	cc.Chaincode.Ctor = fmt.Sprintf(`{"Args":["init"]}`)
+	cc.Chaincode.Ctor = `{"Args":["init"]}`
 	cc.Chaincode.PackageFile = packageFile
 
 	return cc, port

--- a/token/core/identity/msp/idemix/wallet.go
+++ b/token/core/identity/msp/idemix/wallet.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package idemix
 
 import (
-	"fmt"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"go.uber.org/zap/zapcore"
@@ -144,7 +142,7 @@ func (w *wallet) MapToID(v interface{}) (view.Identity, string) {
 		}
 		return nil, label
 	default:
-		panic(fmt.Sprintf("[AnonymousIdentity] identifier not recognised, expected []byte or view.Identity"))
+		panic("[AnonymousIdentity] identifier not recognised, expected []byte or view.Identity")
 	}
 }
 

--- a/token/core/identity/msp/x509/wallet.go
+++ b/token/core/identity/msp/x509/wallet.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package x509
 
 import (
-	"fmt"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"go.uber.org/zap/zapcore"
@@ -161,7 +159,7 @@ func (w *wallet) MapToID(v interface{}) (view.Identity, string) {
 		}
 		return nil, label
 	default:
-		panic(fmt.Sprintf("[LongTermIdentity] identifier not recognised, expected []byte or view.Identity"))
+		panic("[LongTermIdentity] identifier not recognised, expected []byte or view.Identity")
 	}
 }
 

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -113,7 +113,7 @@ func NewQuantityFromUInt64(q uint64) Quantity {
 
 func NewQuantityFromBig64(q *big.Int) Quantity {
 	if q.BitLen() > 64 {
-		panic(fmt.Sprintf("invalid precision, expected at most 64 bits"))
+		panic("invalid precision, expected at most 64 bits")
 	}
 	return &UInt64Quantity{Value: q.Uint64()}
 }


### PR DESCRIPTION
As part of issue https://github.com/hyperledger-labs/fabric-token-sdk/issues/317, removed warnings related to:
* S1039: removed unnecessary uses of fmt.Sprintf