### PR TITLE
new public params management

### DIFF
--- a/cmd/tokengen/samples/topology/fungible.yaml
+++ b/cmd/tokengen/samples/topology/fungible.yaml
@@ -108,7 +108,6 @@ topologies:
   - network: default
     channel: testchannel
     namespace: tns
-    driver: dlog
     publicparamsgenargs:
     - "100"
     - "2"

--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -18,11 +18,9 @@ token:
       network: default # the name of the network this TMS refers to (Fabric, Orion, etc)
       channel: testchannel # the name of the network's channel this TMS refers to, if applicable
       namespace: tns # the name of the channel's namespace this TMS refers to, if applicable
-      # the name of the driver that provides the implementation of the Driver API.
-      # This field is optional. If not specified, the Token-SDK will derive this information by fetching the public parameters
-      # from the remote network
-      driver: zkatdlog 
-      # sections dedicated to the definition of the wallets 
+      # sections dedicated to the definition of the wallets
+      publicParameters:
+        path: # path to the file containing the public parameters. This field is optional
       wallets:
         # Default cache size reference that can be used by any wallet that support caching
         defaultCacheSize: 3

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -746,6 +746,18 @@ func CheckPublicParamsForTMSID(network *integration.Infrastructure, tmsId *token
 	}
 }
 
+func CheckPublicParamsMatch(network *integration.Infrastructure, tmsId *token2.TMSID, ids ...string) bool {
+	for _, id := range ids {
+		_, err := network.Client(id).CallView("CheckPublicParamsMatch", common.JSONMarshall(&views.CheckPublicParamsMatch{
+			TMSID: tmsId,
+		}))
+		if err != nil {
+			return false
+		}
+	}
+	return true
+}
+
 func GetTMS(network *integration.Infrastructure, networkName string) *topology.TMS {
 	var tms *topology.TMS
 	p := network.Ctx.PlatformsByName["token"]

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -861,10 +861,10 @@ func TestMixed(network *integration.Infrastructure) {
 	RegisterAuditorForTMSID(network, "auditor2", fabTokenId, nil)
 
 	// give some time to the nodes to get the public parameters
-	time.Sleep(10 * time.Second)
+	time.Sleep(40 * time.Second)
 
-	CheckPublicParamsForTMSID(network, dlogId, "issuer1", "auditor1", "alice", "bob")
-	CheckPublicParamsForTMSID(network, fabTokenId, "issuer2", "auditor2", "alice", "bob")
+	Eventually(CheckPublicParamsMatch).WithArguments(network, dlogId, "issuer1", "auditor1", "alice", "bob").WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(true))
+	Eventually(CheckPublicParamsMatch).WithArguments(network, fabTokenId, "issuer2", "auditor2", "alice", "bob").WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(true))
 
 	IssueCashForTMSID(network, "", "USD", 110, "alice", "auditor1", true, "issuer1", dlogId)
 	IssueCashForTMSID(network, "", "USD", 115, "alice", "auditor2", true, "issuer2", fabTokenId)

--- a/integration/token/fungible/views/info.go
+++ b/integration/token/fungible/views/info.go
@@ -66,8 +66,7 @@ func (p *CheckPublicParamsMatchView) Call(context view.Context) (interface{}, er
 	assert.NoError(tms.PublicParametersManager().Validate(), "failed to validate local public parameters")
 	ppRaw := GetTMSPublicParams(tms)
 
-	fetchedPPRaw, err := tms.PublicParametersManager().Fetch()
-
+	fetchedPPRaw, err := network.GetInstance(context, tms.Network(), tms.Channel()).FetchPublicParameters(tms.Namespace())
 	assert.NoError(err, "failed to fetch public params")
 	ppm, err := token.NewPublicParametersManagerFromPublicParams(fetchedPPRaw)
 

--- a/token/core/driver.go
+++ b/token/core/driver.go
@@ -10,18 +10,18 @@ import (
 	"sort"
 	"sync"
 
-	api2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 )
 
 var (
 	driversMu sync.RWMutex
-	drivers   = make(map[string]api2.Driver)
+	drivers   = make(map[string]driver.Driver)
 )
 
 // Register makes a kvs driver available by the provided name.
 // If Register is called twice with the same name or if driver is nil,
 // it panics.
-func Register(name string, driver api2.Driver) {
+func Register(name string, driver driver.Driver) {
 	driversMu.Lock()
 	defer driversMu.Unlock()
 	if driver == nil {

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -32,7 +32,7 @@ func (d *Driver) PublicParametersFromBytes(params []byte) (driver.PublicParamete
 	return pp, nil
 }
 
-func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher driver.PublicParamsFetcher, networkID string, channel string, namespace string) (driver.TokenManagerService, error) {
+func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, channel string, namespace string) (driver.TokenManagerService, error) {
 	n := network.GetInstance(sp, networkID, channel)
 	if n == nil {
 		return nil, errors.Errorf("network [%s] does not exists", networkID)
@@ -115,10 +115,6 @@ func (d *Driver) NewTokenService(sp view.ServiceProvider, publicParamsFetcher dr
 		ppm.NewPublicParamsManager(
 			fabtoken.PublicParameters,
 			qe,
-			&fabtoken.PublicParamsLoader{
-				PublicParamsFetcher: publicParamsFetcher,
-				PPLabel:             fabtoken.PublicParameters,
-			},
 		),
 		&fabtoken.VaultTokenLoader{TokenVault: qe},
 		qe,
@@ -148,7 +144,7 @@ func (d *Driver) NewPublicParametersManager(params driver.PublicParameters) (dri
 	return ppm.NewPublicParamsManagerFromParams(pp)
 }
 
-func (d *Driver) NewWalletService(sp view.ServiceProvider, networkID string, channel string, namespace string, params driver.PublicParameters) (driver.WalletService, error) {
+func (d *Driver) NewWalletService(sp driver.ServiceProvider, networkID string, channel string, namespace string, params driver.PublicParameters) (driver.WalletService, error) {
 	tmsConfig, err := config.NewTokenSDK(view.GetConfigService(sp)).GetTMS(networkID, channel, namespace)
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create config manager")

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -32,7 +32,10 @@ func (d *Driver) PublicParametersFromBytes(params []byte) (driver.PublicParamete
 	return pp, nil
 }
 
-func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, channel string, namespace string) (driver.TokenManagerService, error) {
+func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, channel string, namespace string, publicParams []byte) (driver.TokenManagerService, error) {
+	if len(publicParams) == 0 {
+		return nil, errors.Errorf("empty public parameters")
+	}
 	n := network.GetInstance(sp, networkID, channel)
 	if n == nil {
 		return nil, errors.Errorf("network [%s] does not exists", networkID)
@@ -122,7 +125,7 @@ func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, ch
 		fabtoken.NewDeserializer(),
 		tmsConfig,
 	)
-	if err := service.PPM.Load(); err != nil {
+	if err := service.PPM.SetPublicParameters(publicParams); err != nil {
 		return nil, errors.WithMessage(err, "failed to update public parameters")
 	}
 	return service, nil

--- a/token/core/fabtoken/loaders.go
+++ b/token/core/fabtoken/loaders.go
@@ -7,10 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
-	"github.com/pkg/errors"
 )
 
 type TokenVault interface {
@@ -25,43 +23,4 @@ type VaultTokenLoader struct {
 // in the vault and the content of the tokens
 func (s *VaultTokenLoader) GetTokens(ids []*token.ID) ([]string, []*token.Token, error) {
 	return s.TokenVault.GetTokens(ids...)
-}
-
-// PublicParamsLoader allows one to fetch the public parameters for fabtoken
-type PublicParamsLoader struct {
-	PublicParamsFetcher driver.PublicParamsFetcher
-	PPLabel             string
-}
-
-// Fetch fetches the public parameters from the backend
-func (s *PublicParamsLoader) Fetch() ([]byte, error) {
-	logger.Debugf("fetch public parameters...")
-	raw, err := s.PublicParamsFetcher.Fetch()
-	if err != nil {
-		logger.Errorf("failed retrieving public params [%s]", err)
-		return nil, err
-	}
-	logger.Debugf("fetched public parameters [%s]", hash.Hashable(raw).String())
-	return raw, nil
-}
-
-// FetchParams fetches the public parameters from the backend and unmarshal them
-func (s *PublicParamsLoader) FetchParams() (*PublicParams, error) {
-	logger.Debugf("fetch public parameters...")
-	raw, err := s.PublicParamsFetcher.Fetch()
-	if err != nil {
-		logger.Errorf("failed retrieving public params [%s]", err)
-		return nil, err
-	}
-
-	logger.Debugf("fetched public parameters [%s], unmarshal them...", hash.Hashable(raw).String())
-	pp, err := NewPublicParamsFromBytes(raw, s.PPLabel)
-	if err != nil {
-		return nil, err
-	}
-	if err := pp.Validate(); err != nil {
-		return nil, errors.Wrap(err, "failed to validate public parameters")
-	}
-	logger.Debugf("fetched public parameters [%s], unmarshal them...done", hash.Hashable(raw).String())
-	return pp, nil
 }

--- a/token/core/fabtoken/ppm/ppm.go
+++ b/token/core/fabtoken/ppm/ppm.go
@@ -54,7 +54,11 @@ func NewPublicParamsManagerFromParams(pp *fabtoken.PublicParams) (*PublicParamsM
 
 // PublicParameters returns the public parameters of PublicParamsManager
 func (v *PublicParamsManager) PublicParameters() driver.PublicParameters {
-	return v.PublicParams()
+	pp := v.PublicParams()
+	if pp == nil {
+		return nil
+	}
+	return pp
 }
 
 // SerializePublicParameters returns the public params in a serialized form

--- a/token/core/fabtoken/ppm/ppm.go
+++ b/token/core/fabtoken/ppm/ppm.go
@@ -92,6 +92,10 @@ func (v *PublicParamsManager) SetPublicParameters(raw []byte) error {
 	v.Mutex.Lock()
 	defer v.Mutex.Unlock()
 
+	if len(raw) == 0 {
+		return errors.Errorf("empty public parameters")
+	}
+
 	pp, err := fabtoken.NewPublicParamsFromBytes(raw, v.PPLabel)
 	if err != nil {
 		return err

--- a/token/core/fabtoken/ppm/ppm.go
+++ b/token/core/fabtoken/ppm/ppm.go
@@ -54,11 +54,7 @@ func NewPublicParamsManagerFromParams(pp *fabtoken.PublicParams) (*PublicParamsM
 
 // PublicParameters returns the public parameters of PublicParamsManager
 func (v *PublicParamsManager) PublicParameters() driver.PublicParameters {
-	pp := v.PublicParams()
-	if pp == nil {
-		return nil
-	}
-	return pp
+	return v.PublicParams()
 }
 
 // SerializePublicParameters returns the public params in a serialized form

--- a/token/core/fabtoken/ppm/ppm.go
+++ b/token/core/fabtoken/ppm/ppm.go
@@ -19,14 +19,6 @@ import (
 
 var logger = flogging.MustGetLogger("token-sdk.fabtoken")
 
-type PublicParamsLoader interface {
-	// Fetch fetches the public parameters from the backend
-	Fetch() ([]byte, error)
-	// FetchParams fetches the public parameters from the backend and unmarshal them.
-	// The public parameters are also validated.
-	FetchParams() (*fabtoken.PublicParams, error)
-}
-
 type Vault interface {
 	// PublicParams returns the public parameters
 	PublicParams() ([]byte, error)
@@ -36,8 +28,6 @@ type Vault interface {
 type PublicParamsManager struct {
 	// fabtoken public parameters
 	PP *fabtoken.PublicParams
-	// a loader for fabric public parameters
-	PublicParamsLoader PublicParamsLoader
 	// the vault
 	Vault Vault
 	// label of the public params
@@ -47,8 +37,8 @@ type PublicParamsManager struct {
 }
 
 // NewPublicParamsManager initializes a PublicParamsManager with the passed PublicParamsLoader
-func NewPublicParamsManager(PPLabel string, vault Vault, publicParamsLoader PublicParamsLoader) *PublicParamsManager {
-	return &PublicParamsManager{PPLabel: PPLabel, Vault: vault, PublicParamsLoader: publicParamsLoader, Mutex: sync.RWMutex{}}
+func NewPublicParamsManager(PPLabel string, vault Vault) *PublicParamsManager {
+	return &PublicParamsManager{PPLabel: PPLabel, Vault: vault, Mutex: sync.RWMutex{}}
 }
 
 // NewPublicParamsManagerFromParams initializes a PublicParamsManager with the passed PublicParams
@@ -107,18 +97,6 @@ func (v *PublicParamsManager) SetPublicParameters(raw []byte) error {
 
 	v.PP = pp
 	return nil
-}
-
-// Fetch fetches the public parameters from the backend
-func (v *PublicParamsManager) Fetch() ([]byte, error) {
-	if v.PublicParamsLoader == nil {
-		return nil, errors.New("public parameters loader not set")
-	}
-	raw, err := v.PublicParamsLoader.Fetch()
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed force fetching public parameters")
-	}
-	return raw, nil
 }
 
 // AuditorIdentity returns the identity of the auditor

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -117,7 +117,8 @@ func (m *TMSProvider) Update(opts driver.ServiceOptions) error {
 		if err != nil {
 			return errors.WithMessage(err, "failed unmarshalling public parameters")
 		}
-		if service.PublicParamsManager().PublicParameters() == nil || newPP.Identifier == service.PublicParamsManager().PublicParameters().Identifier() {
+		if service.PublicParamsManager().PublicParameters() == nil ||
+			(service.PublicParamsManager().PublicParameters() != nil && newPP.Identifier == service.PublicParamsManager().PublicParameters().Identifier()) {
 			return service.PublicParamsManager().SetPublicParameters(opts.PublicParams)
 		}
 

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -148,9 +148,11 @@ func (m *TMSProvider) newTMS(opts *driver.ServiceOptions) (driver.TokenManagerSe
 	}
 
 	if m.callbackFunc != nil {
-		if err := m.callbackFunc(ts, opts.Network, opts.Channel, opts.Namespace); err != nil {
-			return nil, err
-		}
+		go func() {
+			if err := m.callbackFunc(ts, opts.Network, opts.Channel, opts.Namespace); err != nil {
+				logger.Fatalf("failure [%s]", err)
+			}
+		}()
 	}
 	return ts, nil
 }

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -142,7 +142,7 @@ func (m *TMSProvider) newTMS(opts *driver.ServiceOptions) (driver.TokenManagerSe
 	}
 	logger.Debugf("instantiating token service for [%s:%s:%s], with driver identifier [%s]", opts.Network, opts.Channel, opts.Namespace, driverName)
 
-	ts, err := d.NewTokenService(m.sp, opts.PublicParamsFetcher, opts.Network, opts.Channel, opts.Namespace)
+	ts, err := d.NewTokenService(m.sp, opts.Network, opts.Channel, opts.Namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to instantiate token service for [%s:%s:%s]", opts.Network, opts.Channel, opts.Namespace)
 	}

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -117,7 +117,7 @@ func (m *TMSProvider) Update(opts driver.ServiceOptions) error {
 		if err != nil {
 			return errors.WithMessage(err, "failed unmarshalling public parameters")
 		}
-		if newPP.Identifier == service.PublicParamsManager().PublicParameters().Identifier() {
+		if service.PublicParamsManager().PublicParameters() == nil || newPP.Identifier == service.PublicParamsManager().PublicParameters().Identifier() {
 			return service.PublicParamsManager().SetPublicParameters(opts.PublicParams)
 		}
 

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -77,11 +77,11 @@ func (m *TMSProvider) GetTokenManagerService(opts driver.ServiceOptions) (servic
 		}
 	}()
 
-	key := opts.Network + opts.Channel + opts.Network
+	key := opts.Network + opts.Channel + opts.Namespace
 	var ok bool
 	service, ok = m.services[key]
 	if !ok {
-		logger.Debugf("creating new token manager service for [%s:%s:%s]", opts.Network, opts.Channel, opts.Namespace)
+		logger.Debugf("creating new token manager service for [%s:%s:%s] with key [%s]", opts.Network, opts.Channel, opts.Namespace, key)
 		var err error
 		service, err = m.newTMS(&opts)
 		if err != nil {
@@ -122,7 +122,8 @@ func (m *TMSProvider) Update(opts driver.ServiceOptions) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	key := opts.Network + opts.Channel + opts.Network
+	key := opts.Network + opts.Channel + opts.Namespace
+	logger.Debugf("update tms for [%s:%s:%s] with key [%s]", opts.Network, opts.Channel, opts.Namespace, key)
 	service, ok := m.services[key]
 	if ok {
 		// if the public params identifiers are the same, then just pass the new public params

--- a/token/core/tms.go
+++ b/token/core/tms.go
@@ -117,8 +117,8 @@ func (m *TMSProvider) Update(opts driver.ServiceOptions) error {
 		if err != nil {
 			return errors.WithMessage(err, "failed unmarshalling public parameters")
 		}
-		if service.PublicParamsManager().PublicParameters() == nil ||
-			(service.PublicParamsManager().PublicParameters() != nil && newPP.Identifier == service.PublicParamsManager().PublicParameters().Identifier()) {
+		oldPP := service.PublicParamsManager().PublicParameters()
+		if oldPP == nil || (oldPP != nil && newPP.Identifier == oldPP.Identifier()) {
 			return service.PublicParamsManager().SetPublicParameters(opts.PublicParams)
 		}
 

--- a/token/core/zkatdlog/crypto/ppm/ppm.go
+++ b/token/core/zkatdlog/crypto/ppm/ppm.go
@@ -83,6 +83,10 @@ func (v *PublicParamsManager) SetPublicParameters(raw []byte) error {
 	v.Mutex.Lock()
 	defer v.Mutex.Unlock()
 
+	if len(raw) == 0 {
+		return errors.Errorf("empty public parameters")
+	}
+
 	pp, err := crypto.NewPublicParamsFromBytes(raw, v.PPLabel)
 	if err != nil {
 		return err

--- a/token/core/zkatdlog/crypto/ppm/ppm.go
+++ b/token/core/zkatdlog/crypto/ppm/ppm.go
@@ -20,21 +20,13 @@ var logger = flogging.MustGetLogger("token-sdk.driver.zkatdlog")
 
 type SetPublicParametersCallbackFunc = func(pp driver.PublicParameters) error
 
-type PublicParamsLoader interface {
-	// Fetch fetches the public parameters from the backend
-	Fetch() ([]byte, error)
-	// FetchParams fetches the public parameters from the backend and unmarshal them
-	FetchParams() (*crypto.PublicParams, error)
-}
-
 type Vault interface {
 	// PublicParams returns the public parameters
 	PublicParams() ([]byte, error)
 }
 
 type PublicParamsManager struct {
-	PP                 *crypto.PublicParams
-	PublicParamsLoader PublicParamsLoader
+	PP *crypto.PublicParams
 	// the vault
 	Vault Vault
 	// label of the public params
@@ -45,8 +37,8 @@ type PublicParamsManager struct {
 	Callbacks []SetPublicParametersCallbackFunc
 }
 
-func NewPublicParamsManager(PPLabel string, vault Vault, publicParamsLoader PublicParamsLoader) *PublicParamsManager {
-	return &PublicParamsManager{PPLabel: PPLabel, Vault: vault, PublicParamsLoader: publicParamsLoader, Mutex: sync.RWMutex{}}
+func NewPublicParamsManager(PPLabel string, vault Vault) *PublicParamsManager {
+	return &PublicParamsManager{PPLabel: PPLabel, Vault: vault, Mutex: sync.RWMutex{}}
 }
 
 func NewFromParams(pp *crypto.PublicParams) (*PublicParamsManager, error) {
@@ -110,20 +102,6 @@ func (v *PublicParamsManager) SetPublicParameters(raw []byte) error {
 	v.PP = pp
 
 	return nil
-}
-
-func (v *PublicParamsManager) Fetch() ([]byte, error) {
-	logger.Debugf("fetch public parameters...")
-	if v.PublicParamsLoader == nil {
-		return nil, errors.New("public parameters loader not set")
-	}
-	raw, err := v.PublicParamsLoader.Fetch()
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed force fetching public parameters")
-	}
-	logger.Debugf("fetched public parameters [%s]", hash.Hashable(raw).String())
-
-	return raw, nil
 }
 
 func (v *PublicParamsManager) PublicParams() *crypto.PublicParams {

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -9,8 +9,6 @@ package driver
 import (
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
-
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -24,6 +22,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/validator"
 	zkatdlog "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/pkg/errors"
 )
 
@@ -38,7 +37,10 @@ func (d *Driver) PublicParametersFromBytes(params []byte) (driver.PublicParamete
 	return pp, nil
 }
 
-func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, channel string, namespace string) (driver.TokenManagerService, error) {
+func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, channel string, namespace string, publicParams []byte) (driver.TokenManagerService, error) {
+	if len(publicParams) == 0 {
+		return nil, errors.Errorf("empty public parameters")
+	}
 	n := network.GetInstance(sp, networkID, channel)
 	if n == nil {
 		return nil, errors.Errorf("network [%s] does not exists", networkID)
@@ -134,7 +136,7 @@ func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, ch
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed to create token service")
 	}
-	if err := ppm.Load(); err != nil {
+	if err := ppm.SetPublicParameters(publicParams); err != nil {
 		return nil, errors.WithMessage(err, "failed to fetch public parameters")
 	}
 

--- a/token/core/zkatdlog/nogh/loaders.go
+++ b/token/core/zkatdlog/nogh/loaders.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	token3 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -133,47 +132,4 @@ func (s *VaultTokenLoader) LoadTokens(ids []*token3.ID) ([]string, []*token.Toke
 	}
 
 	return inputIDs, tokens, inputInf, signerIds, nil
-}
-
-type PublicParamsLoader struct {
-	PublicParamsFetcher driver.PublicParamsFetcher
-	PPLabel             string
-}
-
-func NewPublicParamsLoader(publicParamsFetcher driver.PublicParamsFetcher, PPLabel string) *PublicParamsLoader {
-	return &PublicParamsLoader{PublicParamsFetcher: publicParamsFetcher, PPLabel: PPLabel}
-}
-
-// Fetch fetches the public parameters from the backend
-func (s *PublicParamsLoader) Fetch() ([]byte, error) {
-	logger.Debugf("fetch public parameters...")
-	raw, err := s.PublicParamsFetcher.Fetch()
-	if err != nil {
-		logger.Errorf("failed retrieving public params [%s]", err)
-		return nil, err
-	}
-	logger.Debugf("fetched public parameters [%s]", hash.Hashable(raw).String())
-	return raw, nil
-}
-
-// FetchParams fetches the public parameters from the backend and unmarshal them
-func (s *PublicParamsLoader) FetchParams() (*crypto.PublicParams, error) {
-	logger.Debugf("fetch public parameters...")
-	raw, err := s.PublicParamsFetcher.Fetch()
-	if err != nil {
-		logger.Errorf("failed retrieving public params [%s]", err)
-		return nil, err
-	}
-
-	logger.Debugf("fetched public parameters [%s], unmarshal them...", hash.Hashable(raw).String())
-	pp := &crypto.PublicParams{}
-	pp.Label = s.PPLabel
-	if err := pp.Deserialize(raw); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal public parameters")
-	}
-	logger.Debugf("fetched public parameters [%s], unmarshal them...done", hash.Hashable(raw).String())
-	if err := pp.Validate(); err != nil {
-		return nil, errors.Wrap(err, "failed to validate public parameters")
-	}
-	return pp, nil
 }

--- a/token/driver/config/config.go
+++ b/token/driver/config/config.go
@@ -47,7 +47,6 @@ type TMS struct {
 	Network          string            `yaml:"network,omitempty"`
 	Channel          string            `yaml:"channel,omitempty"`
 	Namespace        string            `yaml:"namespace,omitempty"`
-	Driver           string            `yaml:"driver,omitempty"`
 	PublicParameters *PublicParameters `yaml:"publicParameters,omitempty"`
 	Certification    *Certification    `yaml:"certification,omitempty"`
 	Wallets          *Wallets          `yaml:"wallets,omitempty"`

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -17,7 +17,7 @@ type Driver interface {
 	// PublicParametersFromBytes unmarshals the bytes to a PublicParameters instance.
 	PublicParametersFromBytes(params []byte) (PublicParameters, error)
 	// NewTokenService returns a new TokenManagerService instance.
-	NewTokenService(sp ServiceProvider, networkID string, channel string, namespace string) (TokenManagerService, error)
+	NewTokenService(sp ServiceProvider, networkID string, channel string, namespace string, publicParams []byte) (TokenManagerService, error)
 	// NewPublicParametersManager returns a new PublicParametersManager instance from the passed public parameters
 	NewPublicParametersManager(pp PublicParameters) (PublicParamsManager, error)
 	// NewValidator returns a new Validator instance from the passed public parameters

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -6,16 +6,18 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import (
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-)
+// ServiceProvider is used to return instances of a given type
+type ServiceProvider interface {
+	// GetService returns an instance of the given type
+	GetService(v interface{}) (interface{}, error)
+}
 
 // Driver is the interface that must be implemented by a token driver.
 type Driver interface {
 	// PublicParametersFromBytes unmarshals the bytes to a PublicParameters instance.
 	PublicParametersFromBytes(params []byte) (PublicParameters, error)
 	// NewTokenService returns a new TokenManagerService instance.
-	NewTokenService(sp view.ServiceProvider, publicParamsFetcher PublicParamsFetcher, network string, channel string, namespace string) (TokenManagerService, error)
+	NewTokenService(sp ServiceProvider, networkID string, channel string, namespace string) (TokenManagerService, error)
 	// NewPublicParametersManager returns a new PublicParametersManager instance from the passed public parameters
 	NewPublicParametersManager(pp PublicParameters) (PublicParamsManager, error)
 	// NewValidator returns a new Validator instance from the passed public parameters
@@ -25,5 +27,5 @@ type Driver interface {
 // ExtendedDriver is the interface that models additional services a token driver may offer
 type ExtendedDriver interface {
 	// NewWalletService returns an instance of the WalletService interface for the passed arguments
-	NewWalletService(sp view.ServiceProvider, network string, channel string, namespace string, params PublicParameters) (WalletService, error)
+	NewWalletService(sp ServiceProvider, networkID string, channel string, namespace string, params PublicParameters) (WalletService, error)
 }

--- a/token/driver/publicparams.go
+++ b/token/driver/publicparams.go
@@ -56,8 +56,6 @@ type PublicParameters interface {
 type PublicParamsManager interface {
 	// Load loads the public parameters either from the local storage, if available
 	Load() error
-	// Fetch fetches the public parameters
-	Fetch() ([]byte, error)
 	// PublicParameters returns the public parameters.
 	PublicParameters() PublicParameters
 	// SetPublicParameters updates the public parameters with the passed value

--- a/token/driver/tms.go
+++ b/token/driver/tms.go
@@ -6,7 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import "github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+import (
+	"fmt"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/config"
+	"github.com/pkg/errors"
+)
 
 // TokenManagerService is the entry point of the Driver API and gives access to the rest of the API
 type TokenManagerService interface {
@@ -25,8 +30,51 @@ type TokenManagerService interface {
 	ConfigManager() config.Manager
 }
 
+// ServiceOptions is used to configure the service
+type ServiceOptions struct {
+	// Network is the name of the network
+	Network string
+	// Channel is the name of the channel, if meaningful for the underlying backend
+	Channel string
+	// Namespace is the namespace of the token
+	Namespace string
+	// PublicParamsFetcher is used to fetch the public parameters
+	PublicParamsFetcher PublicParamsFetcher
+	// PublicParams contains the public params to use to instantiate the driver
+	PublicParams []byte
+	// Params is used to store any application specific parameter
+	Params map[string]interface{}
+}
+
+func (o ServiceOptions) String() string {
+	return fmt.Sprintf("%s,%s,%s", o.Network, o.Channel, o.Namespace)
+}
+
+// ParamAsString returns the value bound to the passed key.
+// If the key is not found, it returns the empty string.
+// if the value bound to the passed key is not a string, it returns an error.
+func (o ServiceOptions) ParamAsString(key string) (string, error) {
+	if o.Params == nil {
+		return "", nil
+	}
+	v, ok := o.Params[key]
+	if !ok {
+		return "", nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", errors.Errorf("expecting string, found [%T]", o)
+	}
+	return s, nil
+}
+
 type TokenManagerServiceProvider interface {
 	// GetTokenManagerService returns a TokenManagerService instance for the passed parameters
 	// If a TokenManagerService is not available, it creates one.
-	GetTokenManagerService(network string, channel string, namespace string, publicParamsFetcher PublicParamsFetcher) (TokenManagerService, error)
+	GetTokenManagerService(opts ServiceOptions) (TokenManagerService, error)
+
+	// NewTokenManagerService returns a new TokenManagerService instance for the passed parameters
+	NewTokenManagerService(opts ServiceOptions) (TokenManagerService, error)
+
+	Update(options ServiceOptions) error
 }

--- a/token/provider.go
+++ b/token/provider.go
@@ -76,6 +76,15 @@ func NewManagementServiceProvider(
 // GetManagementService returns an instance of the management service for the passed options.
 // If the management service has not been created yet, it will be created.
 func (p *ManagementServiceProvider) GetManagementService(opts ...ServiceOption) (*ManagementService, error) {
+	return p.managementService(false, opts...)
+}
+
+// NewManagementService returns a new instance of the management service for the passed options.
+func (p *ManagementServiceProvider) NewManagementService(opts ...ServiceOption) (*ManagementService, error) {
+	return p.managementService(true, opts...)
+}
+
+func (p *ManagementServiceProvider) managementService(aNew bool, opts ...ServiceOption) (*ManagementService, error) {
 	opt, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compile options")
@@ -86,14 +95,23 @@ func (p *ManagementServiceProvider) GetManagementService(opts ...ServiceOption) 
 	}
 
 	logger.Debugf("get tms for [%s,%s,%s]", opt.Network, opt.Channel, opt.Namespace)
-	tokenService, err := p.tmsProvider.GetTokenManagerService(
-		opt.Network,
-		opt.Channel,
-		opt.Namespace,
-		opt.PublicParamsFetcher,
-	)
+
+	var tokenService driver.TokenManagerService
+	driverOpts := driver.ServiceOptions{
+		Network:             opt.Network,
+		Channel:             opt.Channel,
+		Namespace:           opt.Namespace,
+		PublicParamsFetcher: opt.PublicParamsFetcher,
+		PublicParams:        opt.PublicParams,
+		Params:              opt.Params,
+	}
+	if aNew {
+		tokenService, err = p.tmsProvider.NewTokenManagerService(driverOpts)
+	} else {
+		tokenService, err = p.tmsProvider.GetTokenManagerService(driverOpts)
+	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed getting TMS for [%s]", opt.TMSID())
+		return nil, errors.Wrapf(err, "failed getting TMS for [%s]", opt)
 	}
 
 	logger.Debugf("returning tms for [%s,%s,%s]", opt.Network, opt.Channel, opt.Namespace)
@@ -115,6 +133,19 @@ func (p *ManagementServiceProvider) GetManagementService(opts ...ServiceOption) 
 		return nil, errors.WithMessagef(err, "failed to initialize token management service")
 	}
 	return ms, nil
+}
+
+func (p *ManagementServiceProvider) Update(tmsID TMSID, val []byte) error {
+	err := p.tmsProvider.Update(driver.ServiceOptions{
+		Network:      tmsID.Network,
+		Channel:      tmsID.Channel,
+		Namespace:    tmsID.Namespace,
+		PublicParams: val,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed updating tms [%s]", tmsID)
+	}
+	return nil
 }
 
 // GetManagementServiceProvider returns the management service provider from the passed service provider.

--- a/token/provider.go
+++ b/token/provider.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/pkg/errors"
 )
@@ -136,6 +137,7 @@ func (p *ManagementServiceProvider) managementService(aNew bool, opts ...Service
 }
 
 func (p *ManagementServiceProvider) Update(tmsID TMSID, val []byte) error {
+	logger.Debugf("update tms [%s] with public params [%s]", tmsID, hash.Hashable(val))
 	err := p.tmsProvider.Update(driver.ServiceOptions{
 		Network:      tmsID.Network,
 		Channel:      tmsID.Channel,
@@ -145,6 +147,7 @@ func (p *ManagementServiceProvider) Update(tmsID TMSID, val []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed updating tms [%s]", tmsID)
 	}
+	logger.Debugf("update tms [%s] with public params [%s]...done", tmsID, hash.Hashable(val))
 	return nil
 }
 

--- a/token/publicparams.go
+++ b/token/publicparams.go
@@ -85,8 +85,3 @@ func (c *PublicParametersManager) Validate() error {
 func (c *PublicParametersManager) SetPublicParameters(raw []byte) error {
 	return c.ppm.SetPublicParameters(raw)
 }
-
-// Fetch fetches the public parameters from the backend
-func (c *PublicParametersManager) Fetch() ([]byte, error) {
-	return c.ppm.Fetch()
-}

--- a/token/request.go
+++ b/token/request.go
@@ -975,7 +975,7 @@ func (r *Request) Transfers() []*Transfer {
 // AuditCheck performs the audit check of the request in addition to
 // the checks of the token request itself via IsValid.
 func (r *Request) AuditCheck() error {
-	logger.Debugf("audit check request [%s] on tms [%s]", r.Anchor, r.TokenService.ID().String())
+	logger.Debugf("audit check request [%s] on tms [%s]", r.Anchor, r.TokenService.ID())
 	if err := r.IsValid(); err != nil {
 		return err
 	}

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -166,12 +166,14 @@ func (p *SDK) Start(ctx context.Context) error {
 		return errors.WithMessagef(err, "failed get the TMS configurations")
 	}
 	tmsProvider := token.GetManagementServiceProvider(p.registry)
+	logger.Infof("configured token management system [%d]", len(tmsConfigs))
 	for _, tmsConfig := range tmsConfigs {
 		tmsID := token.TMSID{
 			Network:   tmsConfig.TMS().Network,
 			Channel:   tmsConfig.TMS().Channel,
 			Namespace: tmsConfig.TMS().Namespace,
 		}
+		logger.Infof("configured token management system [%s]", tmsID)
 		_, err := tmsProvider.GetManagementService(token.WithTMSID(tmsID))
 		if err != nil {
 			return errors.WithMessagef(err, "failed to load configured TMS [%s]", tmsID)

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -53,8 +53,8 @@ type Registry interface {
 }
 
 type SDK struct {
-	registry       Registry
-	auditorManager *auditor.Manager
+	registry        Registry
+	postInitializer *tms.PostInitializer
 }
 
 func NewSDK(registry Registry) *SDK {
@@ -89,14 +89,15 @@ func (p *SDK) Install() error {
 	assert.NoError(p.registry.RegisterService(ttxdbManager))
 	ownerManager := owner.NewManager(networkProvider, ttxdbManager, storage.NewDBEntriesStorage("owner", kvs.GetService(p.registry)))
 	assert.NoError(p.registry.RegisterService(ownerManager))
-	p.auditorManager = auditor.NewManager(networkProvider, ttxdbManager, storage.NewDBEntriesStorage("auditor", kvs.GetService(p.registry)))
-	assert.NoError(p.registry.RegisterService(p.auditorManager))
+	auditorManager := auditor.NewManager(networkProvider, ttxdbManager, storage.NewDBEntriesStorage("auditor", kvs.GetService(p.registry)))
+	assert.NoError(p.registry.RegisterService(auditorManager))
+	p.postInitializer = tms.NewPostInitializer(p.registry, ownerManager, auditorManager)
 
 	tmsProvider := tms2.NewTMSProvider(
 		p.registry,
 		configProvider,
 		&vault.PublicParamsProvider{Provider: vaultProvider},
-		tms.NewPostInitializer(p.registry, ownerManager, p.auditorManager).PostInit,
+		p.postInitializer.PostInit,
 	)
 	assert.NoError(p.registry.RegisterService(tmsProvider))
 
@@ -166,14 +167,21 @@ func (p *SDK) Start(ctx context.Context) error {
 		return errors.WithMessagef(err, "failed get the TMS configurations")
 	}
 	tmsProvider := token.GetManagementServiceProvider(p.registry)
-	logger.Infof("configured token management system [%d]", len(tmsConfigs))
+	logger.Infof("configured token management service [%d]", len(tmsConfigs))
 	for _, tmsConfig := range tmsConfigs {
 		tmsID := token.TMSID{
 			Network:   tmsConfig.TMS().Network,
 			Channel:   tmsConfig.TMS().Channel,
 			Namespace: tmsConfig.TMS().Namespace,
 		}
-		logger.Infof("configured token management system [%s]", tmsID)
+		logger.Infof("start token management service [%s]...", tmsID)
+
+		// connect network
+		if err := p.postInitializer.ConnectNetwork(tmsID.Network, tmsID.Channel, tmsID.Namespace); err != nil {
+			return errors.WithMessagef(err, "failed to connect to connect backend to tms [%s]", tmsID)
+		}
+
+		// load management service
 		_, err := tmsProvider.GetManagementService(token.WithTMSID(tmsID))
 		if err != nil {
 			return errors.WithMessagef(err, "failed to load configured TMS [%s]", tmsID)

--- a/token/sdk/tms/tms.go
+++ b/token/sdk/tms/tms.go
@@ -30,13 +30,19 @@ import (
 var logger = flogging.MustGetLogger("token-sdk")
 
 type PostInitializer struct {
-	sp             view.ServiceProvider
-	ownerManager   *owner.Manager
-	auditorManager *auditor.Manager
+	sp              view.ServiceProvider
+	networkProvider *network.Provider
+	ownerManager    *owner.Manager
+	auditorManager  *auditor.Manager
 }
 
-func NewPostInitializer(sp view.ServiceProvider, ownerManager *owner.Manager, auditorManager *auditor.Manager) *PostInitializer {
-	return &PostInitializer{sp: sp, ownerManager: ownerManager, auditorManager: auditorManager}
+func NewPostInitializer(sp view.ServiceProvider, networkProvider *network.Provider, ownerManager *owner.Manager, auditorManager *auditor.Manager) *PostInitializer {
+	return &PostInitializer{
+		sp:              sp,
+		networkProvider: networkProvider,
+		ownerManager:    ownerManager,
+		auditorManager:  auditorManager,
+	}
 }
 
 func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, channel, namespace string) error {
@@ -72,33 +78,23 @@ func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, ch
 		return errors.WithMessagef(err, "failed to restore auditor dbs for [%s]", tmsID)
 	}
 
-	if orion.GetOrionNetworkService(p.sp, networkID) != nil {
-		// fetch public params
-		nw := network.GetInstance(p.sp, networkID, channel)
-		ppRaw, err := nw.FetchPublicParameters(namespace)
-		if err != nil {
-			return errors.WithMessagef(err, "failed to fetch public parameters for [%s:%s:%s]", networkID, channel, namespace)
-		}
-		if err := tms.PublicParamsManager().SetPublicParameters(ppRaw); err != nil {
-			return errors.WithMessagef(err, "failed to set public params for [%s:%s:%s]", networkID, channel, namespace)
-		}
-		return nil
-	}
-
 	return nil
 }
 
 func (p *PostInitializer) ConnectNetwork(networkID, channel, namespace string) error {
 	n := fabric.GetFabricNetworkService(p.sp, networkID)
 	if n == nil && orion.GetOrionNetworkService(p.sp, networkID) != nil {
+		// ORION
+
 		// register processor
-		logger.Debugf("register orion committer processor for [%s:%s:%s]", networkID, channel, namespace)
 		ons := orion.GetOrionNetworkService(p.sp, networkID)
-		tokenStore, err := processor.NewCommonTokenStore(p.sp, token3.TMSID{
+		tmsID := token3.TMSID{
 			Network:   ons.Name(),
 			Channel:   channel,
 			Namespace: namespace,
-		})
+		}
+		logger.Debugf("register orion committer processor for [%s]", tmsID)
+		tokenStore, err := processor.NewCommonTokenStore(p.sp, tmsID)
 		if err != nil {
 			return errors.WithMessagef(err, "failed to get token store")
 		}
@@ -113,18 +109,32 @@ func (p *PostInitializer) ConnectNetwork(networkID, channel, namespace string) e
 				tokenStore,
 			),
 		); err != nil {
-			return errors.WithMessagef(err, "failed to add processor to orion network [%s]", networkID)
+			return errors.WithMessagef(err, "failed to add processor to orion network [%s]", tmsID)
+		}
+
+		// fetch public params and instantiate the tms
+		nw := network.GetInstance(p.sp, networkID, channel)
+		ppRaw, err := nw.FetchPublicParameters(namespace)
+		if err != nil {
+			return errors.WithMessagef(err, "failed to fetch public parameters for [%s]", tmsID)
+		}
+		_, err = token3.GetManagementServiceProvider(p.sp).GetManagementService(token3.WithTMSID(tmsID), token3.WithPublicParameter(ppRaw))
+		if err != nil {
+			return errors.WithMessagef(err, "failed to instantiate tms [%s]", tmsID)
 		}
 		return nil
 	}
 
-	// register processor
+	// FABRIC
+
+	// register commit pipeline processor
 	logger.Debugf("register fabric committer processor for [%s:%s:%s]", networkID, channel, namespace)
-	tokenStore, err := processor.NewCommonTokenStore(p.sp, token3.TMSID{
+	tmsID := token3.TMSID{
 		Network:   n.Name(),
 		Channel:   channel,
 		Namespace: namespace,
-	})
+	}
+	tokenStore, err := processor.NewCommonTokenStore(p.sp, tmsID)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get token store")
 	}
@@ -142,6 +152,27 @@ func (p *PostInitializer) ConnectNetwork(networkID, channel, namespace string) e
 		return errors.WithMessagef(err, "failed to add processor to fabric network [%s]", networkID)
 	}
 
+	// check the vault for public parameters,
+	// use them if they exists
+	net, err := p.networkProvider.GetNetwork(networkID, channel)
+	if err != nil {
+		return errors.WithMessagef(err, "cannot find network at [%s]", tmsID)
+	}
+	v, err := net.Vault(namespace)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get network at [%s]", tmsID)
+	}
+	ppRaw, err := v.QueryEngine().PublicParams()
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get public params at [%s]", tmsID)
+	}
+	if len(ppRaw) != 0 {
+		// initialize the TMS with the public params from the vault
+		_, err := token3.GetManagementServiceProvider(p.sp).GetManagementService(token3.WithTMSID(tmsID), token3.WithPublicParameter(ppRaw))
+		if err != nil {
+			return errors.WithMessagef(err, "failed to instantiate tms [%s]", tmsID)
+		}
+	}
 	return nil
 }
 

--- a/token/sdk/tms/tms.go
+++ b/token/sdk/tms/tms.go
@@ -75,6 +75,7 @@ func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, ch
 	n := fabric.GetFabricNetworkService(p.sp, networkID)
 	if n == nil && orion.GetOrionNetworkService(p.sp, networkID) != nil {
 		// register processor
+		logger.Debugf("register orion committer processor for [%s]", tmsID)
 		ons := orion.GetOrionNetworkService(p.sp, networkID)
 		tokenStore, err := processor.NewCommonTokenStore(p.sp, token3.TMSID{
 			Network:   ons.Name(),
@@ -110,6 +111,7 @@ func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, ch
 	}
 
 	// register processor
+	logger.Debugf("register fabric committer processor for [%s]", tmsID)
 	tokenStore, err := processor.NewCommonTokenStore(p.sp, token3.TMSID{
 		Network:   n.Name(),
 		Channel:   channel,

--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -94,7 +94,6 @@ func (r *RWSetProcessor) init(tx fabric.ProcessTransaction, rws *fabric.RWSet, n
 			logger.Debugf("Parsing write key [%s]", key)
 		}
 		if key == setUpKey {
-			logger.Debugf("setting new public parameters...")
 			if err := tsmProvider.Update(token.TMSID{
 				Network:   tx.Network(),
 				Channel:   tx.Channel(),
@@ -102,11 +101,9 @@ func (r *RWSetProcessor) init(tx fabric.ProcessTransaction, rws *fabric.RWSet, n
 			}, val); err != nil {
 				return errors.Wrapf(err, "failed updating public params ")
 			}
-			logger.Debugf("setting new public parameters...done.")
 			break
 		}
 	}
-	logger.Debugf("Successfully updated public parameters")
 	return nil
 }
 

--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -80,16 +80,7 @@ func (r *RWSetProcessor) Process(req fabric.Request, tx fabric.ProcessTransactio
 
 // init when invoked extracts the public params from rwset and updates the local version
 func (r *RWSetProcessor) init(tx fabric.ProcessTransaction, rws *fabric.RWSet, ns string) error {
-	tms := token.GetManagementService(
-		r.sp,
-		token.WithNetwork(tx.Network()),
-		token.WithChannel(tx.Channel()),
-		token.WithNamespace(ns),
-	)
-	if tms == nil {
-		return errors.Errorf("failed getting token management service [%s:%s:%s]", tx.Network(), tx.Channel(), ns)
-	}
-
+	tsmProvider := token.GetManagementServiceProvider(r.sp)
 	setUpKey, err := keys.CreateSetupKey()
 	if err != nil {
 		return errors.Errorf("failed creating setup key")
@@ -104,8 +95,11 @@ func (r *RWSetProcessor) init(tx fabric.ProcessTransaction, rws *fabric.RWSet, n
 		}
 		if key == setUpKey {
 			logger.Debugf("setting new public parameters...")
-			err = tms.PublicParametersManager().SetPublicParameters(val)
-			if err != nil {
+			if err := tsmProvider.Update(token.TMSID{
+				Network:   tx.Network(),
+				Channel:   tx.Channel(),
+				Namespace: ns,
+			}, val); err != nil {
 				return errors.Wrapf(err, "failed updating public params ")
 			}
 			logger.Debugf("setting new public parameters...done.")

--- a/token/services/owner/manager.go
+++ b/token/services/owner/manager.go
@@ -68,7 +68,7 @@ func (cm *Manager) Owner(tmsID token.TMSID) (*Owner, error) {
 func (cm *Manager) newOwner(tmsID token.TMSID) (*Owner, error) {
 	db, err := cm.ttxdbProvider.DBByTMSId(tmsID)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get ttxdb for [%s:%s]", tmsID.Network, tmsID.Channel)
+		return nil, errors.WithMessagef(err, "failed to get ttxdb for [%s]", tmsID)
 	}
 	owner := &Owner{
 		networkProvider: cm.networkProvider,

--- a/token/services/owner/manager.go
+++ b/token/services/owner/manager.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package owner
 
 import (
-	"fmt"
 	"reflect"
 	"sync"
 
@@ -19,17 +18,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-type TokenManagementServiceProvider interface {
-	GetManagementService(opts ...token.ServiceOption) (*token.ManagementService, error)
-}
-
 type TTXDBProvider interface {
-	DB(w ttxdb.Wallet) (*ttxdb.DB, error)
+	DBByTMSId(id token.TMSID) (*ttxdb.DB, error)
 }
 
 // Manager handles the databases
 type Manager struct {
-	tmsProvider     TokenManagementServiceProvider
 	networkProvider NetworkProvider
 	ttxdbProvider   TTXDBProvider
 
@@ -39,9 +33,8 @@ type Manager struct {
 }
 
 // NewManager creates a new Owner manager.
-func NewManager(tmsProvide TokenManagementServiceProvider, np NetworkProvider, ttxdbManager TTXDBProvider, storage storage.DBEntriesStorage) *Manager {
+func NewManager(np NetworkProvider, ttxdbManager TTXDBProvider, storage storage.DBEntriesStorage) *Manager {
 	return &Manager{
-		tmsProvider:     tmsProvide,
 		networkProvider: np,
 		storage:         storage,
 		ttxdbProvider:   ttxdbManager,
@@ -50,99 +43,66 @@ func NewManager(tmsProvide TokenManagementServiceProvider, np NetworkProvider, t
 }
 
 // Owner returns the Owner for the given TMS
-func (cm *Manager) Owner(tms *token.ManagementService) (*Owner, error) {
+func (cm *Manager) Owner(tmsID token.TMSID) (*Owner, error) {
 	cm.mutex.Lock()
 	defer cm.mutex.Unlock()
 
-	id := tms.ID().String()
+	id := tmsID.String()
 	logger.Debugf("get ttxdb for [%s]", id)
 	c, ok := cm.owners[id]
 	if !ok {
 		// add an entry
-		if err := cm.storage.Put(tms.ID(), ""); err != nil {
-			return nil, errors.Wrapf(err, "failed to store db entry in KVS [%s]", tms.ID())
+		if err := cm.storage.Put(tmsID, ""); err != nil {
+			return nil, errors.Wrapf(err, "failed to store db entry in KVS [%s]", tmsID)
 		}
 		var err error
-		c, err = cm.newOwner(tms)
+		c, err = cm.newOwner(tmsID)
 		if err != nil {
-			return nil, errors.WithMessagef(err, "failed to instantiate owner for wallet [%s]", tms.ID())
+			return nil, errors.WithMessagef(err, "failed to instantiate owner for wallet [%s]", tmsID)
 		}
 		cm.owners[id] = c
 	}
 	return c, nil
 }
 
-func (cm *Manager) Restore() error {
-	logger.Infof("restore owner dbs...")
-	it, err := cm.storage.Iterator()
+func (cm *Manager) newOwner(tmsID token.TMSID) (*Owner, error) {
+	db, err := cm.ttxdbProvider.DBByTMSId(tmsID)
 	if err != nil {
-		return errors.WithMessagef(err, "failed to list existing owners")
-	}
-	defer func(it storage.Iterator[*storage.DBEntry]) {
-		err := it.Close()
-		if err != nil {
-			logger.Warnf("failed to close iterator [%s]", err)
-		}
-	}(it)
-	for {
-		if !it.HasNext() {
-			logger.Infof("restore owner dbs...done")
-			return nil
-		}
-		entry, err := it.Next()
-		if err != nil {
-			return errors.Wrapf(err, "failed to get next entry")
-		}
-		logger.Infof("restore owner dbs for entry [%s]...", entry.TMSID.String())
-		tms, err := cm.tmsProvider.GetManagementService(token.WithTMSID(entry.TMSID))
-		if err != nil {
-			return errors.WithMessagef(err, "cannot find TMS [%s]", entry.TMSID)
-		}
-		if err := cm.restore(tms); err != nil {
-			return errors.Errorf("cannot bootstrap auditdb for [%s]", entry.TMSID)
-		}
-		logger.Infof("restore owner dbs for entry [%s]...done", entry.TMSID.String())
-	}
-}
-
-func (cm *Manager) newOwner(tms *token.ManagementService) (*Owner, error) {
-	db, err := cm.ttxdbProvider.DB(&tmsWallet{tms: tms})
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get ttxdb for [%s:%s]", tms.ID().Network, tms.ID().Channel)
+		return nil, errors.WithMessagef(err, "failed to get ttxdb for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
 	owner := &Owner{
 		networkProvider: cm.networkProvider,
 		db:              db,
 	}
-	_, err = cm.networkProvider.GetNetwork(tms.ID().Network, tms.ID().Channel)
+	_, err = cm.networkProvider.GetNetwork(tmsID.Network, tmsID.Channel)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tms.ID().Network, tms.ID().Channel)
+		return nil, errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
 	return owner, nil
 }
 
-func (cm *Manager) restore(tms *token.ManagementService) error {
-	net, err := cm.networkProvider.GetNetwork(tms.ID().Network, tms.ID().Channel)
+func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
+	net, err := cm.networkProvider.GetNetwork(tmsID.Network, tmsID.Channel)
 	if err != nil {
-		return errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tms.ID().Network, tms.ID().Channel)
+		return errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
 
-	owner, err := cm.Owner(tms)
+	owner, err := cm.Owner(tmsID)
 	if err != nil {
-		return errors.WithMessagef(err, "failed to get owner for [%s:%s]", tms.ID().Network, tms.ID().Channel)
+		return errors.WithMessagef(err, "failed to get owner for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
 	qe := owner.NewQueryExecutor()
 	defer qe.Done()
 
 	it, err := qe.Transactions(ttxdb.QueryTransactionsParams{})
 	if err != nil {
-		return errors.Errorf("failed to get tx iterator for [%s:%s:%s]", tms.ID().Network, tms.ID().Channel, tms.ID())
+		return errors.Errorf("failed to get tx iterator for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID)
 	}
 	defer it.Close()
 
-	v, err := net.Vault(tms.ID().Channel)
+	v, err := net.Vault(tmsID.Channel)
 	if err != nil {
-		return errors.Errorf("failed to get vault for [%s:%s:%s]", tms.ID().Network, tms.ID().Channel, tms.ID())
+		return errors.Errorf("failed to get vault for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID)
 	}
 	var pendingTXs []string
 	type ToBeUpdated struct {
@@ -153,13 +113,13 @@ func (cm *Manager) restore(tms *token.ManagementService) error {
 	for {
 		tr, err := it.Next()
 		if err != nil {
-			return errors.Errorf("failed to get next tx record for [%s:%s:%s]", tms.ID().Network, tms.ID().Channel, tms.ID())
+			return errors.Errorf("failed to get next tx record for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID)
 		}
 		if tr == nil {
 			break
 		}
 		if tr.Status == ttxdb.Pending {
-			logger.Debugf("found pending transaction [%s] at [%s:%s]", tr.TxID, tms.ID().Network, tms.ID().Channel)
+			logger.Debugf("found pending transaction [%s] at [%s:%s]", tr.TxID, tmsID.Network, tmsID.Channel)
 			found := false
 			for _, txID := range pendingTXs {
 				if tr.TxID == txID {
@@ -204,11 +164,11 @@ func (cm *Manager) restore(tms *token.ManagementService) error {
 		logger.Infof("found transaction [%s] in vault with status [%s], corresponding pending transaction updated", updated.TxID, updated.Status)
 	}
 
-	logger.Infof("ownerdb [%s:%s], found [%d] pending transactions", tms.ID().Network, tms.ID().Channel, len(pendingTXs))
+	logger.Infof("ownerdb [%s:%s], found [%d] pending transactions", tmsID.Network, tmsID.Channel, len(pendingTXs))
 
 	for _, txID := range pendingTXs {
 		if err := net.SubscribeTxStatusChanges(txID, &TxStatusChangesListener{net, owner.db}); err != nil {
-			return errors.WithMessagef(err, "failed to subscribe event listener to network [%s:%s] for [%s]", tms.ID().Network, tms.ID().Channel, txID)
+			return errors.WithMessagef(err, "failed to subscribe event listener to network [%s:%s] for [%s]", tmsID.Network, tmsID.Channel, txID)
 		}
 	}
 
@@ -230,7 +190,7 @@ func Get(sp view.ServiceProvider, tms *token.ManagementService) *Owner {
 		logger.Errorf("failed to get manager service: [%s]", err)
 		return nil
 	}
-	auditor, err := s.(*Manager).Owner(tms)
+	auditor, err := s.(*Manager).Owner(tms.ID())
 	if err != nil {
 		logger.Errorf("failed to get db for TMS [%s]: [%s]", tms.ID(), err)
 		return nil
@@ -241,17 +201,4 @@ func Get(sp view.ServiceProvider, tms *token.ManagementService) *Owner {
 // New returns the Owner instance for the passed TMS
 func New(sp view.ServiceProvider, tms *token.ManagementService) *Owner {
 	return Get(sp, tms)
-}
-
-type tmsWallet struct {
-	tms *token.ManagementService
-}
-
-func (t *tmsWallet) ID() string {
-	id := t.tms.ID()
-	return fmt.Sprintf("%s-%s-%s", id.Network, id.Channel, id.Namespace)
-}
-
-func (t *tmsWallet) TMS() *token.ManagementService {
-	return t.tms
 }

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -658,6 +658,10 @@ func (cm *Manager) DB(w Wallet) (*DB, error) {
 	return cm.DBByID(w.TMS().ID().String() + w.ID())
 }
 
+func (cm *Manager) DBByIDs(tmsID token.TMSID, walletID string) (*DB, error) {
+	return cm.DBByID(tmsID.String() + walletID)
+}
+
 // DBByTMSId returns a DB for the given TMS id
 func (cm *Manager) DBByTMSId(id token.TMSID) (*DB, error) {
 	return cm.DBByID(id.String() + fmt.Sprintf("%s-%s-%s", id.Network, id.Channel, id.Namespace))

--- a/token/tms.go
+++ b/token/tms.go
@@ -50,6 +50,8 @@ type ServiceOptions struct {
 	Namespace string
 	// PublicParamsFetcher is used to fetch the public parameters
 	PublicParamsFetcher PublicParamsFetcher
+	// PublicParams contains the public params to use to instantiate the driver
+	PublicParams []byte
 	// Params is used to store any application specific parameter
 	Params map[string]interface{}
 }
@@ -119,10 +121,18 @@ func WithNamespace(namespace string) ServiceOption {
 	}
 }
 
-// WithPublicParameterFetcher sets the public parameter fetcher
+// WithPublicParameterFetcher sets the public parameters fetcher
 func WithPublicParameterFetcher(ppFetcher PublicParamsFetcher) ServiceOption {
 	return func(o *ServiceOptions) error {
 		o.PublicParamsFetcher = ppFetcher
+		return nil
+	}
+}
+
+// WithPublicParameter sets the public parameters
+func WithPublicParameter(publicParams []byte) ServiceOption {
+	return func(o *ServiceOptions) error {
+		o.PublicParams = publicParams
 		return nil
 	}
 }


### PR DESCRIPTION
This PR introduces the following changes:
- Token Driver: public parameters must be available at time of instantiation
- AuditorDB does not require a tms anymore
- if the vault contains the public params, the corresponding tms is instantiated immediately