### PR TITLE
allow empty prefix

### DIFF
--- a/token/services/ttxdb/db/sql/init.go
+++ b/token/services/ttxdb/db/sql/init.go
@@ -54,9 +54,6 @@ func (d Driver) Open(sp view2.ServiceProvider, name string) (driver.TokenTransac
 			"environment variable must be set to a dataSourceName that can be used with the %s golang driver",
 			OptsKey, EnvVarKey, opts.Driver)
 	}
-	if opts.TablePrefix == "" {
-		opts.TablePrefix = ""
-	}
 	return OpenDB(opts.Driver, dataSourceName, opts.TablePrefix, name, opts.CreateSchema)
 }
 
@@ -72,8 +69,7 @@ func OpenDB(driverName, dataSourceName, tablePrefix, name string, createSchema b
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
 	}
-	err = db.Ping()
-	if err != nil {
+	if err = db.Ping(); err != nil {
 		return nil, errors.Wrapf(err, "failed to ping db [%s]", driverName)
 	}
 	logger.Infof("connected to [%s:%s] database", driverName, tablePrefix)

--- a/token/services/ttxdb/db/sql/sql.go
+++ b/token/services/ttxdb/db/sql/sql.go
@@ -495,11 +495,11 @@ type tableNames struct {
 }
 
 func getTableNames(prefix, name string) (tableNames, error) {
-	r := regexp.MustCompile("^[a-zA-Z_]+$")
-	if !r.MatchString(prefix) {
-		return tableNames{}, errors.New("Illegal character in table prefix, only letters and underscores allowed")
-	}
 	if prefix != "" {
+		r := regexp.MustCompile("^[a-zA-Z_]+$")
+		if !r.MatchString(prefix) {
+			return tableNames{}, errors.New("Illegal character in table prefix, only letters and underscores allowed")
+		}
 		prefix = prefix + "_"
 	}
 

--- a/token/services/ttxdb/db/sql/sql_test.go
+++ b/token/services/ttxdb/db/sql/sql_test.go
@@ -104,6 +104,7 @@ func TestGetTableNames(t *testing.T) {
 		expectedResult tableNames
 		expectErr      bool
 	}{
+		{"", tableNames{Transactions: "transactions_5193a5", Movements: "movements_5193a5", Requests: "requests_5193a5", Validations: "validations_5193a5"}, false},
 		{"valid_prefix", tableNames{Transactions: "valid_prefix_transactions_5193a5", Movements: "valid_prefix_movements_5193a5", Requests: "valid_prefix_requests_5193a5", Validations: "valid_prefix_validations_5193a5"}, false},
 		{"Valid_prefix", tableNames{Transactions: "Valid_prefix_transactions_5193a5", Movements: "Valid_prefix_movements_5193a5", Requests: "Valid_prefix_requests_5193a5", Validations: "Valid_prefix_validations_5193a5"}, false},
 		{"valid", tableNames{Transactions: "valid_transactions_5193a5", Movements: "valid_movements_5193a5", Requests: "valid_requests_5193a5", Validations: "valid_validations_5193a5"}, false},


### PR DESCRIPTION
Table prefixes for the sql driver are useful for data segregation if you have multiple instances of the token sdk running with different configuration / owner wallets and want to connect them to the same database instance (e.g. to save cost or ease operations in a non-production environment).

The current code defaults to an empty prefix if the tablePrefix configuration is not set, but then fails because the regex does not allow an empty prefix. This PR fixes that, so that the user can not set the tablePrefix if they don't need it.