### PR TITLE
add dependency to the hash of public params in the rws

### DIFF
--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -226,6 +226,10 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 			return shim.Error("failed to write token action: " + err.Error())
 		}
 	}
+	err = w.AddPublicParamsDependency()
+	if err != nil {
+		return shim.Error("failed to add public params dependency:" + err.Error())
+	}
 	err = w.CommitTokenRequest(raw, false)
 	if err != nil {
 		return shim.Error("failed to write token request:" + err.Error())

--- a/token/services/network/fabric/tcc/tcc_test.go
+++ b/token/services/network/fabric/tcc/tcc_test.go
@@ -73,6 +73,8 @@ var _ = Describe("ccvalidator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				fakestub.GetArgsReturns(args)
 				fakestub.GetTransientReturns(map[string][]byte{"token_request": []byte("token request")}, nil)
+				fakestub.GetStateReturnsOnCall(0, []byte("pp"), nil)
+				fakestub.GetStateReturnsOnCall(1, nil, nil)
 				fakeValidator.UnmarshallAndVerifyReturns([]interface{}{}, nil)
 			})
 			It("succeeds", func() {

--- a/token/services/vault/rws/keys/keys.go
+++ b/token/services/vault/rws/keys/keys.go
@@ -20,9 +20,10 @@ const (
 
 	numComponentsInKey = 2 // 2 components: txid, index, excluding TokenKeyPrefix
 
-	TokenKeyPrefix      = "ztoken"
-	TokenMineKeyPrefix  = "mine"
-	TokenSetupKeyPrefix = "setup"
+	TokenKeyPrefix          = "ztoken"
+	TokenMineKeyPrefix      = "mine"
+	TokenSetupKeyPrefix     = "setup"
+	TokenSetupHashKeyPrefix = "setup.hash"
 
 	TokenRequestKeyPrefix  = "token_request"
 	SerialNumber           = "sn"
@@ -58,6 +59,10 @@ func CreateSNKey(sn string) (string, error) {
 
 func CreateSetupKey() (string, error) {
 	return CreateCompositeKey(TokenKeyPrefix, []string{TokenSetupKeyPrefix})
+}
+
+func CreateSetupHashKey() (string, error) {
+	return CreateCompositeKey(TokenKeyPrefix, []string{TokenSetupHashKeyPrefix})
 }
 
 func CreateTokenRequestKey(txID string) (string, error) {


### PR DESCRIPTION
This PR adds an additional dependency to the current public parameters in the RWSet. 
This is helpful every time one wants to update the public parameters without upgrading the chaincode.