### PR TITLE
change max token calculation to use big int because high float64 is h…

### DIFF
--- a/token/core/zkatdlog/crypto/setup.go
+++ b/token/core/zkatdlog/crypto/setup.go
@@ -265,7 +265,7 @@ func (pp *PublicParams) ComputeMaxTokenValue() uint64 {
 	// 9223372036854775808 on x86 and 18446744073709551615 on arm).
 	var i, e = big.NewInt(2), big.NewInt(int64(pp.RangeProofParams.BitLength))
 	i.Exp(i, e, nil)
-	return i.Sub(i, big.NewInt(2)).Uint64()
+	return i.Sub(i, big.NewInt(1)).Uint64()
 }
 
 func (pp *PublicParams) String() string {

--- a/token/core/zkatdlog/crypto/setup_test.go
+++ b/token/core/zkatdlog/crypto/setup_test.go
@@ -50,3 +50,13 @@ func TestSerialization(t *testing.T) {
 	assert.NoError(t, pp.Validate())
 
 }
+
+func TestComputeMaxTokenValue(t *testing.T) {
+	pp := PublicParams{
+		RangeProofParams: &RangeProofParams{
+			BitLength: 64,
+		},
+	}
+	max := pp.ComputeMaxTokenValue()
+	assert.Equal(t, uint64(18446744073709551614), max)
+}

--- a/token/core/zkatdlog/crypto/setup_test.go
+++ b/token/core/zkatdlog/crypto/setup_test.go
@@ -58,5 +58,13 @@ func TestComputeMaxTokenValue(t *testing.T) {
 		},
 	}
 	max := pp.ComputeMaxTokenValue()
-	assert.Equal(t, uint64(18446744073709551614), max)
+	assert.Equal(t, uint64(18446744073709551615), max)
+
+	pp = PublicParams{
+		RangeProofParams: &RangeProofParams{
+			BitLength: 16,
+		},
+	}
+	max = pp.ComputeMaxTokenValue()
+	assert.Equal(t, uint64(65535), max)
 }


### PR DESCRIPTION
…andled unreliably across architectures.

Found this out when creating the tokengen params on arm64 and then running the code on amd64... See also https://groups.google.com/g/golang-nuts/c/YxpOo02fT9s?pli=1. I also noticed the original code does -1, whereas I had to -2 to get the same result for a bitlength of 64.
