### PR TITLE
fabric-ca support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,7 @@ jobs:
         tests: [
           dlog-fabric-t1,
           dlog-fabric-t2,
+          dlog-fabric-t3,
           fabtoken-dlog-fabric,
           dloghsm-fabric-t1,
           dloghsm-fabric-t2,

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # pinned versions
 FABRIC_VERSION ?= 2.5.0
+FABRIC_CA_VERSION ?= 1.5.6
 FABRIC_TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VERSION) | cut -d '.' -f 1,2)
 ORION_VERSION=v0.2.5
 
@@ -24,7 +25,7 @@ install-tools:
 
 .PHONY: download-fabric
 download-fabric:
-	./ci/scripts/download_fabric.sh $(FABRIC_BINARY_BASE) $(FABRIC_VERSION)
+	./ci/scripts/download_fabric.sh $(FABRIC_BINARY_BASE) $(FABRIC_VERSION) $(FABRIC_CA_VERSION)
 
 # include the checks target
 include $(TOP)/checks.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # pinned versions
 FABRIC_VERSION ?= 2.5.0
-FABRIC_CA_VERSION ?= 1.5.6
+FABRIC_CA_VERSION ?= 1.5.7
 FABRIC_TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VERSION) | cut -d '.' -f 1,2)
 ORION_VERSION=v0.2.5
 

--- a/fungible.mk
+++ b/fungible.mk
@@ -10,6 +10,10 @@ integration-tests-dlog-fabric-t1:
 integration-tests-dlog-fabric-t2:
 	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "Fungible with Auditor = Issuer" .
 
+.PHONY: integration-tests-dlog-fabric-t3
+integration-tests-dlog-fabric-t3:
+	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "Fungible with Auditor ne Issuer + Fabric CA" .
+
 .PHONY: integration-tests-fabtoken-dlog-fabric
 integration-tests-fabtoken-dlog-fabric:
 	cd ./integration/token/fungible/mixed; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) .

--- a/integration/nwo/token/fabric/ca.go
+++ b/integration/nwo/token/fabric/ca.go
@@ -11,23 +11,32 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/runner"
+	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/generators"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
 	"github.com/tedsuo/ifrit"
 	"github.com/tedsuo/ifrit/grouper"
 )
 
-type CAFactory = func(string) (CA, error)
+type CAFactory = func(generators.TokenPlatform, *topology.TMS, string) (CA, error)
 
 type CA interface {
 	Start() error
+	Stop()
+	Gen(owner string) (string, error)
 }
 
 type CAServer struct {
@@ -46,16 +55,81 @@ func (c CAServer) Args() []string {
 	}
 }
 
+type CAClientRegister struct {
+	NetworkPrefix  string
+	CAServerURL    string
+	CAName         string
+	IDName         string
+	IDSecret       string
+	IDType         string
+	EnrollmentType string
+	IdemixCurve    string
+	MSPDir         string
+}
+
+func (c CAClientRegister) SessionName() string {
+	return c.NetworkPrefix + "-fabric-ca-client-register"
+}
+
+func (c CAClientRegister) Args() []string {
+	return []string{
+		"register",
+		"-d",
+		"--mspdir", c.MSPDir,
+		"-u", c.CAServerURL,
+		"--caname", c.CAName,
+		"--id.name", c.IDName,
+		"--id.secret", c.IDSecret,
+		"--id.type", c.IDType,
+		"--enrollment.type", c.EnrollmentType,
+		"--idemix.curve", c.IdemixCurve,
+	}
+}
+
+type CAClientEnroll struct {
+	NetworkPrefix  string
+	Home           string
+	CAServerURL    string
+	CAName         string
+	Output         string
+	EnrollmentType string
+	IdemixCurve    string
+}
+
+func (c CAClientEnroll) SessionName() string {
+	return c.NetworkPrefix + "-fabric-ca-server"
+}
+
+func (c CAClientEnroll) Args() []string {
+	return []string{
+		"enroll",
+		"-d",
+		"--home", c.Home,
+		"-u", c.CAServerURL,
+		"--caname", c.CAName,
+		"-M", c.Output,
+		"--enrollment.type", c.EnrollmentType,
+		"--idemix.curve", c.IdemixCurve,
+	}
+}
+
 type IdemixCASupport struct {
 	IssuerCryptoMaterialPath string
 	ColorIndex               int
 	StartEventuallyTimeout   time.Duration
+	EventuallyTimeout        time.Duration
+	process                  ifrit.Process
+	TokenPlatform            generators.TokenPlatform
+	TMS                      *topology.TMS
 }
 
-func NewIdemixCASupport(issuerCryptoMaterialPath string) (CA, error) {
+func NewIdemixCASupport(tokenPlatform generators.TokenPlatform, tms *topology.TMS, issuerCryptoMaterialPath string) (CA, error) {
 	return &IdemixCASupport{
 		IssuerCryptoMaterialPath: issuerCryptoMaterialPath,
 		StartEventuallyTimeout:   1 * time.Minute,
+		EventuallyTimeout:        1 * time.Minute,
+		TokenPlatform:            tokenPlatform,
+		TMS:                      tms,
 	}, nil
 }
 
@@ -65,11 +139,11 @@ func (i *IdemixCASupport) Start() error {
 		return errors.Wrap(err, "failed to generate fabric-ca-server configuration")
 	}
 
-	// start
+	// start fabric-ca-server
 	fabricCAServerExePath := findCmdAtEnv(fabricCaServerCMD)
 	command := &CAServer{
 		NetworkPrefix: "",
-		ConfigPath:    filepath.Join(i.IssuerCryptoMaterialPath, "ca", "fabric-ca-server.yaml"),
+		ConfigPath:    filepath.Join(i.IssuerCryptoMaterialPath, "fabric-ca-server", "fabric-ca-server.yaml"),
 	}
 	cmd := common.NewCommand(fabricCAServerExePath, command)
 
@@ -82,14 +156,89 @@ func (i *IdemixCASupport) Start() error {
 	}
 	members := grouper.Members{}
 	members = append(members, grouper.Member{Name: command.SessionName(), Runner: runner.New(config)})
-	process := ifrit.Invoke(grouper.NewOrdered(syscall.SIGTERM, members))
-	Eventually(process.Ready(), i.StartEventuallyTimeout).Should(BeClosed(), "fabric-ca-server didn't start timely")
+	i.process = ifrit.Invoke(grouper.NewOrdered(syscall.SIGTERM, members))
+	Eventually(i.process.Ready(), i.StartEventuallyTimeout).Should(BeClosed(), "fabric-ca-server didn't start timely")
+
+	// enroll admin
+	caName := i.TMS.ID() + ".example.com"
+	fabricCAClientExePath := findCmdAtEnv(fabricCaClientCMD)
+	enrollCommand := &CAClientEnroll{
+		Home:        "",
+		CAServerURL: fmt.Sprintf("http://%s:%s@localhost:7054", "admin", "adminpw"),
+		CAName:      caName,
+		Output:      filepath.Join(i.IssuerCryptoMaterialPath, "fabric-ca-server", "admin", "msp"),
+	}
+	cmd = common.NewCommand(fabricCAClientExePath, enrollCommand)
+	sess, err := i.StartSession(cmd, enrollCommand.SessionName())
+	if err != nil {
+		return errors.Wrap(err, "failed to start admin enrollment")
+	}
+	Eventually(sess, i.EventuallyTimeout).Should(gexec.Exit(0))
 
 	return nil
 }
 
+func (i *IdemixCASupport) Stop() {
+	if i.process != nil {
+		i.process.Signal(syscall.SIGTERM)
+	}
+}
+
+func (i *IdemixCASupport) Gen(owner string) (string, error) {
+	//fabric-ca-client register --caname ca-org1 --id.name owner1a --id.secret password --id.type client --enrollment.type idemix --idemix.curve gurvy.Bn254 --tls.certfiles "${CERT_FILES}"
+	//fabric-ca-client enroll -u https://owner1a:password@localhost:7054 --caname ca-org1  -M "${PWD}/keys/owner1/wallet/owner1a/msp" --enrollment.type idemix --idemix.curve gurvy.Bn254 --tls.certfiles "${CERT_FILES}"
+
+	tmsID := i.TMS.ID()
+	logger.Debugf("Generating owner identity [%s] for [%s]", owner, tmsID)
+	userOutput := filepath.Join(i.TokenPlatform.TokenDir(), "crypto", tmsID, "idemix", owner)
+	if err := os.MkdirAll(userOutput, 0766); err != nil {
+		return "", nil
+	}
+
+	caName := tmsID + ".example.com"
+	fabricCAClientExePath := findCmdAtEnv(fabricCaClientCMD)
+
+	// register
+	registerCommand := &CAClientRegister{
+		MSPDir:         filepath.Join(i.IssuerCryptoMaterialPath, "fabric-ca-server", "admin", "msp"),
+		CAServerURL:    fmt.Sprintf("http://localhost:%s", "7054"),
+		CAName:         caName,
+		IDName:         owner,
+		IDSecret:       "password",
+		IDType:         "client",
+		EnrollmentType: "idemix",
+		IdemixCurve:    "gurvy.Bn254",
+	}
+	cmd := common.NewCommand(fabricCAClientExePath, registerCommand)
+	sess, err := i.StartSession(cmd, registerCommand.SessionName())
+	if err != nil {
+		return "", err
+	}
+	Eventually(sess, i.EventuallyTimeout).Should(gexec.Exit(0))
+
+	enrollCommand := &CAClientEnroll{
+		Home:           "",
+		CAServerURL:    fmt.Sprintf("http://%s:%s@localhost:7054", registerCommand.IDName, registerCommand.IDSecret),
+		CAName:         caName,
+		Output:         userOutput,
+		EnrollmentType: "idemix",
+		IdemixCurve:    "gurvy.Bn254",
+	}
+	cmd = common.NewCommand(fabricCAClientExePath, enrollCommand)
+	sess, err = i.StartSession(cmd, enrollCommand.SessionName())
+	if err != nil {
+		return "", err
+	}
+	Eventually(sess, i.EventuallyTimeout).Should(gexec.Exit(0))
+
+	return userOutput, nil
+}
+
 func (i *IdemixCASupport) GenerateConfiguration() error {
 	t, err := template.New("fabric-ca-server").Funcs(template.FuncMap{
+		"caname": func() string {
+			return i.TMS.ID() + ".example.com"
+		},
 		"issuerpublickeyfile": func() string {
 			return filepath.Join(i.IssuerCryptoMaterialPath, "ca", "IssuerPublicKey")
 		},
@@ -110,10 +259,36 @@ func (i *IdemixCASupport) GenerateConfiguration() error {
 	if err := t.Execute(io.MultiWriter(ext), i); err != nil {
 		return errors.Wrap(err, "failed to generate fabric-ca-server configuration")
 	}
-	if err := os.WriteFile(filepath.Join(i.IssuerCryptoMaterialPath, "ca", "fabric-ca-server.yaml"), ext.Bytes(), 0766); err != nil {
+	if err := os.MkdirAll(filepath.Join(i.IssuerCryptoMaterialPath, "fabric-ca-server"), 0766); err != nil {
+		return errors.Wrap(err, "failed to create fabric-ca-server configuration folder")
+	}
+	if err := os.WriteFile(filepath.Join(i.IssuerCryptoMaterialPath, "fabric-ca-server", "fabric-ca-server.yaml"), ext.Bytes(), 0766); err != nil {
 		return errors.Wrap(err, "failed to write fabric-ca-server configuration")
 	}
 	return nil
+}
+
+func (i *IdemixCASupport) StartSession(cmd *exec.Cmd, name string) (*gexec.Session, error) {
+	ansiColorCode := i.nextColor()
+	fmt.Fprintf(
+		ginkgo.GinkgoWriter,
+		"\x1b[33m[d]\x1b[%s[%s]\x1b[0m starting %s %s\n",
+		ansiColorCode,
+		name,
+		filepath.Base(cmd.Args[0]),
+		strings.Join(cmd.Args[1:], " "),
+	)
+	return gexec.Start(
+		cmd,
+		gexec.NewPrefixedWriter(
+			fmt.Sprintf("\x1b[32m[o]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
+			ginkgo.GinkgoWriter,
+		),
+		gexec.NewPrefixedWriter(
+			fmt.Sprintf("\x1b[91m[e]\x1b[%s[%s]\x1b[0m ", ansiColorCode, name),
+			ginkgo.GinkgoWriter,
+		),
+	)
 }
 
 func (i *IdemixCASupport) nextColor() string {

--- a/integration/nwo/token/fabric/ca.go
+++ b/integration/nwo/token/fabric/ca.go
@@ -1,0 +1,127 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"text/template"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common/runner"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"github.com/tedsuo/ifrit"
+	"github.com/tedsuo/ifrit/grouper"
+)
+
+type CAFactory = func(string) (CA, error)
+
+type CA interface {
+	Start() error
+}
+
+type CAServer struct {
+	NetworkPrefix string
+	ConfigPath    string
+}
+
+func (c CAServer) SessionName() string {
+	return c.NetworkPrefix + "-fabric-ca-server"
+}
+
+func (c CAServer) Args() []string {
+	return []string{
+		"start",
+		"--config", c.ConfigPath,
+	}
+}
+
+type IdemixCASupport struct {
+	IssuerCryptoMaterialPath string
+	ColorIndex               int
+	StartEventuallyTimeout   time.Duration
+}
+
+func NewIdemixCASupport(issuerCryptoMaterialPath string) (CA, error) {
+	return &IdemixCASupport{
+		IssuerCryptoMaterialPath: issuerCryptoMaterialPath,
+		StartEventuallyTimeout:   1 * time.Minute,
+	}, nil
+}
+
+func (i *IdemixCASupport) Start() error {
+	// generate configuration
+	if err := i.GenerateConfiguration(); err != nil {
+		return errors.Wrap(err, "failed to generate fabric-ca-server configuration")
+	}
+
+	// start
+	fabricCAServerExePath := findCmdAtEnv(fabricCaServerCMD)
+	command := &CAServer{
+		NetworkPrefix: "",
+		ConfigPath:    filepath.Join(i.IssuerCryptoMaterialPath, "ca", "fabric-ca-server.yaml"),
+	}
+	cmd := common.NewCommand(fabricCAServerExePath, command)
+
+	config := runner.Config{
+		AnsiColorCode:     i.nextColor(),
+		Name:              command.SessionName(),
+		Command:           cmd,
+		StartCheck:        `Listening on .*`,
+		StartCheckTimeout: 1 * time.Minute,
+	}
+	members := grouper.Members{}
+	members = append(members, grouper.Member{Name: command.SessionName(), Runner: runner.New(config)})
+	process := ifrit.Invoke(grouper.NewOrdered(syscall.SIGTERM, members))
+	Eventually(process.Ready(), i.StartEventuallyTimeout).Should(BeClosed(), "fabric-ca-server didn't start timely")
+
+	return nil
+}
+
+func (i *IdemixCASupport) GenerateConfiguration() error {
+	t, err := template.New("fabric-ca-server").Funcs(template.FuncMap{
+		"issuerpublickeyfile": func() string {
+			return filepath.Join(i.IssuerCryptoMaterialPath, "ca", "IssuerPublicKey")
+		},
+		"issuersecretkeyfile": func() string {
+			return filepath.Join(i.IssuerCryptoMaterialPath, "ca", "IssuerSecretKey")
+		},
+		"revocationpublickeyfile": func() string {
+			return filepath.Join(i.IssuerCryptoMaterialPath, "msp", "RevocationPublicKey")
+		},
+		"revocationprivatekeyfile": func() string {
+			return filepath.Join(i.IssuerCryptoMaterialPath, "ca", "RevocationKey")
+		},
+	}).Parse(CACfgTemplate)
+	if err != nil {
+		return errors.Wrap(err, "failed to prepare fabric-ca-server configuration template")
+	}
+	ext := bytes.NewBufferString("")
+	if err := t.Execute(io.MultiWriter(ext), i); err != nil {
+		return errors.Wrap(err, "failed to generate fabric-ca-server configuration")
+	}
+	if err := os.WriteFile(filepath.Join(i.IssuerCryptoMaterialPath, "ca", "fabric-ca-server.yaml"), ext.Bytes(), 0766); err != nil {
+		return errors.Wrap(err, "failed to write fabric-ca-server configuration")
+	}
+	return nil
+}
+
+func (i *IdemixCASupport) nextColor() string {
+	color := i.ColorIndex%14 + 31
+	if color > 37 {
+		color = color + 90 - 37
+	}
+
+	i.ColorIndex++
+	return fmt.Sprintf("%dm", color)
+}

--- a/integration/nwo/token/fabric/fabric.go
+++ b/integration/nwo/token/fabric/fabric.go
@@ -156,11 +156,13 @@ func (p *NetworkHandler) GenerateArtifacts(tms *topology2.TMS) {
 	}
 
 	// Prepare CA, if needed
-	caFactory, found := p.CASupports[tms.Driver]
-	if found {
-		ca, err := caFactory(p.TokenPlatform, tms, root)
-		Expect(err).ToNot(HaveOccurred(), "failed to instantiate CA for [%s]", tms.ID())
-		entry.CA = ca
+	if IsFabricCA(tms) {
+		caFactory, found := p.CASupports[tms.Driver]
+		if found {
+			ca, err := caFactory(p.TokenPlatform, tms, root)
+			Expect(err).ToNot(HaveOccurred(), "failed to instantiate CA for [%s]", tms.ID())
+			entry.CA = ca
+		}
 	}
 
 	entry.TCC = &TCC{Chaincode: chaincode}

--- a/integration/nwo/token/fabric/opts.go
+++ b/integration/nwo/token/fabric/opts.go
@@ -1,0 +1,23 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+
+// WithFabricCA notify the backend to activate fabric-ca for the issuance of identities
+func WithFabricCA(tms *topology.TMS) {
+	tms.BackendParams["fabricca"] = true
+}
+
+// IsFabricCA return true if this TMS requires to enable Fabric-CA
+func IsFabricCA(tms *topology.TMS) bool {
+	boxed, ok := tms.BackendParams["fabricca"]
+	if ok {
+		return boxed.(bool)
+	}
+	return false
+}

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -138,7 +138,7 @@ token:
 version: v1.5.6
 
 # Server's listening port (default: 7054)
-port: 7054
+port: {{ Port }}
 
 # Cross-Origin Resource Sharing (CORS)
 cors:
@@ -451,11 +451,6 @@ idemix:
   # It can be any of: {"amcl.Fp256bn", "gurvy.Bn254", "amcl.Fp256Miraclbn"}.
   # If unspecified, it defaults to 'amcl.Fp256bn'.
   curve: gurvy.Bn254
-
-  issuerpublickeyfile: {{ issuerpublickeyfile }}
-  issuersecretkeyfile: {{ issuersecretkeyfile }}
-  revocationpublickeyfile: {{ revocationpublickeyfile }}
-  revocationprivatekeyfile: {{ revocationprivatekeyfile }}
 
 #############################################################################
 # BCCSP (BlockChain Crypto Service Provider) section is used to select which

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -183,7 +183,7 @@ tls:
 #############################################################################
 ca:
   # Name of this CA
-  name:
+  name: {{ caname }}
   # Key file (is only used to import a private key into BCCSP)
   keyfile:
   # Certificate file (default: ca-cert.pem)

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -6,7 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package fabric
 
-const Extension = `
+const (
+	Extension = `
 token:
   # TMS stands for Token Management Service. A TMS is uniquely identified by a network, channel, and 
   # namespace identifiers. The network identifier should refer to a configure network (Fabric, Orion, and so on).
@@ -93,3 +94,522 @@ token:
       {{ end }}
       {{ end }}
   `
+
+	CACfgTemplate = `
+#############################################################################
+#   This is a configuration file for the fabric-ca-server command.
+#
+#   COMMAND LINE ARGUMENTS AND ENVIRONMENT VARIABLES
+#   ------------------------------------------------
+#   Each configuration element can be overridden via command line
+#   arguments or environment variables.  The precedence for determining
+#   the value of each element is as follows:
+#   1) command line argument
+#      Examples:
+#      a) --port 443
+#         To set the listening port
+#      b) --ca.keyfile ../mykey.pem
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '.' separator character.
+#   2) environment variable
+#      Examples:
+#      a) FABRIC_CA_SERVER_PORT=443
+#         To set the listening port
+#      b) FABRIC_CA_SERVER_CA_KEYFILE="../mykey.pem"
+#         To set the "keyfile" element in the "ca" section below;
+#         note the '_' separator character.
+#   3) configuration file
+#   4) default value (if there is one)
+#      All default values are shown beside each element below.
+#
+#   FILE NAME ELEMENTS
+#   ------------------
+#   The value of all fields whose name ends with "file" or "files" are
+#   name or names of other files.
+#   For example, see "tls.certfile" and "tls.clientauth.certfiles".
+#   The value of each of these fields can be a simple filename, a
+#   relative path, or an absolute path.  If the value is not an
+#   absolute path, it is interpreted as being relative to the location
+#   of this configuration file.
+#
+#############################################################################
+
+# Version of config file
+version: v1.5.6
+
+# Server's listening port (default: 7054)
+port: 7054
+
+# Cross-Origin Resource Sharing (CORS)
+cors:
+    enabled: false
+    origins:
+      - "*"
+
+# Enables debug logging (default: false)
+debug: false
+
+# Size limit of an acceptable CRL in bytes (default: 512000)
+crlsizelimit: 512000
+
+#############################################################################
+#  TLS section for the server's listening port
+#
+#  The following types are supported for client authentication: NoClientCert,
+#  RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven,
+#  and RequireAndVerifyClientCert.
+#
+#  Certfiles is a list of root certificate authorities that the server uses
+#  when verifying client certificates.
+#############################################################################
+tls:
+  # Enable TLS (default: false)
+  enabled: false
+  # TLS for the server's listening port
+  certfile:
+  keyfile:
+  clientauth:
+    type: noclientcert
+    certfiles:
+
+#############################################################################
+#  The CA section contains information related to the Certificate Authority
+#  including the name of the CA, which should be unique for all members
+#  of a blockchain network.  It also includes the key and certificate files
+#  used when issuing enrollment certificates (ECerts).
+#  The chainfile (if it exists) contains the certificate chain which
+#  should be trusted for this CA, where the 1st in the chain is always the
+#  root CA certificate.
+#############################################################################
+ca:
+  # Name of this CA
+  name:
+  # Key file (is only used to import a private key into BCCSP)
+  keyfile:
+  # Certificate file (default: ca-cert.pem)
+  certfile:
+  # Chain file
+  chainfile:
+  # Ignore Certificate Expiration in the case of re-enroll
+  reenrollIgnoreCertExpiry: false
+
+#############################################################################
+#  The gencrl REST endpoint is used to generate a CRL that contains revoked
+#  certificates. This section contains configuration options that are used
+#  during gencrl request processing.
+#############################################################################
+crl:
+  # Specifies expiration for the generated CRL. The number of hours
+  # specified by this property is added to the UTC time, the resulting time
+  # is used to set the 'Next Update' date of the CRL.
+  expiry: 24h
+
+#############################################################################
+#  The registry section controls how the fabric-ca-server does two things:
+#  1) authenticates enrollment requests which contain a username and password
+#     (also known as an enrollment ID and secret).
+#  2) once authenticated, retrieves the identity's attribute names and values.
+#     These attributes are useful for making access control decisions in
+#     chaincode.
+#  There are two main configuration options:
+#  1) The fabric-ca-server is the registry.
+#     This is true if "ldap.enabled" in the ldap section below is false.
+#  2) An LDAP server is the registry, in which case the fabric-ca-server
+#     calls the LDAP server to perform these tasks.
+#     This is true if "ldap.enabled" in the ldap section below is true,
+#     which means this "registry" section is ignored.
+#############################################################################
+registry:
+  # Maximum number of times a password/secret can be reused for enrollment
+  # (default: -1, which means there is no limit)
+  maxenrollments: -1
+
+  # Contains identity information which is used when LDAP is disabled
+  identities:
+     - name: admin
+       pass: adminpw
+       type: client
+       affiliation: ""
+       attrs:
+          hf.Registrar.Roles: "*"
+          hf.Registrar.DelegateRoles: "*"
+          hf.Revoker: true
+          hf.IntermediateCA: true
+          hf.GenCRL: true
+          hf.Registrar.Attributes: "*"
+          hf.AffiliationMgr: true
+
+#############################################################################
+#  Database section
+#  Supported types are: "sqlite3", "postgres", and "mysql".
+#  The datasource value depends on the type.
+#  If the type is "sqlite3", the datasource value is a file name to use
+#  as the database store.  Since "sqlite3" is an embedded database, it
+#  may not be used if you want to run the fabric-ca-server in a cluster.
+#  To run the fabric-ca-server in a cluster, you must choose "postgres"
+#  or "mysql".
+#############################################################################
+db:
+  type: sqlite3
+  datasource: fabric-ca-server.db
+  tls:
+      enabled: false
+      certfiles:
+      client:
+        certfile:
+        keyfile:
+
+#############################################################################
+#  LDAP section
+#  If LDAP is enabled, the fabric-ca-server calls LDAP to:
+#  1) authenticate enrollment ID and secret (i.e. username and password)
+#     for enrollment requests;
+#  2) To retrieve identity attributes
+#############################################################################
+ldap:
+   # Enables or disables the LDAP client (default: false)
+   # If this is set to true, the "registry" section is ignored.
+   enabled: false
+   # The URL of the LDAP server
+   url: ldap://<adminDN>:<adminPassword>@<host>:<port>/<base>
+   # TLS configuration for the client connection to the LDAP server
+   tls:
+      certfiles:
+      client:
+         certfile:
+         keyfile:
+   # Attribute related configuration for mapping from LDAP entries to Fabric CA attributes
+   attribute:
+      # 'names' is an array of strings containing the LDAP attribute names which are
+      # requested from the LDAP server for an LDAP identity's entry
+      names: ['uid','member']
+      # The 'converters' section is used to convert an LDAP entry to the value of
+      # a fabric CA attribute.
+      # For example, the following converts an LDAP 'uid' attribute
+      # whose value begins with 'revoker' to a fabric CA attribute
+      # named "hf.Revoker" with a value of "true" (because the boolean expression
+      # evaluates to true).
+      #    converters:
+      #       - name: hf.Revoker
+      #         value: attr("uid") =~ "revoker*"
+      converters:
+         - name:
+           value:
+      # The 'maps' section contains named maps which may be referenced by the 'map'
+      # function in the 'converters' section to map LDAP responses to arbitrary values.
+      # For example, assume a user has an LDAP attribute named 'member' which has multiple
+      # values which are each a distinguished name (i.e. a DN). For simplicity, assume the
+      # values of the 'member' attribute are 'dn1', 'dn2', and 'dn3'.
+      # Further assume the following configuration.
+      #    converters:
+      #       - name: hf.Registrar.Roles
+      #         value: map(attr("member"),"groups")
+      #    maps:
+      #       groups:
+      #          - name: dn1
+      #            value: peer
+      #          - name: dn2
+      #            value: client
+      # The value of the user's 'hf.Registrar.Roles' attribute is then computed to be
+      # "peer,client,dn3".  This is because the value of 'attr("member")' is
+      # "dn1,dn2,dn3", and the call to 'map' with a 2nd argument of
+      # "group" replaces "dn1" with "peer" and "dn2" with "client".
+      maps:
+         groups:
+            - name:
+              value:
+
+#############################################################################
+# Affiliations section. Fabric CA server can be bootstrapped with the
+# affiliations specified in this section. Affiliations are specified as maps.
+# For example:
+#   businessunit1:
+#     department1:
+#       - team1
+#   businessunit2:
+#     - department2
+#     - department3
+#
+# Affiliations are hierarchical in nature. In the above example,
+# department1 (used as businessunit1.department1) is the child of businessunit1.
+# team1 (used as businessunit1.department1.team1) is the child of department1.
+# department2 (used as businessunit2.department2) and department3 (businessunit2.department3)
+# are children of businessunit2.
+# Note: Affiliations are case sensitive except for the non-leaf affiliations
+# (like businessunit1, department1, businessunit2) that are specified in the configuration file,
+# which are always stored in lower case.
+#############################################################################
+affiliations:
+   org1:
+      - department1
+      - department2
+   org2:
+      - department1
+
+#############################################################################
+#  Signing section
+#
+#  The "default" subsection is used to sign enrollment certificates;
+#  the default expiration ("expiry" field) is "8760h", which is 1 year in hours.
+#
+#  The "ca" profile subsection is used to sign intermediate CA certificates;
+#  the default expiration ("expiry" field) is "43800h" which is 5 years in hours.
+#  Note that "isca" is true, meaning that it issues a CA certificate.
+#  A maxpathlen of 0 means that the intermediate CA cannot issue other
+#  intermediate CA certificates, though it can still issue end entity certificates.
+#  (See RFC 5280, section 4.2.1.9)
+#
+#  The "tls" profile subsection is used to sign TLS certificate requests;
+#  the default expiration ("expiry" field) is "8760h", which is 1 year in hours.
+#############################################################################
+signing:
+    default:
+      usage:
+        - digital signature
+      expiry: 8760h
+    profiles:
+      ca:
+         usage:
+           - cert sign
+           - crl sign
+         expiry: 43800h
+         caconstraint:
+           isca: true
+           maxpathlen: 0
+      tls:
+         usage:
+            - signing
+            - key encipherment
+            - server auth
+            - client auth
+            - key agreement
+         expiry: 8760h
+
+###########################################################################
+#  Certificate Signing Request (CSR) section.
+#  This controls the creation of the root CA certificate.
+#  The expiration for the root CA certificate is configured with the
+#  "ca.expiry" field below, whose default value is "131400h" which is
+#  15 years in hours.
+#  The pathlength field is used to limit CA certificate hierarchy as described
+#  in section 4.2.1.9 of RFC 5280.
+#  Examples:
+#  1) No pathlength value means no limit is requested.
+#  2) pathlength == 1 means a limit of 1 is requested which is the default for
+#     a root CA.  This means the root CA can issue intermediate CA certificates,
+#     but these intermediate CAs may not in turn issue other CA certificates
+#     though they can still issue end entity certificates.
+#  3) pathlength == 0 means a limit of 0 is requested;
+#     this is the default for an intermediate CA, which means it can not issue
+#     CA certificates though it can still issue end entity certificates.
+#  The "hosts" field will be used to specify Subject Alternative Names
+#  if the server creates a self-signed TLS certificate.
+###########################################################################
+csr:
+   cn: fabric-ca-server
+   keyrequest:
+     algo: ecdsa
+     size: 256
+   names:
+      - C: US
+        ST: "North Carolina"
+        L:
+        O: Hyperledger
+        OU: Fabric
+   hosts:
+     - Macallan
+     - localhost
+   ca:
+      expiry: 131400h
+      pathlength: 1
+
+###########################################################################
+# Each CA can issue both X509 enrollment certificate as well as Idemix
+# Credential. This section specifies configuration for the issuer component
+# that is responsible for issuing Idemix credentials.
+###########################################################################
+idemix:
+  # Specifies pool size for revocation handles. A revocation handle is an unique identifier of an
+  # Idemix credential. The issuer will create a pool revocation handles of this specified size. When
+  # a credential is requested, issuer will get handle from the pool and assign it to the credential.
+  # Issuer will repopulate the pool with new handles when the last handle in the pool is used.
+  # A revocation handle and credential revocation information (CRI) are used to create non revocation proof
+  # by the prover to prove to the verifier that her credential is not revoked.
+  rhpoolsize: 1000
+
+  # The Idemix credential issuance is a two step process. First step is to  get a nonce from the issuer
+  # and second step is send credential request that is constructed using the nonce to the isuser to
+  # request a credential. This configuration property specifies expiration for the nonces. By default is
+  # nonces expire after 15 seconds. The value is expressed in the time.Duration format (see https://golang.org/pkg/time/#ParseDuration).
+  nonceexpiration: 15s
+
+  # Specifies interval at which expired nonces are removed from datastore. Default value is 15 minutes.
+  #  The value is expressed in the time.Duration format (see https://golang.org/pkg/time/#ParseDuration)
+  noncesweepinterval: 15m
+
+  # Specifies the Elliptic Curve used by Identity Mixer.
+  # It can be any of: {"amcl.Fp256bn", "gurvy.Bn254", "amcl.Fp256Miraclbn"}.
+  # If unspecified, it defaults to 'amcl.Fp256bn'.
+  curve: gurvy.Bn254
+
+  issuerpublickeyfile: {{ issuerpublickeyfile }}
+  issuersecretkeyfile: {{ issuersecretkeyfile }}
+  revocationpublickeyfile: {{ revocationpublickeyfile }}
+  revocationprivatekeyfile: {{ revocationprivatekeyfile }}
+
+#############################################################################
+# BCCSP (BlockChain Crypto Service Provider) section is used to select which
+# crypto library implementation to use
+#############################################################################
+bccsp:
+    default: SW
+    sw:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            # The directory used for the software file-based keystore
+            keystore: msp/keystore
+
+#############################################################################
+# Multi CA section
+#
+# Each Fabric CA server contains one CA by default.  This section is used
+# to configure multiple CAs in a single server.
+#
+# 1) --cacount <number-of-CAs>
+# Automatically generate <number-of-CAs> non-default CAs.  The names of these
+# additional CAs are "ca1", "ca2", ... "caN", where "N" is <number-of-CAs>
+# This is particularly useful in a development environment to quickly set up
+# multiple CAs. Note that, this config option is not applicable to intermediate CA server
+# i.e., Fabric CA server that is started with intermediate.parentserver.url config
+# option (-u command line option)
+#
+# 2) --cafiles <CA-config-files>
+# For each CA config file in the list, generate a separate signing CA.  Each CA
+# config file in this list MAY contain all of the same elements as are found in
+# the server config file except port, debug, and tls sections.
+#
+# Examples:
+# fabric-ca-server start -b admin:adminpw --cacount 2
+#
+# fabric-ca-server start -b admin:adminpw --cafiles ca/ca1/fabric-ca-server-config.yaml
+# --cafiles ca/ca2/fabric-ca-server-config.yaml
+#
+#############################################################################
+
+cacount:
+
+cafiles:
+
+#############################################################################
+# Intermediate CA section
+#
+# The relationship between servers and CAs is as follows:
+#   1) A single server process may contain or function as one or more CAs.
+#      This is configured by the "Multi CA section" above.
+#   2) Each CA is either a root CA or an intermediate CA.
+#   3) Each intermediate CA has a parent CA which is either a root CA or another intermediate CA.
+#
+# This section pertains to configuration of #2 and #3.
+# If the "intermediate.parentserver.url" property is set,
+# then this is an intermediate CA with the specified parent
+# CA.
+#
+# parentserver section
+#    url - The URL of the parent server
+#    caname - Name of the CA to enroll within the server
+#
+# enrollment section used to enroll intermediate CA with parent CA
+#    profile - Name of the signing profile to use in issuing the certificate
+#    label - Label to use in HSM operations
+#
+# tls section for secure socket connection
+#   certfiles - PEM-encoded list of trusted root certificate files
+#   client:
+#     certfile - PEM-encoded certificate file for when client authentication
+#     is enabled on server
+#     keyfile - PEM-encoded key file for when client authentication
+#     is enabled on server
+#############################################################################
+intermediate:
+  parentserver:
+    url:
+    caname:
+
+  enrollment:
+    hosts:
+    profile:
+    label:
+
+  tls:
+    certfiles:
+    client:
+      certfile:
+      keyfile:
+
+#############################################################################
+# CA configuration section
+#
+# Configure the number of incorrect password attempts are allowed for
+# identities. By default, the value of 'passwordattempts' is 10, which
+# means that 10 incorrect password attempts can be made before an identity get
+# locked out.
+#############################################################################
+cfg:
+  identities:
+    passwordattempts: 10
+
+###############################################################################
+#
+#    Operations section
+#
+###############################################################################
+operations:
+    # host and port for the operations server
+    listenAddress: 127.0.0.1:9443
+
+    # TLS configuration for the operations endpoint
+    tls:
+        # TLS enabled
+        enabled: false
+
+        # path to PEM encoded server certificate for the operations server
+        cert:
+            file:
+
+        # path to PEM encoded server key for the operations server
+        key:
+            file:
+
+        # require client certificate authentication to access all resources
+        clientAuthRequired: false
+
+        # paths to PEM encoded ca certificates to trust for client authentication
+        clientRootCAs:
+            files: []
+
+###############################################################################
+#
+#    Metrics section
+#
+###############################################################################
+metrics:
+    # statsd, prometheus, or disabled
+    provider: disabled
+
+    # statsd configuration
+    statsd:
+        # network type: tcp or udp
+        network: udp
+
+        # statsd server address
+        address: 127.0.0.1:8125
+
+        # the interval at which locally cached counters and gauges are pushed
+        # to statsd; timings are pushed immediately
+        writeInterval: 10s
+
+        # prefix is prepended to all emitted statsd metrics
+        prefix: server
+`
+)

--- a/integration/nwo/token/fabric/utils.go
+++ b/integration/nwo/token/fabric/utils.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabric
+
+import (
+	"os"
+	"path"
+)
+
+const (
+	FabricBinsPathEnvKey = "FAB_BINS"
+	fabricCaClientCMD    = "fabric-ca-client"
+	fabricCaServerCMD    = "fabric-ca-server"
+)
+
+func pathExists(path string) bool {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+// findCmdAtEnv tries to find cmd at the path specified via FabricBinsPathEnvKey
+// Returns the full path of cmd if exists; otherwise an empty string
+// Example:
+//
+//	export FAB_BINS=/tmp/fabric/bin/
+//	findCmdAtEnv("peer") will return "/tmp/fabric/bin/peer" if exists
+func findCmdAtEnv(cmd string) string {
+	cmdPath := path.Join(os.Getenv(FabricBinsPathEnvKey), cmd)
+	if !pathExists(cmdPath) {
+		// cmd does not exist in folder provided via FabricBinsPathEnvKey
+		return ""
+	}
+
+	return cmdPath
+}

--- a/integration/nwo/token/orion/orion.go
+++ b/integration/nwo/token/orion/orion.go
@@ -169,6 +169,9 @@ func (p *NetworkHandler) PostRun(load bool, tms *topology2.TMS) {
 	Expect(err).ToNot(HaveOccurred(), "Failed to commit transaction")
 }
 
+func (p *NetworkHandler) Cleanup() {
+}
+
 func (p *NetworkHandler) UpdateChaincodePublicParams(tms *topology2.TMS, ppRaw []byte) {
 	panic("Should not be invoked")
 }
@@ -188,7 +191,7 @@ func (p *NetworkHandler) GenIssuerCryptoMaterial(tms *topology2.TMS, nodeID stri
 	return ""
 }
 
-func (p *NetworkHandler) GenOwnerCryptoMaterial(tms *topology2.TMS, nodeID string, walletID string) string {
+func (p *NetworkHandler) GenOwnerCryptoMaterial(tms *topology2.TMS, nodeID string, walletID string, useCAIfAvailable bool) string {
 	cmGenerator := p.CryptoMaterialGenerators[tms.Driver]
 	Expect(cmGenerator).NotTo(BeNil(), "Crypto material generator for driver %s not found", tms.Driver)
 

--- a/integration/token/common/topology.go
+++ b/integration/token/common/topology.go
@@ -12,10 +12,12 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func SetDefaultParams(tokenSDKDriver string, tms *topology.TMS) {
+func SetDefaultParams(tokenSDKDriver string, tms *topology.TMS, aries bool) {
 	switch tokenSDKDriver {
 	case "dlog":
-		dlog.WithAries(tms)
+		if aries {
+			dlog.WithAries(tms)
+		}
 		// max token value is 100^2 - 1 = 9999
 		tms.SetTokenGenPublicParams("100", "2")
 	case "fabtoken":

--- a/integration/token/dvp/topology.go
+++ b/integration/token/dvp/topology.go
@@ -91,7 +91,7 @@ func Topology(tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), fabricTopology, fabricTopology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
 

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -9,8 +9,9 @@ package dlog
 import (
 	"os"
 
-	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible"

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -9,9 +9,8 @@ package dlog
 import (
 	"os"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
-
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible"

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -31,8 +31,9 @@ var _ = Describe("EndToEnd", func() {
 
 	Describe("Fungible with Auditor ne Issuer", func() {
 		BeforeEach(func() {
+			// notice that fabric-ca does not support yet aries
 			var err error
-			network, err = integration.New(StartPortDlog(), "", topology2.Topology("fabric", "dlog", false)...)
+			network, err = integration.New(StartPortDlog(), "", topology2.Topology("fabric", "dlog", false, true)...)
 			Expect(err).NotTo(HaveOccurred())
 			network.RegisterPlatformFactory(token.NewPlatformFactory())
 			network.Generate()
@@ -40,7 +41,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "auditor", nil)
+			fungible.TestAll(network, "auditor", nil, true)
 		})
 
 		It("Update public params", func() {
@@ -59,7 +60,7 @@ var _ = Describe("EndToEnd", func() {
 	Describe("Fungible with Auditor = Issuer", func() {
 		BeforeEach(func() {
 			var err error
-			network, err = integration.New(StartPortDlog(), "", topology2.Topology("fabric", "dlog", true)...)
+			network, err = integration.New(StartPortDlog(), "", topology2.Topology("fabric", "dlog", true, true)...)
 			Expect(err).NotTo(HaveOccurred())
 			network.RegisterPlatformFactory(token.NewPlatformFactory())
 			network.Generate()
@@ -67,7 +68,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "issuer", nil)
+			fungible.TestAll(network, "issuer", nil, true)
 		})
 
 		It("Update public params", func() {
@@ -75,6 +76,21 @@ var _ = Describe("EndToEnd", func() {
 			fungible.TestPublicParamsUpdate(network, "newIssuer", PrepareUpdatedPublicParams(network, "newIssuer", tms), tms, true)
 		})
 
+	})
+
+	Describe("Fungible with Auditor ne Issuer + Fabric CA", func() {
+		BeforeEach(func() {
+			var err error
+			network, err = integration.New(StartPortDlog(), "", topology2.Topology("fabric", "dlog", false, false)...)
+			Expect(err).NotTo(HaveOccurred())
+			network.RegisterPlatformFactory(token.NewPlatformFactory())
+			network.Generate()
+			network.Start()
+		})
+
+		It("succeeded", func() {
+			fungible.TestAll(network, "auditor", nil, false)
+		})
 	})
 
 })

--- a/integration/token/fungible/dloghsm/dlog_test.go
+++ b/integration/token/fungible/dloghsm/dlog_test.go
@@ -35,7 +35,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "auditor", nil)
+			fungible.TestAll(network, "auditor", nil, true)
 		})
 	})
 
@@ -50,7 +50,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "issuer", nil)
+			fungible.TestAll(network, "issuer", nil, true)
 		})
 	})
 

--- a/integration/token/fungible/dloghsm/topology.go
+++ b/integration/token/fungible/dloghsm/topology.go
@@ -221,7 +221,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 
 	tokenTopology := token.NewTopology()
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), backendNetwork, backendChannel, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {
 		// we need to define the custodian

--- a/integration/token/fungible/fabtoken/fabtoken_test.go
+++ b/integration/token/fungible/fabtoken/fabtoken_test.go
@@ -30,7 +30,7 @@ var _ = Describe("EndToEnd", func() {
 	Describe("Fungible", func() {
 		BeforeEach(func() {
 			var err error
-			network, err = integration.New(StartPortDlog(), "", topology.Topology("fabric", "fabtoken", false)...)
+			network, err = integration.New(StartPortDlog(), "", topology.Topology("fabric", "fabtoken", false, true)...)
 			Expect(err).NotTo(HaveOccurred())
 			network.RegisterPlatformFactory(token.NewPlatformFactory())
 			network.Generate()
@@ -38,7 +38,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "auditor", nil)
+			fungible.TestAll(network, "auditor", nil, true)
 		})
 
 		It("Update public params", func() {

--- a/integration/token/fungible/odlog/dlog_test.go
+++ b/integration/token/fungible/odlog/dlog_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Orion EndToEnd", func() {
 	Describe("Orion ZKAT-DLog", func() {
 		BeforeEach(func() {
 			var err error
-			network, err = integration.New(StartPortDlog(), "", topology.Topology("orion", "dlog", false)...)
+			network, err = integration.New(StartPortDlog(), "", topology.Topology("orion", "dlog", false, true)...)
 			Expect(err).NotTo(HaveOccurred())
 			network.RegisterPlatformFactory(token.NewPlatformFactory())
 			network.Generate()
@@ -35,7 +35,7 @@ var _ = Describe("Orion EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "auditor", nil)
+			fungible.TestAll(network, "auditor", nil, true)
 		})
 	})
 

--- a/integration/token/fungible/ofabtoken/fabtoken_test.go
+++ b/integration/token/fungible/ofabtoken/fabtoken_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Orion EndToEnd", func() {
 	Describe("Orion FabToken", func() {
 		BeforeEach(func() {
 			var err error
-			network, err = integration.New(StartPortDlog(), "", topology.Topology("orion", "fabtoken", false)...)
+			network, err = integration.New(StartPortDlog(), "", topology.Topology("orion", "fabtoken", false, true)...)
 			Expect(err).NotTo(HaveOccurred())
 			network.RegisterPlatformFactory(token.NewPlatformFactory())
 			network.Generate()
@@ -36,7 +36,7 @@ var _ = Describe("Orion EndToEnd", func() {
 		})
 
 		It("succeeded", func() {
-			fungible.TestAll(network, "auditor", nil)
+			fungible.TestAll(network, "auditor", nil, true)
 		})
 	})
 

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -803,9 +803,9 @@ func TestPublicParamsUpdate(network *integration.Infrastructure, auditor string,
 
 func testTwoGeneratedOwnerWalletsSameNode(network *integration.Infrastructure, auditor string) {
 	tokenPlatform := token.GetPlatform(network.Ctx, "token")
-	newOwnerWalletPath1 := tokenPlatform.GenOwnerCryptoMaterial(tokenPlatform.GetTopology().TMSs[0].BackendTopology.Name(), "charlie", "charlie.ExtraId1")
+	newOwnerWalletPath1 := tokenPlatform.GenOwnerCryptoMaterial(tokenPlatform.GetTopology().TMSs[0].BackendTopology.Name(), "charlie", "charlie.ExtraId1", false)
 	RegisterOwnerWallet(network, "charlie", "charlie.ExtraId1", newOwnerWalletPath1)
-	newOwnerWalletPath2 := tokenPlatform.GenOwnerCryptoMaterial(tokenPlatform.GetTopology().TMSs[0].BackendTopology.Name(), "charlie", "charlie.ExtraId2")
+	newOwnerWalletPath2 := tokenPlatform.GenOwnerCryptoMaterial(tokenPlatform.GetTopology().TMSs[0].BackendTopology.Name(), "charlie", "charlie.ExtraId2", true)
 	RegisterOwnerWallet(network, "charlie", "charlie.ExtraId2", newOwnerWalletPath2)
 
 	IssueCash(network, "", "SPE", 100, "charlie", auditor, true, "issuer")

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -261,7 +261,7 @@ var BobAcceptedTransactions = []*ttxdb.TransactionRecord{
 
 type OnAuditorRestartFunc = func(*integration.Infrastructure, string)
 
-func TestAll(network *integration.Infrastructure, auditor string, onAuditorRestart OnAuditorRestartFunc) {
+func TestAll(network *integration.Infrastructure, auditor string, onAuditorRestart OnAuditorRestartFunc, aries bool) {
 	RegisterAuditor(network, auditor, nil)
 
 	// give some time to the nodes to get the public parameters
@@ -406,7 +406,9 @@ func TestAll(network *integration.Infrastructure, auditor string, onAuditorResta
 
 	IssueCash(network, "", "USD", 1, "alice", auditor, true, "issuer")
 
-	testTwoGeneratedOwnerWalletsSameNode(network, auditor)
+	if !aries {
+		testTwoGeneratedOwnerWalletsSameNode(network, auditor)
+	}
 
 	CheckBalanceAndHolding(network, "alice", "", "USD", 10, auditor)
 	CheckBalanceAndHolding(network, "alice", "", "EUR", 0, auditor)

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -42,7 +42,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool, aries
 	// FSC
 	fscTopology := fsc.NewTopology()
 	//fscTopology.SetLogging("token-sdk.core=debug:orion-sdk.rwset=debug:token-sdk.network.processor=debug:token-sdk.network.orion.custodian=debug:token-sdk.driver.identity=debug:token-sdk.driver.zkatdlog=debug:orion-sdk.vault=debug:orion-sdk.delivery=debug:orion-sdk.committer=debug:token-sdk.vault.processor=debug:info", "")
-	//fscTopology.SetLogging("token-sdk=debug:info", "")
+	fscTopology.SetLogging("token-sdk=debug:info", "")
 
 	issuer := fscTopology.AddNodeByName("issuer").AddOptions(
 		fabric.WithOrganization("Org1"),

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -267,6 +267,10 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool, aries
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), backendNetwork, backendChannel, tokenSDKDriver)
 	tms.SetNamespace("token-chaincode")
 	common.SetDefaultParams(tokenSDKDriver, tms, aries)
+	if !aries {
+		// Enable Fabric-CA
+		fabric2.WithFabricCA(tms)
+	}
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {
 		// we need to define the custodian

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -21,7 +21,7 @@ import (
 	sdk "github.com/hyperledger-labs/fabric-token-sdk/token/sdk"
 )
 
-func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api.Topology {
+func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool, aries bool) []api.Topology {
 	var backendNetwork api.Topology
 	backendChannel := ""
 	switch backend {
@@ -266,7 +266,7 @@ func Topology(backend string, tokenSDKDriver string, auditorAsIssuer bool) []api
 	tokenTopology := token.NewTopology()
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), backendNetwork, backendChannel, tokenSDKDriver)
 	tms.SetNamespace("token-chaincode")
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, aries)
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {
 		// we need to define the custodian

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -93,7 +93,7 @@ func HTLCSingleFabricNetworkTopology(tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), fabricTopology, fabricTopology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
 
@@ -181,7 +181,7 @@ func HTLCSingleOrionNetworkTopology(tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), orionTopology, "", tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
 	orion2.SetCustodian(tms, custodian)
@@ -279,12 +279,12 @@ func HTLCTwoFabricNetworksTopology(tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), f1Topology, f1Topology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
 
 	tms = tokenTopology.AddTMS(fscTopology.ListNodes(), f2Topology, f2Topology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org3")
 	tms.AddAuditor(auditor)
 
@@ -380,12 +380,12 @@ func HTLCNoCrossClaimTopology(tokenSDKDriver string) []api.Topology {
 	tokenTopology := token.NewTopology()
 	tokenTopology.SetSDK(fscTopology, &sdk.SDK{})
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "alice"), f1Topology, f1Topology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
 
 	tms = tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "bob"), f2Topology, f2Topology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org3")
 	tms.AddAuditor(auditor)
 
@@ -486,14 +486,14 @@ func HTLCNoCrossClaimWithOrionTopology(tokenSDKDriver string) []api.Topology {
 
 	// TMS for the Fabric Network
 	tmsFabric := tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "alice"), f1Topology, f1Topology.Channels[0].Name, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tmsFabric)
+	common.SetDefaultParams(tokenSDKDriver, tmsFabric, true)
 	fabric2.SetOrgs(tmsFabric, "Org1")
 	tmsFabric.AddAuditor(auditor)
 
 	// TMS for the Orion Network
 	fscTopology.SetBootstrapNode(custodian)
 	tmsOrion := tokenTopology.AddTMS(fscTopology.ListNodes("custodian", "auditor", "issuer", "bob"), orionTopology, "", tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tmsOrion)
+	common.SetDefaultParams(tokenSDKDriver, tmsOrion, true)
 	tmsOrion.AddAuditor(auditor)
 	orion2.SetCustodian(tmsOrion, custodian)
 

--- a/integration/token/nft/topology.go
+++ b/integration/token/nft/topology.go
@@ -83,7 +83,7 @@ func Topology(backend, tokenSDKDriver string) []api.Topology {
 
 	tokenTopology := token.NewTopology()
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes(), backendNetwork, backendChannel, tokenSDKDriver)
-	common.SetDefaultParams(tokenSDKDriver, tms)
+	common.SetDefaultParams(tokenSDKDriver, tms, true)
 	fabric2.SetOrgs(tms, "Org1")
 	if backend == "orion" {
 		// we need to define the custodian

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity/msp/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
-	"github.com/hyperledger/fabric/msp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
@@ -231,7 +230,7 @@ func (lm *LocalMembership) registerIdentity(id string, path string, setDefault b
 }
 
 func (lm *LocalMembership) registerMSPProvider(id, translatedPath string, curveID math3.CurveID, setDefault bool) error {
-	conf, err := msp.GetLocalMspConfigWithType(translatedPath, nil, lm.mspID, MSP)
+	conf, err := idemix2.GetLocalMspConfigWithType(translatedPath, nil, lm.mspID)
 	if err != nil {
 		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", translatedPath)
 	}
@@ -252,7 +251,7 @@ func (lm *LocalMembership) registerMSPProvider(id, translatedPath string, curveI
 
 	lm.deserializerManager.AddDeserializer(provider)
 	lm.addResolver(id, provider.EnrollmentID(), setDefault, NewIdentityCache(provider.Identity, cacheSize).Identity)
-	logger.Debugf("added [%s] resolver for id [%s] with cache of size %d", MSP, id+"@"+provider.EnrollmentID(), cacheSize)
+	logger.Debugf("added idemix resolver for id %s with cache of size %d", id+"@"+provider.EnrollmentID(), cacheSize)
 	return nil
 }
 

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -232,7 +232,12 @@ func (lm *LocalMembership) registerIdentity(id string, path string, setDefault b
 func (lm *LocalMembership) registerMSPProvider(id, translatedPath string, curveID math3.CurveID, setDefault bool) error {
 	conf, err := idemix2.GetLocalMspConfigWithType(translatedPath, nil, lm.mspID)
 	if err != nil {
-		return errors.Wrapf(err, "failed reading idemix msp configuration from [%s]", translatedPath)
+		logger.Debugf("failed reading idemix msp configuration from [%s]: [%s], try adding 'msp'...", translatedPath, err)
+		// Try with "msp"
+		conf, err = idemix2.GetLocalMspConfigWithType(filepath.Join(translatedPath, "msp"), nil, lm.mspID)
+		if err != nil {
+			return errors.Wrapf(err, "failed reading idemix msp configuration from [%s] and with 'msp'", translatedPath)
+		}
 	}
 	// TODO: remove the need for ServiceProvider
 	cryptoProvider, err := NewKVSBCCSP(kvs.GetService(lm.sp), curveID)

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -262,6 +262,7 @@ func (lm *LocalMembership) registerMSPProviders(translatedPath string, curveID m
 		logger.Warnf("failed reading from [%s]: [%s]", translatedPath, err)
 		return nil
 	}
+	found := 0
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -269,7 +270,12 @@ func (lm *LocalMembership) registerMSPProviders(translatedPath string, curveID m
 		id := entry.Name()
 		if err := lm.registerMSPProvider(id, filepath.Join(translatedPath, id), curveID, false); err != nil {
 			logger.Errorf("failed registering msp provider [%s]: [%s]", id, err)
+			continue
 		}
+		found++
+	}
+	if found == 0 {
+		return errors.Errorf("no valid identities found in [%s]", translatedPath)
 	}
 	return nil
 }

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -28,10 +28,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const (
-	MSP = "idemix"
-)
-
 var logger = flogging.MustGetLogger("token-sdk.msp.idemix")
 
 type PublicParametersWithIdemixSupport interface {

--- a/token/core/identity/msp/idemix/wallet.go
+++ b/token/core/identity/msp/idemix/wallet.go
@@ -115,7 +115,7 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 		return nil, string(id), nil
 	case string:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[%s] mapping string identifier for [%s,%s], default identities [%s:%s]",
+			logger.Debugf("[AnonymousIdentity] [%s] mapping string identifier for [%s,%s], default identities [%s:%s]",
 				w.networkID,
 				v,
 				hash.Hashable(vv).String(),
@@ -154,7 +154,7 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 			return nil, defaultIdentifier, nil
 		case w.nodeIdentity.Equal(viewIdentity):
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("[AnonymousIdentity] passed nide identity as view identity")
+				logger.Debugf("[AnonymousIdentity] passed node identity as view identity")
 			}
 			return nil, defaultIdentifier, nil
 		case w.localMembership.IsMe(viewIdentity):

--- a/token/core/identity/msp/idemix/wallet.go
+++ b/token/core/identity/msp/idemix/wallet.go
@@ -61,18 +61,18 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 	defaultID := w.localMembership.DefaultNetworkIdentity()
 	defaultIdentifier := w.localMembership.GetDefaultIdentifier()
 
-	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
-			w.networkID,
-			v,
-			string(defaultID),
-			defaultID.String(),
-			w.nodeIdentity.String(),
-		)
-	}
-
 	switch vv := v.(type) {
 	case view.Identity:
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
+				w.networkID,
+				v,
+				vv.String(),
+				defaultID.String(),
+				w.nodeIdentity.String(),
+			)
+		}
+
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("[AnonymousIdentity] looking up identifier for identity [%s]", vv.String())
 		}
@@ -117,6 +117,16 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 		}
 		return nil, string(id), nil
 	case string:
+		if logger.IsEnabledFor(zapcore.DebugLevel) {
+			logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
+				w.networkID,
+				v,
+				hash.Hashable(vv).String(),
+				defaultID.String(),
+				w.nodeIdentity.String(),
+			)
+		}
+
 		label := vv
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			logger.Debugf("[AnonymousIdentity] looking up identifier for label [%d,%s]", vv)

--- a/token/core/identity/msp/idemix/wallet.go
+++ b/token/core/identity/msp/idemix/wallet.go
@@ -64,7 +64,7 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 	switch vv := v.(type) {
 	case view.Identity:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
+			logger.Debugf("[AnonymousIdentity] [%s] mapping view.Identity identifier for [%s,%s], default identities [%s:%s]",
 				w.networkID,
 				v,
 				vv.String(),
@@ -73,9 +73,6 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 			)
 		}
 
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[AnonymousIdentity] looking up identifier for identity [%s]", vv.String())
-		}
 		id := vv
 		switch {
 		case id.IsNone():
@@ -113,12 +110,12 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 			return nil, idIdentifier, nil
 		}
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[AnonymousIdentity] cannot find match for view.Identity string [%s]", vv)
+			logger.Debugf("[AnonymousIdentity] cannot find match for view.Identity string [%s]", hash.Hashable(vv).String())
 		}
 		return nil, string(id), nil
 	case string:
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
+			logger.Debugf("[%s] mapping string identifier for [%s,%s], default identities [%s:%s]",
 				w.networkID,
 				v,
 				hash.Hashable(vv).String(),
@@ -128,31 +125,50 @@ func (w *Wallet) MapToID(v interface{}) (view.Identity, string, error) {
 		}
 
 		label := vv
-		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[AnonymousIdentity] looking up identifier for label [%d,%s]", vv)
-		}
+		viewIdentity := view.Identity(label)
 		switch {
 		case len(label) == 0:
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed empty identity")
+			}
 			return nil, defaultIdentifier, nil
 		case label == defaultIdentifier:
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed default identifier")
+			}
 			return nil, defaultIdentifier, nil
 		case label == defaultID.UniqueID():
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed default identity")
+			}
 			return nil, defaultIdentifier, nil
 		case label == string(defaultID):
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed default identity as string")
+			}
 			return nil, defaultIdentifier, nil
-		case defaultID.Equal(view.Identity(label)):
+		case defaultID.Equal(viewIdentity):
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed default identity as view identity")
+			}
 			return nil, defaultIdentifier, nil
-		case w.nodeIdentity.Equal(view.Identity(label)):
+		case w.nodeIdentity.Equal(viewIdentity):
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed nide identity as view identity")
+			}
 			return nil, defaultIdentifier, nil
-		case w.localMembership.IsMe(view.Identity(label)):
+		case w.localMembership.IsMe(viewIdentity):
+			if logger.IsEnabledFor(zapcore.DebugLevel) {
+				logger.Debugf("[AnonymousIdentity] passed a local member")
+			}
 			return nil, defaultIdentifier, nil
 		}
 
-		if idIdentifier, err := w.localMembership.GetIdentifier(view.Identity(label)); err == nil {
+		if idIdentifier, err := w.localMembership.GetIdentifier(viewIdentity); err == nil {
 			return nil, idIdentifier, nil
 		}
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[AnonymousIdentity] cannot find match for view.Identity string [%s]", vv)
+			logger.Debugf("[AnonymousIdentity] cannot find match for string [%s]", vv)
 		}
 		return nil, label, nil
 	default:

--- a/token/core/identity/msp/x509/wallet.go
+++ b/token/core/identity/msp/x509/wallet.go
@@ -60,7 +60,7 @@ func (w *wallet) MapToID(v interface{}) (view.Identity, string, error) {
 	defaultIdentifier := w.localMembership.GetDefaultIdentifier()
 
 	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s,%s]",
+		logger.Debugf("[%s] mapping identifier for [%s,%s], default identities [%s:%s]",
 			w.networkID,
 			v,
 			string(defaultID),
@@ -120,7 +120,7 @@ func (w *wallet) MapToID(v interface{}) (view.Identity, string, error) {
 	case string:
 		label := vv
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
-			logger.Debugf("[LongTermIdentity] looking up identifier for label [%d,%s]", vv)
+			logger.Debugf("[LongTermIdentity] looking up identifier for label [%s]", vv)
 		}
 		switch {
 		case len(label) == 0:


### PR DESCRIPTION
This PR adds support for fabric-ca in the NWO infrastructure. This means that token owner identities can be issued using the CA.