### PR TITLE
Reduce staticcheck warnings (SA1019)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220802155344-f87475651bbc
 	github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c
 	github.com/hyperledger-labs/orion-server v0.2.1
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20220128025611-fad7f691a967

--- a/go.sum
+++ b/go.sum
@@ -707,6 +707,8 @@ github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304 h1:c82DVFhyvvOXtBW8rHTylhZbpYTnuft+X7Vl4R9EC7I=
 github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220728121315-292fe4c92304/go.mod h1:lHxLvBxx7U4eniJ6xHGEvqfGuM3KhkWBGlNc7L/XYqU=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220802155344-f87475651bbc h1:2FJ5dnuu+4CfZWbhiPwrxUWCmkUch47ZgfIhZAkWC/k=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220802155344-f87475651bbc/go.mod h1:lHxLvBxx7U4eniJ6xHGEvqfGuM3KhkWBGlNc7L/XYqU=
 github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c h1:niolJc7rAbxKB1aJQH9aDvu4WteX6V2bZA/hFc2u8YE=
 github.com/hyperledger-labs/orion-sdk-go v0.0.0-20220213082028-b0ee3d8f361c/go.mod h1:VDuSI17SlxWJCs+p/WYzXRT8g9FhOuL96C15zt+9Pw0=
 github.com/hyperledger-labs/orion-server v0.2.1 h1:uLhuSprg5EWWLs047+54f2ZGuhbZrMa/c38rqpj2FKQ=

--- a/token/core/identity/msp/idemix/audit.go
+++ b/token/core/identity/msp/idemix/audit.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 
 	csp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"
 )

--- a/token/core/identity/msp/idemix/common.go
+++ b/token/core/identity/msp/idemix/common.go
@@ -8,7 +8,7 @@ package idemix
 
 import (
 	bccsp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/pkg/errors"

--- a/token/core/identity/msp/idemix/id.go
+++ b/token/core/identity/msp/idemix/id.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	bccsp "github.com/IBM/idemix/bccsp/schemes"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	m "github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/msp"

--- a/token/core/identity/msp/x509/ecdsa.go
+++ b/token/core/identity/msp/x509/ecdsa.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger/fabric-protos-go/msp"

--- a/token/core/identity/msp/x509/mspx509.go
+++ b/token/core/identity/msp/x509/mspx509.go
@@ -9,7 +9,7 @@ package x509
 import (
 	ecdsa2 "crypto/ecdsa"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"

--- a/token/core/zkatdlog/crypto/ecdsa/ecdsa.go
+++ b/token/core/zkatdlog/crypto/ecdsa/ecdsa.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric/bccsp/utils"
 	"github.com/pkg/errors"


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* SA1019: Used fabric-smart-client proto package to work around deprecated package

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>