### PR TITLE
let the token driver decide how to marshal a token request

### DIFF
--- a/token/core/fabtoken/service.go
+++ b/token/core/fabtoken/service.go
@@ -112,7 +112,7 @@ func (s *Service) ConfigManager() config.Manager {
 	return s.CM
 }
 
-func (s *Service) MarshalToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
+func (s *Service) MarshalTokenRequestToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
 	newReq := &driver.TokenRequest{
 		Issues:    request.Issues,
 		Transfers: request.Transfers,

--- a/token/core/fabtoken/service.go
+++ b/token/core/fabtoken/service.go
@@ -111,3 +111,11 @@ func (s *Service) PublicParamsManager() driver.PublicParamsManager {
 func (s *Service) ConfigManager() config.Manager {
 	return s.CM
 }
+
+func (s *Service) MarshalToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
+	newReq := &driver.TokenRequest{
+		Issues:    request.Issues,
+		Transfers: request.Transfers,
+	}
+	return newReq.Bytes()
+}

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -171,7 +171,7 @@ func (s *Service) Deserializer() (driver.Deserializer, error) {
 	return d, nil
 }
 
-func (s *Service) MarshalToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
+func (s *Service) MarshalTokenRequestToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
 	newReq := &driver.TokenRequest{
 		Issues:    request.Issues,
 		Transfers: request.Transfers,

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -170,3 +170,11 @@ func (s *Service) Deserializer() (driver.Deserializer, error) {
 	}
 	return d, nil
 }
+
+func (s *Service) MarshalToSign(request *driver.TokenRequest, meta *driver.TokenRequestMetadata) ([]byte, error) {
+	newReq := &driver.TokenRequest{
+		Issues:    request.Issues,
+		Transfers: request.Transfers,
+	}
+	return newReq.Bytes()
+}

--- a/token/driver/tms.go
+++ b/token/driver/tms.go
@@ -17,6 +17,7 @@ type TokenManagerService interface {
 	WalletService
 	CertificationService
 	Deserializer
+	Serializer
 
 	IdentityProvider() IdentityProvider
 	Validator() Validator

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -153,3 +153,7 @@ type Deserializer interface {
 	// GetOwnerMatcher returns an identity matcher for the passed identity audit data.
 	GetOwnerMatcher(auditData []byte) (Matcher, error)
 }
+
+type Serializer interface {
+	MarshalToSign(request *TokenRequest, meta *TokenRequestMetadata) ([]byte, error)
+}

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -154,6 +154,8 @@ type Deserializer interface {
 	GetOwnerMatcher(auditData []byte) (Matcher, error)
 }
 
+// Serializer models the serialization needs of the Token Service
 type Serializer interface {
-	MarshalToSign(request *TokenRequest, meta *TokenRequestMetadata) ([]byte, error)
+	// MarshalTokenRequestToSign marshals the to token request to a byte array representation on which a signature must be produced
+	MarshalTokenRequestToSign(request *TokenRequest, meta *TokenRequestMetadata) ([]byte, error)
 }

--- a/token/request.go
+++ b/token/request.go
@@ -661,11 +661,7 @@ func (r *Request) MarshalToSign() ([]byte, error) {
 	if r.Actions == nil {
 		return nil, errors.Errorf("failed to marshal request in tx [%s] for signing", r.Anchor)
 	}
-	req := &driver.TokenRequest{
-		Issues:    r.Actions.Issues,
-		Transfers: r.Actions.Transfers,
-	}
-	return req.Bytes()
+	return r.TokenService.tms.MarshalToSign(r.Actions, r.Metadata)
 }
 
 // RequestToBytes marshals the request's actions to bytes.

--- a/token/request.go
+++ b/token/request.go
@@ -661,7 +661,7 @@ func (r *Request) MarshalToSign() ([]byte, error) {
 	if r.Actions == nil {
 		return nil, errors.Errorf("failed to marshal request in tx [%s] for signing", r.Anchor)
 	}
-	return r.TokenService.tms.MarshalToSign(r.Actions, r.Metadata)
+	return r.TokenService.tms.MarshalTokenRequestToSign(r.Actions, r.Metadata)
 }
 
 // RequestToBytes marshals the request's actions to bytes.


### PR DESCRIPTION
This PR let the token driver decide how to marshal a token request to a message on which a signature must be generated.
This is particularly useful in a context where transactions are post-order executed and therefore signatures must be collected directly on the backend transaction format 

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>