### PR TITLE
missing underlying validation

### DIFF
--- a/token/core/fabtoken/ppm.go
+++ b/token/core/fabtoken/ppm.go
@@ -103,5 +103,9 @@ func (v *PublicParamsManager) PublicParams() *PublicParams {
 
 // Validate validates the public parameters
 func (v *PublicParamsManager) Validate() error {
-	return nil
+	pp := v.PublicParams()
+	if pp == nil {
+		return errors.New("public parameters not set")
+	}
+	return pp.Validate()
 }

--- a/token/core/zkatdlog/crypto/ppm/ppm.go
+++ b/token/core/zkatdlog/crypto/ppm/ppm.go
@@ -94,5 +94,9 @@ func (v *PublicParamsManager) PublicParams() *crypto.PublicParams {
 
 // Validate validates the public parameters
 func (v *PublicParamsManager) Validate() error {
-	return nil
+	pp := v.PublicParams()
+	if pp == nil {
+		return errors.New("public parameters not set")
+	}
+	return pp.Validate()
 }


### PR DESCRIPTION
Currently, the public params manager's `Validation` function is missing. This PR fixes it.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>