### PR TITLE
double spending bugfix

### DIFF
--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -9,9 +9,8 @@ package dlog
 import (
 	"os"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
-
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible"

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -247,7 +247,7 @@ func TransferCash(network *integration.Infrastructure, id string, wallet string,
 	return ""
 }
 
-func TransferCashMultiActions(network *integration.Infrastructure, id string, wallet string, typ string, amounts []uint64, receivers []string, auditor string, expectedErrorMsgs ...string) string {
+func TransferCashMultiActions(network *integration.Infrastructure, id string, wallet string, typ string, amounts []uint64, receivers []string, auditor string, tokenID *token.ID, expectedErrorMsgs ...string) string {
 	Expect(len(amounts) > 1).To(BeTrue())
 	Expect(len(receivers)).To(BeEquivalentTo(len(amounts)))
 	transfer := &views.Transfer{
@@ -257,6 +257,7 @@ func TransferCashMultiActions(network *integration.Infrastructure, id string, wa
 		Amount:       amounts[0],
 		Recipient:    network.Identity(receivers[0]),
 		RecipientEID: receivers[0],
+		TokenIDs:     []*token.ID{tokenID},
 	}
 	for i := 1; i < len(amounts); i++ {
 		transfer.TransferAction = append(transfer.TransferAction, views.TransferAction{

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -382,11 +382,14 @@ func TestAll(network *integration.Infrastructure, auditor string, onAuditorResta
 
 	// test multi action transfer...
 	t13 := time.Now()
-	IssueCash(network, "", "LIRA", 3, "alice", auditor, true, "issuer")
+	txIssuedLira1 := IssueCash(network, "", "LIRA", 3, "alice", auditor, true, "issuer")
 	IssueCash(network, "", "LIRA", 3, "alice", auditor, true, "issuer")
 	t14 := time.Now()
 	CheckAuditedTransactions(network, auditor, AuditedTransactions[10:12], &t13, &t14)
-	txLiraTransfer := TransferCashMultiActions(network, "alice", "", "LIRA", []uint64{2, 3}, []string{"bob", "charlie"}, auditor)
+	// use the same token for both actions, this must fail
+	TransferCashMultiActions(network, "alice", "", "LIRA", []uint64{2, 3}, []string{"bob", "charlie"}, auditor, &token2.ID{TxId: txIssuedLira1}, "failed to append spent id", txIssuedLira1)
+	// perform the normal transaction
+	txLiraTransfer := TransferCashMultiActions(network, "alice", "", "LIRA", []uint64{2, 3}, []string{"bob", "charlie"}, auditor, nil)
 	t16 := time.Now()
 	AuditedTransactions[12].TxID = txLiraTransfer
 	AuditedTransactions[13].TxID = txLiraTransfer

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -122,6 +122,7 @@ func (t *TransferView) Call(context view.Context) (interface{}, error) {
 			t.Type,
 			[]uint64{action.Amount},
 			[]view.Identity{additionalRecipients[i]},
+			token2.WithTokenIDs(t.TokenIDs...),
 		)
 		assert.NoError(err, "failed adding transfer action [%d:%d]", action.Amount, action.Recipient)
 	}

--- a/token/request.go
+++ b/token/request.go
@@ -1093,6 +1093,9 @@ func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType st
 	var tokenIDs []*token.ID
 	var inputSum token.Quantity
 	var err error
+
+	transferOpts.TokenIDs = r.cleanupInputIDs(transferOpts.TokenIDs)
+
 	// if inputs have been passed, parse and certify them, if needed
 	if len(transferOpts.TokenIDs) != 0 {
 		tokenIDs, inputSum, tokenType, err = r.parseInputIDs(transferOpts.TokenIDs)
@@ -1191,6 +1194,16 @@ func (r *Request) genOutputs(values []uint64, owners []view.Identity, tokenType 
 		})
 	}
 	return outputTokens, outputSum, nil
+}
+
+func (r *Request) cleanupInputIDs(ds []*token.ID) []*token.ID {
+	newSlice := make([]*token.ID, 0, len(ds))
+	for _, item := range ds {
+		if item != nil {
+			newSlice = append(newSlice, item)
+		}
+	}
+	return newSlice
 }
 
 type requestSer struct {

--- a/token/services/vault/translator/translator.go
+++ b/token/services/vault/translator/translator.go
@@ -24,7 +24,7 @@ type Translator struct {
 	RWSet RWSet
 	TxID  string
 	// SpentIDs the spent IDs added so far
-	SpentIDs [][]byte
+	SpentIDs []string
 
 	counter   uint64
 	namespace string
@@ -385,7 +385,9 @@ func (w *Translator) spendTokens(ids []string, graphHiding bool) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to delete output %s", id)
 			}
-			w.SpentIDs = append(w.SpentIDs, []byte(id))
+			if err := w.appendSpentID(id); err != nil {
+				return errors.Wrapf(err, "failed to append spent id [%s]", id)
+			}
 		}
 	} else {
 		for _, id := range ids {
@@ -394,7 +396,9 @@ func (w *Translator) spendTokens(ids []string, graphHiding bool) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to add serial number %s", id)
 			}
-			w.SpentIDs = append(w.SpentIDs, []byte(id))
+			if err := w.appendSpentID(id); err != nil {
+				return errors.Wrapf(err, "failed to append spent id [%s]", id)
+			}
 		}
 	}
 
@@ -424,4 +428,15 @@ func (w *Translator) areTokensSpent(ids []string, graphHiding bool) ([]bool, err
 	}
 
 	return res, nil
+}
+
+func (w *Translator) appendSpentID(id string) error {
+	// check first it is already in the list
+	for _, d := range w.SpentIDs {
+		if d == id {
+			return errors.Errorf("[%s] already spent", id)
+		}
+	}
+	w.SpentIDs = append(w.SpentIDs, id)
+	return nil
 }


### PR DESCRIPTION
This PR does the following:
- It identifies an attack that allows the attacker to spend the same token in multiple actions via an update to the existing integration test
- It fixes the bug