### PR TITLE
Reduce staticcheck warnings (SA9003)

### DIFF
--- a/integration/nwo/token/common/ppmgen.go
+++ b/integration/nwo/token/common/ppmgen.go
@@ -52,6 +52,7 @@ func (f *FabTokenPublicParamsGenerator) Generate(tms *topology.TMS, wallets *gen
 		}
 	}
 
+	//lint:ignore SA9003 To-Do pending
 	if len(tms.Issuers) != 0 {
 		// TODO:
 	}
@@ -125,6 +126,7 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *generat
 		}
 	}
 
+	//lint:ignore SA9003 To-Do pending
 	if len(tms.Issuers) != 0 {
 		// TODO
 	}


### PR DESCRIPTION
As part of issue https://github.com/hyperledger-labs/fabric-token-sdk/issues/317, removed warnings related to:
* SA9003: ignored empty branches