### PR TITLE
Postgres compatibility

### DIFF
--- a/token/services/db/sql/init_test.go
+++ b/token/services/db/sql/init_test.go
@@ -29,6 +29,7 @@ import (
 var Transactions *TransactionDB
 var Tokens *TokenDB
 var Identity *IdentityDB
+var Wallet *WalletDB
 
 func Init(driverName, dataSourceName, tablePrefix, name string, createSchema bool, maxOpenConns int) error {
 	logger.Infof("connecting to sql database [%s:%s]", driverName, tablePrefix) // dataSource can contain a password
@@ -73,8 +74,13 @@ func Init(driverName, dataSourceName, tablePrefix, name string, createSchema boo
 		AuditInfo:              tables.AuditInfo,
 		Signers:                tables.Signers,
 	}, secondcache.New(1000))
+	Wallet, err = NewWalletDB(db, tablePrefix, "test", true)
+	if err != nil {
+		return err
+	}
+
 	if createSchema {
-		if err = initSchema(db, Transactions.GetSchema(), Tokens.GetSchema(), Identity.GetSchema()); err != nil {
+		if err = initSchema(db, Transactions.GetSchema(), Tokens.GetSchema(), Identity.GetSchema(), Wallet.GetSchema()); err != nil {
 			return err
 		}
 	}

--- a/token/services/db/sql/tokens.go
+++ b/token/services/db/sql/tokens.go
@@ -809,8 +809,7 @@ func (db *TokenDB) GetSchema() string {
 		-- Public Parameters
 		CREATE TABLE IF NOT EXISTS %s (
 			raw BYTEA NOT NULL,
-			stored_at TIMESTAMP NOT NULL,
-			PRIMARY KEY (raw)
+			stored_at TIMESTAMP NOT NULL PRIMARY KEY
 		);
 
 		-- Certifications

--- a/token/services/db/sql/wallet_test.go
+++ b/token/services/db/sql/wallet_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/test-go/testify/assert"
+)
+
+func TestWalletSqlite(t *testing.T) {
+	tempDir := t.TempDir()
+
+	for _, c := range WalletCases {
+		initSqlite(t, tempDir, c.Name)
+		t.Run(c.Name, func(xt *testing.T) {
+			defer Transactions.Close() // TODO
+			c.Fn(xt, Wallet)
+		})
+	}
+}
+
+func TestWalletPostgres(t *testing.T) {
+	terminate, pgConnStr := startPostgresContainer(t)
+	defer terminate()
+
+	for _, c := range WalletCases {
+		initPostgres(t, pgConnStr, c.Name)
+		t.Run(c.Name, func(xt *testing.T) {
+			defer Transactions.Close()
+			c.Fn(xt, Wallet)
+		})
+	}
+}
+
+var WalletCases = []struct {
+	Name string
+	Fn   func(*testing.T, *WalletDB)
+}{
+	{"Duplicate", TDuplicate},
+}
+
+func TDuplicate(t *testing.T, db *WalletDB) {
+	id := view.Identity([]byte{254, 0, 155, 1})
+
+	err := db.StoreIdentity(id, "duplicate", "meta")
+	assert.NoError(t, err)
+
+	var meta string
+	err = db.LoadMeta(id, &meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "meta", meta)
+
+	err = db.StoreIdentity(id, "duplicate", "")
+	assert.NoError(t, err)
+
+	err = db.LoadMeta(id, &meta)
+	assert.NoError(t, err)
+	assert.Equal(t, "meta", meta)
+}

--- a/token/services/storage/storage.go
+++ b/token/services/storage/storage.go
@@ -16,4 +16,5 @@ type DBEntry struct {
 type DBEntriesStorage interface {
 	Put(tmsID token.TMSID, walletID string) error
 	Iterator() (Iterator[*DBEntry], error)
+	ByTMS(tmsID token.TMSID) ([]*DBEntry, error)
 }


### PR DESCRIPTION
This PR improves the compatibility with postgres by fixing some bugs encountered while running a token sdk application:

-`identity_id` has non-utf8 characters which is not supported in a `TEXT` column by postgres.
- `raw` cannot be the primary key for params if the params are too large. This PR changes the primary key to the time stored in the database, which is also unique.
- postgres does not have `ON CONFLICT REPLACE` on columns
- the 'restore auditor db' feature was doing writes while iterating over the dbentries, which causes a deadlock with a single threaded KVS.