### PR TITLE
Export `ttxdb` SetStatus function

### DIFF
--- a/integration/token/fungible/dloghsm/topology.go
+++ b/integration/token/fungible/dloghsm/topology.go
@@ -71,6 +71,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 		issuer.RegisterViewFactory("historyAuditing", &views.ListAuditedTransactionsViewFactory{})
 		issuer.RegisterViewFactory("holding", &views.CurrentHoldingViewFactory{})
 		issuer.RegisterViewFactory("spending", &views.CurrentSpendingViewFactory{})
+		issuer.RegisterViewFactory("SetTransactionAuditStatus", &views.SetTransactionAuditStatusViewFactory{})
 		auditor = issuer
 	} else {
 		auditor = fscTopology.AddNodeByName("auditor").AddOptions(
@@ -84,7 +85,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 		auditor.RegisterViewFactory("holding", &views.CurrentHoldingViewFactory{})
 		auditor.RegisterViewFactory("spending", &views.CurrentSpendingViewFactory{})
 		auditor.RegisterViewFactory("CheckPublicParamsMatch", &views.CheckPublicParamsMatchViewFactory{})
-
+		auditor.RegisterViewFactory("SetTransactionAuditStatus", &views.SetTransactionAuditStatusViewFactory{})
 	}
 
 	alice := fscTopology.AddNodeByName("alice").AddOptions(
@@ -96,6 +97,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.IssueCashView{})
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.TransferView{})
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.TransferWithSelectorView{})
+	alice.RegisterResponder(&views.AcceptPreparedCashView{}, &views.PrepareTransferView{})
 	alice.RegisterViewFactory("transfer", &views.TransferViewFactory{})
 	alice.RegisterViewFactory("transferWithSelector", &views.TransferWithSelectorViewFactory{})
 	alice.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
@@ -129,6 +131,8 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 	bob.RegisterViewFactory("acceptedTransactionHistory", &views.ListAcceptedTransactionsViewFactory{})
 	bob.RegisterViewFactory("transactionInfo", &views.TransactionInfoViewFactory{})
 	bob.RegisterViewFactory("CheckPublicParamsMatch", &views.CheckPublicParamsMatchViewFactory{})
+	bob.RegisterViewFactory("prepareTransfer", &views.PrepareTransferViewFactory{})
+	bob.RegisterViewFactory("TokenSelectorUnlock", &views.TokenSelectorUnlockViewFactory{})
 
 	charlie := fscTopology.AddNodeByName("charlie").AddOptions(
 		fabric.WithOrganization("Org2"),

--- a/integration/token/fungible/topology.go
+++ b/integration/token/fungible/topology.go
@@ -71,6 +71,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 		issuer.RegisterViewFactory("historyAuditing", &views.ListAuditedTransactionsViewFactory{})
 		issuer.RegisterViewFactory("holding", &views.CurrentHoldingViewFactory{})
 		issuer.RegisterViewFactory("spending", &views.CurrentSpendingViewFactory{})
+		issuer.RegisterViewFactory("SetTransactionAuditStatus", &views.SetTransactionAuditStatusViewFactory{})
 		auditor = issuer
 	} else {
 		auditor = fscTopology.AddNodeByName("auditor").AddOptions(
@@ -84,6 +85,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 		auditor.RegisterViewFactory("holding", &views.CurrentHoldingViewFactory{})
 		auditor.RegisterViewFactory("spending", &views.CurrentSpendingViewFactory{})
 		auditor.RegisterViewFactory("CheckPublicParamsMatch", &views.CheckPublicParamsMatchViewFactory{})
+		auditor.RegisterViewFactory("SetTransactionAuditStatus", &views.SetTransactionAuditStatusViewFactory{})
 	}
 
 	alice := fscTopology.AddNodeByName("alice").AddOptions(
@@ -95,6 +97,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.IssueCashView{})
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.TransferView{})
 	alice.RegisterResponder(&views.AcceptCashView{}, &views.TransferWithSelectorView{})
+	alice.RegisterResponder(&views.AcceptPreparedCashView{}, &views.PrepareTransferView{})
 	alice.RegisterViewFactory("transfer", &views.TransferViewFactory{})
 	alice.RegisterViewFactory("transferWithSelector", &views.TransferWithSelectorViewFactory{})
 	alice.RegisterViewFactory("redeem", &views.RedeemViewFactory{})
@@ -128,6 +131,8 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 	bob.RegisterViewFactory("acceptedTransactionHistory", &views.ListAcceptedTransactionsViewFactory{})
 	bob.RegisterViewFactory("transactionInfo", &views.TransactionInfoViewFactory{})
 	bob.RegisterViewFactory("CheckPublicParamsMatch", &views.CheckPublicParamsMatchViewFactory{})
+	bob.RegisterViewFactory("prepareTransfer", &views.PrepareTransferViewFactory{})
+	bob.RegisterViewFactory("TokenSelectorUnlock", &views.TokenSelectorUnlockViewFactory{})
 
 	charlie := fscTopology.AddNodeByName("charlie").AddOptions(
 		fabric.WithOrganization("Org2"),

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -239,3 +239,33 @@ func (p *CurrentSpendingViewFactory) NewView(in []byte) (view.View, error) {
 
 	return f, nil
 }
+
+type SetTransactionAuditStatus struct {
+	TxID   string
+	Status ttx.TxStatus
+}
+
+// SetTransactionAuditStatusView is used to set the status of a given transaction in the audit db
+type SetTransactionAuditStatusView struct {
+	*SetTransactionAuditStatus
+}
+
+func (r *SetTransactionAuditStatusView) Call(context view.Context) (interface{}, error) {
+	w := ttx.MyAuditorWallet(context)
+	assert.NotNil(w, "failed getting default auditor wallet")
+
+	auditor := ttx.NewAuditor(context, w)
+	assert.NoError(auditor.SetStatus(r.TxID, r.Status), "failed to set status of [%s] to [%d]", r.TxID, r.Status)
+
+	return nil, nil
+}
+
+type SetTransactionAuditStatusViewFactory struct{}
+
+func (p *SetTransactionAuditStatusViewFactory) NewView(in []byte) (view.View, error) {
+	f := &SetTransactionAuditStatusView{SetTransactionAuditStatus: &SetTransactionAuditStatus{}}
+	err := json.Unmarshal(in, f.SetTransactionAuditStatus)
+	assert.NoError(err, "failed unmarshalling input")
+
+	return f, nil
+}

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -391,3 +391,27 @@ func (p *BroadcastPreparedTransferViewFactory) NewView(in []byte) (view.View, er
 	assert.NoError(err, "failed unmarshalling input")
 	return f, nil
 }
+
+type TokenSelectorUnlock struct {
+	TxID string
+}
+
+// TokenSelectorUnlockView is a view that broadcasts a prepared transfer transaction
+type TokenSelectorUnlockView struct {
+	*TokenSelectorUnlock
+}
+
+func (t *TokenSelectorUnlockView) Call(context view.Context) (interface{}, error) {
+	assert.NoError(token2.GetManagementService(context).SelectorManager().Unlock(t.TxID), "failed to unlock tokens locked by transaction [%s]", t.TxID)
+
+	return nil, nil
+}
+
+type TokenSelectorUnlockViewFactory struct{}
+
+func (p *TokenSelectorUnlockViewFactory) NewView(in []byte) (view.View, error) {
+	f := &TokenSelectorUnlockView{TokenSelectorUnlock: &TokenSelectorUnlock{}}
+	err := json.Unmarshal(in, f.TokenSelectorUnlock)
+	assert.NoError(err, "failed unmarshalling input")
+	return f, nil
+}

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -17,6 +17,19 @@ import (
 
 var logger = flogging.MustGetLogger("token-sdk.auditor")
 
+// TxStatus is the status of a transaction
+type TxStatus = ttxdb.TxStatus
+
+const (
+	// Pending is the status of a transaction that has been submitted to the ledger
+	Pending TxStatus = "Pending"
+	// Confirmed is the status of a transaction that has been confirmed by the ledger
+	Confirmed TxStatus = "Confirmed"
+	// Deleted is the status of a transaction that has been deleted due to a failure to commit
+	Deleted TxStatus = "Deleted"
+)
+
+// Transaction models a generic token transaction
 type Transaction interface {
 	ID() string
 	Network() string
@@ -97,6 +110,11 @@ func (a *Auditor) Append(tx Transaction) error {
 	}
 	logger.Debugf("append done for request %s", tx.ID())
 	return nil
+}
+
+// SetStatus sets the status of the audit records with the passed transaction id to the passed status
+func (a *Auditor) SetStatus(txID string, status TxStatus) error {
+	return a.db.SetStatus(txID, status)
 }
 
 type TxStatusChangesListener struct {


### PR DESCRIPTION
Currently, the auditor was not able to explicitly call `SetStatus` on a given transaction to update its status. This is of particular use in recovery situations.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>