### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,11 +5,16 @@ Maintainers
 
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
-| Elli Androulaki | [elli-androulaki][elli-androulaki] | elli-androulaki | <lli@zurich.ibm.com>
 | Angelo De Caro | [adecaro][adecaro] | adecaro | <adc@zurich.ibm.com>
 | Kaoutar Elkhiyaoui | [KElkhiyaoui][KElkhiyaoui] | KElkhiyaoui | <kao@zurich.ibm.com>
 | Mathilde Ffrench | [mffrench][mffrench] | mffrench | <mathilde.ffrench@fr.ibm.com>
+
+**Emeritus Maintainers**
+
+| Name | GitHub | Chat | email
+|------|--------|------|----------------------
 | Alessandro Sorniotti | [ale-linux][ale-linux] | aso | <ale.linux@sopit.net>
+| Elli Androulaki | [elli-androulaki][elli-androulaki] | elli-androulaki | <lli@zurich.ibm.com>
 
 [elli-androulaki]: https://github.com/elli-androulaki
 [adecaro]: https://github.com/adecaro


### PR DESCRIPTION
The TSC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32
Signed-off-by: Ry Jones <ry@linux.com>