### PR TITLE
Add manual CI test trigger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      fsc-version:
+        default: 'github.com/hyperledger-labs/fabric-smart-client@main'
+        required: true
+        description: 'FSC dependency'
 
 env:
   GOPATH: ${{ github.workspace }}
@@ -25,6 +31,17 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version-file: "${{ env.FTS_PATH }}/go.mod"
+
+      - name: Replace FSC dep
+        working-directory: ${{ env.FTS_PATH }}
+        run: |
+          if [ -n "${{ github.event.inputs.fsc-version }}" ]; then
+            echo "Replace FSC dependency"
+            go mod edit -replace=github.com/hyperledger-labs/fabric-smart-client=${{ github.event.inputs.fsc-version }}
+            go mod tidy || true
+          else
+            echo "Skipping FSC dependency replacement"
+          fi
 
       - name: Set up tools
         working-directory: ${{ env.FTS_PATH }}


### PR DESCRIPTION
This PR adds support to manually start CI test and set the FSC dependency. Thereby, we can easily check if open PR on FSC is working fine with FTS.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>