### PR TITLE
identity storage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,7 @@ jobs:
           dlog-fabric-t1-extras,
           dlog-fabric-t2,
           dlog-fabric-t3,
+          dlog-fabric-t4,
           fabtoken-dlog-fabric,
           dloghsm-fabric-t1,
           dloghsm-fabric-t2,

--- a/fungible.mk
+++ b/fungible.mk
@@ -4,7 +4,7 @@ integration-tests-dlog-fabric:
 
 .PHONY: integration-tests-dlog-fabric-t1
 integration-tests-dlog-fabric-t1:
-	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "ne" .
+	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "T1" .
 
 .PHONY: integration-tests-dlog-fabric-t1-extras
 integration-tests-dlog-fabric-t1-extras:
@@ -12,11 +12,15 @@ integration-tests-dlog-fabric-t1-extras:
 
 .PHONY: integration-tests-dlog-fabric-t2
 integration-tests-dlog-fabric-t2:
-	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "=" .
+	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "T2" .
 
 .PHONY: integration-tests-dlog-fabric-t3
 integration-tests-dlog-fabric-t3:
-	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "CA" .
+	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "T3" .
+
+.PHONY: integration-tests-dlog-fabric-t4
+integration-tests-dlog-fabric-t4:
+	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --focus "T4" .
 
 .PHONY: integration-tests-fabtoken-dlog-fabric
 integration-tests-fabtoken-dlog-fabric:

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -31,7 +31,7 @@ var _ = Describe("EndToEnd", func() {
 		network.Stop()
 	})
 
-	Describe("Fungible with Auditor ne Issuer", func() {
+	Describe("T1 Fungible with Auditor ne Issuer", func() {
 		BeforeEach(func() {
 			// notice that fabric-ca does not support yet aries
 			var err error
@@ -90,7 +90,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	Describe("Fungible with Auditor = Issuer", func() {
+	Describe("T2 Fungible with Auditor = Issuer", func() {
 		BeforeEach(func() {
 			var err error
 			network, err = integration.New(StartPortDlog(), "", topology2.Topology(
@@ -119,7 +119,7 @@ var _ = Describe("EndToEnd", func() {
 
 	})
 
-	Describe("Fungible with Auditor ne Issuer + Fabric CA", func() {
+	Describe("T3 Fungible with Auditor ne Issuer + Fabric CA", func() {
 		BeforeEach(func() {
 			var err error
 			network, err = integration.New(StartPortDlog(), "", topology2.Topology(
@@ -139,7 +139,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 	})
 
-	Describe("Fungible with Auditor ne Issuer + SQL", func() {
+	Describe("T4 Fungible with Auditor ne Issuer + SQL", func() {
 		BeforeEach(func() {
 			var err error
 			network, err = integration.New(StartPortDlog(), "", topology2.Topology(

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -8,7 +8,6 @@ package driver
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
@@ -51,6 +50,10 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 	}
 
 	// Prepare wallets
+	storageProvider, err := identity.GetStorageProvider(sp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get identity storage provider")
+	}
 	fscIdentity := view.GetIdentityProvider(sp).DefaultIdentity()
 	wallets := identity.NewWallets()
 	dsManager, err := common.GetDeserializerManager(sp)
@@ -65,7 +68,7 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 		networkLocalMembership.DefaultIdentity(), // network default identity
 		msp.NewSigService(view.GetSigService(sp)), // signer service
 		view.GetEndpointService(sp),               // endpoint service
-		kvs.GetService(sp),
+		storageProvider,
 		dsManager,
 		false,
 	)
@@ -96,11 +99,7 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 		Channel:   channel,
 		Namespace: namespace,
 	}
-	storageProvider, err := identity.GetStorageProvider(sp)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get identity storage provider")
-	}
-	identityStorage, err := storageProvider.New(tmsID)
+	identityStorage, err := storageProvider.NewStorage(tmsID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get identity storage provider")
 	}
@@ -157,6 +156,10 @@ func (d *Driver) NewWalletService(sp view.ServiceProvider, networkID string, cha
 	}
 
 	// Prepare wallets
+	storageProvider, err := identity.GetStorageProvider(sp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get identity storage provider")
+	}
 	wallets := identity.NewWallets()
 	dsManager, err := common.GetDeserializerManager(sp)
 	if err != nil {
@@ -170,7 +173,7 @@ func (d *Driver) NewWalletService(sp view.ServiceProvider, networkID string, cha
 		nil,       // network default identity
 		msp.NewSigService(view.GetSigService(sp)), // signer service
 		nil, // endpoint service
-		kvs.GetService(sp),
+		storageProvider,
 		dsManager,
 		true,
 	)
@@ -202,11 +205,7 @@ func (d *Driver) NewWalletService(sp view.ServiceProvider, networkID string, cha
 		Namespace: namespace,
 	}
 	// wallet service
-	storageProvider, err := identity.GetStorageProvider(sp)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get identity storage provider")
-	}
-	identityStorage, err := storageProvider.New(tmsID)
+	identityStorage, err := storageProvider.NewStorage(tmsID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get identity storage provider")
 	}

--- a/token/core/identity/kvs/storage.go
+++ b/token/core/identity/kvs/storage.go
@@ -87,3 +87,56 @@ func (s *IdentityStorage) IdentityExists(identity view.Identity, wID identity.Wa
 func (s *IdentityStorage) walletPrefix(wID identity.WalletID) string {
 	return fmt.Sprintf("%s-%s-%s-%s", s.tmsID.Network, s.tmsID.Channel, s.tmsID.Namespace, wID)
 }
+
+type WalletPathStorage struct {
+	kvs    KVS
+	prefix string
+}
+
+func NewWalletPathStorage(kvs KVS, prefix string) *WalletPathStorage {
+	return &WalletPathStorage{kvs: kvs, prefix: prefix}
+}
+
+func (w *WalletPathStorage) AddWallet(id string, path string) error {
+	k, err := kvs.CreateCompositeKey("token-sdk", []string{"msp", w.prefix, "registeredIdentity", id})
+	if err != nil {
+		return errors.Wrapf(err, "failed to create identity key")
+	}
+	return w.kvs.Put(k, path)
+}
+
+func (w *WalletPathStorage) WalletPaths() (identity.Iterator[identity.WalletPath], error) {
+	it, err := w.kvs.GetByPartialCompositeID("token-sdk", []string{"msp", w.prefix, "registeredIdentity"})
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed to get registered identities from kvs")
+	}
+	return &WalletPathStorageIterator{Iterator: it}, nil
+}
+
+type WalletPathStorageIterator struct {
+	kvs.Iterator
+}
+
+func (w *WalletPathStorageIterator) HasNext() bool {
+	return w.Iterator.HasNext()
+}
+
+func (w *WalletPathStorageIterator) Close() error {
+	return w.Iterator.Close()
+}
+
+func (w *WalletPathStorageIterator) Next() (identity.WalletPath, error) {
+	var path string
+	k, err := w.Iterator.Next(&path)
+	if err != nil {
+		return identity.WalletPath{}, err
+	}
+	_, attrs, err := kvs.SplitCompositeKey(k)
+	if err != nil {
+		return identity.WalletPath{}, errors.WithMessagef(err, "failed to split key [%s]", k)
+	}
+	return identity.WalletPath{
+		ID:   attrs[3],
+		Path: path,
+	}, nil
+}

--- a/token/core/identity/kvs/storage.go
+++ b/token/core/identity/kvs/storage.go
@@ -97,15 +97,15 @@ func NewWalletPathStorage(kvs KVS, prefix string) *WalletPathStorage {
 	return &WalletPathStorage{kvs: kvs, prefix: prefix}
 }
 
-func (w *WalletPathStorage) AddWallet(id string, path string) error {
-	k, err := kvs.CreateCompositeKey("token-sdk", []string{"msp", w.prefix, "registeredIdentity", id})
+func (w *WalletPathStorage) Add(wp identity.WalletPath) error {
+	k, err := kvs.CreateCompositeKey("token-sdk", []string{"msp", w.prefix, "registeredIdentity", wp.ID})
 	if err != nil {
 		return errors.Wrapf(err, "failed to create identity key")
 	}
-	return w.kvs.Put(k, path)
+	return w.kvs.Put(k, wp.Path)
 }
 
-func (w *WalletPathStorage) WalletPaths() (identity.Iterator[identity.WalletPath], error) {
+func (w *WalletPathStorage) Iterator() (identity.Iterator[identity.WalletPath], error) {
 	it, err := w.kvs.GetByPartialCompositeID("token-sdk", []string{"msp", w.prefix, "registeredIdentity"})
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to get registered identities from kvs")
@@ -115,14 +115,6 @@ func (w *WalletPathStorage) WalletPaths() (identity.Iterator[identity.WalletPath
 
 type WalletPathStorageIterator struct {
 	kvs.Iterator
-}
-
-func (w *WalletPathStorageIterator) HasNext() bool {
-	return w.Iterator.HasNext()
-}
-
-func (w *WalletPathStorageIterator) Close() error {
-	return w.Iterator.Close()
 }
 
 func (w *WalletPathStorageIterator) Next() (identity.WalletPath, error) {

--- a/token/core/identity/kvs/storage.go
+++ b/token/core/identity/kvs/storage.go
@@ -9,11 +9,10 @@ package kvs
 import (
 	"fmt"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
 	"github.com/pkg/errors"
 )
 

--- a/token/core/identity/msp/common/common.go
+++ b/token/core/identity/msp/common/common.go
@@ -13,17 +13,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/core/sig"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/pkg/errors"
 )
-
-type KVS interface {
-	Exists(id string) bool
-	Put(id string, state interface{}) error
-	Get(id string, state interface{}) error
-	GetByPartialCompositeID(prefix string, attrs []string) (kvs.Iterator, error)
-}
 
 // GetIdentityFunc is a function that returns an Identity and its associated audit info for the given options
 type GetIdentityFunc func(opts *driver.IdentityOptions) (view.Identity, []byte, error)

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -160,7 +160,7 @@ func (lm *LocalMembership) RegisterIdentity(id string, path string) error {
 	lm.resolversMutex.Lock()
 	defer lm.resolversMutex.Unlock()
 
-	if err := lm.storeEntryInKVS(id, path); err != nil {
+	if err := lm.storage.Add(identity.WalletPath{ID: id, Path: path}); err != nil {
 		return err
 	}
 	return lm.registerIdentity(config.Identity{ID: id, Path: path, Default: lm.GetDefaultIdentifier() == ""}, lm.curveID)
@@ -352,12 +352,8 @@ func (lm *LocalMembership) cacheSizeForID(id string) (int, error) {
 	return lm.cacheSize, nil
 }
 
-func (lm *LocalMembership) storeEntryInKVS(id string, path string) error {
-	return lm.storage.AddWallet(id, path)
-}
-
 func (lm *LocalMembership) loadFromKVS() error {
-	it, err := lm.storage.WalletPaths()
+	it, err := lm.storage.Iterator()
 	if err != nil {
 		return errors.WithMessage(err, "failed to get registered identities from kvs")
 	}

--- a/token/core/identity/msp/idemix/lm.go
+++ b/token/core/identity/msp/idemix/lm.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 
 	"github.com/IBM/idemix"
+	"github.com/IBM/idemix/bccsp/keystore"
 	"github.com/IBM/idemix/idemixmsp"
 	math3 "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -21,9 +22,9 @@ import (
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	config2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/identity/msp/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
@@ -48,7 +49,8 @@ type LocalMembership struct {
 	defaultNetworkIdentity view.Identity
 	signerService          common.SignerService
 	deserializerManager    common.DeserializerManager
-	kvs                    common.KVS
+	storage                identity.WalletPathStorage
+	keystore               keystore.KVS
 	mspID                  string
 	cacheSize              int
 
@@ -68,7 +70,8 @@ func NewLocalMembership(
 	defaultNetworkIdentity view.Identity,
 	signerService common.SignerService,
 	deserializerManager common.DeserializerManager,
-	kvs common.KVS,
+	walletPathStorage identity.WalletPathStorage,
+	keystore keystore.KVS,
 	mspID string,
 	cacheSize int,
 	curveID math3.CurveID,
@@ -81,7 +84,8 @@ func NewLocalMembership(
 		defaultNetworkIdentity:  defaultNetworkIdentity,
 		signerService:           signerService,
 		deserializerManager:     deserializerManager,
-		kvs:                     kvs,
+		storage:                 walletPathStorage,
+		keystore:                keystore,
 		mspID:                   mspID,
 		cacheSize:               cacheSize,
 		resolversByEnrollmentID: map[string]*common.Resolver{},
@@ -246,7 +250,7 @@ func (lm *LocalMembership) registerProvider(identity config.Identity, curveID ma
 		}
 	}
 	// TODO: remove the need for ServiceProvider
-	cryptoProvider, err := NewKVSBCCSP(lm.kvs, curveID)
+	cryptoProvider, err := NewKVSBCCSP(lm.keystore, curveID)
 	if err != nil {
 		return errors.WithMessage(err, "failed to instantiate crypto provider")
 	}
@@ -349,37 +353,26 @@ func (lm *LocalMembership) cacheSizeForID(id string) (int, error) {
 }
 
 func (lm *LocalMembership) storeEntryInKVS(id string, path string) error {
-	k, err := kvs.CreateCompositeKey("token-sdk", []string{"msp", "idemix", "registeredIdentity", id})
-	if err != nil {
-		return errors.Wrapf(err, "failed to create identity key")
-	}
-	return lm.kvs.Put(k, path)
+	return lm.storage.AddWallet(id, path)
 }
 
 func (lm *LocalMembership) loadFromKVS() error {
-	it, err := lm.kvs.GetByPartialCompositeID("token-sdk", []string{"msp", "idemix", "registeredIdentity"})
+	it, err := lm.storage.WalletPaths()
 	if err != nil {
 		return errors.WithMessage(err, "failed to get registered identities from kvs")
 	}
 	defer it.Close()
 	for it.HasNext() {
-		var path string
-		k, err := it.Next(&path)
+		entry, err := it.Next()
 		if err != nil {
 			return errors.WithMessagef(err, "failed to get next registered identities from kvs")
 		}
 
-		_, attrs, err := kvs.SplitCompositeKey(k)
-		if err != nil {
-			return errors.WithMessagef(err, "failed to split key [%s]", k)
-		}
-
-		id := attrs[3]
+		id := entry.ID
 		if lm.getResolver(id) != nil {
 			continue
 		}
-
-		if err := lm.registerIdentity(config.Identity{ID: id, Path: path, Default: lm.GetDefaultIdentifier() == ""}, lm.curveID); err != nil {
+		if err := lm.registerIdentity(config.Identity{ID: id, Path: entry.Path, Default: lm.GetDefaultIdentifier() == ""}, lm.curveID); err != nil {
 			return err
 		}
 	}

--- a/token/core/identity/msp/x509/lm.go
+++ b/token/core/identity/msp/x509/lm.go
@@ -156,7 +156,7 @@ func (lm *LocalMembership) GetIdentityInfo(label string, auditInfo []byte) (driv
 }
 
 func (lm *LocalMembership) RegisterIdentity(id string, path string) error {
-	if err := lm.storeEntryInKVS(id, path); err != nil {
+	if err := lm.walletPathStorage.Add(identity.WalletPath{ID: id, Path: path}); err != nil {
 		return err
 	}
 	return lm.registerIdentity(&config.Identity{
@@ -317,12 +317,8 @@ func (lm *LocalMembership) getResolver(label string) *common.Resolver {
 	return nil
 }
 
-func (lm *LocalMembership) storeEntryInKVS(id string, path string) error {
-	return lm.walletPathStorage.AddWallet(id, path)
-}
-
 func (lm *LocalMembership) loadFromKVS() error {
-	it, err := lm.walletPathStorage.WalletPaths()
+	it, err := lm.walletPathStorage.Iterator()
 	if err != nil {
 		return errors.WithMessage(err, "failed to get registered identities from kvs")
 	}

--- a/token/core/identity/storage.go
+++ b/token/core/identity/storage.go
@@ -9,13 +9,25 @@ package identity
 import (
 	"reflect"
 
+	"github.com/IBM/idemix/bccsp/keystore"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/pkg/errors"
 )
 
+type Iterator[T any] interface {
+	HasNext() bool
+	Close() error
+	Next() (T, error)
+}
+
 type WalletID = string
+
+type WalletPath struct {
+	ID   string
+	Path string
+}
 
 type Storage interface {
 	StoreWalletID(wID WalletID) error
@@ -26,8 +38,15 @@ type Storage interface {
 	LoadMeta(identity view.Identity, meta any) error
 }
 
+type WalletPathStorage interface {
+	AddWallet(id string, path string) error
+	WalletPaths() (Iterator[WalletPath], error)
+}
+
 type StorageProvider interface {
-	New(tmsID token.TMSID) (Storage, error)
+	NewStorage(tmsID token.TMSID) (Storage, error)
+	GetWalletPathStorage(id string) (WalletPathStorage, error)
+	NewKeystore() (keystore.KVS, error)
 }
 
 var (

--- a/token/core/identity/storage.go
+++ b/token/core/identity/storage.go
@@ -39,8 +39,8 @@ type Storage interface {
 }
 
 type WalletPathStorage interface {
-	AddWallet(id string, path string) error
-	WalletPaths() (Iterator[WalletPath], error)
+	Add(wp WalletPath) error
+	Iterator() (Iterator[WalletPath], error)
 }
 
 type StorageProvider interface {

--- a/token/sdk/identity/provider.go
+++ b/token/sdk/identity/provider.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package identity
 
 import (
+	"github.com/IBM/idemix/bccsp/keystore"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	kvs2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -22,6 +23,14 @@ func NewKVSStorageProvider(sp view.ServiceProvider) *KVSStorageProvider {
 	return &KVSStorageProvider{sp: sp}
 }
 
-func (s *KVSStorageProvider) New(tmsID token.TMSID) (identity.Storage, error) {
+func (s *KVSStorageProvider) NewStorage(tmsID token.TMSID) (identity.Storage, error) {
 	return kvs.NewIdentityStorage(kvs2.GetService(s.sp), tmsID), nil
+}
+
+func (s *KVSStorageProvider) GetWalletPathStorage(id string) (identity.WalletPathStorage, error) {
+	return kvs.NewWalletPathStorage(kvs2.GetService(s.sp), id), nil
+}
+
+func (s *KVSStorageProvider) NewKeystore() (keystore.KVS, error) {
+	return kvs2.GetService(s.sp), nil
 }

--- a/token/services/ttxdb/db/sql/sql.go
+++ b/token/services/ttxdb/db/sql/sql.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
-	"runtime/debug"
 	"sync"
 	"time"
 
@@ -332,7 +331,7 @@ func (db *Persistence) QueryValidations(params driver.QueryValidationRecordsPara
 }
 
 func (db *Persistence) AddTransactionEndorsementAck(txID string, endorser view.Identity, sigma []byte) error {
-	logger.Infof("adding transaction endorse ack record [%s] [%s]", txID, string(debug.Stack()))
+	logger.Debugf("adding transaction endorse ack record [%s]", txID)
 
 	now := time.Now().UTC()
 	query := fmt.Sprintf("INSERT INTO %s (id, tx_id, endorser, sigma, stored_at) VALUES ($1, $2, $3, $4, $5)", db.table.TransactionEndorseAck)

--- a/token/services/ttxdb/db/sql/sql.go
+++ b/token/services/ttxdb/db/sql/sql.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -333,7 +334,7 @@ func (db *Persistence) QueryValidations(params driver.QueryValidationRecordsPara
 }
 
 func (db *Persistence) AddTransactionEndorsementAck(txID string, endorser view.Identity, sigma []byte) error {
-	logger.Debugf("adding transaction endorse ack record [%s]", txID)
+	logger.Infof("adding transaction endorse ack record [%s] [%s]", txID, string(debug.Stack()))
 
 	now := time.Now().UTC()
 	query := fmt.Sprintf("INSERT INTO %s (id, tx_id, endorser, sigma, stored_at) VALUES ($1, $2, $3, $4, $5)", db.table.TransactionEndorseAck)

--- a/token/services/ttxdb/db/sql/sql.go
+++ b/token/services/ttxdb/db/sql/sql.go
@@ -30,8 +30,6 @@ type Persistence struct {
 
 	txn     *sql.Tx
 	txnLock sync.Mutex
-
-	mutex sync.RWMutex
 }
 
 func (db *Persistence) Close() error {

--- a/token/services/ttxdb/db/sql/sql.go
+++ b/token/services/ttxdb/db/sql/sql.go
@@ -29,6 +29,8 @@ type Persistence struct {
 
 	txn     *sql.Tx
 	txnLock sync.Mutex
+
+	mutex sync.RWMutex
 }
 
 func (db *Persistence) Close() error {
@@ -331,6 +333,9 @@ func (db *Persistence) QueryValidations(params driver.QueryValidationRecordsPara
 }
 
 func (db *Persistence) AddTransactionEndorsementAck(txID string, endorser view.Identity, sigma []byte) error {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
 	tx, err := db.db.Begin()
 	if err != nil {
 		return errors.New("failed starting a transaction")
@@ -357,6 +362,9 @@ func (db *Persistence) AddTransactionEndorsementAck(txID string, endorser view.I
 }
 
 func (db *Persistence) GetTransactionEndorsementAcks(txID string) (map[string][]byte, error) {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
 	query := fmt.Sprintf("SELECT endorser, sigma FROM %s WHERE tx_id=$1;", db.table.TransactionEndorseAck)
 	logger.Debug(query, txID)
 


### PR DESCRIPTION
This PR extends the `StorageProvider` to add support for `WalletPathStorage` and `keystore.KVS`.
This further reduces direct dependency to the FSC's KVS.