### PR TITLE
Reduce staticcheck warnings (SA4022)

### DIFF
--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -327,9 +327,7 @@ func GetAuditInfoForIssues(issues [][]byte, metadata []driver.IssueMetadata) ([]
 		if err != nil {
 			return nil, err
 		}
-		if &md == nil {
-			return nil, errors.Errorf("invalid issue metadata: it is nil")
-		}
+
 		if len(ia.OutputTokens) != len(md.ReceiversAuditInfos) || len(ia.OutputTokens) != len(md.TokenInfo) {
 			return nil, errors.Errorf("number of output does not match number of provided metadata")
 		}


### PR DESCRIPTION
As part of issue #317, removed warnings related to:
* SA4022: Removed redundant nil check

Signed-off-by: Alexandros Filios <alexandros.filios@ibm.com>