### PR TITLE
Reduce staticcheck warnings (S1011)

### DIFF
--- a/token/core/fabtoken/validator.go
+++ b/token/core/fabtoken/validator.go
@@ -102,9 +102,7 @@ func NewValidator(pp *PublicParams, deserializer driver.Deserializer, extraValid
 	if deserializer == nil {
 		return nil, errors.New("please provide a non-nil deserializer")
 	}
-	for _, f := range extraValidators {
-		defaultValidators = append(defaultValidators, f)
-	}
+	defaultValidators = append(defaultValidators, extraValidators...)
 	return &Validator{
 		pp:              pp,
 		deserializer:    deserializer,

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -94,9 +94,7 @@ type Validator struct {
 }
 
 func New(pp *crypto.PublicParams, deserializer driver.Deserializer, extraValidators ...ValidateTransfer) *Validator {
-	for _, f := range extraValidators {
-		defaultValidators = append(defaultValidators, f)
-	}
+	defaultValidators = append(defaultValidators, extraValidators...)
 	return &Validator{
 		pp:              pp,
 		deserializer:    deserializer,


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* S1011: Replaced unnecessary loop for append

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>