### PR TITLE
Delete tokens: move nilcheck and simplify the call used by HTLC

### DIFF
--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -61,7 +61,7 @@ type TokenDBTransaction interface {
 	// TransactionExists returns true if a token with that transaction id exists in the db
 	TransactionExists(id string) (bool, error)
 	// GetToken returns the owned tokens and their identifier keys for the passed ids.
-	GetToken(txID string, index uint64) (*token.Token, error)
+	GetToken(txID string, index uint64, includeDeleted bool) (*token.Token, error)
 	// OwnersOf returns the list of owner of a given token
 	OwnersOf(txID string, index uint64) ([]string, error)
 	// Delete marks the passed token as deleted by a given identifier (idempotent)

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -64,7 +64,7 @@ type TokenDBTransaction interface {
 	GetToken(txID string, index uint64) (*token.Token, error)
 	// OwnersOf returns the list of owner of a given token
 	OwnersOf(txID string, index uint64) ([]string, error)
-	// Delete marks the passed token as deleted by a given identifier
+	// Delete marks the passed token as deleted by a given identifier (idempotent)
 	Delete(txID string, index uint64, deletedBy string) error
 	// StoreToken stores the passed token record in relation to the passed owner identifiers, if any
 	StoreToken(tr TokenRecord, owners []string) error

--- a/token/services/db/sql/tokens.go
+++ b/token/services/db/sql/tokens.go
@@ -80,37 +80,13 @@ func (db *TokenDB) StoreToken(tr driver.TokenRecord, owners []string) (err error
 	return nil
 }
 
-// Delete is called when spending a token
-func (db *TokenDB) Delete(txID string, index uint64, deletedBy string) (err error) {
-	tx, err := db.NewTokenDBTransaction()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err != nil && tx != nil {
-			if err := tx.Rollback(); err != nil {
-				logger.Errorf("failed to rollback [%s][%s]", err, debug.Stack())
-			}
-		}
-	}()
-	if err = tx.Delete(txID, index, deletedBy); err != nil {
-		return err
-	}
-	if err = tx.Commit(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// DeleteTokens delete multiple tokens at the same time (e.g. when invalid or expired)
+// DeleteTokens deletes multiple tokens at the same time (when spent, invalid or expired)
 func (db *TokenDB) DeleteTokens(deletedBy string, ids ...*token.ID) error {
 	logger.Debugf("delete tokens [%s:%v]", ids)
 	if len(ids) == 0 {
 		return nil
 	}
-	now := time.Now().UTC()
-
-	args := []interface{}{deletedBy, now}
+	args := []interface{}{deletedBy, time.Now().UTC()}
 	where := whereTokenIDs(&args, ids)
 
 	query := fmt.Sprintf("UPDATE %s SET is_deleted = true, spent_by = $1, spent_at = $2 WHERE %s", db.table.Tokens, where)

--- a/token/services/db/sql/tokens_test.go
+++ b/token/services/db/sql/tokens_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
-	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"github.com/test-go/testify/assert"
 )
@@ -95,6 +94,7 @@ var TokensCases = []struct {
 	Name string
 	Fn   func(*testing.T, *TokenDB)
 }{
+	{"Transaction", TTransaction},
 	{"SaveAndGetToken", TSaveAndGetToken},
 	{"DeleteAndMine", TDeleteAndMine},
 	{"GetTokenInfos", TGetTokenInfos},
@@ -103,6 +103,58 @@ var TokensCases = []struct {
 	{"DeleteMultiple", TDeleteMultiple},
 	{"PublicParams", TPublicParams},
 	{"TCertification", TCertification},
+}
+
+func TTransaction(t *testing.T, db *TokenDB) {
+	tx, err := db.NewTokenDBTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tx.StoreToken(driver.TokenRecord{
+		TxID:           "tx1",
+		Index:          0,
+		IssuerRaw:      []byte{},
+		OwnerRaw:       []byte{1, 2, 3},
+		Ledger:         []byte("ledger"),
+		LedgerMetadata: []byte{},
+		Quantity:       "0x02",
+		Type:           "TST",
+		Amount:         2,
+		Owner:          true,
+		Auditor:        false,
+		Issuer:         false,
+	}, []string{"alice"})
+	assert.NoError(t, err)
+	assert.NoError(t, tx.Commit())
+
+	tx, err = db.NewTokenDBTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err := tx.GetToken("tx1", 0, false)
+	assert.NoError(t, err)
+	assert.Equal(t, "0x02", tok.Quantity)
+	assert.NoError(t, tx.Delete("tx1", 0, "me"))
+	tok, err = tx.GetToken("tx1", 0, false)
+	assert.NoError(t, err)
+	assert.Nil(t, tok)
+	tok, err = tx.GetToken("tx1", 0, true) // include deleted
+	assert.NoError(t, err)
+	assert.Equal(t, "0x02", tok.Quantity)
+	assert.NoError(t, tx.Rollback())
+
+	tx, err = db.NewTokenDBTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err = tx.GetToken("tx1", 0, false)
+	assert.NoError(t, err)
+	assert.NotNil(t, tok)
+	assert.Equal(t, "0x02", tok.Quantity)
+	tx.Rollback()
+
+	// get owners of deleted tx
+
 }
 
 func TSaveAndGetToken(t *testing.T, db *TokenDB) {
@@ -619,15 +671,15 @@ func TCertification(t *testing.T, db *TokenDB) {
 	wg.Add(40)
 	for i := 0; i < 40; i++ {
 		go func(i int) {
-			tokenID := &token2.ID{
+			tokenID := &token.ID{
 				TxId:  fmt.Sprintf("tx_%d", i),
 				Index: 0,
 			}
-			assert.NoError(t, db.StoreCertifications(map[*token2.ID][]byte{
+			assert.NoError(t, db.StoreCertifications(map[*token.ID][]byte{
 				tokenID: []byte(fmt.Sprintf("certification_%d", i)),
 			}))
 			assert.True(t, db.ExistsCertification(tokenID))
-			certifications, err := db.GetCertifications([]*token2.ID{tokenID})
+			certifications, err := db.GetCertifications([]*token.ID{tokenID})
 			assert.NoError(t, err)
 			for _, bytes := range certifications {
 				assert.Equal(t, fmt.Sprintf("certification_%d", i), string(bytes))
@@ -638,12 +690,12 @@ func TCertification(t *testing.T, db *TokenDB) {
 	wg.Wait()
 
 	for i := 0; i < 40; i++ {
-		tokenID := &token2.ID{
+		tokenID := &token.ID{
 			TxId:  fmt.Sprintf("tx_%d", i),
 			Index: 0,
 		}
 		assert.True(t, db.ExistsCertification(tokenID))
-		certifications, err := db.GetCertifications([]*token2.ID{tokenID})
+		certifications, err := db.GetCertifications([]*token.ID{tokenID})
 		assert.NoError(t, err)
 		for _, bytes := range certifications {
 			assert.Equal(t, fmt.Sprintf("certification_%d", i), string(bytes))
@@ -651,21 +703,21 @@ func TCertification(t *testing.T, db *TokenDB) {
 	}
 
 	// check the certification of a token that was never stored
-	tokenID := &token2.ID{
+	tokenID := &token.ID{
 		TxId:  "pineapple",
 		Index: 0,
 	}
 	assert.False(t, db.ExistsCertification(tokenID))
 
-	certifications, err := db.GetCertifications([]*token2.ID{tokenID})
+	certifications, err := db.GetCertifications([]*token.ID{tokenID})
 	assert.Error(t, err)
 	assert.Empty(t, certifications)
 
 	// store an empty certification and check that an error is returned
-	assert.NoError(t, db.StoreCertifications(map[*token2.ID][]byte{
+	assert.NoError(t, db.StoreCertifications(map[*token.ID][]byte{
 		tokenID: {},
 	}))
-	certifications, err = db.GetCertifications([]*token2.ID{tokenID})
+	certifications, err = db.GetCertifications([]*token.ID{tokenID})
 	assert.Error(t, err)
 	assert.Empty(t, certifications)
 }

--- a/token/services/db/sql/tokens_test.go
+++ b/token/services/db/sql/tokens_test.go
@@ -151,10 +151,17 @@ func TTransaction(t *testing.T, db *TokenDB) {
 	assert.NoError(t, err)
 	assert.NotNil(t, tok)
 	assert.Equal(t, "0x02", tok.Quantity)
-	tx.Rollback()
+	assert.NoError(t, tx.Delete("tx1", 0, "me"))
+	assert.NoError(t, tx.Commit())
 
-	// get owners of deleted tx
-
+	tx, err = db.NewTokenDBTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, err = tx.GetToken("tx1", 0, false)
+	assert.NoError(t, err)
+	assert.Nil(t, tok)
+	assert.NoError(t, tx.Commit())
 }
 
 func TSaveAndGetToken(t *testing.T, db *TokenDB) {

--- a/token/services/db/sql/tokens_test.go
+++ b/token/services/db/sql/tokens_test.go
@@ -267,7 +267,7 @@ func TDeleteAndMine(t *testing.T, db *TokenDB) {
 		Issuer:         false,
 	}
 	assert.NoError(t, db.StoreToken(tr, []string{"alice"}))
-	assert.NoError(t, db.Delete("tx101", 0, "tx103"))
+	assert.NoError(t, db.DeleteTokens("tx103", &token.ID{TxId: "tx101", Index: 0}))
 
 	tok, err := db.ListUnspentTokens()
 	assert.NoError(t, err)

--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -65,7 +65,7 @@ func (r *RWSetProcessor) Process(req fabric.Request, tx fabric.ProcessTransactio
 	case "init":
 		return r.init(tx, rws, ns)
 	default:
-		return r.tokenRequest(req, tx, rws, ns)
+		return r.tokenRequest(tx, ns)
 	}
 }
 
@@ -105,7 +105,7 @@ func (r *RWSetProcessor) init(tx fabric.ProcessTransaction, rws *fabric.RWSet, n
 	return nil
 }
 
-func (r *RWSetProcessor) tokenRequest(req fabric.Request, tx fabric.ProcessTransaction, rws *fabric.RWSet, ns string) error {
+func (r *RWSetProcessor) tokenRequest(tx fabric.ProcessTransaction, ns string) error {
 	txID := tx.ID()
 
 	tms, err := r.GetTMSProvider().GetManagementService(

--- a/token/services/network/orion/processor.go
+++ b/token/services/network/orion/processor.go
@@ -60,10 +60,10 @@ func (r *RWSetProcessor) Process(req orion.Request, tx orion.ProcessTransaction,
 		return nil
 	}
 
-	return r.tokenRequest(req, tx, rws, ns)
+	return r.tokenRequest(tx, ns)
 }
 
-func (r *RWSetProcessor) tokenRequest(req orion.Request, tx orion.ProcessTransaction, rws *orion.RWSet, ns string) error {
+func (r *RWSetProcessor) tokenRequest(tx orion.ProcessTransaction, ns string) error {
 	txID := tx.ID()
 
 	tms, err := r.GetTMSProvider().GetManagementService(

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -63,7 +63,7 @@ func NewTransaction(notifier events.Publisher, tx *tokendb.Transaction, tmsID to
 }
 
 func (t *transaction) DeleteToken(txID string, index uint64, deletedBy string) error {
-	tok, err := t.tx.GetToken(txID, index)
+	tok, err := t.tx.GetToken(txID, index, true)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get token [%s:%d]", txID, index)
 	}

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -79,6 +79,10 @@ func (t *transaction) DeleteToken(txID string, index uint64, deletedBy string) e
 		}
 		return errors.WithMessagef(err, "failed to delete token [%s:%d]", txID, index)
 	}
+	if tok == nil {
+		logger.Debugf("nothing further to delete for [%s:%d]", txID, index)
+		return nil
+	}
 	for _, id := range owners {
 		logger.Debugf("post new delete-token event")
 		t.Notify(DeleteToken, t.tmsID, id, tok.Type, txID, index)

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -228,25 +228,5 @@ func (t *Tokens) StorePublicParams(raw []byte) error {
 // DeleteToken marks the entries corresponding to the passed token ids as deleted.
 // The deletion is attributed to the passed deletedBy argument.
 func (t *Tokens) DeleteToken(deletedBy string, ids ...*token2.ID) (err error) {
-	ts, err := t.Storage.NewTransaction()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := ts.Rollback(); err != nil {
-			logger.Errorf("failed to rollback [%s]", err)
-		}
-	}()
-
-	for _, id := range ids {
-		if id != nil {
-			if err = ts.DeleteToken(id.TxId, id.Index, deletedBy); err != nil {
-				return errors.WithMessagef(err, "failed to delete [%s] by [%s]", id, deletedBy)
-			}
-		}
-	}
-	if err = ts.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return t.Storage.tokenDB.DeleteTokens(deletedBy, ids...)
 }


### PR DESCRIPTION
This moves the nilcheck to make sure it gets used (Delete does not fail if the token doesn't exist).

When running two replicas of Token SDK, one instance will delete the token from the database and notify its mailman. A current limitation is that the mailman of the second replica will not be notified (if tok turns out to be nil we don't post the event). This is not new in this PR, but we should consider it when working on the statelessness of the Token SDK instance.