### PR TITLE
Reduce staticcheck warnings (SA5007)

### DIFF
--- a/token/wallet.go
+++ b/token/wallet.go
@@ -178,7 +178,7 @@ func (w *Wallet) Contains(identity view.Identity) bool {
 
 // ContainsToken returns true if the wallet contains an identity that owns the passed token.
 func (w *Wallet) ContainsToken(token *token2.UnspentToken) bool {
-	return w.ContainsToken(token)
+	return w.w.ContainsToken(token)
 }
 
 // AuditorWallet models the wallet of an auditor


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* SA5007: fixed infinite recursion

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>