### PR TITLE
move owner into ttx

### DIFF
--- a/integration/token/dvp/views/auditor.go
+++ b/integration/token/dvp/views/auditor.go
@@ -9,7 +9,6 @@ package views
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 )
 

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
 	"github.com/pkg/errors"
 )
 
@@ -313,7 +312,7 @@ func (r *SetTransactionAuditStatusView) Call(context view.Context) (interface{},
 	assert.NoError(err, "failed to get auditor instance")
 	assert.NoError(auditor.SetStatus(r.TxID, r.Status), "failed to set status of [%s] to [%d]", r.TxID, r.Status)
 
-	if r.Status == ttxdb.Deleted {
+	if r.Status == ttx.Deleted {
 		tms := token.GetManagementService(context)
 		assert.NotNil(tms, "failed to get default tms")
 		net := network.GetInstance(context, tms.Network(), tms.Channel())

--- a/integration/token/fungible/views/owner.go
+++ b/integration/token/fungible/views/owner.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
 )
 
 type SetTransactionOwnerStatus struct {
@@ -31,7 +30,7 @@ func (r *SetTransactionOwnerStatusView) Call(context view.Context) (interface{},
 	owner := ttx.NewOwner(context, token.GetManagementService(context))
 	assert.NoError(owner.SetStatus(r.TxID, r.Status), "failed to set status of [%s] to [%d]", r.TxID, r.Status)
 
-	if r.Status == ttxdb.Deleted {
+	if r.Status == ttx.Deleted {
 		tms := token.GetManagementService(context)
 		assert.NotNil(tms, "failed to get default tms")
 		net := network.GetInstance(context, tms.Network(), tms.Channel())

--- a/token/sdk/sdk.go
+++ b/token/sdk/sdk.go
@@ -40,7 +40,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	_ "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/orion"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/owner"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/mailman"
 	selector "github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/simple"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokendb"
@@ -102,7 +101,7 @@ func (p *SDK) Install() error {
 	auditDBManager := auditdb.NewManager(p.registry, dbconfig.NewConfig(configProvider, "auditdb.persistence.type"))
 	assert.NoError(p.registry.RegisterService(auditDBManager))
 
-	ownerManager := owner.NewManager(networkProvider, ttxdbManager, storage.NewDBEntriesStorage("owner", kvs.GetService(p.registry)))
+	ownerManager := ttx.NewManager(networkProvider, ttxdbManager, storage.NewDBEntriesStorage("owner", kvs.GetService(p.registry)))
 	assert.NoError(p.registry.RegisterService(ownerManager))
 	auditorManager := auditor.NewManager(networkProvider, auditDBManager, storage.NewDBEntriesStorage("auditor", kvs.GetService(p.registry)))
 	assert.NoError(p.registry.RegisterService(auditorManager))

--- a/token/sdk/tms/db/tms.go
+++ b/token/sdk/tms/db/tms.go
@@ -21,8 +21,8 @@ import (
 	fabric2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric"
 	orion2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/orion"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/processor/db"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/owner"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokendb"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/pkg/errors"
 )
 
@@ -31,11 +31,11 @@ var logger = flogging.MustGetLogger("token-sdk")
 type PostInitializer struct {
 	sp              view.ServiceProvider
 	networkProvider *network.Provider
-	ownerManager    *owner.Manager
+	ownerManager    *ttx.Manager
 	auditorManager  *auditor.Manager
 }
 
-func NewPostInitializer(sp view.ServiceProvider, networkProvider *network.Provider, ownerManager *owner.Manager, auditorManager *auditor.Manager) *PostInitializer {
+func NewPostInitializer(sp view.ServiceProvider, networkProvider *network.Provider, ownerManager *ttx.Manager, auditorManager *auditor.Manager) *PostInitializer {
 	return &PostInitializer{
 		sp:              sp,
 		networkProvider: networkProvider,
@@ -66,7 +66,7 @@ func (p *PostInitializer) ConnectNetwork(networkID, channel, namespace string) e
 		return token3.GetManagementServiceProvider(p.sp)
 	}
 	GetTokenRequest := func(tms *token3.ManagementService, txID string) ([]byte, error) {
-		tr, err := owner.Get(p.sp, tms).GetTokenRequest(txID)
+		tr, err := ttx.Get(p.sp, tms).GetTokenRequest(txID)
 		if err != nil || len(tr) == 0 {
 			return auditor.GetByTMSID(p.sp, tms.ID()).GetTokenRequest(txID)
 		}

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -22,20 +22,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// TxStatus is the status of a transaction
-type TxStatus = auditdb.TxStatus
-
-const (
-	// Unknown is the status of a transaction that is unknown
-	Unknown = auditdb.Unknown
-	// Pending is the status of a transaction that has been submitted to the ledger
-	Pending TxStatus = auditdb.Pending
-	// Confirmed is the status of a transaction that has been confirmed by the ledger
-	Confirmed TxStatus = auditdb.Confirmed
-	// Deleted is the status of a transaction that has been deleted due to a failure to commit
-	Deleted TxStatus = auditdb.Deleted
-)
-
 type TxAuditor struct {
 	sp                      view2.ServiceProvider
 	w                       *token.AuditorWallet
@@ -85,7 +71,7 @@ func (a *TxAuditor) NewQueryExecutor() *auditor.QueryExecutor {
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status
 func (a *TxAuditor) SetStatus(txID string, status TxStatus) error {
-	return a.auditDB.SetStatus(txID, status)
+	return a.auditDB.SetStatus(txID, auditdb.TxStatus(status))
 }
 
 func (a *TxAuditor) GetTokenRequest(txID string) ([]byte, error) {

--- a/token/services/ttx/manager.go
+++ b/token/services/ttx/manager.go
@@ -25,20 +25,20 @@ type DBProvider interface {
 // Manager handles the databases
 type Manager struct {
 	networkProvider NetworkProvider
-	ttxdbProvider   DBProvider
+	dbProvider      DBProvider
 
 	storage storage.DBEntriesStorage
 	mutex   sync.Mutex
-	owners  map[string]*DB
+	dbs     map[string]*DB
 }
 
 // NewManager creates a new DB manager.
-func NewManager(np NetworkProvider, ttxdbManager DBProvider, storage storage.DBEntriesStorage) *Manager {
+func NewManager(np NetworkProvider, dbProvider DBProvider, storage storage.DBEntriesStorage) *Manager {
 	return &Manager{
 		networkProvider: np,
 		storage:         storage,
-		ttxdbProvider:   ttxdbManager,
-		owners:          map[string]*DB{},
+		dbProvider:      dbProvider,
+		dbs:             map[string]*DB{},
 	}
 }
 
@@ -49,28 +49,28 @@ func (cm *Manager) DB(tmsID token.TMSID) (*DB, error) {
 
 	id := tmsID.String()
 	logger.Debugf("get ttxdb for [%s]", id)
-	c, ok := cm.owners[id]
+	c, ok := cm.dbs[id]
 	if !ok {
 		// add an entry
 		if err := cm.storage.Put(tmsID, ""); err != nil {
 			return nil, errors.Wrapf(err, "failed to store db entry in KVS [%s]", tmsID)
 		}
 		var err error
-		c, err = cm.newOwner(tmsID)
+		c, err = cm.newDB(tmsID)
 		if err != nil {
-			return nil, errors.WithMessagef(err, "failed to instantiate owner for wallet [%s]", tmsID)
+			return nil, errors.WithMessagef(err, "failed to instantiate db for TMS [%s]", tmsID)
 		}
-		cm.owners[id] = c
+		cm.dbs[id] = c
 	}
 	return c, nil
 }
 
-func (cm *Manager) newOwner(tmsID token.TMSID) (*DB, error) {
-	db, err := cm.ttxdbProvider.DBByTMSId(tmsID)
+func (cm *Manager) newDB(tmsID token.TMSID) (*DB, error) {
+	db, err := cm.dbProvider.DBByTMSId(tmsID)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get ttxdb for [%s]", tmsID)
 	}
-	owner := &DB{
+	wrapper := &DB{
 		networkProvider: cm.networkProvider,
 		db:              db,
 	}
@@ -78,7 +78,7 @@ func (cm *Manager) newOwner(tmsID token.TMSID) (*DB, error) {
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
-	return owner, nil
+	return wrapper, nil
 }
 
 func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
@@ -87,11 +87,11 @@ func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
 		return errors.WithMessagef(err, "failed to get network instance for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
 
-	owner, err := cm.DB(tmsID)
+	db, err := cm.DB(tmsID)
 	if err != nil {
-		return errors.WithMessagef(err, "failed to get owner for [%s:%s]", tmsID.Network, tmsID.Channel)
+		return errors.WithMessagef(err, "failed to get db for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
-	qe := owner.NewQueryExecutor()
+	qe := db.NewQueryExecutor()
 	defer qe.Done()
 
 	it, err := qe.Transactions(ttxdb.QueryTransactionsParams{})
@@ -158,7 +158,7 @@ func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
 	qe.Done()
 
 	for _, updated := range toBeUpdated {
-		if err := owner.db.SetStatus(updated.TxID, updated.Status); err != nil {
+		if err := db.db.SetStatus(updated.TxID, updated.Status); err != nil {
 			return errors.WithMessagef(err, "failed setting status for request %s", updated.TxID)
 		}
 		logger.Infof("found transaction [%s] in vault with status [%s], corresponding pending transaction updated", updated.TxID, updated.Status)
@@ -167,7 +167,7 @@ func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
 	logger.Infof("ttxdb [%s:%s], found [%d] pending transactions", tmsID.Network, tmsID.Channel, len(pendingTXs))
 
 	for _, txID := range pendingTXs {
-		if err := net.SubscribeTxStatusChanges(txID, &TxStatusChangesListener{net, owner.db}); err != nil {
+		if err := net.SubscribeTxStatusChanges(txID, &TxStatusChangesListener{net, db.db}); err != nil {
 			return errors.WithMessagef(err, "failed to subscribe event listener to network [%s:%s] for [%s]", tmsID.Network, tmsID.Channel, txID)
 		}
 	}

--- a/token/services/ttx/owner.go
+++ b/token/services/ttx/owner.go
@@ -10,19 +10,18 @@ import (
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/owner"
 )
 
 type TxOwner struct {
 	sp                      view2.ServiceProvider
 	tms                     *token.ManagementService
-	owner                   *owner.Owner
+	owner                   *DB
 	transactionInfoProvider *TransactionInfoProvider
 }
 
 // NewOwner returns a new owner service.
 func NewOwner(sp view2.ServiceProvider, tms *token.ManagementService) *TxOwner {
-	backend := owner.New(sp, tms)
+	backend := New(sp, tms)
 	return &TxOwner{
 		sp:                      sp,
 		tms:                     tms,
@@ -34,7 +33,7 @@ func NewOwner(sp view2.ServiceProvider, tms *token.ManagementService) *TxOwner {
 // NewQueryExecutor returns a new query executor.
 // The query executor is used to execute queries against the token transaction DB.
 // The function `Done` on the query executor must be called when it is no longer needed.
-func (a *TxOwner) NewQueryExecutor() *owner.QueryExecutor {
+func (a *TxOwner) NewQueryExecutor() *QueryExecutor {
 	return a.owner.NewQueryExecutor()
 }
 

--- a/token/services/ttx/status.go
+++ b/token/services/ttx/status.go
@@ -1,0 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ttx
+
+// TxStatus is the status of a transaction
+type TxStatus string
+
+const (
+	// Unknown is the status of a transaction that is unknown
+	Unknown TxStatus = "Unknown"
+	// Pending is the status of a transaction that has been submitted to the ledger
+	Pending TxStatus = "Pending"
+	// Confirmed is the status of a transaction that has been confirmed by the ledger
+	Confirmed TxStatus = "Confirmed"
+	// Deleted is the status of a transaction that has been deleted due to a failure to commit
+	Deleted TxStatus = "Deleted"
+)


### PR DESCRIPTION
This PR moves the owner service inside the ttx service. This is in alignment with `audit` and `auditdb` services, and `tokens` and `tokendb` services.