### PR TITLE
ZKATDLOG: Improved VaultTokenCommitmentLoader

### DIFF
--- a/integration/token/fungible/views/checks.go
+++ b/integration/token/fungible/views/checks.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/pkg/errors"
 )
 
 type CheckTTXDB struct {
@@ -265,6 +266,9 @@ func (c *CheckIfExistsInVaultView) Call(context view.Context) (interface{}, erro
 	var IDs []*token2.ID
 	count := 0
 	assert.NoError(qe.GetTokenCommitments(c.IDs, func(id *token2.ID, tokenRaw []byte) error {
+		if len(tokenRaw) == 0 {
+			return errors.Errorf("token id [%s] is nil", id)
+		}
 		IDs = append(IDs, id)
 		count++
 		return nil

--- a/integration/token/fungible/views/checks.go
+++ b/integration/token/fungible/views/checks.go
@@ -168,7 +168,7 @@ func (m *CheckTTXDBView) Call(context view.Context) (interface{}, error) {
 		} else {
 			assert.Equal(len(unspentTokenIDs), len(ledgerTokenContent))
 			index := 0
-			assert.NoError(v.TokenVault().QueryEngine().GetTokenCommitments(unspentTokenIDs, func(id *token2.ID, tokenRaw []byte) error {
+			assert.NoError(v.TokenVault().QueryEngine().GetTokenOutputs(unspentTokenIDs, func(id *token2.ID, tokenRaw []byte) error {
 				if !bytes.Equal(ledgerTokenContent[index], tokenRaw) {
 					errorMessages = append(errorMessages, fmt.Sprintf("[ow:%s] token content do not match at [%d], [%s]!=[%s]",
 						defaultOwnerWallet.ID(),
@@ -265,7 +265,7 @@ func (c *CheckIfExistsInVaultView) Call(context view.Context) (interface{}, erro
 	qe := vault.TokenVault().QueryEngine()
 	var IDs []*token2.ID
 	count := 0
-	assert.NoError(qe.GetTokenCommitments(c.IDs, func(id *token2.ID, tokenRaw []byte) error {
+	assert.NoError(qe.GetTokenOutputs(c.IDs, func(id *token2.ID, tokenRaw []byte) error {
 		if len(tokenRaw) == 0 {
 			return errors.Errorf("token id [%s] is nil", id)
 		}

--- a/integration/token/interop/support.go
+++ b/integration/token/interop/support.go
@@ -376,7 +376,8 @@ func fastExchange(network *integration.Infrastructure, id string, recipient stri
 		ReclamationDeadline: deadline,
 	}))
 	Expect(err).NotTo(HaveOccurred())
-	time.Sleep(5 * time.Second)
+	// give time to bob to commit the transaction
+	time.Sleep(10 * time.Second)
 }
 
 func scan(network *integration.Infrastructure, id string, hash []byte, hashFunc crypto.Hash, startingTransactionID string, opts ...token.ServiceOption) {

--- a/token/core/zkatdlog/nogh/auditor.go
+++ b/token/core/zkatdlog/nogh/auditor.go
@@ -19,9 +19,9 @@ func (s *Service) AuditorCheck(tokenRequest *driver.TokenRequest, tokenRequestMe
 	logger.Debugf("check token request validity...")
 	var inputTokens [][]*token.Token
 	for _, transfer := range tokenRequestMetadata.Transfers {
-		inputs, err := s.TokenCommitmentLoader.GetTokenCommitments(transfer.TokenIDs)
+		inputs, err := s.TokenCommitmentLoader.GetTokenOutputs(transfer.TokenIDs)
 		if err != nil {
-			return errors.Wrapf(err, "failed getting token commitments to perform auditor check")
+			return errors.Wrapf(err, "failed getting token outputs to perform auditor check")
 		}
 		inputTokens = append(inputTokens, inputs)
 	}

--- a/token/core/zkatdlog/nogh/auditor.go
+++ b/token/core/zkatdlog/nogh/auditor.go
@@ -31,6 +31,9 @@ func (s *Service) AuditorCheck(tokenRequest *driver.TokenRequest, tokenRequestMe
 		return errors.WithMessagef(err, "failed getting deserializer for auditor check")
 	}
 	pp := s.PublicParams()
+	if pp == nil {
+		return errors.Errorf("public parameters not inizialized")
+	}
 	if err := audit.NewAuditor(des, pp.PedParams, pp.IdemixIssuerPK, nil, math.Curves[pp.Curve]).Check(
 		tokenRequest,
 		tokenRequestMetadata,

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package driver
 
 import (
+	"time"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -88,6 +90,7 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 		Channel:   channel,
 		Namespace: namespace,
 	}
+	qe := v.TokenVault().QueryEngine()
 	service, err := zkatdlog.NewTokenService(
 		sp,
 		tmsID,
@@ -95,9 +98,9 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 			crypto.DLogPublicParameters,
 			v.TokenVault().QueryEngine(),
 			zkatdlog.NewPublicParamsLoader(publicParamsFetcher, crypto.DLogPublicParameters)),
-		&zkatdlog.VaultTokenLoader{TokenVault: v.TokenVault().QueryEngine()},
-		&zkatdlog.VaultTokenCommitmentLoader{TokenVault: v.TokenVault().QueryEngine()},
-		v.TokenVault().QueryEngine(),
+		&zkatdlog.VaultTokenLoader{TokenVault: qe},
+		zkatdlog.NewVaultTokenCommitmentLoader(qe, 3, 3*time.Second),
+		qe,
 		identity.NewProvider(sp, zkatdlog.NewEnrollmentIDDeserializer(), wallets),
 		zkatdlog.NewDeserializerProvider().Deserialize,
 		crypto.DLogPublicParameters,

--- a/token/core/zkatdlog/nogh/issuer.go
+++ b/token/core/zkatdlog/nogh/issuer.go
@@ -36,6 +36,9 @@ func (s *Service) Issue(issuerIdentity view.Identity, typ string, values []uint6
 	}
 
 	pp := s.PublicParams()
+	if pp == nil {
+		return nil, nil, nil, errors.Errorf("public parameters not inizialized")
+	}
 	issuer := &nonanonym.Issuer{}
 	issuer.New(typ, &common.WrappedSigningIdentity{
 		Identity: issuerIdentity,
@@ -74,6 +77,9 @@ func (s *Service) VerifyIssue(ia driver.IssueAction, outputsMetadata [][]byte) e
 		return errors.New("failed to verify issue: expected *zkatdlog.IssueAction")
 	}
 	pp := s.PublicParams()
+	if pp == nil {
+		return errors.Errorf("public parameters not inizialized")
+	}
 	coms, err := action.GetCommitments()
 	if err != nil {
 		return errors.New("failed to verify issue")

--- a/token/core/zkatdlog/nogh/loaders.go
+++ b/token/core/zkatdlog/nogh/loaders.go
@@ -77,6 +77,9 @@ func (s *VaultTokenCommitmentLoader) GetTokenOutputs(ids []*token3.ID) ([]*token
 
 			return nil, errors.Wrapf(err, "failed to get token outputs")
 		}
+
+		// The execution was successful, we can stop
+		break
 	}
 
 	return tokens, nil

--- a/token/core/zkatdlog/nogh/loaders.go
+++ b/token/core/zkatdlog/nogh/loaders.go
@@ -26,7 +26,7 @@ type TokenVault interface {
 
 type VaultTokenCommitmentLoader struct {
 	TokenVault TokenVault
-	// Variable used to control retry condition
+	// Variables used to control retry condition
 	NumRetries int
 	RetryDelay time.Duration
 }
@@ -42,11 +42,11 @@ func (s *VaultTokenCommitmentLoader) GetTokenOutputs(ids []*token3.ID) ([]*token
 	for i := 0; i < s.NumRetries; i++ {
 		if err := s.TokenVault.GetTokenOutputs(ids, func(id *token3.ID, bytes []byte) error {
 			if len(bytes) == 0 {
-				return errors.Errorf("failed getting state for id [%v], nil value", id)
+				return errors.Errorf("failed getting serialized token output for id [%v], nil value", id)
 			}
 			ti := &token.Token{}
 			if err := ti.Deserialize(bytes); err != nil {
-				return errors.Wrapf(err, "failed deserializeing token for id [%v][%s]", id, string(bytes))
+				return errors.Wrapf(err, "failed deserializing token for id [%v][%s]", id, string(bytes))
 			}
 			tokens = append(tokens, ti)
 			return nil
@@ -60,7 +60,7 @@ func (s *VaultTokenCommitmentLoader) GetTokenOutputs(ids []*token3.ID) ([]*token
 					break
 				}
 				if pending {
-					logger.Warnf("cannot get state for id [%d] because the relative transaction is pending, retry at [%d]", id, i)
+					logger.Warnf("failed getting serialized token output for id [%v] because the relative transaction is pending, retry at [%d]", id, i)
 					if i == s.NumRetries-1 {
 						return nil, errors.Wrapf(err, "failed to get token outputs, tx [%s] is still pending", id.TxId)
 					}

--- a/token/core/zkatdlog/nogh/sender.go
+++ b/token/core/zkatdlog/nogh/sender.go
@@ -30,6 +30,9 @@ func (s *Service) Transfer(txID string, wallet driver.OwnerWallet, ids []*token3
 		return nil, nil, errors.Wrapf(err, "failed to load tokens")
 	}
 	pp := s.PublicParams()
+	if pp == nil {
+		return nil, nil, errors.Errorf("public parameters not inizialized")
+	}
 	for _, id := range signerIds {
 		// get signers for each input token
 		si, err := s.identityProvider.GetSigner(id)
@@ -152,6 +155,9 @@ func (s *Service) VerifyTransfer(action driver.TransferAction, outputsMetadata [
 
 	// get commitments from outputs
 	pp := s.PublicParams()
+	if pp == nil {
+		return errors.Errorf("public parameters not inizialized")
+	}
 	com := make([]*math.G1, len(tr.OutputTokens))
 	for i := 0; i < len(tr.OutputTokens); i++ {
 		com[i] = tr.OutputTokens[i].Data

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -118,6 +118,9 @@ func (s *Service) DeserializeToken(tok []byte, infoRaw []byte) (*token3.Token, v
 		return nil, nil, errors.Wrap(err, "failed to deserialize token information")
 	}
 	pp := s.PublicParams()
+	if pp == nil {
+		return nil, nil, errors.Errorf("public parameters not inizialized")
+	}
 	to, err := output.GetTokenInTheClear(ti, pp)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to deserialize token")
@@ -138,6 +141,9 @@ func (s *Service) Validator() (driver.Validator, error) {
 		return nil, errors.WithMessagef(err, "failed to get deserializer")
 	}
 	pp := s.PublicParams()
+	if pp == nil {
+		return nil, errors.Errorf("public parameters not inizialized")
+	}
 	return validator.New(pp, d), nil
 }
 
@@ -162,6 +168,9 @@ func (s *Service) LoadPublicParams() error {
 
 func (s *Service) Deserializer() (driver.Deserializer, error) {
 	pp := s.PublicParams()
+	if pp == nil {
+		return nil, errors.Errorf("public parameters not inizialized")
+	}
 	d, err := s.DeserializerProvider(pp)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get deserializer")

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -25,6 +25,7 @@ type TokenCommitmentLoader interface {
 }
 
 type QueryEngine interface {
+	// IsPending returns true if the transaction the passed id refers to is still pending, false otherwise
 	IsPending(id *token3.ID) (bool, error)
 	IsMine(id *token3.ID) (bool, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -21,10 +21,11 @@ import (
 )
 
 type TokenCommitmentLoader interface {
-	GetTokenCommitments(ids []*token3.ID) ([]*token.Token, error)
+	GetTokenOutputs(ids []*token3.ID) ([]*token.Token, error)
 }
 
 type QueryEngine interface {
+	IsPending(id *token3.ID) (bool, error)
 	IsMine(id *token3.ID) (bool, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.
 	// The token type can be empty. In that case, tokens of any type are returned.

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -29,6 +29,8 @@ type CertificationStorage interface {
 }
 
 type QueryEngine interface {
+	// IsPending returns true if the transaction the passed id refers to is still pending, false otherwise
+	IsPending(id *token.ID) (bool, error)
 	// IsMine returns true if the passed id is owned by any known wallet
 	IsMine(id *token.ID) (bool, error)
 	// UnspentTokensIterator returns an iterator over all unspent tokens
@@ -47,11 +49,11 @@ type QueryEngine interface {
 	// GetTokenInfos retrieves the token information for the passed ids.
 	// For each id, the callback is invoked to unmarshal the token information
 	GetTokenInfos(ids []*token.ID, callback QueryCallbackFunc) error
-	// GetTokenCommitments retrieves the token commitments for the passed ids.
-	// For each id, the callback is invoked to unmarshal the token commitment
-	GetTokenCommitments(ids []*token.ID, callback QueryCallbackFunc) error
-
-	GetTokenInfoAndCommitments(ids []*token.ID, callback QueryCallback2Func) error
+	// GetTokenOutputs retrieves the token output as stored on the ledger for the passed ids.
+	// For each id, the callback is invoked to unmarshal the output
+	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
+	// GetTokenInfoAndOutputs retrieves both the token output and information the passed ids.
+	GetTokenInfoAndOutputs(ids []*token.ID, callback QueryCallback2Func) error
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]string, []*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -52,7 +52,7 @@ type QueryEngine interface {
 	// GetTokenOutputs retrieves the token output as stored on the ledger for the passed ids.
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
-	// GetTokenInfoAndOutputs retrieves both the token output and information the passed ids.
+	// GetTokenInfoAndOutputs retrieves both the token output and information for the passed ids.
 	GetTokenInfoAndOutputs(ids []*token.ID, callback QueryCallback2Func) error
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]string, []*token.Token, error)

--- a/token/services/certifier/interactive/service.go
+++ b/token/services/certifier/interactive/service.go
@@ -56,7 +56,7 @@ func (c *CertificationService) Call(context view.Context) (interface{}, error) {
 
 	// TODO: 2. validate request, if needed
 
-	// 3. invoke chaincode to get token commitment
+	// 3. invoke chaincode to get token outputs
 	logger.Debugf("invoke chaincode to get commitments for [%v]", cr.IDs)
 	// TODO: if the certifier fetches all token transactions, it might have the tokens in its on vault.
 	tokensBoxed, err := context.RunView(tcc.NewGetTokensView(cr.Channel, cr.Namespace, cr.IDs...))
@@ -69,7 +69,7 @@ func (c *CertificationService) Call(context view.Context) (interface{}, error) {
 		return nil, errors.Errorf("expected [][]byte, got [%T]", tokens)
 	}
 
-	// 4. certify token commitment
+	// 4. certify token output
 	logger.Debugf("certify commitments for [%v]...", cr.IDs)
 	tms := token2.GetManagementService(
 		context,

--- a/token/services/network/fabric/vault.go
+++ b/token/services/network/fabric/vault.go
@@ -72,6 +72,11 @@ func (v *Vault) DeleteTokens(ns string, ids ...*token.ID) error {
 	return nil
 }
 
+func (v *Vault) TransactionStatus(txID string) (driver.ValidationCode, error) {
+	vc, _, err := v.ch.Vault().Status(txID)
+	return driver.ValidationCode(vc), err
+}
+
 type Executor struct {
 	qe *fabric.QueryExecutor
 }

--- a/token/services/network/orion/vault.go
+++ b/token/services/network/orion/vault.go
@@ -69,6 +69,11 @@ func (v *Vault) DeleteTokens(ns string, ids ...*token.ID) error {
 	return nil
 }
 
+func (v *Vault) TransactionStatus(txID string) (driver.ValidationCode, error) {
+	vc, err := v.ons.Vault().Status(txID)
+	return driver.ValidationCode(vc), err
+}
+
 type Executor struct {
 	qe *orion.QueryExecutor
 }

--- a/token/services/vault/driver/driver.go
+++ b/token/services/vault/driver/driver.go
@@ -8,6 +8,17 @@ package driver
 
 import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
+type ValidationCode int
+
+const (
+	_               ValidationCode = iota
+	Valid                          // Transaction is valid and committed
+	Invalid                        // Transaction is invalid and has been discarded
+	Busy                           // Transaction does not yet have a validity state
+	Unknown                        // Transaction is unknown
+	HasDependencies                // Transaction is unknown but has known dependencies
+)
+
 // RWSet interface, used to read from, and write to, a rwset.
 type RWSet interface {
 	SetState(namespace string, key string, value []byte) error
@@ -35,4 +46,5 @@ type Executor interface {
 type Vault interface {
 	NewQueryExecutor() (Executor, error)
 	DeleteTokens(ns string, ids ...*token.ID) error
+	TransactionStatus(txID string) (ValidationCode, error)
 }

--- a/token/services/vault/query/query.go
+++ b/token/services/vault/query/query.go
@@ -8,7 +8,6 @@ package query
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	driver2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -30,8 +29,6 @@ type Engine struct {
 	namespace string
 
 	unspentTokensCache cache
-	GetStatNumRetries  int
-	GetStateRetryDelay time.Duration
 }
 
 func NewEngine(vault driver.Vault, namespace string, cache cache) *Engine {
@@ -39,9 +36,15 @@ func NewEngine(vault driver.Vault, namespace string, cache cache) *Engine {
 		Vault:              vault,
 		namespace:          namespace,
 		unspentTokensCache: cache,
-		GetStatNumRetries:  3,
-		GetStateRetryDelay: 5 * time.Second,
 	}
+}
+
+func (e *Engine) IsPending(id *token.ID) (bool, error) {
+	vc, err := e.Vault.TransactionStatus(id.TxId)
+	if err != nil {
+		return false, err
+	}
+	return vc == driver.Busy, nil
 }
 
 func (e *Engine) IsMine(id *token.ID) (bool, error) {
@@ -310,23 +313,19 @@ func (e *Engine) GetTokenInfos(ids []*token.ID, callback driver2.QueryCallbackFu
 	return nil
 }
 
-func (e *Engine) GetTokenCommitments(ids []*token.ID, callback driver2.QueryCallbackFunc) error {
+func (e *Engine) GetTokenOutputs(ids []*token.ID, callback driver2.QueryCallbackFunc) error {
 	qe, err := e.Vault.NewQueryExecutor()
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if qe != nil {
-			qe.Done()
-		}
-	}()
+	defer qe.Done()
+
 	for _, id := range ids {
 		outputID, err := keys.CreateTokenKey(id.TxId, id.Index)
 		if err != nil {
 			return errors.Wrapf(err, "error creating output ID: %v", id)
 		}
-		var val []byte
-		qe, val, err = e.getState(qe, e.namespace, outputID, id)
+		val, err := qe.GetState(e.namespace, outputID)
 		if err != nil {
 			return errors.Wrapf(err, "failed getting state for id [%v]", id)
 		}
@@ -337,7 +336,7 @@ func (e *Engine) GetTokenCommitments(ids []*token.ID, callback driver2.QueryCall
 	return nil
 }
 
-func (e *Engine) GetTokenInfoAndCommitments(ids []*token.ID, callback driver2.QueryCallback2Func) error {
+func (e *Engine) GetTokenInfoAndOutputs(ids []*token.ID, callback driver2.QueryCallback2Func) error {
 	qe, err := e.Vault.NewQueryExecutor()
 	if err != nil {
 		return err
@@ -475,46 +474,6 @@ func (e *Engine) unmarshalUnspentToken(key string, raw []byte, extended bool) (*
 	// store in cache and return
 	e.unspentTokensCache.Add(key, ut)
 	return ut, nil
-}
-
-func (e *Engine) getState(qe driver.Executor, namespace, key string, id *token.ID) (driver.Executor, []byte, error) {
-	var val []byte
-	var err error
-	for i := 0; i < e.GetStatNumRetries; i++ {
-		val, err = qe.GetState(namespace, key)
-		if err != nil {
-			// check the transaction status
-			vc, tsErr := e.Vault.TransactionStatus(id.TxId)
-			logger.Warnf("cannot get state for id [%d] because transaction's status is [%d:%s], retry at [%d]", id, vc, tsErr, i)
-			if i == e.GetStatNumRetries-1 || vc != driver.Busy {
-				return qe, nil, errors.Wrapf(err, "failed getting state for id [%v], transaction's status is [%d:%s]", id, vc, tsErr)
-			}
-			qe.Done()
-			qe, err = e.Vault.NewQueryExecutor()
-			if err != nil {
-				return nil, nil, err
-			}
-			time.Sleep(e.GetStateRetryDelay)
-			continue
-		}
-		if len(val) == 0 {
-			// check the transaction status
-			vc, tsErr := e.Vault.TransactionStatus(id.TxId)
-			logger.Warnf("nil state value for id [%d] because transaction's status is [%d:%s], retry at [%d]", id, vc, tsErr, i)
-			if i == e.GetStatNumRetries-1 || vc != driver.Busy {
-				return qe, nil, errors.Wrapf(err, "found empty state for id [%v], transaction's status is [%d:%s]", id, vc, tsErr)
-			}
-			qe.Done()
-			qe, err = e.Vault.NewQueryExecutor()
-			if err != nil {
-				return nil, nil, err
-			}
-			time.Sleep(e.GetStateRetryDelay)
-			continue
-		}
-		break
-	}
-	return qe, val, err
 }
 
 type UnspentTokensIterator struct {

--- a/token/vault.go
+++ b/token/vault.go
@@ -7,13 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
+	"time"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/pkg/errors"
 )
 
 // QueryEngine models a token query engine
 type QueryEngine struct {
 	qe driver.QueryEngine
+
+	// Variable used to control retry condition
+	NumRetries int
+	RetryDelay time.Duration
+}
+
+func NewQueryEngine(qe driver.QueryEngine, numRetries int, retryDelay time.Duration) *QueryEngine {
+	return &QueryEngine{qe: qe, NumRetries: numRetries, RetryDelay: retryDelay}
 }
 
 // IsMine returns true is the given token is in this vault and therefore owned by this client
@@ -45,7 +56,45 @@ func (q *QueryEngine) ListUnspentTokens() (*token2.UnspentTokens, error) {
 }
 
 func (q *QueryEngine) ListAuditTokens(ids ...*token2.ID) ([]*token2.Token, error) {
-	return q.qe.ListAuditTokens(ids...)
+	var tokens []*token2.Token
+	var err error
+
+	for i := 0; i < q.NumRetries; i++ {
+		tokens, err = q.qe.ListAuditTokens(ids...)
+
+		if err != nil {
+			// check if there is any token id whose corresponding transaction is pending
+			// if there is, then wait a bit and retry to load the outputs
+			retry := false
+			for _, id := range ids {
+				pending, err := q.qe.IsPending(id)
+				if err != nil {
+					break
+				}
+				if pending {
+					logger.Warnf("cannot get audit token for id [%d] because the relative transaction is pending, retry at [%d]", id, i)
+					if i == q.NumRetries-1 {
+						return nil, errors.Wrapf(err, "failed to get audit tokens, tx [%s] is still pending", id.TxId)
+					}
+					time.Sleep(q.RetryDelay)
+					retry = true
+					break
+				}
+			}
+
+			if retry {
+				tokens = nil
+				continue
+			}
+
+			return nil, errors.Wrapf(err, "failed to get audit tokens")
+		}
+
+		// The execution was successful, we can stop
+		break
+	}
+
+	return tokens, nil
 }
 
 func (q *QueryEngine) ListHistoryIssuedTokens() (*token2.IssuedTokens, error) {
@@ -70,9 +119,7 @@ type Vault struct {
 
 // NewQueryEngine returns a new query engine
 func (v *Vault) NewQueryEngine() *QueryEngine {
-	return &QueryEngine{
-		qe: v.v.QueryEngine(),
-	}
+	return NewQueryEngine(v.v.QueryEngine(), 3, 3*time.Second)
 }
 
 // UnspentTokensIterator models an iterator over all unspent tokens stored in the vault

--- a/token/vault.go
+++ b/token/vault.go
@@ -18,7 +18,7 @@ import (
 type QueryEngine struct {
 	qe driver.QueryEngine
 
-	// Variable used to control retry condition
+	// Variables used to control retry condition
 	NumRetries int
 	RetryDelay time.Duration
 }


### PR DESCRIPTION
The current loader fails if the commitment of a given token does not exists, but it might be that the corresponding transaction is still pending. This means that the commit pipeline hasn't had time to process the transaction yet.

This PR improves the loader by adding the possibility to retry after some time. 

Signed-off-by: Angelo De Caro <adc@zurich.ibm.com>