### PR TITLE
double check the use of NewQuantityFromUInt64 #218

### DIFF
--- a/integration/token/fungible/views/accept.go
+++ b/integration/token/fungible/views/accept.go
@@ -24,13 +24,13 @@ func (a *AcceptCashView) Call(context view.Context) (interface{}, error) {
 	id, err := ttx.RespondRequestRecipientIdentityUsingWallet(context, "")
 	assert.NoError(err, "failed to respond to identity request")
 
-	// At some point, the recipient receives the token transaction that in the mean time has been assembled
+	// At some point, the recipient receives the token transaction that in the meantime has been assembled
 	tx, err := ttx.ReceiveTransaction(context)
 	assert.NoError(err, "failed to receive tokens")
 
 	// The recipient can perform any check on the transaction as required by the business process
 	// In particular, here, the recipient checks that the transaction contains at least one output, and
-	// that there is at least one output that names the recipient. (The recipient is receiving something.
+	// that there is at least one output that names the recipient.(The recipient is receiving something).
 	outputs, err := tx.Outputs()
 	assert.NoError(err, "failed getting outputs")
 	assert.True(outputs.Count() > 0)
@@ -39,13 +39,13 @@ func (a *AcceptCashView) Call(context view.Context) (interface{}, error) {
 	// The recipient here is checking that, for each type of token she is receiving,
 	// she does not hold already more than 3000 units of that type.
 	// Just a fancy query to show the capabilities of the services we are using.
+	precision := tx.TokenService().PublicParametersManager().Precision()
 	for _, output := range outputs.ByRecipient(id).Outputs() {
 		unspentTokens, err := ttx.MyWallet(context).ListUnspentTokens(ttx.WithType(output.Type))
 		assert.NoError(err, "failed retrieving the unspent tokens for type [%s]", output.Type)
-		assert.True(
-			unspentTokens.Sum(tx.TokenService().PublicParametersManager().Precision()).Cmp(token2.NewQuantityFromUInt64(3000)) <= 0,
-			"cannot have more than 3000 unspent quantity for type [%s]", output.Type,
-		)
+		upperBound, err := token2.UInt64ToQuantity(3000, precision)
+		assert.NoError(err, "failed to convert to quantity")
+		assert.True(unspentTokens.Sum(precision).Cmp(upperBound) <= 0, "cannot have more than 3000 unspent quantity for type [%s]", output.Type)
 	}
 
 	// If everything is fine, the recipient accepts and sends back her signature.
@@ -89,13 +89,13 @@ func (a *AcceptPreparedCashView) Call(context view.Context) (interface{}, error)
 	id, err := ttx.RespondRequestRecipientIdentityUsingWallet(context, "")
 	assert.NoError(err, "failed to respond to identity request")
 
-	// At some point, the recipient receives the token transaction that in the mean time has been assembled
+	// At some point, the recipient receives the token transaction that in the meantime has been assembled
 	tx, err := ttx.ReceiveTransaction(context)
 	assert.NoError(err, "failed to receive tokens")
 
 	// The recipient can perform any check on the transaction as required by the business process
 	// In particular, here, the recipient checks that the transaction contains at least one output, and
-	// that there is at least one output that names the recipient. (The recipient is receiving something.
+	// that there is at least one output that names the recipient (The recipient is receiving something).
 	outputs, err := tx.Outputs()
 	assert.NoError(err, "failed getting outputs")
 	assert.True(outputs.Count() > 0)

--- a/integration/token/fungible/views/issue.go
+++ b/integration/token/fungible/views/issue.go
@@ -62,7 +62,11 @@ func (p *IssueCashView) Call(context view.Context) (interface{}, error) {
 		fmt.Printf("History [%s,%s]<[241]?\n", history.Sum(precision).ToBigInt().Text(10), p.TokenType)
 
 		// Fail if the sum of the issued tokens and the current quest is larger than 241
-		assert.True(history.Sum(precision).Add(token2.NewQuantityFromUInt64(p.Quantity)).Cmp(token2.NewQuantityFromUInt64(241)) <= 0)
+		q, err := token2.UInt64ToQuantity(p.Quantity, precision)
+		assert.NoError(err, "failed to covert to quantity")
+		upperBound, err := token2.UInt64ToQuantity(241, precision)
+		assert.NoError(err, "failed to covert to quantity")
+		assert.True(history.Sum(precision).Add(q).Cmp(upperBound) <= 0)
 	}
 
 	// At this point, the issuer is ready to prepare the token transaction.

--- a/samples/fungible/views/accept.go
+++ b/samples/fungible/views/accept.go
@@ -39,11 +39,14 @@ func (a *AcceptCashView) Call(context view.Context) (interface{}, error) {
 	// The recipient here is checking that, for each type of token she is receiving,
 	// she does not hold already more than 3000 units of that type.
 	// Just a fancy query to show the capabilities of the services we are using.
+	precision := tx.TokenService().PublicParametersManager().Precision()
 	for _, output := range outputs.ByRecipient(id).Outputs() {
 		unspentTokens, err := ttx.MyWallet(context).ListUnspentTokens(ttx.WithType(output.Type))
 		assert.NoError(err, "failed retrieving the unspent tokens for type [%s]", output.Type)
+		upperLimit, err := token2.UInt64ToQuantity(3000, precision)
+		assert.NoError(err, "failed to convert to quantity")
 		assert.True(
-			unspentTokens.Sum(tx.TokenService().PublicParametersManager().Precision()).Cmp(token2.NewQuantityFromUInt64(3000)) <= 0,
+			unspentTokens.Sum(precision).Cmp(upperLimit) <= 0,
 			"cannot have more than 3000 unspent quantity for type [%s]", output.Type,
 		)
 	}

--- a/samples/fungible/views/accept.go
+++ b/samples/fungible/views/accept.go
@@ -45,10 +45,7 @@ func (a *AcceptCashView) Call(context view.Context) (interface{}, error) {
 		assert.NoError(err, "failed retrieving the unspent tokens for type [%s]", output.Type)
 		upperLimit, err := token2.UInt64ToQuantity(3000, precision)
 		assert.NoError(err, "failed to convert to quantity")
-		assert.True(
-			unspentTokens.Sum(precision).Cmp(upperLimit) <= 0,
-			"cannot have more than 3000 unspent quantity for type [%s]", output.Type,
-		)
+		assert.True(unspentTokens.Sum(precision).Cmp(upperLimit) <= 0, "cannot have more than 3000 unspent quantity for type [%s]", output.Type)
 	}
 
 	// If everything is fine, the recipient accepts and sends back her signature.

--- a/samples/fungible/views/issue.go
+++ b/samples/fungible/views/issue.go
@@ -61,7 +61,11 @@ func (p *IssueCashView) Call(context view.Context) (interface{}, error) {
 		fmt.Printf("History [%s,%s]<[230]?\n", history.Sum(precision).ToBigInt().Text(10), p.TokenType)
 
 		// Fail if the sum of the issued tokens and the current quest is larger than 230
-		assert.True(history.Sum(precision).Add(token2.NewQuantityFromUInt64(p.Quantity)).Cmp(token2.NewQuantityFromUInt64(230)) <= 0)
+		q, err := token2.UInt64ToQuantity(p.Quantity, precision)
+		assert.NoError(err, "failed to convert quantity")
+		upperBound, err := token2.UInt64ToQuantity(230, precision)
+		assert.NoError(err, "failed to convert upper bound")
+		assert.True(history.Sum(precision).Add(q).Cmp(upperBound) <= 0)
 	}
 
 	// At this point, the issuer is ready to prepare the token transaction.

--- a/token/core/fabtoken/issuer.go
+++ b/token/core/fabtoken/issuer.go
@@ -26,14 +26,19 @@ func (s *Service) Issue(issuerIdentity view.Identity, typ string, values []uint6
 
 	var outs []*Output
 	var metas [][]byte
+	precision := s.PublicParamsManager().PublicParameters().Precision()
 	for i, v := range values {
+		q, err := token2.UInt64ToQuantity(v, precision)
+		if err != nil {
+			return nil, nil, nil, errors.Wrapf(err, "failed to convert [%d] to quantity of precision [%d]", v, precision)
+		}
 		outs = append(outs, &Output{
 			Output: &token2.Token{
 				Owner: &token2.Owner{
 					Raw: owners[i],
 				},
 				Type:     typ,
-				Quantity: token2.NewQuantityFromUInt64(v).Hex(),
+				Quantity: q.Hex(),
 			},
 		})
 

--- a/token/services/nfttx/qe.go
+++ b/token/services/nfttx/qe.go
@@ -73,7 +73,7 @@ func (s *QueryExecutor) QueryByKey(state interface{}, key string, value string) 
 		if err != nil {
 			return errors.Wrap(err, "failed to convert quantity")
 		}
-		if q.Cmp(token2.NewQuantityFromUInt64(1)) == 0 {
+		if q.Cmp(token2.NewOneQuantity(s.precision)) == 0 {
 			// this is the token
 			decoded, err := base64.StdEncoding.DecodeString(t.Type)
 			if err != nil {

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -43,7 +43,7 @@ type Quantity interface {
 // The precision is expressed in bits.
 func ToQuantity(q string, precision uint64) (Quantity, error) {
 	if precision == 0 {
-		return nil, errors.New("precision be larger than 0")
+		return nil, errors.New("precision must be larger than 0")
 	}
 	v, success := big.NewInt(0).SetString(q, 0)
 	if !success {
@@ -69,7 +69,7 @@ func ToQuantity(q string, precision uint64) (Quantity, error) {
 // The precision is expressed in bits.
 func UInt64ToQuantity(u uint64, precision uint64) (Quantity, error) {
 	if precision == 0 {
-		return nil, errors.New("precision be larger than 0")
+		return nil, errors.New("precision must be larger than 0")
 	}
 	v := big.NewInt(0).SetUint64(u)
 	if v.Cmp(big.NewInt(0)) < 0 {
@@ -114,7 +114,7 @@ type BigQuantity struct {
 
 func NewUBigQuantity(q string, precision uint64) (*BigQuantity, error) {
 	if precision == 0 {
-		return nil, errors.New("precision be larger than 0")
+		return nil, errors.New("precision must be larger than 0")
 	}
 	v, success := big.NewInt(0).SetString(q, 0)
 	if !success {

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -38,7 +38,7 @@ type Quantity interface {
 	ToBigInt() *big.Int
 }
 
-// ToQuantity converts a string q to a BigQuantity of a given precision.
+// ToQuantity converts a string q to a Quantity of a given precision.
 // Argument q is supposed to be formatted following big.Int#scan specification.
 // The precision is expressed in bits.
 func ToQuantity(q string, precision uint64) (Quantity, error) {
@@ -54,6 +54,29 @@ func ToQuantity(q string, precision uint64) (Quantity, error) {
 	}
 	if v.BitLen() > int(precision) {
 		return nil, errors.Errorf("%s has precision %d > %d", q, v.BitLen(), precision)
+	}
+
+	switch precision {
+	case 64:
+		return &UInt64Quantity{Value: v.Uint64()}, nil
+	default:
+		return &BigQuantity{Int: v, Precision: precision}, nil
+	}
+}
+
+// UInt64ToQuantity converts a uint64 q to a Quantity of a given precision.
+// Argument q is supposed to be formatted following big.Int#scan specification.
+// The precision is expressed in bits.
+func UInt64ToQuantity(u uint64, precision uint64) (Quantity, error) {
+	if precision == 0 {
+		return nil, errors.New("precision be larger than 0")
+	}
+	v := big.NewInt(0).SetUint64(u)
+	if v.Cmp(big.NewInt(0)) < 0 {
+		return nil, errors.New("quantity must be larger than 0")
+	}
+	if v.BitLen() > int(precision) {
+		return nil, errors.Errorf("%d has precision %d > %d", u, v.BitLen(), precision)
 	}
 
 	switch precision {

--- a/token/token/quantity_test.go
+++ b/token/token/quantity_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestToQuantity(t *testing.T) {
 	_, err := token2.ToQuantity(ToHex(100), 0)
-	assert.Equal(t, "precision be larger than 0", err.Error())
+	assert.Equal(t, "precision must be larger than 0", err.Error())
 
 	_, err = token2.ToQuantity(IntToHex(-100), 64)
 	assert.Equal(t, "invalid input [0x-64,64]", err.Error())


### PR DESCRIPTION
This PR ensures that `token.Quantity` is used properly. Public parameters' precision field must be used when parsing quantities unless it is clear otherwise like in some tests.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>