### PR TITLE
store mine key in tokenstore instead of processor directly

### DIFF
--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -269,16 +269,6 @@ func (r *RWSetProcessor) tokenRequest(req fabric.Request, tx fabric.ProcessTrans
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("transaction [%s], found a token and it is mine", txID)
 			}
-			// Add a lookup key to identity quickly that this token belongs to this
-			mineTokenID, err := keys.CreateTokenMineKey(components[0], index)
-			if err != nil {
-				return errors.Wrapf(err, "failed computing mine key for for key [%s]", key)
-			}
-			err = rws.SetState(ns, mineTokenID, []byte{1})
-			if err != nil {
-				return err
-			}
-
 			// Store Fabtoken-like entry
 			if err := r.tokenStore.StoreFabToken(ns, txID, index, tok, wrappedRWS, tokenInfoRaw, ids); err != nil {
 				return err

--- a/token/services/network/orion/processor.go
+++ b/token/services/network/orion/processor.go
@@ -223,16 +223,6 @@ func (r *RWSetProcessor) tokenRequest(req orion.Request, tx orion.ProcessTransac
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
 				logger.Debugf("transaction [%s], found a token and it is mine", txID)
 			}
-			// Add a lookup key to identity quickly that this token belongs to this
-			mineTokenID, err := keys.CreateTokenMineKey(components[0], index)
-			if err != nil {
-				return errors.Wrapf(err, "failed computing mine key for for key [%s]", key)
-			}
-			err = rws.SetState(ns, mineTokenID, []byte{1})
-			if err != nil {
-				return err
-			}
-
 			// Store Fabtoken-like entry
 			if err := r.tokenStore.StoreFabToken(ns, txID, index, tok, wrappedRWS, tokenInfoRaw, ids); err != nil {
 				return err

--- a/token/services/network/processor/common.go
+++ b/token/services/network/processor/common.go
@@ -130,6 +130,17 @@ func (cts *CommonTokenStore) DeleteFabToken(ns string, txID string, index uint64
 }
 
 func (cts *CommonTokenStore) StoreFabToken(ns string, txID string, index uint64, tok *token2.Token, rws RWSet, infoRaw []byte, ids []string) error {
+	// Add a lookup key to identify quickly that this token belongs to this instance
+	mineTokenID, err := keys.CreateTokenMineKey(txID, index)
+	if err != nil {
+		return errors.Wrapf(err, "failed computing mine key for for tx [%s]", txID)
+	}
+	err = rws.SetState(ns, mineTokenID, []byte{1})
+	if err != nil {
+		return err
+	}
+
+	// Store token
 	outputID, err := keys.CreateFabTokenKey(txID, index)
 	if err != nil {
 		return errors.Wrapf(err, "error creating output ID: %s", err)


### PR DESCRIPTION
Moving the storage of the mine key to the TokenStore makes the code more flexible to change; now the processor only uses the TokenStore for any storage instead of using the rwSet directly. An implementation of the TokenStore interface would be independent of the processor to decide how to store tokens and lookup values.

Note that the code assumes that tokens stored via `StoreFabToken` are always 'mine'. If that's not true we could change the signature of the method to add a boolean flag for 'mine'.