### PR TITLE
remove suffix, use prefixes consistently, only rollback on error

### DIFF
--- a/token/services/auditdb/db/memory/memory.go
+++ b/token/services/auditdb/db/memory/memory.go
@@ -26,9 +26,8 @@ type Driver struct {
 
 // Open returns a pure go sqlite implementation in memory for testing purposes.
 func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.AuditTransactionDB, error) {
-	name := sqldb.DatasourceName(tmsID)
 	h := sha256.New()
-	if _, err := h.Write([]byte(name)); err != nil {
+	if _, err := h.Write([]byte(tmsID.String())); err != nil {
 		return nil, err
 	}
 
@@ -41,7 +40,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Audit
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)
 	}
 
-	return sqldb.NewTransactionDB(sqlDB, "memory", name, true)
+	return sqldb.NewTransactionDB(sqlDB, "memory", true)
 }
 
 func init() {

--- a/token/services/auditdb/db/sql/driver.go
+++ b/token/services/auditdb/db/sql/driver.go
@@ -57,10 +57,9 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.AuditT
 		return nil, errors.Wrapf(err, "failed getting opts for vault")
 	}
 	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set. See https://github.com/golang/go/wiki/SQLDrivers", OptsKey))
+		panic(fmt.Sprintf("%s.driver not set", OptsKey))
 	}
 
-	name := sqldb.DatasourceName(tmsID)
 	dataSourceName := os.Getenv(EnvVarKey)
 	if dataSourceName == "" {
 		dataSourceName = opts.DataSource
@@ -76,7 +75,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.AuditT
 		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
 	}
 
-	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, name, opts.CreateSchema)
+	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix+"_audit", opts.CreateSchema)
 }
 
 func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {

--- a/token/services/db/sql/common.go
+++ b/token/services/db/sql/common.go
@@ -8,15 +8,9 @@ package sql
 
 import (
 	"database/sql"
-	"fmt"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/pkg/errors"
 )
-
-func DatasourceName(tmsID token.TMSID) string {
-	return fmt.Sprintf("%s-%s-%s", tmsID.Network, tmsID.Channel, tmsID.Namespace)
-}
 
 func QueryUnique[T any](db *sql.DB, query string, args ...any) (T, error) {
 	logger.Debug(query, args)

--- a/token/services/db/sql/driver.go
+++ b/token/services/db/sql/driver.go
@@ -63,7 +63,7 @@ func (d *DBOpener) compileOpts(sp view.ServiceProvider, tmsID token.TMSID) (*Opt
 		return nil, errors.Wrapf(err, "failed getting opts for vault")
 	}
 	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set. See https://github.com/golang/go/wiki/SQLDrivers", d.optsKey))
+		panic(fmt.Sprintf("%s.driver not set", d.optsKey))
 	}
 
 	dataSourceName := os.Getenv(d.envVarKey)

--- a/token/services/db/sql/identity.go
+++ b/token/services/db/sql/identity.go
@@ -47,8 +47,8 @@ func newIdentityDB(db *sql.DB, tables identityTables, singerInfoCache cache) *Id
 	}
 }
 
-func NewIdentityDB(db *sql.DB, tablePrefix, name string, createSchema bool, singerInfoCache cache) (*IdentityDB, error) {
-	tables, err := getTableNames(tablePrefix, name)
+func NewIdentityDB(db *sql.DB, tablePrefix string, createSchema bool, signerInfoCache cache) (*IdentityDB, error) {
+	tables, err := getTableNames(tablePrefix)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get table names")
 	}
@@ -57,7 +57,7 @@ func NewIdentityDB(db *sql.DB, tablePrefix, name string, createSchema bool, sing
 		IdentityConfigurations: tables.IdentityConfigurations,
 		AuditInfo:              tables.AuditInfo,
 		Signers:                tables.Signers,
-	}, singerInfoCache)
+	}, signerInfoCache)
 	if createSchema {
 		if err = initSchema(db, identityDB.GetSchema()); err != nil {
 			return nil, err

--- a/token/services/db/sql/init.go
+++ b/token/services/db/sql/init.go
@@ -7,9 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"regexp"
 	"runtime/debug"
@@ -33,11 +31,8 @@ func initSchema(db *sql.DB, schemas ...string) (err error) {
 			}
 		}
 	}()
-
-	fmt.Println("schema")
 	for _, schema := range schemas {
 		logger.Debug(schema)
-		fmt.Println(schema)
 		if _, err = db.Exec(schema); err != nil {
 			return errors.Wrap(err, "error creating schema")
 		}
@@ -64,7 +59,7 @@ type tableNames struct {
 	Signers                string
 }
 
-func getTableNames(prefix, name string) (tableNames, error) {
+func getTableNames(prefix string) (tableNames, error) {
 	if prefix != "" {
 		r := regexp.MustCompile("^[a-zA-Z_]+$")
 		if !r.MatchString(prefix) {
@@ -73,27 +68,19 @@ func getTableNames(prefix, name string) (tableNames, error) {
 		prefix = prefix + "_"
 	}
 
-	// name is usually something like "default,testchannel,token-chaincode",
-	// so we shorten it to the first 6 hex characters of the hash.
-	h := sha256.New()
-	if _, err := h.Write([]byte(name)); err != nil {
-		return tableNames{}, errors.Wrapf(err, "error hashing name [%s]", name)
-	}
-	suffix := "_" + hex.EncodeToString(h.Sum(nil)[:3])
-
 	return tableNames{
-		Movements:              fmt.Sprintf("%smovements%s", prefix, suffix),
-		Transactions:           fmt.Sprintf("%stransactions%s", prefix, suffix),
-		Requests:               fmt.Sprintf("%srequests%s", prefix, suffix),
-		Validations:            fmt.Sprintf("%svalidations%s", prefix, suffix),
-		TransactionEndorseAck:  fmt.Sprintf("%stea%s", prefix, suffix),
-		Certifications:         fmt.Sprintf("%scertifications%s", prefix, suffix),
-		Tokens:                 fmt.Sprintf("%stokens%s", prefix, suffix),
-		Ownership:              fmt.Sprintf("%sownership%s", prefix, suffix),
-		PublicParams:           fmt.Sprintf("%spublic_params%s", prefix, suffix),
-		Wallets:                fmt.Sprintf("%swallet%s", prefix, suffix),
-		IdentityConfigurations: fmt.Sprintf("%s%sd_configs%s", prefix, "i", suffix),
-		AuditInfo:              fmt.Sprintf("%saudit_info%s", prefix, suffix),
-		Signers:                fmt.Sprintf("%ssigners%s", prefix, suffix),
+		Movements:              fmt.Sprintf("%smovements", prefix),
+		Transactions:           fmt.Sprintf("%stransactions", prefix),
+		Requests:               fmt.Sprintf("%srequests", prefix),
+		Validations:            fmt.Sprintf("%svalidations", prefix),
+		TransactionEndorseAck:  fmt.Sprintf("%stea", prefix),
+		Certifications:         fmt.Sprintf("%scertifications", prefix),
+		Tokens:                 fmt.Sprintf("%stokens", prefix),
+		Ownership:              fmt.Sprintf("%sownership", prefix),
+		PublicParams:           fmt.Sprintf("%spublic_params", prefix),
+		Wallets:                fmt.Sprintf("%swallet", prefix),
+		IdentityConfigurations: fmt.Sprintf("%sid_configs", prefix),
+		AuditInfo:              fmt.Sprintf("%saudit_info", prefix),
+		Signers:                fmt.Sprintf("%ssigners", prefix),
 	}, nil
 }

--- a/token/services/db/sql/tokens.go
+++ b/token/services/db/sql/tokens.go
@@ -39,8 +39,8 @@ func newTokenDB(db *sql.DB, tables tokenTables) *TokenDB {
 	}
 }
 
-func NewTokenDB(db *sql.DB, tablePrefix, name string, createSchema bool) (*TokenDB, error) {
-	tables, err := getTableNames(tablePrefix, name)
+func NewTokenDB(db *sql.DB, tablePrefix string, createSchema bool) (*TokenDB, error) {
+	tables, err := getTableNames(tablePrefix)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get table names")
 	}
@@ -772,8 +772,6 @@ func (db *TokenDB) GetCertifications(ids []*token.ID, callback func(*token.ID, [
 }
 
 func (db *TokenDB) GetSchema() string {
-	// owner_raw is as1 encoded Type(string), Identity([]byte) (see token/core/identity/owner.go).
-	// If Type is "htlc", Identity is a json encoded Script.
 	return fmt.Sprintf(`
 		-- Tokens
 		CREATE TABLE IF NOT EXISTS %s (

--- a/token/services/db/sql/transactions.go
+++ b/token/services/db/sql/transactions.go
@@ -44,12 +44,11 @@ func newTransactionDB(db *sql.DB, tables transactionTables) *TransactionDB {
 	}
 }
 
-func NewTransactionDB(db *sql.DB, tablePrefix, name string, createSchema bool) (*TransactionDB, error) {
-	tables, err := getTableNames(tablePrefix, name)
+func NewTransactionDB(db *sql.DB, tablePrefix string, createSchema bool) (*TransactionDB, error) {
+	tables, err := getTableNames(tablePrefix)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get table names")
 	}
-
 	transactionsDB := newTransactionDB(db, transactionTables{
 		Movements:             tables.Movements,
 		Transactions:          tables.Transactions,

--- a/token/services/db/sql/transactions_test.go
+++ b/token/services/db/sql/transactions_test.go
@@ -7,30 +7,68 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
+	"database/sql"
+	"fmt"
+	"path"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb/db/dbtest"
+	"github.com/pkg/errors"
 )
+
+func initTransactionsDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*TransactionDB, error) {
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
+	}
+	db.SetMaxOpenConns(maxOpenConns)
+
+	if err = db.Ping(); err != nil {
+		return nil, errors.Wrapf(err, "failed to ping db [%s]", driverName)
+	}
+	logger.Infof("connected to [%s:%s] database", driverName, tablePrefix)
+
+	tables, err := getTableNames(tablePrefix)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get table names")
+	}
+	transactions := newTransactionDB(db, transactionTables{
+		Movements:             tables.Movements,
+		Transactions:          tables.Transactions,
+		Requests:              tables.Requests,
+		Validations:           tables.Validations,
+		TransactionEndorseAck: tables.TransactionEndorseAck,
+	})
+	if err = initSchema(db, transactions.GetSchema()); err != nil {
+		return transactions, err
+	}
+	return transactions, nil
+}
 
 func TestTransactionsSqlite(t *testing.T) {
 	tempDir := t.TempDir()
-
 	for _, c := range dbtest.Cases {
-		initSqlite(t, tempDir, c.Name)
+		db, err := initTransactionsDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close()
-			c.Fn(xt, Transactions)
+			defer db.Close()
+			c.Fn(xt, db)
 		})
 	}
 }
 
 func TestTransactionsSqliteMemory(t *testing.T) {
 	for _, c := range dbtest.Cases {
-		initSqliteMemory(t, c.Name)
-
+		db, err := initTransactionsDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close()
-			c.Fn(xt, Transactions)
+			defer db.Close()
+			c.Fn(xt, db)
 		})
 	}
 }
@@ -40,10 +78,13 @@ func TestTransactionsPostgres(t *testing.T) {
 	defer terminate()
 
 	for _, c := range dbtest.Cases {
-		initPostgres(t, pgConnStr, c.Name)
+		db, err := initTransactionsDB("postgres", pgConnStr, c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close()
-			c.Fn(xt, Transactions)
+			defer db.Close()
+			c.Fn(xt, db)
 		})
 	}
 }

--- a/token/services/identitydb/db/sql/driver.go
+++ b/token/services/identitydb/db/sql/driver.go
@@ -34,7 +34,7 @@ func (d *Driver) OpenIdentityDB(sp view.ServiceProvider, tmsID token.TMSID) (dri
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewIdentityDB(sqlDB, opts.TablePrefix, sqldb.DatasourceName(tmsID), opts.CreateSchema, secondcache.New(1000))
+	return sqldb.NewIdentityDB(sqlDB, opts.TablePrefix, opts.CreateSchema, secondcache.New(1000))
 }
 
 func (d *Driver) OpenWalletDB(sp view.ServiceProvider, tmsID token.TMSID) (driver.WalletDB, error) {
@@ -42,7 +42,7 @@ func (d *Driver) OpenWalletDB(sp view.ServiceProvider, tmsID token.TMSID) (drive
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewWalletDB(sqlDB, opts.TablePrefix, sqldb.DatasourceName(tmsID), opts.CreateSchema)
+	return sqldb.NewWalletDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
 }
 
 func init() {

--- a/token/services/tokendb/db/memory/memory.go
+++ b/token/services/tokendb/db/memory/memory.go
@@ -26,9 +26,8 @@ type Driver struct {
 
 // Open returns a pure go sqlite implementation in memory for testing purposes.
 func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.TokenDB, error) {
-	name := sqldb.DatasourceName(tmsID)
 	h := sha256.New()
-	if _, err := h.Write([]byte(name)); err != nil {
+	if _, err := h.Write([]byte(tmsID.String())); err != nil {
 		return nil, err
 	}
 
@@ -41,7 +40,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)
 	}
 
-	return sqldb.NewTokenDB(sqlDB, "memory", name, true)
+	return sqldb.NewTokenDB(sqlDB, "memory", true)
 }
 
 func init() {

--- a/token/services/tokendb/db/sql/driver.go
+++ b/token/services/tokendb/db/sql/driver.go
@@ -57,10 +57,9 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenD
 		return nil, errors.Wrapf(err, "failed getting opts for vault")
 	}
 	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set. See https://github.com/golang/go/wiki/SQLDrivers", OptsKey))
+		panic(fmt.Sprintf("%s.driver not set", OptsKey))
 	}
 
-	name := sqldb.DatasourceName(tmsID)
 	dataSourceName := os.Getenv(EnvVarKey)
 	if dataSourceName == "" {
 		dataSourceName = opts.DataSource
@@ -76,7 +75,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenD
 		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
 	}
 
-	return sqldb.NewTokenDB(sqlDB, opts.TablePrefix, name, opts.CreateSchema)
+	return sqldb.NewTokenDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
 }
 
 func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -233,10 +233,8 @@ func (t *Tokens) DeleteToken(deletedBy string, ids ...*token2.ID) (err error) {
 		return err
 	}
 	defer func() {
-		if err != nil && ts != nil {
-			if err := ts.Rollback(); err != nil {
-				logger.Errorf("failed to rollback [%s][%s]", err, debug.Stack())
-			}
+		if err := ts.Rollback(); err != nil {
+			logger.Errorf("failed to rollback [%s]", err)
 		}
 	}()
 

--- a/token/services/ttxdb/db/memory/memory.go
+++ b/token/services/ttxdb/db/memory/memory.go
@@ -30,9 +30,8 @@ func NewDriver() *Driver {
 
 // Open returns a pure go sqlite implementation in memory for testing purposes.
 func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.TokenTransactionDB, error) {
-	name := sqldb.DatasourceName(tmsID)
 	h := sha256.New()
-	if _, err := h.Write([]byte(name)); err != nil {
+	if _, err := h.Write([]byte(tmsID.String())); err != nil {
 		return nil, err
 	}
 
@@ -45,7 +44,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)
 	}
 
-	return sqldb.NewTransactionDB(sqlDB, "memory", name, true)
+	return sqldb.NewTransactionDB(sqlDB, "memory", true)
 }
 
 func init() {

--- a/token/services/ttxdb/db/sql/driver.go
+++ b/token/services/ttxdb/db/sql/driver.go
@@ -57,10 +57,9 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenT
 		return nil, errors.Wrapf(err, "failed getting opts for vault")
 	}
 	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set. See https://github.com/golang/go/wiki/SQLDrivers", OptsKey))
+		panic(fmt.Sprintf("%s.driver not set", OptsKey))
 	}
 
-	name := sqldb.DatasourceName(tmsID)
 	dataSourceName := os.Getenv(EnvVarKey)
 	if dataSourceName == "" {
 		dataSourceName = opts.DataSource
@@ -76,7 +75,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenT
 		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
 	}
 
-	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, name, opts.CreateSchema)
+	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
 }
 
 func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {


### PR DESCRIPTION
We don't need the tablesuffix because the db is configured by the user per TMS. Even if they choose to use the same database for multiple TMS, they can use the prefix to have different tables per TMS.