### PR TITLE
Reduce staticcheck warnings (S1038, S1012, S1021, SA4001)

### DIFF
--- a/token/core/zkatdlog/crypto/transfer/transfer.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer.go
@@ -122,7 +122,7 @@ func (p *Prover) Prove() ([]byte, error) {
 
 // Verify checks validity of serialized Proof
 func (v *Verifier) Verify(proof []byte) error {
-	tp := *&Proof{}
+	tp := Proof{}
 	err := tp.Deserialize(proof)
 	if err != nil {
 		return errors.Wrap(err, "invalid transfer proof")

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -211,9 +211,9 @@ func (cc *TokenChaincode) ReadParamsFromFile() string {
 	fmt.Println("reading " + publicParamsPath + " ...")
 	paramsAsBytes, err := ioutil.ReadFile(publicParamsPath)
 	if err != nil {
-		fmt.Println(fmt.Sprintf(
-			"unable to read file %s (%s). continue looking pub params from init args or cc", publicParamsPath, err.Error(),
-		))
+		fmt.Printf(
+			"unable to read file %s (%s). continue looking pub params from init args or cc\n", publicParamsPath, err.Error(),
+		)
 		return ""
 	}
 

--- a/token/services/selector/inmemory/locker.go
+++ b/token/services/selector/inmemory/locker.go
@@ -206,7 +206,7 @@ func (d *locker) scan() {
 			switch status {
 			case Valid:
 				// remove only if elapsed enough time from last access, to avoid concurrency issue
-				if time.Now().Sub(entry.LastAccess) > d.validTxEvictionTimeout {
+				if time.Since(entry.LastAccess) > d.validTxEvictionTimeout {
 					removeList = append(removeList, id)
 					if logger.IsEnabledFor(zapcore.DebugLevel) {
 						logger.Debugf("token [%s] locked by [%s] in status [%s], time elapsed, remove", id, entry, status)

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -189,8 +189,7 @@ func (q *UInt64Quantity) Add(b Quantity) Quantity {
 	}
 
 	// Check overflow
-	var sum uint64
-	sum = q.Value + bq.Value
+	var sum = q.Value + bq.Value
 
 	if sum < q.Value {
 		panic(fmt.Sprintf("%d < %d", q.Value, bq.Value))


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* S1038: removed redundant Sprintf
* S1012: replaced time.Now().Sub with time.Since,
* S1021: merged variable declaration and assignment
* SA4001: simplified *&x to x

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>