### PR TITLE
network service cleanup

### DIFF
--- a/integration/token/fungible/views/checks.go
+++ b/integration/token/fungible/views/checks.go
@@ -116,10 +116,6 @@ func (m *CheckTTXDBView) Call(context view.Context) (interface{}, error) {
 		if !net.ExistEnvelope(transactionRecord.TxID) {
 			errorMessages = append(errorMessages, fmt.Sprintf("no envelope found for transaction record [%s]", transactionRecord.TxID))
 		}
-		// check metadata
-		if !net.ExistTransient(transactionRecord.TxID) {
-			errorMessages = append(errorMessages, fmt.Sprintf("no metadata found for transaction record [%s]", transactionRecord.TxID))
-		}
 
 		tokenRequest, err := tokenDB.GetTokenRequest(transactionRecord.TxID)
 		assert.NoError(err, "failed to retrieve token request for [%s]", transactionRecord.TxID)

--- a/token/services/db/sql/tokens.go
+++ b/token/services/db/sql/tokens.go
@@ -72,7 +72,8 @@ func (db *TokenDB) StoreToken(tr driver.TokenRecord, owners []string) (err error
 		}
 	}()
 	if err = tx.StoreToken(tr, owners); err != nil {
-		return err
+
+		return
 	}
 	if err = tx.Commit(); err != nil {
 		return err
@@ -687,7 +688,7 @@ func (db *TokenDB) StoreCertifications(certifications map[*token.ID][]byte) (err
 	if err = tx.Commit(); err != nil {
 		return errors.Wrap(err, "failed committing status update")
 	}
-	return nil
+	return
 }
 
 func (db *TokenDB) ExistsCertification(tokenID *token.ID) bool {

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -68,15 +68,6 @@ type Network interface {
 	// NewEnvelope returns a new instance of an envelope
 	NewEnvelope() Envelope
 
-	// StoreTransient stores the passed transient map and maps it to the passed id
-	StoreTransient(id string, transient TransientMap) error
-
-	// TransientExists returns true if a transient map exists for the passed id, false otherwise
-	TransientExists(id string) bool
-
-	// GetTransient retrieves the transient map bound to the passed id
-	GetTransient(id string) (TransientMap, error)
-
 	// RequestApproval requests approval for the passed request and returns the returned envelope
 	RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID TxID) (Envelope, error)
 

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -314,10 +314,6 @@ func (n *Network) ExistEnvelope(id string) bool {
 	return n.n.EnvelopeExists(id)
 }
 
-func (n *Network) ExistTransient(id string) bool {
-	return n.n.TransientExists(id)
-}
-
 // Broadcast sends the given blob to the network
 func (n *Network) Broadcast(context context.Context, blob interface{}) error {
 	switch b := blob.(type) {
@@ -349,20 +345,6 @@ func (n *Network) AnonymousIdentity() view.Identity {
 // NewEnvelope creates a new envelope
 func (n *Network) NewEnvelope() *Envelope {
 	return &Envelope{e: n.n.NewEnvelope()}
-}
-
-// StoreTransient stores locally the given transient data and associated it with the given id
-func (n *Network) StoreTransient(id string, transient TransientMap) error {
-	return n.n.StoreTransient(id, driver.TransientMap(transient))
-}
-
-// GetTransient retrieves the transient map bound to the passed id
-func (n *Network) GetTransient(id string) (TransientMap, error) {
-	tm, err := n.n.GetTransient(id)
-	if err != nil {
-		return nil, err
-	}
-	return TransientMap(tm), nil
 }
 
 // RequestApproval requests approval for the given token request

--- a/token/services/ttx/accept.go
+++ b/token/services/ttx/accept.go
@@ -46,12 +46,6 @@ func (s *AcceptView) Call(context view.Context) (interface{}, error) {
 		return nil, errors.Errorf("expected fabric envelope")
 	}
 
-	// Store transient
-	err = s.tx.storeTransient()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed storing transient")
-	}
-
 	// Store envelope
 	if !s.options.SkipApproval {
 		if err := StoreEnvelope(context, s.tx); err != nil {

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -292,11 +292,6 @@ func (a *AuditApproveView) signAndSendBack(context view.Context) error {
 		return errors.WithMessagef(err, "failed getting signing identity for auditor identity [%s]", context.Me())
 	}
 
-	err = a.tx.storeTransient()
-	if err != nil {
-		return errors.Wrapf(err, "failed storing transient for [%s]", a.tx.ID())
-	}
-
 	logger.Debug("signer at auditor", signer, aid)
 
 	raw, err := a.tx.MarshallToAudit()

--- a/token/services/ttx/endorse.go
+++ b/token/services/ttx/endorse.go
@@ -72,12 +72,6 @@ func NewCollectEndorsementsView(tx *Transaction, opts ...EndorsementsOpt) *Colle
 func (c *CollectEndorsementsView) Call(context view.Context) (interface{}, error) {
 	metrics := GetMetrics(context)
 
-	// Store transient
-	err := c.tx.storeTransient()
-	if err != nil {
-		return nil, errors.WithMessagef(err, "failed storing transient")
-	}
-
 	externalWallets := make(map[string]ExternalWalletSigner)
 	// 1. First collect signatures on the token request
 	issueSigmas, err := c.requestSignaturesOnIssues(context, externalWallets)
@@ -764,11 +758,6 @@ func (s *EndorseView) Call(context view.Context) (interface{}, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed sending signature back")
 		}
-	}
-
-	// Store transient
-	if err := s.tx.storeTransient(); err != nil {
-		return nil, errors.Wrapf(err, "failed storing transient")
 	}
 
 	// Receive transaction with envelope

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -282,22 +282,6 @@ func (t *Transaction) TMSID() token.TMSID {
 	return t.TokenRequest.TokenService.ID()
 }
 
-func (t *Transaction) storeTransient() error {
-	if logger.IsEnabledFor(zapcore.DebugLevel) {
-		logger.Debugf("Storing transient for [%s]", t.ID())
-	}
-	raw, err := t.TokenRequest.MetadataToBytes()
-	if err != nil {
-		return err
-	}
-
-	if err := t.Payload.Transient.Set(TokenRequestMetadata, raw); err != nil {
-		return err
-	}
-
-	return network.GetInstance(t.SP, t.Network(), t.Channel()).StoreTransient(t.ID(), t.Payload.Transient)
-}
-
 func (t *Transaction) setEnvelope(envelope *network.Envelope) error {
 	if len(envelope.Nonce()) != 0 {
 		networkTxID := &network.TxID{


### PR DESCRIPTION
This PR proposes the following:
- remove transient-related function from the network service, they are not needed anymore
- cleanup sql db logs