### PR TITLE
Fix Audit Lock mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,8 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huin/goupnp v1.0.0 // indirect
+	github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 // indirect
+	github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c // indirect
 	github.com/hyperledger/fabric-amcl v0.0.0-20210603140002-2670f91851c8 // indirect
 	github.com/hyperledger/fabric-config v0.1.0 // indirect
 	github.com/hyperledger/fabric-lib-go v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -808,6 +808,10 @@ github.com/hyperledger-labs/orion-sdk-go v0.2.5 h1:HFGRTuMZgzo9EtyJeFAhVSlbrj6x3
 github.com/hyperledger-labs/orion-sdk-go v0.2.5/go.mod h1:At8hiFATfkDXQ4AFLVbaTiC9GDhVDo8aN/supb1KBb4=
 github.com/hyperledger-labs/orion-server v0.2.5 h1:aFudmB9SAnsT5v8jhazkuszEu0pdJNFqaYZF2GpvAuI=
 github.com/hyperledger-labs/orion-server v0.2.5/go.mod h1:8kXVAU1wvFYGbFL1qmXwMi2i8gKV2smOdp1F1kq0HMk=
+github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1 h1:vBvo0PNm82ht7wpBjlYY4ZHxV3YprCfdVd3T4JG9vBw=
+github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go v1.2.3-alpha.1/go.mod h1:POCGO/RK9YDfgdhuyqjoD9tRNtWfK7Rh5AYYmsb1Chc=
+github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c h1:pKr8VnHlduEgdInwLWykYAw+lpUizjQJaJ8I5fVoRUo=
+github.com/hyperledger-labs/weaver-dlt-interoperability/sdks/fabric/go-sdk v1.2.3-alpha.1.0.20210812140206-37f430515b8c/go.mod h1:si2XAWZclHXC359OyYMpNHfonf2P7P2nzABdCA8mPqs=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20201118191903-ec81f3e74fa1/go.mod h1:ppiyrJ+sUSk/rAX9cTd8xwAwSQ7chEbOQMAqtQ3pLG4=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20220808214918-83596078d0c3 h1:jyvu6MbYQFamEnJs9+sptdgtuJcuTlE1plZEMSun3OQ=
 github.com/hyperledger/fabric v1.4.0-rc1.0.20220808214918-83596078d0c3/go.mod h1:owdt10WC1/pKP9Qgayq7Abj/P4I7yPXlJ3fNTCUk4eI=

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -53,12 +53,7 @@ func (a *AuditView) Call(context view.Context) (interface{}, error) {
 	inputs, outputs, err := auditor.Audit(tx)
 	assert.NoError(err, "failed retrieving inputs and outputs")
 	logger.Debugf("AuditView: audit done [%s]", tx.ID())
-
-	// acquire locks on inputs and outputs' enrollment IDs
-	logger.Debugf("AuditView: acquire locks [%s]", tx.ID())
-	assert.NoError(auditor.AcquireLocks(append(inputs.EnrollmentIDs(), outputs.EnrollmentIDs()...)...), "failed acquiring locks")
-	defer auditor.Unlock(append(inputs.EnrollmentIDs(), outputs.EnrollmentIDs()...))
-	logger.Debugf("AuditView: acquire locks done [%s]", tx.ID())
+	defer auditor.Release(tx)
 
 	logger.Debugf("AuditView: [%s] get query executor... ", tx.ID())
 	aqe := auditor.NewQueryExecutor()

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -113,7 +113,7 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	CheckAuditorDB(network, token.TMSID{}, "auditor", "", func(errs []string) error {
 		fmt.Printf("Got errors [%v]", errs)
 		if len(errs) != 4 {
-			return errors.Errorf("expected 8 errors, got [%d]", len(errs))
+			return errors.Errorf("expected 4 errors, got [%d]", len(errs))
 		}
 		for _, err := range errs {
 			if strings.Contains(err, failedClaimTXID) {
@@ -139,7 +139,7 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	CheckAuditorDB(network, token.TMSID{}, "auditor", "", func(errs []string) error {
 		fmt.Printf("Got errors [%v]", errs)
 		if len(errs) != 12 {
-			return errors.Errorf("expected 8 errors, got [%d]", len(errs))
+			return errors.Errorf("expected 12 errors, got [%d]", len(errs))
 		}
 		for _, err := range errs[:4] {
 			if strings.Contains(err, failedClaimTXID) {

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -116,6 +116,7 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 			base64.StdEncoding.EncodeToString(htlc.LockValue(hash)),
 		),
 	)
+	htlcLock(network, defaultTMSID, "alice", "", "USD", 1, "bob", 1*time.Hour, nil, crypto.SHA3_256)
 
 	CheckPublicParams(network, defaultTMSID, "issuer", "auditor", "alice", "bob")
 	CheckOwnerDB(network, defaultTMSID, nil, "issuer", "auditor", "alice", "bob")

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestHTLCSingleNetwork(network *integration.Infrastructure) {
+	defaultTMSID := token.TMSID{}
 	RegisterAuditor(network)
 
 	IssueCash(network, "", "USD", 110, "alice")
@@ -64,13 +65,18 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	Restart(network, "issuer", "auditor", "alice", "bob")
 	RegisterAuditor(network)
 
-	// htlc (lock, reclaim)
-	htlcLock(network, token.TMSID{}, "alice", "", "USD", 10, "bob", 10*time.Second, nil, crypto.SHA512)
+	// htlc (lock, failing claim, reclaim)
+	_, preImage, _ := htlcLock(network, token.TMSID{}, "alice", "", "USD", 10, "bob", 10*time.Second, nil, crypto.SHA512)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "USD", 110, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "EUR", 0, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "EUR", 30, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "USD", 0, 10, 0, -1)
 	time.Sleep(15 * time.Second)
+	CheckBalanceWithLockedAndHolding(network, "alice", "", "USD", 110, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, "alice", "", "EUR", 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, "bob", "", "EUR", 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, "bob", "", "USD", 0, 0, 10, -1)
+	htlcClaim(network, defaultTMSID, "bob", "", preImage, "deadline elapsed")
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "USD", 110, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "EUR", 0, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "EUR", 30, 0, 0, -1)
@@ -83,14 +89,13 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "USD", 0, 0, 0, -1)
 
 	// htlc (lock, claim)
-	defaultTMSID := token.TMSID{}
-	_, preImage, _ := htlcLock(network, defaultTMSID, "alice", "", "USD", 20, "bob", 1*time.Hour, nil, crypto.SHA3_256)
+	_, preImage, _ = htlcLock(network, defaultTMSID, "alice", "", "USD", 20, "bob", 1*time.Hour, nil, crypto.SHA3_256)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "USD", 100, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "EUR", 0, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "EUR", 30, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "USD", 0, 20, 0, -1)
 
-	htlcClaim(network, defaultTMSID, "bob", "", preImage)
+	failedClaimTXID := htlcClaim(network, defaultTMSID, "bob", "", preImage)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "USD", 100, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "alice", "", "EUR", 0, 0, 0, -1)
 	CheckBalanceWithLockedAndHolding(network, "bob", "", "EUR", 30, 0, 0, -1)
@@ -105,7 +110,18 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 
 	CheckPublicParams(network, defaultTMSID, "issuer", "auditor", "alice", "bob")
 	CheckOwnerDB(network, defaultTMSID, nil, "issuer", "auditor", "alice", "bob")
-	CheckAuditorDB(network, token.TMSID{}, "auditor", "", nil)
+	CheckAuditorDB(network, token.TMSID{}, "auditor", "", func(errs []string) error {
+		fmt.Printf("Got errors [%v]", errs)
+		if len(errs) != 4 {
+			return errors.Errorf("expected 8 errors, got [%d]", len(errs))
+		}
+		for _, err := range errs {
+			if strings.Contains(err, failedClaimTXID) {
+				return errors.Errorf("[%s] does not contain [%s]", err, failedClaimTXID)
+			}
+		}
+		return nil
+	})
 
 	// lock two times with the same hash, the second lock should fail
 	_, _, hash := htlcLock(network, defaultTMSID, "alice", "", "USD", 1, "bob", 1*time.Hour, nil, crypto.SHA3_256)
@@ -122,14 +138,19 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure) {
 	CheckOwnerDB(network, defaultTMSID, nil, "issuer", "auditor", "alice", "bob")
 	CheckAuditorDB(network, token.TMSID{}, "auditor", "", func(errs []string) error {
 		fmt.Printf("Got errors [%v]", errs)
-		if len(errs) != 8 {
+		if len(errs) != 12 {
 			return errors.Errorf("expected 8 errors, got [%d]", len(errs))
 		}
+		for _, err := range errs[:4] {
+			if strings.Contains(err, failedClaimTXID) {
+				return errors.Errorf("[%s] does not contain [%s]", err, failedClaimTXID)
+			}
+		}
 		firstError := fmt.Sprintf("transaction record [%s] is unknown for vault but not for the db [%s]", failedLockTXID, auditor.Pending)
-		if errs[0] != firstError {
+		if errs[4] != firstError {
 			return errors.Errorf("expected first error to be [%s], got [%s]", firstError, errs[0])
 		}
-		for _, err := range errs {
+		for _, err := range errs[4:] {
 			if !strings.Contains(err, failedLockTXID) {
 				return errors.Errorf("[%s] does not contain [%s]", err, failedLockTXID)
 			}

--- a/integration/token/interop/views/auditor.go
+++ b/integration/token/interop/views/auditor.go
@@ -40,10 +40,7 @@ func (a *AuditView) Call(context view.Context) (interface{}, error) {
 	// extract inputs and outputs
 	inputs, outputs, err := auditor.Audit(tx)
 	assert.NoError(err, "failed retrieving inputs and outputs")
-
-	// acquire locks on inputs and outputs' enrollment IDs
-	assert.NoError(auditor.AcquireLocks(append(inputs.EnrollmentIDs(), outputs.EnrollmentIDs()...)...), "failed acquiring locks")
-	defer auditor.Unlock(append(inputs.EnrollmentIDs(), outputs.EnrollmentIDs()...))
+	defer auditor.Release(tx)
 
 	// For example, all payments of an amount less than or equal to payment limit is valid
 	eIDs := inputs.EnrollmentIDs()

--- a/integration/token/interop/views/htlc/claim.go
+++ b/integration/token/interop/views/htlc/claim.go
@@ -38,8 +38,12 @@ func (r *ClaimView) Call(context view.Context) (res interface{}, err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			if tx != nil {
-				fmt.Printf("add to err tx id [%s]", tx.ID())
-				err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
+				fmt.Printf("add to err tx id [%s]\n", tx.ID())
+				if err == nil {
+					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), e)
+				} else {
+					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
+				}
 			}
 		}
 	}()

--- a/integration/token/interop/views/htlc/claim.go
+++ b/integration/token/interop/views/htlc/claim.go
@@ -8,7 +8,6 @@ package htlc
 
 import (
 	"encoding/json"
-	"fmt"
 
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
@@ -37,13 +36,14 @@ func (r *ClaimView) Call(context view.Context) (res interface{}, err error) {
 	var tx *htlc.Transaction
 	defer func() {
 		if e := recover(); e != nil {
+			txID := "none"
 			if tx != nil {
-				fmt.Printf("add to err tx id [%s]\n", tx.ID())
-				if err == nil {
-					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), e)
-				} else {
-					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
-				}
+				txID = tx.ID()
+			}
+			if err == nil {
+				err = errors.Errorf("<<<[%s]>>>: %s", txID, e)
+			} else {
+				err = errors.Errorf("<<<[%s]>>>: %s", txID, err)
 			}
 		}
 	}()

--- a/integration/token/interop/views/htlc/lock.go
+++ b/integration/token/interop/views/htlc/lock.go
@@ -58,7 +58,11 @@ func (hv *LockView) Call(context view.Context) (res interface{}, err error) {
 		if e := recover(); e != nil {
 			if tx != nil {
 				fmt.Printf("add to err tx id [%s]", tx.ID())
-				err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
+				if err == nil {
+					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), e)
+				} else {
+					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
+				}
 			}
 		}
 	}()

--- a/integration/token/interop/views/htlc/lock.go
+++ b/integration/token/interop/views/htlc/lock.go
@@ -9,7 +9,6 @@ package htlc
 import (
 	"crypto"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
@@ -56,13 +55,14 @@ func (hv *LockView) Call(context view.Context) (res interface{}, err error) {
 	var tx *htlc.Transaction
 	defer func() {
 		if e := recover(); e != nil {
+			txID := "none"
 			if tx != nil {
-				fmt.Printf("add to err tx id [%s]", tx.ID())
-				if err == nil {
-					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), e)
-				} else {
-					err = errors.Errorf("<<<[%s]>>>: %s", tx.ID(), err)
-				}
+				txID = tx.ID()
+			}
+			if err == nil {
+				err = errors.Errorf("<<<[%s]>>>: %s", txID, e)
+			} else {
+				err = errors.Errorf("<<<[%s]>>>: %s", txID, err)
 			}
 		}
 	}()

--- a/samples/fungible/views/auditor.go
+++ b/samples/fungible/views/auditor.go
@@ -40,6 +40,7 @@ func (a *AuditView) Call(context view.Context) (interface{}, error) {
 
 	inputs, outputs, err := auditor.Audit(tx)
 	assert.NoError(err, "failed retrieving inputs and outputs")
+	defer auditor.Release(tx)
 
 	aqe := auditor.NewQueryExecutor()
 	defer aqe.Done()

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -93,7 +93,7 @@ func (a *Auditor) Audit(tx Transaction) (*token.InputStream, *token.OutputStream
 }
 
 // Append adds the passed transaction to the auditor database.
-// It also releases the locks aquired by Audit.
+// It also releases the locks acquired by Audit.
 func (a *Auditor) Append(tx Transaction) error {
 	defer a.Release(tx)
 

--- a/token/services/interop/htlc/signer.go
+++ b/token/services/interop/htlc/signer.go
@@ -97,11 +97,14 @@ type Verifier struct {
 func (v *Verifier) Verify(msg []byte, sigma []byte) error {
 	// if timeout has not elapsed, only claim is allowed
 	if time.Now().Before(v.Deadline) {
-		cv := &ClaimVerifier{Recipient: v.Recipient, HashInfo: HashInfo{
-			Hash:         v.HashInfo.Hash,
-			HashFunc:     v.HashInfo.HashFunc,
-			HashEncoding: v.HashInfo.HashEncoding,
-		}}
+		cv := &ClaimVerifier{
+			Recipient: v.Recipient,
+			HashInfo: HashInfo{
+				Hash:         v.HashInfo.Hash,
+				HashFunc:     v.HashInfo.HashFunc,
+				HashEncoding: v.HashInfo.HashEncoding,
+			},
+		}
 		if err := cv.Verify(msg, sigma); err != nil {
 			return errors.WithMessagef(err, "failed verifying htlc claim signature")
 		}
@@ -109,7 +112,7 @@ func (v *Verifier) Verify(msg []byte, sigma []byte) error {
 	}
 	// if timeout has elapsed, only a reclaim is possible
 	if err := v.Sender.Verify(msg, sigma); err != nil {
-		return errors.WithMessagef(err, "failed verifying htlc reclaim signature")
+		return errors.WithMessagef(err, "deadline elapsed, failed verifying htlc reclaim signature")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes the audit lock mechanism.
Before, the unlock could be delayed by up 4 minutes if the sender does not send the envelope due to
some failure happening in the meantime.
Now, the locks are released as soon as the auditor approves the transaction.

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>