### PR TITLE
Transfer metadata rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # pinned versions
 FABRIC_VERSION=2.2
+ORION_VERSION=v0.2.5
 
 # integration test options
 GINKGO_TEST_OPTS ?=
@@ -52,7 +53,8 @@ monitoring-docker-images:
 
 .PHONY: orion-server-images
 orion-server-images:
-	docker pull orionbcdb/orion-server:latest
+	docker pull orionbcdb/orion-server:$(ORION_VERSION)
+	docker image tag orionbcdb/orion-server:$(ORION_VERSION) hyperledger/fabric-baseos:latest
 
 .PHONY: integration-tests-dlog-fabric
 integration-tests-dlog-fabric:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ monitoring-docker-images:
 .PHONY: orion-server-images
 orion-server-images:
 	docker pull orionbcdb/orion-server:$(ORION_VERSION)
-	docker image tag orionbcdb/orion-server:$(ORION_VERSION) hyperledger/fabric-baseos:latest
+	docker image tag orionbcdb/orion-server:$(ORION_VERSION) orionbcdb/orion-server:latest
 
 .PHONY: integration-tests-dlog-fabric
 integration-tests-dlog-fabric:

--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,8 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
+	github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 // indirect
+	github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20210603140002-2670f91851c8 // indirect
 	github.com/hyperledger/fabric-config v0.1.0 // indirect
 	github.com/hyperledger/fabric-lib-go v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220921132501-961ff7dd714d
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4
 	github.com/hyperledger-labs/orion-sdk-go v0.2.5
 	github.com/hyperledger-labs/orion-server v0.2.5
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20220128025611-fad7f691a967

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4
+	github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220927082230-58f6f39d8b7c
 	github.com/hyperledger-labs/orion-sdk-go v0.2.5
 	github.com/hyperledger-labs/orion-server v0.2.5
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20220128025611-fad7f691a967
@@ -105,8 +105,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
-	github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 // indirect
-	github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20210603140002-2670f91851c8 // indirect
 	github.com/hyperledger/fabric-config v0.1.0 // indirect
 	github.com/hyperledger/fabric-lib-go v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -766,15 +766,13 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4 h1:SyAH3SUZ2Z4toezCq5usZg768IRj0R/iUnMu0TEt2e4=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4/go.mod h1:L2ofOZpk4xaJ7fB2CNQdr2zywUoTs5KKld87vRcVCG0=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220927082230-58f6f39d8b7c h1:IJhkhkZ0lnIASv3lpEsp2oZHJRsfvI/WadOgW7/0Ed4=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220927082230-58f6f39d8b7c/go.mod h1:L2ofOZpk4xaJ7fB2CNQdr2zywUoTs5KKld87vRcVCG0=
 github.com/hyperledger-labs/orion-sdk-go v0.2.5 h1:HFGRTuMZgzo9EtyJeFAhVSlbrj6x3jtY0aDcghdjzRE=
 github.com/hyperledger-labs/orion-sdk-go v0.2.5/go.mod h1:At8hiFATfkDXQ4AFLVbaTiC9GDhVDo8aN/supb1KBb4=
 github.com/hyperledger-labs/orion-server v0.2.5 h1:aFudmB9SAnsT5v8jhazkuszEu0pdJNFqaYZF2GpvAuI=
 github.com/hyperledger-labs/orion-server v0.2.5/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
-github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 h1:vBvo0PNm82ht7wpBjlYY4ZHxV3YprCfdVd3T4JG9vBw=
 github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1/go.mod h1:POCGO/RK9YDfgdhuyqjoD9tRNtWfK7Rh5AYYmsb1Chc=
-github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c h1:pKr8VnHlduEgdInwLWykYAw+lpUizjQJaJ8I5fVoRUo=
 github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c/go.mod h1:si2XAWZclHXC359OyYMpNHfonf2P7P2nzABdCA8mPqs=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20210722174351-9815a7a8f0f7 h1:LKWVg/yHT1GdNrcmnwp+Fzij8Wlwl7T7l22MP66TVNY=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20210722174351-9815a7a8f0f7/go.mod h1:g/IlXbV5x5GEprnavUFN+YoJZeIjwDocRcmO5ZG4ugc=

--- a/go.sum
+++ b/go.sum
@@ -766,8 +766,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220921132501-961ff7dd714d h1:p3O7vP8QA4XsT5TTBZT/4qNO5/H/25WUu8iVTlXl5T8=
-github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220921132501-961ff7dd714d/go.mod h1:L2ofOZpk4xaJ7fB2CNQdr2zywUoTs5KKld87vRcVCG0=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4 h1:SyAH3SUZ2Z4toezCq5usZg768IRj0R/iUnMu0TEt2e4=
+github.com/hyperledger-labs/fabric-smart-client v0.0.0-20220926115048-8d07761e14c4/go.mod h1:L2ofOZpk4xaJ7fB2CNQdr2zywUoTs5KKld87vRcVCG0=
 github.com/hyperledger-labs/orion-sdk-go v0.2.5 h1:HFGRTuMZgzo9EtyJeFAhVSlbrj6x3jtY0aDcghdjzRE=
 github.com/hyperledger-labs/orion-sdk-go v0.2.5/go.mod h1:At8hiFATfkDXQ4AFLVbaTiC9GDhVDo8aN/supb1KBb4=
 github.com/hyperledger-labs/orion-server v0.2.5 h1:aFudmB9SAnsT5v8jhazkuszEu0pdJNFqaYZF2GpvAuI=

--- a/go.sum
+++ b/go.sum
@@ -772,7 +772,9 @@ github.com/hyperledger-labs/orion-sdk-go v0.2.5 h1:HFGRTuMZgzo9EtyJeFAhVSlbrj6x3
 github.com/hyperledger-labs/orion-sdk-go v0.2.5/go.mod h1:At8hiFATfkDXQ4AFLVbaTiC9GDhVDo8aN/supb1KBb4=
 github.com/hyperledger-labs/orion-server v0.2.5 h1:aFudmB9SAnsT5v8jhazkuszEu0pdJNFqaYZF2GpvAuI=
 github.com/hyperledger-labs/orion-server v0.2.5/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
+github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 h1:vBvo0PNm82ht7wpBjlYY4ZHxV3YprCfdVd3T4JG9vBw=
 github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1/go.mod h1:POCGO/RK9YDfgdhuyqjoD9tRNtWfK7Rh5AYYmsb1Chc=
+github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c h1:pKr8VnHlduEgdInwLWykYAw+lpUizjQJaJ8I5fVoRUo=
 github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c/go.mod h1:si2XAWZclHXC359OyYMpNHfonf2P7P2nzABdCA8mPqs=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20210722174351-9815a7a8f0f7 h1:LKWVg/yHT1GdNrcmnwp+Fzij8Wlwl7T7l22MP66TVNY=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20210722174351-9815a7a8f0f7/go.mod h1:g/IlXbV5x5GEprnavUFN+YoJZeIjwDocRcmO5ZG4ugc=

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -43,6 +43,10 @@ const (
 	ZKATDLogInteropHTLCTwoFabricNetworks
 	ZKATDLogInteropFastExchangeTwoFabricNetworks
 	ZKATDLogInteropHTLCSwapNoCrossTwoFabricNetworks
+	ZKATDLogInteropHTLCOrion
+	ZKATDLogInteropHTLCTwoFabricNetworksOrion
+	ZKATDLogInteropFastExchangeTwoFabricNetworksOrion
+	ZKATDLogInteropHTLCSwapNoCrossTwoFabricNetworksOrion
 )
 
 // StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -46,7 +46,7 @@ const (
 	ZKATDLogInteropHTLCOrion
 	ZKATDLogInteropHTLCTwoFabricNetworksOrion
 	ZKATDLogInteropFastExchangeTwoFabricNetworksOrion
-	ZKATDLogInteropHTLCSwapNoCrossTwoFabricNetworksOrion
+	ZKATDLogInteropHTLCSwapNoCrossWithOrionAndFabricNetworks
 )
 
 // StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -371,7 +371,7 @@ type BroadcastPreparedTransferView struct {
 }
 
 func (t *BroadcastPreparedTransferView) Call(context view.Context) (interface{}, error) {
-	tx, err := ttx.NewTransactionFromBytes(context, "", "", t.Tx)
+	tx, err := ttx.NewTransactionFromBytes(context, t.Tx)
 	assert.NoError(err, "failed unmarshalling transaction")
 
 	// broadcast the transaction to the ordering service
@@ -432,7 +432,7 @@ type FinalityWithTimeoutView struct {
 }
 
 func (r *FinalityWithTimeoutView) Call(ctx view.Context) (interface{}, error) {
-	tx, err := ttx.NewTransactionFromBytes(ctx, "", "", r.Tx)
+	tx, err := ttx.NewTransactionFromBytes(ctx, r.Tx)
 	assert.NoError(err, "failed unmarshalling transaction")
 
 	// broadcast the transaction to the ordering service

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -25,6 +25,7 @@ var _ = Describe("DLog end to end", func() {
 	})
 
 	AfterEach(func() {
+		ii.DeleteOnStop = false
 		ii.Stop()
 	})
 
@@ -43,7 +44,7 @@ var _ = Describe("DLog end to end", func() {
 		})
 
 		It("Performed htlc-related basic operations", func() {
-			interop.TestHTLCSingleFabricNetwork(ii)
+			interop.TestHTLCSingleNetwork(ii)
 		})
 	})
 
@@ -62,7 +63,7 @@ var _ = Describe("DLog end to end", func() {
 		})
 
 		It("Performed htlc-related basic operations", func() {
-			interop.TestHTLCSingleFabricNetwork(ii)
+			interop.TestHTLCSingleNetwork(ii)
 		})
 	})
 
@@ -81,7 +82,7 @@ var _ = Describe("DLog end to end", func() {
 		})
 
 		It("Performed an htlc based atomic swap", func() {
-			interop.TestHTLCTwoFabricNetworks(ii)
+			interop.TestHTLCTwoNetworks(ii)
 		})
 	})
 
@@ -119,7 +120,27 @@ var _ = Describe("DLog end to end", func() {
 		})
 
 		It("Performed an htlc based atomic swap", func() {
-			interop.TestHTLCNoCrossClaimTwoFabricNetworks(ii)
+			interop.TestHTLCNoCrossClaimTwoNetworks(ii)
+		})
+	})
+
+	Describe("HTLC No Cross Claim with Orion and Fabric Networks", func() {
+		BeforeEach(func() {
+			var err error
+			ii, err = integration.New(
+				integration2.ZKATDLogInteropHTLCSwapNoCrossWithOrionAndFabricNetworks.StartPortForNode(),
+				"/home/vagrant/testdata",
+				interop.HTLCNoCrossClaimWithOrionTopology("dlog")...,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			ii.DeleteOnStart = true
+			ii.RegisterPlatformFactory(token.NewPlatformFactory())
+			ii.Generate()
+			ii.Start()
+		})
+
+		It("Performed an htlc based atomic swap", func() {
+			interop.TestHTLCNoCrossClaimTwoNetworks(ii)
 		})
 	})
 

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -25,7 +25,6 @@ var _ = Describe("DLog end to end", func() {
 	})
 
 	AfterEach(func() {
-		ii.DeleteOnStop = false
 		ii.Stop()
 	})
 
@@ -129,11 +128,10 @@ var _ = Describe("DLog end to end", func() {
 			var err error
 			ii, err = integration.New(
 				integration2.ZKATDLogInteropHTLCSwapNoCrossWithOrionAndFabricNetworks.StartPortForNode(),
-				"/home/vagrant/testdata",
+				"",
 				interop.HTLCNoCrossClaimWithOrionTopology("dlog")...,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			ii.DeleteOnStart = true
 			ii.RegisterPlatformFactory(token.NewPlatformFactory())
 			ii.Generate()
 			ii.Start()

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -47,6 +47,25 @@ var _ = Describe("DLog end to end", func() {
 		})
 	})
 
+	Describe("HTLC Single Orion Network", func() {
+		BeforeEach(func() {
+			var err error
+			ii, err = integration.New(
+				integration2.ZKATDLogInteropHTLCOrion.StartPortForNode(),
+				"",
+				interop.HTLCSingleOrionNetworkTopology("dlog")...,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			ii.RegisterPlatformFactory(token.NewPlatformFactory())
+			ii.Generate()
+			ii.Start()
+		})
+
+		It("Performed htlc-related basic operations", func() {
+			interop.TestHTLCSingleFabricNetwork(ii)
+		})
+	})
+
 	Describe("HTLC Two Fabric Networks", func() {
 		BeforeEach(func() {
 			var err error

--- a/integration/token/interop/fabtoken/fabtoken_test.go
+++ b/integration/token/interop/fabtoken/fabtoken_test.go
@@ -47,6 +47,25 @@ var _ = Describe("FabToken end to end", func() {
 		})
 	})
 
+	Describe("HTLC Single Orion Network", func() {
+		BeforeEach(func() {
+			var err error
+			ii, err = integration.New(
+				integration2.FabTokenInteropHTLC.StartPortForNode(),
+				"",
+				interop.HTLCSingleOrionNetworkTopology("fabtoken")...,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			ii.RegisterPlatformFactory(token.NewPlatformFactory())
+			ii.Generate()
+			ii.Start()
+		})
+
+		It("Performed htlc-related basic operations", func() {
+			interop.TestHTLCSingleFabricNetwork(ii)
+		})
+	})
+
 	Describe("HTLC Two Fabric Networks", func() {
 		BeforeEach(func() {
 			var err error

--- a/integration/token/interop/fabtoken/fabtoken_test.go
+++ b/integration/token/interop/fabtoken/fabtoken_test.go
@@ -43,7 +43,7 @@ var _ = Describe("FabToken end to end", func() {
 		})
 
 		It("Performed htlc-related basic operations", func() {
-			interop.TestHTLCSingleFabricNetwork(ii)
+			interop.TestHTLCSingleNetwork(ii)
 		})
 	})
 
@@ -62,7 +62,7 @@ var _ = Describe("FabToken end to end", func() {
 		})
 
 		It("Performed htlc-related basic operations", func() {
-			interop.TestHTLCSingleFabricNetwork(ii)
+			interop.TestHTLCSingleNetwork(ii)
 		})
 	})
 
@@ -81,7 +81,7 @@ var _ = Describe("FabToken end to end", func() {
 		})
 
 		It("Performed an htlc based atomic swap", func() {
-			interop.TestHTLCTwoFabricNetworks(ii)
+			interop.TestHTLCTwoNetworks(ii)
 		})
 	})
 
@@ -119,7 +119,7 @@ var _ = Describe("FabToken end to end", func() {
 		})
 
 		It("Performed an htlc based atomic swap", func() {
-			interop.TestHTLCNoCrossClaimTwoFabricNetworks(ii)
+			interop.TestHTLCNoCrossClaimTwoNetworks(ii)
 		})
 	})
 

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHTLCSingleFabricNetwork(network *integration.Infrastructure) {
+func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	registerAuditor(network)
 
 	issueCash(network, "", "USD", 110, "alice")
@@ -91,7 +91,7 @@ func TestHTLCSingleFabricNetwork(network *integration.Infrastructure) {
 	checkBalance(network, "bob", "", "USD", 20, token.WithTMSID(defaultTMSID))
 }
 
-func TestHTLCTwoFabricNetworks(network *integration.Infrastructure) {
+func TestHTLCTwoNetworks(network *integration.Infrastructure) {
 	alpha := token.TMSID{Network: "alpha"}
 	beta := token.TMSID{Network: "beta"}
 
@@ -136,7 +136,7 @@ func TestHTLCTwoFabricNetworks(network *integration.Infrastructure) {
 	checkBalance(network, "bob", "", "USD", 20, token.WithTMSID(beta))
 }
 
-func TestHTLCNoCrossClaimTwoFabricNetworks(network *integration.Infrastructure) {
+func TestHTLCNoCrossClaimTwoNetworks(network *integration.Infrastructure) {
 	alpha := token.TMSID{Network: "alpha"}
 	beta := token.TMSID{Network: "beta"}
 

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -290,3 +290,88 @@ func HTLCNoCrossClaimTopology(tokenSDKDriver string) []api.Topology {
 
 	return []api.Topology{f1Topology, f2Topology, tokenTopology, fscTopology}
 }
+
+func HTLCNoCrossClaimWithOrionTopology(tokenSDKDriver string) []api.Topology {
+	// Define two Fabric topologies
+	f1Topology := fabric.NewTopologyWithName("alpha").SetDefault()
+	f1Topology.EnableIdemix()
+	f1Topology.AddOrganizationsByName("Org1", "Org2")
+	f1Topology.SetNamespaceApproverOrgs("Org1")
+
+	// Orion
+	orionTopology := orion.NewTopology()
+	orionTopology.SetName("beta")
+
+	// FSC
+	fscTopology := fsc.NewTopology()
+	fscTopology.SetLogging("debug", "")
+
+	issuer := fscTopology.AddNodeByName("issuer").AddOptions(
+		fabric.WithNetworkOrganization("alpha", "Org1"),
+		fabric.WithNetworkOrganization("beta", "Org3"),
+		fabric.WithAnonymousIdentity(),
+		orion.WithRole("issuer"),
+		token.WithIssuerIdentity("issuer.id1"),
+		token.WithOwnerIdentity(tokenSDKDriver, "issuer.owner"),
+	)
+	issuer.RegisterViewFactory("issue", &views2.IssueCashViewFactory{})
+
+	auditor := fscTopology.AddNodeByName("auditor").AddOptions(
+		fabric.WithNetworkOrganization("alpha", "Org1"),
+		fabric.WithNetworkOrganization("beta", "Org3"),
+		fabric.WithAnonymousIdentity(),
+		orion.WithRole("auditor"),
+		token.WithAuditorIdentity(),
+	)
+	auditor.RegisterViewFactory("register", &views2.RegisterAuditorViewFactory{})
+
+	alice := fscTopology.AddNodeByName("alice").AddOptions(
+		fabric.WithNetworkOrganization("alpha", "Org2"),
+		fabric.WithAnonymousIdentity(),
+		token.WithOwnerIdentity(tokenSDKDriver, "alice.id1"),
+		token.WithOwnerIdentity(tokenSDKDriver, "alice.id2"),
+	)
+	alice.RegisterResponder(&views2.AcceptCashView{}, &views2.IssueCashView{})
+	alice.RegisterViewFactory("htlc.lock", &htlc.LockViewFactory{})
+	alice.RegisterViewFactory("htlc.reclaimAll", &htlc.ReclaimAllViewFactory{})
+	alice.RegisterViewFactory("htlc.claim", &htlc.ClaimViewFactory{})
+	alice.RegisterViewFactory("htlc.fastExchange", &htlc.FastExchangeInitiatorViewFactory{})
+	alice.RegisterViewFactory("htlc.scan", &htlc.ScanViewFactory{})
+	alice.RegisterResponder(&htlc.LockAcceptView{}, &htlc.LockView{})
+
+	bob := fscTopology.AddNodeByName("bob").AddOptions(
+		orion.WithRole("bob"),
+		token.WithOwnerIdentity(tokenSDKDriver, "bob.id1"),
+		token.WithOwnerIdentity(tokenSDKDriver, "bob.id2"),
+	)
+	bob.RegisterResponder(&views2.AcceptCashView{}, &views2.IssueCashView{})
+	bob.RegisterViewFactory("htlc.lock", &htlc.LockViewFactory{})
+	bob.RegisterViewFactory("htlc.reclaimAll", &htlc.ReclaimAllViewFactory{})
+	bob.RegisterViewFactory("htlc.claim", &htlc.ClaimViewFactory{})
+	bob.RegisterViewFactory("htlc.scan", &htlc.ScanViewFactory{})
+	bob.RegisterResponder(&htlc.LockAcceptView{}, &htlc.LockView{})
+	bob.RegisterResponder(&htlc.FastExchangeResponderView{}, &htlc.FastExchangeInitiatorView{})
+
+	custodian := fscTopology.AddNodeByName("custodian")
+	custodian.AddOptions(orion.WithRole("custodian"))
+
+	tokenTopology := token.NewTopology()
+	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
+
+	// TMS for the Fabric Network
+	tmsFabric := tokenTopology.AddTMS(f1Topology, f1Topology.Channels[0].Name, tokenSDKDriver)
+	tmsFabric.SetTokenGenPublicParams("100", "2")
+	fabric2.SetOrgs(tmsFabric, "Org1")
+	tmsFabric.AddAuditor(auditor)
+
+	// TMS for the Orion Network
+	tmsOrion := tokenTopology.AddTMS(orionTopology, "", tokenSDKDriver)
+	tmsOrion.SetTokenGenPublicParams("100", "2")
+	tmsOrion.AddAuditor(auditor)
+	orion2.SetCustodian(tmsOrion, custodian)
+
+	orionTopology.AddDB(tmsOrion.Namespace, "custodian", "issuer", "auditor", "bob")
+	orionTopology.SetDefaultSDK(fscTopology)
+
+	return []api.Topology{f1Topology, orionTopology, tokenTopology, fscTopology}
+}

--- a/integration/token/interop/views/htlc/claim.go
+++ b/integration/token/interop/views/htlc/claim.go
@@ -9,7 +9,6 @@ package htlc
 import (
 	"encoding/json"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -40,9 +39,8 @@ func (r *ClaimView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "htlc script has expired")
 	assert.True(len(matched) == 1, "expected only one htlc script to match, got [%d]", len(matched))
 
-	tx, err := htlc.NewTransaction(
+	tx, err := htlc.NewAnonymousTransaction(
 		context,
-		fabric.GetIdentityProvider(context, r.TMSID.Network).DefaultIdentity(),
 		ttx.WithAuditor(view2.GetIdentityProvider(context).Identity("auditor")),
 		ttx.WithTMSID(r.TMSID),
 	)

--- a/integration/token/interop/views/htlc/exchange.go
+++ b/integration/token/interop/views/htlc/exchange.go
@@ -255,7 +255,14 @@ func (v *FastExchangeResponderView) Call(context view.Context) (interface{}, err
 	_, err = view2.AsInitiatorCall(context, v, func(context view.Context) (interface{}, error) {
 		// Scan for the pre-image, this will be the signal that the initiator has claimed responder's script
 		// TODO: fix timeout
-		preImage, err := htlc.ScanForPreImage(context, script.HashInfo.Hash, script.HashInfo.HashFunc, script.HashInfo.HashEncoding, 5*time.Minute, token.WithTMSID(terms.TMSID2))
+		preImage, err := htlc.ScanForPreImage(
+			context,
+			script.HashInfo.Hash,
+			script.HashInfo.HashFunc,
+			script.HashInfo.HashEncoding,
+			5*time.Minute,
+			token.WithTMSID(terms.TMSID2),
+		)
 		// if an error occurred, reclaim
 		if err != nil {
 			// reclaim

--- a/integration/token/interop/views/htlc/exchange.go
+++ b/integration/token/interop/views/htlc/exchange.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	view3 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
@@ -72,9 +71,8 @@ func (v *FastExchangeInitiatorView) Call(context view.Context) (interface{}, err
 	// Initiator's Leg
 	var preImage []byte
 	_, err = view2.RunCall(context, func(context view.Context) (interface{}, error) {
-		tx, err := htlc.NewTransaction(
+		tx, err := htlc.NewAnonymousTransaction(
 			context,
-			fabric.GetIdentityProvider(context, v.TMSID1.Network).DefaultIdentity(),
 			ttx.WithAuditor(view3.GetIdentityProvider(context).Identity("auditor")),
 			ttx.WithTMSID(v.TMSID1),
 		)
@@ -142,9 +140,8 @@ func (v *FastExchangeInitiatorView) Call(context view.Context) (interface{}, err
 		assert.NoError(err, "cannot retrieve list of expired tokens")
 		assert.True(len(matched) == 1, "expected only one htlc script to match, got [%d]", len(matched))
 
-		tx, err := htlc.NewTransaction(
+		tx, err := htlc.NewAnonymousTransaction(
 			context,
-			fabric.GetIdentityProvider(context, v.TMSID2.Network).DefaultIdentity(),
 			ttx.WithAuditor(view3.GetIdentityProvider(context).Identity("auditor")),
 			ttx.WithTMSID(v.TMSID2),
 		)
@@ -219,9 +216,8 @@ func (v *FastExchangeResponderView) Call(context view.Context) (interface{}, err
 
 	// Responder's Leg
 	_, err = view2.AsInitiatorCall(context, v, func(context view.Context) (interface{}, error) {
-		tx, err := htlc.NewTransaction(
+		tx, err := htlc.NewAnonymousTransaction(
 			context,
-			fabric.GetIdentityProvider(context, terms.TMSID2.Network).DefaultIdentity(),
 			ttx.WithAuditor(view3.GetIdentityProvider(context).Identity("auditor")),
 			ttx.WithTMSID(terms.TMSID2),
 		)
@@ -276,9 +272,8 @@ func (v *FastExchangeResponderView) Call(context view.Context) (interface{}, err
 		assert.NoError(err, "cannot retrieve list of expired tokens")
 		assert.True(len(matched) == 1, "expected only one htlc script to match, got [%d]", len(matched))
 
-		tx, err := htlc.NewTransaction(
+		tx, err := htlc.NewAnonymousTransaction(
 			context,
-			fabric.GetIdentityProvider(context, terms.TMSID1.Network).DefaultIdentity(),
 			ttx.WithAuditor(view3.GetIdentityProvider(context).Identity("auditor")),
 			ttx.WithTMSID(terms.TMSID1),
 		)

--- a/integration/token/interop/views/htlc/exchange.go
+++ b/integration/token/interop/views/htlc/exchange.go
@@ -250,7 +250,6 @@ func (v *FastExchangeResponderView) Call(context view.Context) (interface{}, err
 	// Claim initiator's script
 	_, err = view2.AsInitiatorCall(context, v, func(context view.Context) (interface{}, error) {
 		// Scan for the pre-image, this will be the signal that the initiator has claimed responder's script
-		// TODO: fix timeout
 		preImage, err := htlc.ScanForPreImage(
 			context,
 			script.HashInfo.Hash,

--- a/integration/token/interop/views/htlc/lock.go
+++ b/integration/token/interop/views/htlc/lock.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -61,9 +60,8 @@ func (hv *LockView) Call(context view.Context) (interface{}, error) {
 
 	// At this point, the sender is ready to prepare the htlc transaction
 	// and specify the auditor that must be contacted to approve the operation.
-	tx, err := htlc.NewTransaction(
+	tx, err := htlc.NewAnonymousTransaction(
 		context,
-		fabric.GetIdentityProvider(context, hv.TMSID.Network).DefaultIdentity(),
 		ttx.WithAuditor(view2.GetIdentityProvider(context).Identity("auditor")),
 		ttx.WithTMSID(hv.TMSID),
 	)

--- a/integration/token/interop/views/htlc/reclaim.go
+++ b/integration/token/interop/views/htlc/reclaim.go
@@ -9,7 +9,6 @@ package htlc
 import (
 	"encoding/json"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -40,9 +39,8 @@ func (r *ReclaimAllView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "cannot retrieve list of expired tokens")
 	assert.True(len(expired) > 0, "no htlc script has expired")
 
-	tx, err := htlc.NewTransaction(
+	tx, err := htlc.NewAnonymousTransaction(
 		context,
-		fabric.GetDefaultIdentityProvider(context).DefaultIdentity(),
 		ttx.WithAuditor(view2.GetIdentityProvider(context).Identity("auditor")),
 		ttx.WithTMSID(r.TMSID),
 	)

--- a/integration/token/interop/views/issue.go
+++ b/integration/token/interop/views/issue.go
@@ -9,7 +9,6 @@ package views
 import (
 	"encoding/json"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -49,9 +48,8 @@ func (p *IssueCashView) Call(context view.Context) (interface{}, error) {
 
 	// At this point, the issuer is ready to prepare the token transaction.
 	// The issuer creates a transaction and specify the auditor that must be contacted to approve the operation.
-	tx, err := ttx.NewTransaction(
+	tx, err := ttx.NewAnonymousTransaction(
 		context,
-		fabric.GetIdentityProvider(context, p.TMSID.Network).DefaultIdentity(),
 		ttx.WithAuditor(
 			view2.GetIdentityProvider(context).Identity("auditor"), // Retrieve the auditor's FSC node identity
 		),

--- a/token/core/fabtoken/validator.go
+++ b/token/core/fabtoken/validator.go
@@ -258,7 +258,7 @@ func (v *Validator) VerifyTransfer(ledger driver.Ledger, inputTokens []*token2.T
 	counter := 0
 	for k, c := range ctx.MetadataCounter {
 		if c > 1 {
-			return errors.Errorf("metadata key [%s] appeared more than one time", k)
+			return errors.Errorf("metadata key [%s] appeared more than once", k)
 		}
 		counter += c
 	}

--- a/token/core/fabtoken/validator.go
+++ b/token/core/fabtoken/validator.go
@@ -36,16 +36,17 @@ func NewValidator(pp *PublicParams, deserializer driver.Deserializer, extraValid
 	if deserializer == nil {
 		return nil, errors.New("please provide a non-nil deserializer")
 	}
-	validators := []ValidateTransferFunc{
+
+	transferValidators := []ValidateTransferFunc{
 		TransferSignatureValidate,
 		TransferBalanceValidate,
 		TransferHTLCValidate,
 	}
-	validators = append(validators, extraValidators...)
+	transferValidators = append(transferValidators, extraValidators...)
 	v := &Validator{
 		pp:                 pp,
 		deserializer:       deserializer,
-		transferValidators: validators,
+		transferValidators: transferValidators,
 	}
 	return v, nil
 }
@@ -245,11 +246,24 @@ func (v *Validator) VerifyTransfer(ledger driver.Ledger, inputTokens []*token2.T
 		InputTokens:       inputTokens,
 		Action:            tr.(*TransferAction),
 		Ledger:            ledger,
+		MetadataCounter:   map[string]int{},
 	}
 	for _, validator := range v.transferValidators {
 		if err := validator(ctx); err != nil {
 			return err
 		}
+	}
+
+	// Check that all metadata have been validated
+	counter := 0
+	for k, c := range ctx.MetadataCounter {
+		if c > 1 {
+			return errors.Errorf("metadata key [%s] appeared more than one time", k)
+		}
+		counter += c
+	}
+	if len(tr.GetMetadata()) != counter {
+		return errors.Errorf("more metadata than those validated [%d]!=[%d]", len(tr.GetMetadata()), counter)
 	}
 	return nil
 }

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -144,7 +144,9 @@ func TransferHTLCValidate(ctx *Context) error {
 			if err != nil {
 				return errors.WithMessagef(err, "failed to check htlc metadata")
 			}
-			ctx.CountMetadataKey(metadataKey)
+			if op != htlc2.Reclaim {
+				ctx.CountMetadataKey(metadataKey)
+			}
 		}
 	}
 

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -27,6 +27,11 @@ type Context struct {
 	InputTokens       []*token.Token
 	Action            *TransferAction
 	Ledger            driver.Ledger
+	MetadataCounter   map[string]int
+}
+
+func (c *Context) CountMetadataKey(key string) {
+	c.MetadataCounter[key] = c.MetadataCounter[key] + 1
 }
 
 // ValidateTransferFunc is the prototype of a validation function for a transfer action
@@ -135,9 +140,11 @@ func TransferHTLCValidate(ctx *Context) error {
 
 			// check metadata
 			sigma := ctx.Signatures[i]
-			if err := htlc2.MetadataCheck(ctx.Action, script, op, sigma); err != nil {
+			metadataKey, err := htlc2.MetadataCheck(ctx.Action, script, op, sigma)
+			if err != nil {
 				return errors.WithMessagef(err, "failed to check htlc metadata")
 			}
+			ctx.CountMetadataKey(metadataKey)
 		}
 	}
 

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
 	htlc2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/interop/htlc"
@@ -192,7 +194,7 @@ func HTLCMetadataCheck(ctx *Context, op htlc2.OperationType, sig []byte) error {
 	if len(ctx.Action.Metadata) == 0 {
 		return errors.New("cannot find htlc pre-image, no metadata")
 	}
-	value, ok := ctx.Action.Metadata[htlc.ClaimPreImage]
+	value, ok := ctx.Action.Metadata[keys.ClaimPreImage]
 	if !ok {
 		return errors.New("cannot find htlc pre-image, missing metadata entry")
 	}

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
-	"bytes"
 	"encoding/json"
 	"time"
 
@@ -136,7 +135,7 @@ func TransferHTLCValidate(ctx *Context) error {
 
 			// check metadata
 			sigma := ctx.Signatures[i]
-			if err := HTLCMetadataCheck(ctx, script, op, sigma); err != nil {
+			if err := htlc2.MetadataCheck(ctx.Action, script, op, sigma); err != nil {
 				return errors.WithMessagef(err, "failed to check htlc metadata")
 			}
 		}
@@ -168,41 +167,5 @@ func TransferHTLCValidate(ctx *Context) error {
 			continue
 		}
 	}
-	return nil
-}
-
-// HTLCMetadataCheck checks that the HTLC metadata is in place
-func HTLCMetadataCheck(ctx *Context, script *htlc.Script, op htlc2.OperationType, sig []byte) error {
-	if op == htlc2.Reclaim {
-		// No metadata in this case
-		return nil
-	}
-
-	// Unmarshal signature to ClaimSignature
-	claim := &htlc.ClaimSignature{}
-	if err := json.Unmarshal(sig, claim); err != nil {
-		return errors.Wrapf(err, "failed unmarshalling cliam signature [%s]", string(sig))
-	}
-	// Check that it is well-formed
-	if len(claim.Preimage) == 0 || len(claim.RecipientSignature) == 0 {
-		return errors.New("expected a valid claim preImage and recipient signature")
-	}
-
-	// Check that the pre-image is in the action's metadata
-	if len(ctx.Action.Metadata) == 0 {
-		return errors.New("cannot find htlc pre-image, no metadata")
-	}
-	image, err := script.HashInfo.Image(claim.Preimage)
-	if err != nil {
-		return errors.Wrapf(err, "failed to compute image of [%x]", claim.Preimage)
-	}
-	value, ok := ctx.Action.Metadata[htlc.ClaimKey(image)]
-	if !ok {
-		return errors.New("cannot find htlc pre-image, missing metadata entry")
-	}
-	if !bytes.Equal(value, claim.Preimage) {
-		return errors.Errorf("invalid action, cannot match htlc pre-image with metadata [%x]!=[%x]", value, claim.Preimage)
-	}
-
 	return nil
 }

--- a/token/core/interop/htlc/validator.go
+++ b/token/core/interop/htlc/validator.go
@@ -65,7 +65,7 @@ func MetadataCheck(action Action, script *htlc.Script, op OperationType, sig []b
 	// Unmarshal signature to ClaimSignature
 	claim := &htlc.ClaimSignature{}
 	if err := json.Unmarshal(sig, claim); err != nil {
-		return "", errors.Wrapf(err, "failed unmarshalling cliam signature [%s]", string(sig))
+		return "", errors.Wrapf(err, "failed unmarshalling claim signature [%s]", string(sig))
 	}
 	// Check that it is well-formed
 	if len(claim.Preimage) == 0 || len(claim.RecipientSignature) == 0 {

--- a/token/core/interop/htlc/validator.go
+++ b/token/core/interop/htlc/validator.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package htlc
 
 import (
+	"bytes"
 	"encoding/json"
 	"time"
 
@@ -22,6 +23,10 @@ const (
 	Claim
 	Reclaim
 )
+
+type Action interface {
+	GetMetadata() map[string][]byte
+}
 
 // VerifyOwner validates the owners of the transfer in the htlc script
 func VerifyOwner(senderRawOwner []byte, outRawOwner []byte, now time.Time) (*htlc.Script, OperationType, error) {
@@ -48,4 +53,41 @@ func VerifyOwner(senderRawOwner []byte, outRawOwner []byte, now time.Time) (*htl
 		}
 		return script, Reclaim, nil
 	}
+}
+
+// MetadataCheck checks that the HTLC metadata is in place
+func MetadataCheck(action Action, script *htlc.Script, op OperationType, sig []byte) error {
+	if op == Reclaim {
+		// No metadata in this case
+		return nil
+	}
+
+	// Unmarshal signature to ClaimSignature
+	claim := &htlc.ClaimSignature{}
+	if err := json.Unmarshal(sig, claim); err != nil {
+		return errors.Wrapf(err, "failed unmarshalling cliam signature [%s]", string(sig))
+	}
+	// Check that it is well-formed
+	if len(claim.Preimage) == 0 || len(claim.RecipientSignature) == 0 {
+		return errors.New("expected a valid claim preImage and recipient signature")
+	}
+
+	// Check that the pre-image is in the action's metadata
+	metadata := action.GetMetadata()
+	if len(metadata) == 0 {
+		return errors.New("cannot find htlc pre-image, no metadata")
+	}
+	image, err := script.HashInfo.Image(claim.Preimage)
+	if err != nil {
+		return errors.Wrapf(err, "failed to compute image of [%x]", claim.Preimage)
+	}
+	value, ok := metadata[htlc.ClaimKey(image)]
+	if !ok {
+		return errors.New("cannot find htlc pre-image, missing metadata entry")
+	}
+	if !bytes.Equal(value, claim.Preimage) {
+		return errors.Errorf("invalid action, cannot match htlc pre-image with metadata [%x]!=[%x]", value, claim.Preimage)
+	}
+
+	return nil
 }

--- a/token/core/interop/htlc/validator.go
+++ b/token/core/interop/htlc/validator.go
@@ -56,38 +56,39 @@ func VerifyOwner(senderRawOwner []byte, outRawOwner []byte, now time.Time) (*htl
 }
 
 // MetadataCheck checks that the HTLC metadata is in place
-func MetadataCheck(action Action, script *htlc.Script, op OperationType, sig []byte) error {
+func MetadataCheck(action Action, script *htlc.Script, op OperationType, sig []byte) (string, error) {
 	if op == Reclaim {
 		// No metadata in this case
-		return nil
+		return "", nil
 	}
 
 	// Unmarshal signature to ClaimSignature
 	claim := &htlc.ClaimSignature{}
 	if err := json.Unmarshal(sig, claim); err != nil {
-		return errors.Wrapf(err, "failed unmarshalling cliam signature [%s]", string(sig))
+		return "", errors.Wrapf(err, "failed unmarshalling cliam signature [%s]", string(sig))
 	}
 	// Check that it is well-formed
 	if len(claim.Preimage) == 0 || len(claim.RecipientSignature) == 0 {
-		return errors.New("expected a valid claim preImage and recipient signature")
+		return "", errors.New("expected a valid claim preImage and recipient signature")
 	}
 
 	// Check that the pre-image is in the action's metadata
 	metadata := action.GetMetadata()
 	if len(metadata) == 0 {
-		return errors.New("cannot find htlc pre-image, no metadata")
+		return "", errors.New("cannot find htlc pre-image, no metadata")
 	}
 	image, err := script.HashInfo.Image(claim.Preimage)
 	if err != nil {
-		return errors.Wrapf(err, "failed to compute image of [%x]", claim.Preimage)
+		return "", errors.Wrapf(err, "failed to compute image of [%x]", claim.Preimage)
 	}
-	value, ok := metadata[htlc.ClaimKey(image)]
+	key := htlc.ClaimKey(image)
+	value, ok := metadata[key]
 	if !ok {
-		return errors.New("cannot find htlc pre-image, missing metadata entry")
+		return "", errors.New("cannot find htlc pre-image, missing metadata entry")
 	}
 	if !bytes.Equal(value, claim.Preimage) {
-		return errors.Errorf("invalid action, cannot match htlc pre-image with metadata [%x]!=[%x]", value, claim.Preimage)
+		return "", errors.Errorf("invalid action, cannot match htlc pre-image with metadata [%x]!=[%x]", value, claim.Preimage)
 	}
 
-	return nil
+	return key, nil
 }

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -226,7 +226,7 @@ func (v *Validator) verifyTransfer(tr driver.TransferAction, ledger driver.Ledge
 		counter += c
 	}
 	if len(tr.GetMetadata()) != counter {
-		return errors.Errorf("more metadata than those validated [%d]!=[%d]", len(tr.GetMetadata()), counter)
+		return errors.Errorf("more metadata than those validated [%d]!=[%d], [%v]!=[%v]", len(tr.GetMetadata()), counter, tr.GetMetadata(), context.MetadataCounter)
 	}
 
 	return nil

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -23,22 +23,22 @@ import (
 var logger = flogging.MustGetLogger("token-sdk.zkatdlog")
 
 type Validator struct {
-	pp           *crypto.PublicParams
-	deserializer driver.Deserializer
-	validators   []ValidateTransferFunc
+	pp                 *crypto.PublicParams
+	deserializer       driver.Deserializer
+	transferValidators []ValidateTransferFunc
 }
 
 func New(pp *crypto.PublicParams, deserializer driver.Deserializer, extraValidators ...ValidateTransferFunc) *Validator {
-	validators := []ValidateTransferFunc{
+	transferValidators := []ValidateTransferFunc{
 		TransferSignatureValidate,
 		TransferZKProofValidate,
 		TransferHTLCValidate,
 	}
-	validators = append(validators, extraValidators...)
+	transferValidators = append(transferValidators, extraValidators...)
 	return &Validator{
-		pp:           pp,
-		deserializer: deserializer,
-		validators:   validators,
+		pp:                 pp,
+		deserializer:       deserializer,
+		transferValidators: transferValidators,
 	}
 }
 
@@ -209,11 +209,25 @@ func (v *Validator) verifyTransfer(tr driver.TransferAction, ledger driver.Ledge
 		Action:            action,
 		Ledger:            ledger,
 		SignatureProvider: signatureProvider,
+		MetadataCounter:   map[string]int{},
 	}
-	for _, v := range v.validators {
+	for _, v := range v.transferValidators {
 		if err := v(context); err != nil {
 			return err
 		}
 	}
+
+	// Check that all metadata have been validated
+	counter := 0
+	for k, c := range context.MetadataCounter {
+		if c > 1 {
+			return errors.Errorf("metadata key [%s] appeared more than one time", k)
+		}
+		counter += c
+	}
+	if len(tr.GetMetadata()) != counter {
+		return errors.Errorf("more metadata than those validated [%d]!=[%d]", len(tr.GetMetadata()), counter)
+	}
+
 	return nil
 }

--- a/token/core/zkatdlog/crypto/validator/validator_transfer.go
+++ b/token/core/zkatdlog/crypto/validator/validator_transfer.go
@@ -124,7 +124,9 @@ func TransferHTLCValidate(ctx *Context) error {
 			if err != nil {
 				return errors.WithMessagef(err, "failed to check htlc metadata")
 			}
-			ctx.CountMetadataKey(metadataKey)
+			if op != htlc2.Reclaim {
+				ctx.CountMetadataKey(metadataKey)
+			}
 		}
 	}
 

--- a/token/core/zkatdlog/crypto/validator/validator_transfer.go
+++ b/token/core/zkatdlog/crypto/validator/validator_transfer.go
@@ -11,6 +11,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
+
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
@@ -170,7 +172,7 @@ func HTLCMetadataCheck(ctx *Context, op htlc2.OperationType, sig []byte) error {
 	if len(ctx.Action.Metadata) == 0 {
 		return errors.New("cannot find htlc pre-image, no metadata")
 	}
-	value, ok := ctx.Action.Metadata[htlc.ClaimPreImage]
+	value, ok := ctx.Action.Metadata[keys.ClaimPreImage]
 	if !ok {
 		return errors.New("cannot find htlc pre-image, missing metadata entry")
 	}

--- a/token/core/zkatdlog/crypto/validator/validator_transfer.go
+++ b/token/core/zkatdlog/crypto/validator/validator_transfer.go
@@ -30,6 +30,11 @@ type Context struct {
 	InputTokens       []*token.Token
 	Action            *transfer.TransferAction
 	Ledger            driver.Ledger
+	MetadataCounter   map[string]int
+}
+
+func (c *Context) CountMetadataKey(key string) {
+	c.MetadataCounter[key] = c.MetadataCounter[key] + 1
 }
 
 type ValidateTransferFunc func(ctx *Context) error
@@ -115,9 +120,11 @@ func TransferHTLCValidate(ctx *Context) error {
 
 			// check metadata
 			sigma := ctx.Signatures[i]
-			if err := htlc2.MetadataCheck(ctx.Action, script, op, sigma); err != nil {
+			metadataKey, err := htlc2.MetadataCheck(ctx.Action, script, op, sigma)
+			if err != nil {
 				return errors.WithMessagef(err, "failed to check htlc metadata")
 			}
+			ctx.CountMetadataKey(metadataKey)
 		}
 	}
 

--- a/token/request.go
+++ b/token/request.go
@@ -833,6 +833,7 @@ func (r *Request) Import(request *Request) error {
 // AuditCheck performs the audit check of the request in addition to
 // the checks of the token request itself via IsValid.
 func (r *Request) AuditCheck() error {
+	logger.Debugf("audit check request [%s] on tms [%s]", r.Anchor, r.TokenService.ID().String())
 	if err := r.IsValid(); err != nil {
 		return err
 	}

--- a/token/sdk/processor.go
+++ b/token/sdk/processor.go
@@ -35,7 +35,7 @@ func (p *ProcessorManager) New(network, channel, namespace string) error {
 				ons,
 				namespace,
 				p.sp,
-				network2.NewAuthorizationMultiplexer(&network2.TMSAuthorization{}),
+				network2.NewAuthorizationMultiplexer(&network2.TMSAuthorization{}, &htlc.ScriptOwnership{}),
 				network2.NewIssuedMultiplexer(&network2.WalletIssued{}),
 			),
 		); err != nil {

--- a/token/services/interop/htlc/keys.go
+++ b/token/services/interop/htlc/keys.go
@@ -8,12 +8,10 @@ package htlc
 
 import (
 	"encoding/base64"
-
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
 )
 
 const (
-	ClaimPreImage = keys.ClaimPreImage
+	ClaimPreImage = "cpi"
 )
 
 // ClaimKey returns the claim key for the passed byte array

--- a/token/services/interop/htlc/keys.go
+++ b/token/services/interop/htlc/keys.go
@@ -12,6 +12,11 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
 )
 
+const (
+	ClaimPreImage = keys.ClaimPreImage
+)
+
+// ClaimKey returns the claim key for the passed byte array
 func ClaimKey(v []byte) string {
-	return keys.ClaimPreImage + base64.StdEncoding.EncodeToString(v)
+	return ClaimPreImage + base64.StdEncoding.EncodeToString(v)
 }

--- a/token/services/interop/htlc/keys.go
+++ b/token/services/interop/htlc/keys.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc
+
+import (
+	"encoding/base64"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
+)
+
+func ClaimKey(v []byte) string {
+	return keys.ClaimPreImage + base64.StdEncoding.EncodeToString(v)
+}

--- a/token/services/interop/htlc/keys.go
+++ b/token/services/interop/htlc/keys.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package htlc
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 )
 
 const (
@@ -16,5 +16,5 @@ const (
 
 // ClaimKey returns the claim key for the passed byte array
 func ClaimKey(v []byte) string {
-	return ClaimPreImage + base64.StdEncoding.EncodeToString(v)
+	return ClaimPreImage + hex.EncodeToString(v)
 }

--- a/token/services/interop/htlc/scanner.go
+++ b/token/services/interop/htlc/scanner.go
@@ -66,11 +66,10 @@ func ScanForPreImage(ctx view.Context, image []byte, hashFunc crypto.Hash, hashE
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to lookup key [%s]", claimKey)
 	}
-	hi := HashInfo{
+	recomputedImage, err := (&HashInfo{
 		HashFunc:     hashFunc,
 		HashEncoding: hashEncoding,
-	}
-	recomputedImage, err := hi.Image(preImage)
+	}).Image(preImage)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to compute image of [%x]", preImage)
 	}

--- a/token/services/interop/htlc/scanner.go
+++ b/token/services/interop/htlc/scanner.go
@@ -62,7 +62,7 @@ func ScanForPreImage(ctx view.Context, image []byte, hashFunc crypto.Hash, hashE
 	}
 
 	claimKey := ClaimKey(image)
-	preImage, err := network.ScanForKey(tms.Namespace(), startingTxID, claimKey, timeout, opts...)
+	preImage, err := network.LookupTransferMetadataKey(tms.Namespace(), startingTxID, claimKey, timeout, opts...)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to lookup key [%s]", claimKey)
 	}

--- a/token/services/interop/htlc/scanner.go
+++ b/token/services/interop/htlc/scanner.go
@@ -8,21 +8,15 @@ package htlc
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"encoding/base64"
-	"strings"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/encoding"
-	fabric2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/translator"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -55,94 +49,33 @@ func ScanForPreImage(ctx view.Context, image []byte, hashFunc crypto.Hash, hashE
 	if err != nil {
 		return nil, err
 	}
-	ch, err := fabric.GetFabricNetworkService(ctx, tokenOptions.Network).Channel(tokenOptions.Channel)
-	if err != nil {
-		return nil, err
-	}
 	tms := token.GetManagementService(ctx, opts...)
+
+	network := network.GetInstance(ctx, tms.Network(), tms.Channel())
+	if network == nil {
+		return nil, errors.Errorf("cannot find network [%s:%s]", tms.Namespace(), tms.Channel())
+	}
 
 	startingTxID, err := tokenOptions.ParamAsString(ScanForPreImageStartingTransaction)
 	if err != nil {
 		return nil, errors.Wrapf(err, "invalid starting transaction param")
 	}
 
-	var preImage []byte
-	c, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	if err := ch.Delivery().Scan(c, startingTxID, func(tx *fabric.ProcessedTransaction) (bool, error) {
-		logger.Debugf("scanning [%s]...", tx.TxID())
-
-		rws, err := ch.Vault().GetEphemeralRWSet(tx.Results())
-		if err != nil {
-			return false, err
-		}
-
-		found := false
-		for _, ns := range rws.Namespaces() {
-			if ns == tms.Namespace() {
-				found = true
-				break
-			}
-		}
-		if !found {
-			logger.Debugf("scanning [%s] does not contain namespace [%s]", tx.TxID(), tms.Namespace())
-			return false, nil
-		}
-
-		ns := tms.Namespace()
-		w := translator.New(tx.TxID(), fabric2.NewRWSWrapper(rws), tms.Namespace())
-		for i := 0; i < rws.NumWrites(ns); i++ {
-			k, v, err := rws.GetWriteAt(ns, i)
-			if err != nil {
-				return false, err
-			}
-			subKey, err := w.GetTransferMetadataKeyWithSubKey(k)
-			if err != nil {
-				continue
-			}
-			// extract hash
-			if f, err := keys.IsClaimKey(subKey); err == nil && f {
-				// hash + encoding
-				hash := hashFunc.New()
-				if _, err = hash.Write(v); err != nil {
-					return false, err
-				}
-				recomputedImage := hash.Sum(nil)
-				encoding := hashEncoding.New()
-				recomputedImage = []byte(encoding.EncodeToString(recomputedImage))
-
-				// compare
-				if !bytes.Equal(image, recomputedImage) {
-					continue
-				}
-
-				// found
-				preImage = v
-				if logger.IsEnabledFor(zapcore.DebugLevel) {
-					logger.Debugf("preimage of [%s] found [%s]",
-						base64.StdEncoding.EncodeToString(image),
-						base64.StdEncoding.EncodeToString(v),
-					)
-				}
-				return true, nil
-			}
-		}
-		logger.Debugf("scanning for preimage on [%s] not found", tx.TxID())
-		return false, nil
-	}); err != nil {
-		if strings.Contains(err.Error(), "context done") {
-			return nil, errors.WithMessage(err, "timeout reached")
-		}
-		return nil, err
+	claimKey := ClaimKey(image)
+	preImage, err := network.ScanForKey(tms.Namespace(), startingTxID, claimKey, timeout, opts...)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to lookup key [%s]", claimKey)
 	}
-
-	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("scanning for preimage of [%s] with timeout [%s] found, [%s]",
-			base64.StdEncoding.EncodeToString(image),
-			timeout,
-			base64.StdEncoding.EncodeToString(preImage),
-		)
+	hi := HashInfo{
+		HashFunc:     hashFunc,
+		HashEncoding: hashEncoding,
 	}
-
+	recomputedImage, err := hi.Image(preImage)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to compute image of [%x]", preImage)
+	}
+	if !bytes.Equal(image, recomputedImage) {
+		return nil, errors.WithMessagef(err, "pre-image on the ledger does not match the passed image [%x!=%x]", image, recomputedImage)
+	}
 	return preImage, nil
 }

--- a/token/services/interop/htlc/script.go
+++ b/token/services/interop/htlc/script.go
@@ -26,6 +26,7 @@ type HashInfo struct {
 	HashEncoding encoding.Encoding
 }
 
+// Validate checks that the hash and encoding functions are available
 func (i *HashInfo) Validate() error {
 	if !i.HashFunc.Available() {
 		return errors.New("hash function not available")
@@ -36,6 +37,7 @@ func (i *HashInfo) Validate() error {
 	return nil
 }
 
+// Image computes the image of the passer pre-image using the hash and encoding function of this struct
 func (i *HashInfo) Image(preImage []byte) ([]byte, error) {
 	if err := i.Validate(); err != nil {
 		return nil, errors.WithMessagef(err, "hash info not valid")

--- a/token/services/interop/htlc/script.go
+++ b/token/services/interop/htlc/script.go
@@ -37,7 +37,7 @@ func (i *HashInfo) Validate() error {
 	return nil
 }
 
-// Image computes the image of the passer pre-image using the hash and encoding function of this struct
+// Image computes the image of the passed pre-image using the hash and encoding function of this struct
 func (i *HashInfo) Image(preImage []byte) ([]byte, error) {
 	if err := i.Validate(); err != nil {
 		return nil, errors.WithMessagef(err, "hash info not valid")

--- a/token/services/interop/htlc/script.go
+++ b/token/services/interop/htlc/script.go
@@ -26,6 +26,29 @@ type HashInfo struct {
 	HashEncoding encoding.Encoding
 }
 
+func (i *HashInfo) Validate() error {
+	if !i.HashFunc.Available() {
+		return errors.New("hash function not available")
+	}
+	if !i.HashEncoding.Available() {
+		return errors.New("encoding function not available")
+	}
+	return nil
+}
+
+func (i *HashInfo) Image(preImage []byte) ([]byte, error) {
+	if err := i.Validate(); err != nil {
+		return nil, errors.WithMessagef(err, "hash info not valid")
+	}
+	hash := i.HashFunc.New()
+	if _, err := hash.Write(preImage); err != nil {
+		return nil, errors.Wrapf(err, "failed to compute hash image")
+	}
+	image := hash.Sum(nil)
+	image = []byte(i.HashEncoding.New().EncodeToString(image))
+	return image, nil
+}
+
 // Script contains the details of an htlc
 type Script struct {
 	Sender    view.Identity
@@ -49,11 +72,8 @@ func (s *Script) Validate(timeReference time.Time) error {
 	if s.Deadline.Before(timeReference) {
 		return errors.New("expiration date has already passed")
 	}
-	if !s.HashInfo.HashFunc.Available() {
-		return errors.New("hash function not available")
-	}
-	if !s.HashInfo.HashEncoding.Available() {
-		return errors.New("encoding function not available")
+	if err := s.HashInfo.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -100,7 +100,7 @@ func NewAnonymousTransaction(sp view.Context, opts ...ttx.TxOption) (*Transactio
 
 // NewTransactionFromBytes returns a new transaction from the passed bytes
 func NewTransactionFromBytes(ctx view.Context, network, channel string, raw []byte) (*Transaction, error) {
-	tx, err := ttx.NewTransactionFromBytes(ctx, network, channel, raw)
+	tx, err := ttx.NewTransactionFromBytes(ctx, raw)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -13,8 +13,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -275,13 +273,18 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		return err
 	}
 
+	image, err := script.HashInfo.Image(preImage)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to compute image of [%x]", preImage)
+	}
+
 	return t.Transfer(
 		wallet,
 		tok.Type,
 		[]uint64{q.ToBigInt().Uint64()},
 		[]view.Identity{script.Recipient},
 		token.WithTokenIDs(tok.Id),
-		token.WithTransferMetadata(keys.ClaimPreImage+base64.StdEncoding.EncodeToString(preImage), preImage),
+		token.WithTransferMetadata(ClaimKey(image), preImage),
 	)
 }
 

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -87,6 +87,17 @@ func NewTransaction(sp view.Context, signer view.Identity, opts ...ttx.TxOption)
 	}, nil
 }
 
+// NewAnonymousTransaction returns a new anonymous token transaction customized with the passed opts
+func NewAnonymousTransaction(sp view.Context, opts ...ttx.TxOption) (*Transaction, error) {
+	tx, err := ttx.NewAnonymousTransaction(sp, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Transaction{
+		Transaction: tx,
+	}, nil
+}
+
 // NewTransactionFromBytes returns a new transaction from the passed bytes
 func NewTransactionFromBytes(ctx view.Context, network, channel string, raw []byte) (*Transaction, error) {
 	tx, err := ttx.NewTransactionFromBytes(ctx, network, channel, raw)

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -234,7 +234,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		return errors.New("failed to unmarshal RawOwner as an htlc script")
 	}
 
-	if preImage == nil {
+	if len(preImage) == 0 {
 		return errors.New("preImage is nil")
 	}
 

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -280,7 +280,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		[]uint64{q.ToBigInt().Uint64()},
 		[]view.Identity{script.Recipient},
 		token.WithTokenIDs(tok.Id),
-		token.WithTransferMetadata(ClaimPreImage, preImage),
+		token.WithTransferMetadata(ClaimPreImage+base64.StdEncoding.EncodeToString(preImage), preImage),
 	)
 }
 

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -13,6 +13,8 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
+
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -26,7 +28,6 @@ import (
 const (
 	ScriptType            = "htlc" // htlc script
 	defaultDeadlineOffset = time.Hour
-	ClaimPreImage         = "cpi"
 )
 
 // WithHash sets a hash attribute to be used to customize the transfer command
@@ -280,7 +281,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		[]uint64{q.ToBigInt().Uint64()},
 		[]view.Identity{script.Recipient},
 		token.WithTokenIDs(tok.Id),
-		token.WithTransferMetadata(ClaimPreImage+base64.StdEncoding.EncodeToString(preImage), preImage),
+		token.WithTransferMetadata(keys.ClaimPreImage+base64.StdEncoding.EncodeToString(preImage), preImage),
 	)
 }
 

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/certifier/interactive"
 	fabric3 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
@@ -26,10 +25,14 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type QueryEngine interface {
+	ListUnspentTokens() (*token2.UnspentTokens, error)
+}
+
 // OwnerWallet is a combination of a wallet and a query service
 type OwnerWallet struct {
 	wallet       *token.OwnerWallet
-	queryService interactive.QueryEngine
+	queryService QueryEngine
 }
 
 // ListExpired returns a list of tokens with a passed deadline whose sender id is contained within the wallet

--- a/token/services/network/driver/envelope.go
+++ b/token/services/network/driver/envelope.go
@@ -25,4 +25,7 @@ type Envelope interface {
 
 	// Creator returns the creator of this envelope
 	Creator() []byte
+
+	// String returns the string representation of this envelope
+	String() string
 }

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -10,6 +10,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"time"
+
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -93,4 +96,6 @@ type Network interface {
 
 	// UnsubscribeTxStatusChanges unregisters a listener for transaction status changes for the passed id
 	UnsubscribeTxStatusChanges(id string, listener TxStatusChangeListener) error
+
+	ScanForKey(namespace string, startingTxID string, key string, timeout time.Duration, opts ...token2.ServiceOption) ([]byte, error)
 }

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"time"
 
-	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
@@ -97,5 +95,7 @@ type Network interface {
 	// UnsubscribeTxStatusChanges unregisters a listener for transaction status changes for the passed id
 	UnsubscribeTxStatusChanges(id string, listener TxStatusChangeListener) error
 
-	ScanForKey(namespace string, startingTxID string, key string, timeout time.Duration, opts ...token2.ServiceOption) ([]byte, error)
+	// LookupKey searches for the passed key starting from the passed transaction id in the given namespace.
+	// The operation gets canceled if the passed timeout gets reached.
+	LookupKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error)
 }

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -95,7 +95,7 @@ type Network interface {
 	// UnsubscribeTxStatusChanges unregisters a listener for transaction status changes for the passed id
 	UnsubscribeTxStatusChanges(id string, listener TxStatusChangeListener) error
 
-	// LookupKey searches for the passed key starting from the passed transaction id in the given namespace.
+	// LookupTransferMetadataKey searches for a transfer metadata key containing the passed sub-key starting from the passed transaction id in the given namespace.
 	// The operation gets canceled if the passed timeout gets reached.
-	LookupKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error)
+	LookupTransferMetadataKey(namespace string, startingTxID string, subKey string, timeout time.Duration) ([]byte, error)
 }

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -96,6 +96,6 @@ type Network interface {
 	UnsubscribeTxStatusChanges(id string, listener TxStatusChangeListener) error
 
 	// LookupTransferMetadataKey searches for a transfer metadata key containing the passed sub-key starting from the passed transaction id in the given namespace.
-	// The operation gets canceled if the passed timeout gets reached.
+	// The operation gets canceled if the passed timeout elapses.
 	LookupTransferMetadataKey(namespace string, startingTxID string, subKey string, timeout time.Duration) ([]byte, error)
 }

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -14,10 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode"
@@ -28,6 +24,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/translator"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -318,7 +315,7 @@ func (n *Network) UnsubscribeTxStatusChanges(txID string, listener driver.TxStat
 	return n.ch.Committer().UnsubscribeTxStatusChanges(txID, listener)
 }
 
-func (n *Network) ScanForKey(namespace string, startingTxID string, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
+func (n *Network) LookupKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error) {
 	var keyValue []byte
 	c, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode"
@@ -23,6 +21,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -356,7 +356,7 @@ func (n *Network) LookupKey(namespace string, startingTxID string, key string, t
 				return true, nil
 			}
 		}
-		logger.Debugf("scanning for preimage on [%s] not found", tx.TxID())
+		logger.Debugf("scanning for key [%s] on [%s] not found", key, tx.TxID())
 		return false, nil
 	}); err != nil {
 		if strings.Contains(err.Error(), "context done") {

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -350,7 +350,7 @@ func (n *Network) ScanForKey(namespace string, startingTxID string, key string, 
 			if err != nil {
 				return false, err
 			}
-			subKey, err := w.GetTransferMetadataKeyWithSubKey(k)
+			subKey, err := w.GetTransferMetadataSubKey(k)
 			if err != nil {
 				continue
 			}

--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -260,6 +260,10 @@ func (r *RWSetProcessor) tokenRequest(req fabric.Request, tx fabric.ProcessTrans
 			if err := r.tokenStore.StoreFabToken(ns, txID, index, tok, wrappedRWS, tokenInfoRaw, ids); err != nil {
 				return err
 			}
+		} else {
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("transaction [%s], found a token and it is NOT mine", txID)
+			}
 		}
 
 		// if I'm an auditor, store the audit entry

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -323,8 +323,8 @@ func (n *Network) UnsubscribeTxStatusChanges(id string, listener TxStatusChangeL
 	return n.n.UnsubscribeTxStatusChanges(id, listener)
 }
 
-func (n *Network) ScanForKey(ctx view.Context, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
-	panic("implement me")
+func (n *Network) ScanForKey(namespace, startingTxID, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
+	return n.n.ScanForKey(namespace, startingTxID, key, timeout, opts...)
 }
 
 // Provider returns an instance of network provider

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -139,6 +139,10 @@ func (e *Envelope) UnmarshalJSON(raw []byte) error {
 	return e.e.FromBytes(r)
 }
 
+func (e *Envelope) String() string {
+	return e.e.String()
+}
+
 type RWSet struct {
 	rws driver.RWSet
 }
@@ -322,8 +326,10 @@ func (n *Network) UnsubscribeTxStatusChanges(id string, listener TxStatusChangeL
 	return n.n.UnsubscribeTxStatusChanges(id, listener)
 }
 
-func (n *Network) ScanForKey(namespace, startingTxID, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
-	return n.n.LookupKey(namespace, startingTxID, key, timeout)
+// LookupTransferMetadataKey searches for a transfer metadata key containing the passed sub-key starting from the passed transaction id in the given namespace.
+// The operation gets canceled if the passed timeout gets reached.
+func (n *Network) LookupTransferMetadataKey(namespace, startingTxID, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
+	return n.n.LookupTransferMetadataKey(namespace, startingTxID, key, timeout)
 }
 
 // Provider returns an instance of network provider

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -12,6 +12,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -318,6 +321,10 @@ func (n *Network) SubscribeTxStatusChanges(txID string, listener TxStatusChangeL
 // UnsubscribeTxStatusChanges unregisters a listener for transaction status changes for the passed id
 func (n *Network) UnsubscribeTxStatusChanges(id string, listener TxStatusChangeListener) error {
 	return n.n.UnsubscribeTxStatusChanges(id, listener)
+}
+
+func (n *Network) ScanForKey(ctx view.Context, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
+	panic("implement me")
 }
 
 // Provider returns an instance of network provider

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -14,10 +14,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -324,7 +323,7 @@ func (n *Network) UnsubscribeTxStatusChanges(id string, listener TxStatusChangeL
 }
 
 func (n *Network) ScanForKey(namespace, startingTxID, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
-	return n.n.ScanForKey(namespace, startingTxID, key, timeout, opts...)
+	return n.n.LookupKey(namespace, startingTxID, key, timeout)
 }
 
 // Provider returns an instance of network provider

--- a/token/services/network/orion/broadcast.go
+++ b/token/services/network/orion/broadcast.go
@@ -104,7 +104,7 @@ func (r *BroadcastResponderView) Call(context view.Context) (interface{}, error)
 	if err := env.FromBytes(request.Blob); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal envelope")
 	}
-	logger.Debugf("commit envelope [%s]", env.TxID())
+	logger.Debugf("commit envelope [%s][%s]", env.TxID(), env.String())
 	if err := ons.TransactionManager().CommitEnvelope(oSession, env); err != nil {
 		return nil, errors.Wrap(err, "failed to commit envelope")
 	}

--- a/token/services/network/orion/lookupkey.go
+++ b/token/services/network/orion/lookupkey.go
@@ -1,0 +1,97 @@
+package orion
+
+import (
+	"time"
+
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	session2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/pkg/errors"
+)
+
+type LookupKeyRequest struct {
+	Network   string
+	Namespace string
+}
+
+type LookupKeyResponse struct {
+	Raw []byte
+}
+
+type LookupKeyRequestView struct {
+	Network      string
+	Namespace    string
+	StartingTxID string
+	Key          string
+	Timeout      time.Duration
+}
+
+func NewLookupKeyRequestView(network string, namespace string, startingTxID string, key string, timeout time.Duration) *LookupKeyRequestView {
+	return &LookupKeyRequestView{
+		Network:      network,
+		Namespace:    namespace,
+		StartingTxID: startingTxID,
+		Key:          key,
+		Timeout:      timeout,
+	}
+}
+
+func (v *LookupKeyRequestView) Call(context view.Context) (interface{}, error) {
+	cp := view2.GetConfigService(context)
+	isCustodian, err := IsCustodian(cp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to check if custodian")
+	}
+	if isCustodian {
+		logger.Debugf("I'm a custodian, connect directly to orion")
+		// I'm a custodian, connect directly to orion
+		return ReadPublicParameters(context, v.Network, v.Namespace)
+	}
+
+	// this is not a custodian, connect to it
+	logger.Debugf("I'm not a custodian, connect to custodian")
+	custodian, err := GetCustodian(cp, v.Network)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get custodian identifier")
+	}
+	logger.Debugf("custodian: %s", custodian)
+	session, err := session2.NewJSON(context, context.Initiator(), view2.GetIdentityProvider(context).Identity(custodian))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get session to custodian [%s]", custodian)
+	}
+	request := &LookupKeyRequest{
+		Network:   v.Network,
+		Namespace: v.Namespace,
+	}
+	if err := session.Send(request); err != nil {
+		return nil, errors.Wrapf(err, "failed to send request to custodian [%s]", custodian)
+	}
+	response := &LookupKeyResponse{}
+	if err := session.Receive(response); err != nil {
+		return nil, errors.Wrapf(err, "failed to receive response from custodian [%s]", custodian)
+	}
+	return response.Raw, nil
+}
+
+type RespondLookupKeyRequestView struct{}
+
+func (v *RespondLookupKeyRequestView) Call(context view.Context) (interface{}, error) {
+	// receive request
+	session := session2.JSON(context)
+	request := &LookupKeyRequest{}
+	if err := session.Receive(request); err != nil {
+		return nil, errors.Wrapf(err, "failed to receive request")
+	}
+	logger.Debugf("request: %+v", request)
+
+	// Get the public parameters from request network and namespace
+	ppRaw, err := ReadPublicParameters(context, request.Network, request.Namespace)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get public parameters from orion network [%s]", request.Network)
+	}
+	logger.Debugf("reading public parameters, done: %d", len(ppRaw))
+	if err := session.Send(&LookupKeyResponse{Raw: ppRaw}); err != nil {
+		return nil, errors.Wrapf(err, "failed to send response")
+	}
+	return nil, nil
+}

--- a/token/services/network/orion/lookupkey.go
+++ b/token/services/network/orion/lookupkey.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package orion
 
 import (

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -9,6 +9,9 @@ package orion
 import (
 	"context"
 	"sync"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion"
@@ -175,6 +178,10 @@ func (n *Network) SubscribeTxStatusChanges(txID string, listener driver.TxStatus
 
 func (n *Network) UnsubscribeTxStatusChanges(txID string, listener driver.TxStatusChangeListener) error {
 	return n.n.Committer().UnsubscribeTxStatusChanges(txID, listener)
+}
+
+func (n *Network) ScanForKey(namespace string, startingTxID string, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
+	panic("implement me")
 }
 
 type nv struct {

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/keys"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -178,13 +179,17 @@ func (n *Network) UnsubscribeTxStatusChanges(txID string, listener driver.TxStat
 	return n.n.Committer().UnsubscribeTxStatusChanges(txID, listener)
 }
 
-func (n *Network) LookupKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error) {
+func (n *Network) LookupTransferMetadataKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error) {
+	k, err := keys.CreateTransferActionMetadataKey(key)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to generate transfer action metadata key from [%s]", key)
+	}
 	pp, err := view2.GetManager(n.sp).InitiateView(
 		NewLookupKeyRequestView(
 			n.Name(),
 			namespace,
 			startingTxID,
-			key,
+			orionKey(k),
 			timeout,
 		),
 	)

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
-
 	idemix2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/msp/idemix"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
@@ -180,8 +178,20 @@ func (n *Network) UnsubscribeTxStatusChanges(txID string, listener driver.TxStat
 	return n.n.Committer().UnsubscribeTxStatusChanges(txID, listener)
 }
 
-func (n *Network) ScanForKey(namespace string, startingTxID string, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
-	panic("implement me")
+func (n *Network) LookupKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error) {
+	pp, err := view2.GetManager(n.sp).InitiateView(
+		NewLookupKeyRequestView(
+			n.Name(),
+			namespace,
+			startingTxID,
+			key,
+			timeout,
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return pp.([]byte), nil
 }
 
 type nv struct {

--- a/token/services/network/orion/processor.go
+++ b/token/services/network/orion/processor.go
@@ -232,6 +232,10 @@ func (r *RWSetProcessor) tokenRequest(req orion.Request, tx orion.ProcessTransac
 			if err := r.tokenStore.StoreFabToken(ns, txID, index, tok, wrappedRWS, tokenInfoRaw, ids); err != nil {
 				return err
 			}
+		} else {
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("transaction [%s], found a token and it is NOT mine", txID)
+			}
 		}
 
 		// if I'm an auditor, store the audit entry

--- a/token/services/network/orion/publicparams.go
+++ b/token/services/network/orion/publicparams.go
@@ -96,12 +96,6 @@ func (v *RespondPublicParamsRequestView) Call(context view.Context) (interface{}
 	return nil, nil
 }
 
-type AllIssuersValid struct{}
-
-func (i *AllIssuersValid) Validate(creator view.Identity, tokenType string) error {
-	return nil
-}
-
 func ReadPublicParameters(context view2.ServiceProvider, network, namespace string) ([]byte, error) {
 	ons := orion.GetOrionNetworkService(context, network)
 	if ons == nil {

--- a/token/services/network/orion/views.go
+++ b/token/services/network/orion/views.go
@@ -15,6 +15,7 @@ func InstallViews(sp view.ServiceProvider) error {
 	view.GetRegistry(sp).RegisterResponder(&RespondPublicParamsRequestView{}, &PublicParamsRequestView{})
 	view.GetRegistry(sp).RegisterResponder(&RequestApprovalResponderView{}, &RequestApprovalView{})
 	view.GetRegistry(sp).RegisterResponder(&BroadcastResponderView{}, &BroadcastView{})
+	view.GetRegistry(sp).RegisterResponder(&RespondLookupKeyRequestView{}, &LookupKeyRequestView{})
 
 	return nil
 }

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -305,27 +305,27 @@ func (a *AuditApproveView) signAndSendBack(context view.Context) error {
 
 	logger.Debugf("Signing and sending back transaction...done [%s]", a.tx.ID())
 
-	if err := a.waitFabricEnvelope(context); err != nil {
+	if err := a.waitEnvelope(context); err != nil {
 		return errors.WithMessagef(err, "failed obtaining auditor signature")
 	}
 	return nil
 }
 
-func (a *AuditApproveView) waitFabricEnvelope(context view.Context) error {
-	logger.Debugf("Waiting for fabric envelope... [%s]", a.tx.ID())
+func (a *AuditApproveView) waitEnvelope(context view.Context) error {
+	logger.Debugf("Waiting for envelope... [%s]", a.tx.ID())
 	tx, err := ReceiveTransaction(context)
 	if err != nil {
-		return errors.Wrapf(err, "failed receiving transaction")
+		return errors.Wrapf(err, "failed to receive transaction with network envelope")
 	}
-	logger.Debugf("Waiting for fabric envelope...transaction received[%s]", a.tx.ID())
+	logger.Debugf("Waiting for envelope...transaction received[%s]", a.tx.ID())
 
 	// Processes
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("Processes Fabric Envelope...")
+		logger.Debugf("Processes envelope...")
 	}
 	env := tx.Payload.Envelope
 	if env == nil {
-		return errors.Errorf("expected fabric envelope")
+		return errors.Errorf("expected envelope")
 	}
 	// Ack for distribution
 	// Send the signature back
@@ -374,7 +374,7 @@ func (a *AuditApproveView) waitFabricEnvelope(context view.Context) error {
 	agent := metrics.Get(context)
 	agent.EmitKey(0, "ttx", "sent", "txAck", tx.ID())
 
-	logger.Debugf("Waiting for fabric envelope...done [%s]", a.tx.ID())
+	logger.Debugf("Waiting for envelope...done [%s]", a.tx.ID())
 
 	return nil
 }

--- a/token/services/ttx/collect.go
+++ b/token/services/ttx/collect.go
@@ -130,7 +130,7 @@ func (c *collectActionsView) collectRemote(context view.Context, actionTransfer 
 		Transient:    map[string][]byte{},
 		TokenRequest: token.NewRequest(nil, ""),
 	}
-	err = unmarshal(nil, txPayload, msg.Payload)
+	err = unmarshal(context, txPayload, msg.Payload)
 	if err != nil {
 		return errors.Wrap(err, "failed unmarshalling reply")
 	}

--- a/token/services/ttx/endorse.go
+++ b/token/services/ttx/endorse.go
@@ -405,6 +405,10 @@ func (c *collectEndorsementsView) distributeEnv(context view.Context, env *netwo
 		return errors.New("transaction envelope is empty")
 	}
 
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("distribute env [%s]", env.String())
+	}
+
 	// double check that the transaction is valid
 	// if err := c.tx.IsValid(); err != nil {
 	// 	return errors.Wrap(err, "failed verifying transaction content before distributing it")
@@ -642,7 +646,6 @@ func (c *collectEndorsementsView) getSession(context view.Context, p view.Identi
 
 type receiveTransactionView struct {
 	network string
-	channel string
 }
 
 func NewReceiveTransactionView(network string) *receiveTransactionView {
@@ -662,9 +665,9 @@ func (f *receiveTransactionView) Call(context view.Context) (interface{}, error)
 			return nil, errors.New(string(msg.Payload))
 		}
 		logger.Debugf("receiveTransactionView: received transaction, len [%d][%s]", len(msg.Payload), string(msg.Payload))
-		tx, err := NewTransactionFromBytes(context, f.network, f.channel, msg.Payload)
+		tx, err := NewTransactionFromBytes(context, msg.Payload)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed unmarshalling transaction")
+			return nil, errors.Wrap(err, "failed to receive transaction")
 		}
 		// Check that the transaction is valid
 		if err := tx.IsValid(); err != nil {

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -509,6 +509,7 @@ func (cm *Manager) DB(w Wallet) (*DB, error) {
 	defer cm.mutex.Unlock()
 
 	id := w.TMS().ID().String() + w.ID()
+	logger.Debugf("get ttxdb for [%s]", id)
 	c, ok := cm.dbs[id]
 	if !ok {
 		driver, err := drivers[cm.driver].Open(cm.sp, id)

--- a/token/services/vault/keys/keys.go
+++ b/token/services/vault/keys/keys.go
@@ -9,7 +9,6 @@ package keys
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -37,8 +36,6 @@ const (
 	IssueActionMetadata         = "iam"
 	TransferActionMetadata      = "tam"
 	TokenRequestMetadata        = "trmd"
-	// Move back to the interop/htlc package
-	ClaimPreImage = "cpi"
 )
 
 func GetTokenIdFromKey(key string) (*token.ID, error) {
@@ -162,10 +159,6 @@ func GetTransferMetadataSubKey(k string) (string, error) {
 		return "", errors.Errorf("key [%s] doesn not contain the token transfer action medatata prefix", k)
 	}
 	return components[1], nil
-}
-
-func IsClaimKey(subKey string) (bool, error) {
-	return strings.HasPrefix(subKey, ClaimPreImage), nil
 }
 
 // CreateCompositeKey and its related functions and consts copied from core/chaincode/shim/chaincode.go

--- a/token/services/vault/keys/keys.go
+++ b/token/services/vault/keys/keys.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -39,6 +37,8 @@ const (
 	IssueActionMetadata         = "iam"
 	TransferActionMetadata      = "tam"
 	TokenRequestMetadata        = "trmd"
+	// Move back to the interop/htlc package
+	ClaimPreImage = "cpi"
 )
 
 func GetTokenIdFromKey(key string) (*token.ID, error) {
@@ -165,7 +165,7 @@ func GetTransferMetadataSubKey(k string) (string, error) {
 }
 
 func IsClaimKey(subKey string) (bool, error) {
-	return strings.HasPrefix(subKey, htlc.ClaimPreImage), nil
+	return strings.HasPrefix(subKey, ClaimPreImage), nil
 }
 
 // CreateCompositeKey and its related functions and consts copied from core/chaincode/shim/chaincode.go

--- a/token/services/vault/translator/translator.go
+++ b/token/services/vault/translator/translator.go
@@ -144,7 +144,7 @@ func (w *Translator) QueryTokens(ids []*token.ID) ([][]byte, error) {
 	return res, nil
 }
 
-func (w *Translator) GetTransferMetadataKeyWithSubKey(k string) (string, error) {
+func (w *Translator) GetTransferMetadataSubKey(k string) (string, error) {
 	return keys.GetTransferMetadataSubKey(k)
 }
 

--- a/token/services/vault/translator/translator.go
+++ b/token/services/vault/translator/translator.go
@@ -144,8 +144,8 @@ func (w *Translator) QueryTokens(ids []*token.ID) ([][]byte, error) {
 	return res, nil
 }
 
-func (w *Translator) IsTransferMetadataKeyWithSubKey(k string, subKey string) (bool, error) {
-	return keys.IsTransferMetadataKeyWithSubKey(k, subKey)
+func (w *Translator) GetTransferMetadataKeyWithSubKey(k string) (string, error) {
+	return keys.GetTransferMetadataSubKey(k)
 }
 
 func (w *Translator) checkProcess(action interface{}) error {
@@ -349,7 +349,7 @@ func (w *Translator) commitTransferAction(transferAction TransferAction) error {
 	// store metadata
 	metadata := transferAction.GetMetadata()
 	for key, value := range metadata {
-		k, err := keys.CreateTransferActionMetadataKey(w.TxID, key, w.metadataCounter)
+		k, err := keys.CreateTransferActionMetadataKey(key)
 		if err != nil {
 			return errors.Wrapf(err, "failed constructing metadata key")
 		}


### PR DESCRIPTION
- Transfer metadata key does not include txid and metadata counter anymore. It is up to the validator to make sure these keys are used properly
- check that a transfer contains only metadata that has been validated
- extend interop integration tests to orion

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>