### PR TITLE
use 1 connection for sqlite, align database config more with fsc

### DIFF
--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -30,18 +30,16 @@ token:
         persistence:
           type: unity
           opts:
-            createSchema: true 
             driver: sqlite    
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: {{ SQLDataSource }}
       tokendb:
         persistence:
           type: sql
           opts:
-            createSchema: true 
             tablePrefix: tokens  
             driver: sqlite    
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: {{ TokensSQLDataSource }}
       # Wallets associated with this TMS
       wallets:

--- a/integration/nwo/token/orion/template.go
+++ b/integration/nwo/token/orion/template.go
@@ -24,9 +24,8 @@ token:
       db:
         persistence:
           opts:
-            createSchema: true 
             driver: sqlite    
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: {{ SQLDataSource }}
       identitydb:
         persistence:
@@ -41,10 +40,9 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true 
             tablePrefix: tokens  
-            driver: sqlite    
-            maxOpenConns: 10
+            driver: sqlite
+            maxOpenConns: 1
             dataSource: {{ TokensSQLDataSource }}
       {{ if Wallets }}wallets:{{ if Wallets.Certifiers }}
         certifiers: {{ range Wallets.Certifiers }}

--- a/token/services/auditdb/db/memory/memory.go
+++ b/token/services/auditdb/db/memory/memory.go
@@ -34,7 +34,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Audit
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
 		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
-		10,
+		1,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)

--- a/token/services/db/sql/init.go
+++ b/token/services/db/sql/init.go
@@ -33,7 +33,7 @@ func initSchema(db *sql.DB, schemas ...string) (err error) {
 	}()
 	for _, schema := range schemas {
 		logger.Debug(schema)
-		if _, err = db.Exec(schema); err != nil {
+		if _, err = tx.Exec(schema); err != nil {
 			return errors.Wrap(err, "error creating schema")
 		}
 	}

--- a/token/services/identitydb/testdata/sqlite/core.yaml
+++ b/token/services/identitydb/testdata/sqlite/core.yaml
@@ -9,10 +9,9 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true
             tablePrefix: tsdk
             driver: sqlite
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
     grapes:
       network: grapes
@@ -22,8 +21,7 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true
             tablePrefix: tsdk
             driver: sqlite
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)

--- a/token/services/tokendb/db/memory/memory.go
+++ b/token/services/tokendb/db/memory/memory.go
@@ -34,7 +34,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
 		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
-		10,
+		1,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)

--- a/token/services/tokendb/testdata/sqlite/core.yaml
+++ b/token/services/tokendb/testdata/sqlite/core.yaml
@@ -9,10 +9,9 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true
             tablePrefix: tsdk
             driver: sqlite
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
     grapes:
       network: grapes
@@ -22,8 +21,7 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true
             tablePrefix: tsdk
             driver: sqlite
-            maxOpenConns: 10
+            maxOpenConns: 1
             dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)

--- a/token/services/ttxdb/db/memory/memory.go
+++ b/token/services/ttxdb/db/memory/memory.go
@@ -38,7 +38,7 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
 		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
-		10,
+		1,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)


### PR DESCRIPTION
Run the tests with only one concurrent connection to sqlite (the code should support that).

Also, now doing skipCreateTables instead of createSchema, to default to creating them and to align to how it's configured in Fabric Smart Client.