### PR TITLE
store token request hash in rwsets

### DIFF
--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -13,6 +13,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	TokenRequestToSign = "trs"
+)
+
 type Context[P driver.PublicParameters, T any, TA driver.TransferAction, IA driver.IssueAction] struct {
 	PP                P
 	Deserializer      driver.Deserializer
@@ -23,6 +27,7 @@ type Context[P driver.PublicParameters, T any, TA driver.TransferAction, IA driv
 	IssueAction       IA
 	Ledger            driver.Ledger
 	MetadataCounter   map[string]int
+	Attributes        map[string][]byte
 }
 
 func (c *Context[P, T, TA, IA]) CountMetadataKey(key string) {
@@ -44,6 +49,7 @@ type Validator[P driver.PublicParameters, T any, TA driver.TransferAction, IA dr
 	ActionDeserializer ActionDeserializer[TA, IA]
 	TransferValidators []ValidateTransferFunc[P, T, TA, IA]
 	IssueValidators    []ValidateIssueFunc[P, T, TA, IA]
+	Serializer         driver.Serializer
 }
 
 func NewValidator[P driver.PublicParameters, T any, TA driver.TransferAction, IA driver.IssueAction](
@@ -53,6 +59,7 @@ func NewValidator[P driver.PublicParameters, T any, TA driver.TransferAction, IA
 	actionDeserializer ActionDeserializer[TA, IA],
 	transferValidators []ValidateTransferFunc[P, T, TA, IA],
 	issueValidators []ValidateIssueFunc[P, T, TA, IA],
+	serializer driver.Serializer,
 ) *Validator[P, T, TA, IA] {
 	return &Validator[P, T, TA, IA]{
 		Logger:             Logger,
@@ -61,6 +68,7 @@ func NewValidator[P driver.PublicParameters, T any, TA driver.TransferAction, IA
 		ActionDeserializer: actionDeserializer,
 		TransferValidators: transferValidators,
 		IssueValidators:    issueValidators,
+		Serializer:         serializer,
 	}
 }
 
@@ -93,23 +101,29 @@ func (v *Validator[P, T, TA, IA]) VerifyTokenRequestFromRaw(getState driver.GetS
 		signatures = tr.Signatures
 	}
 
+	attributes := make(map[string][]byte)
+	attributes[TokenRequestToSign], err = v.Serializer.MarshalTokenRequestToSign(req, nil)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to marshal signed token request")
+	}
+
 	backend := NewBackend(getState, signed, signatures)
-	return v.VerifyTokenRequest(backend, backend, anchor, tr)
+	return v.VerifyTokenRequest(backend, backend, anchor, tr, attributes)
 }
 
-func (v *Validator[P, T, TA, IA]) VerifyTokenRequest(ledger driver.Ledger, signatureProvider driver.SignatureProvider, anchor string, tr *driver.TokenRequest) ([]interface{}, map[string][]byte, error) {
-	if err := v.verifyAuditorSignature(signatureProvider); err != nil {
+func (v *Validator[P, T, TA, IA]) VerifyTokenRequest(ledger driver.Ledger, signatureProvider driver.SignatureProvider, anchor string, tr *driver.TokenRequest, attributes map[string][]byte) ([]interface{}, map[string][]byte, error) {
+	if err := v.verifyAuditorSignature(signatureProvider, attributes); err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to verifier auditor's signature [%s]", anchor)
 	}
 	ia, ta, err := v.ActionDeserializer.DeserializeActions(tr)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to unmarshal actions [%s]", anchor)
 	}
-	err = v.verifyIssues(ledger, ia, signatureProvider)
+	err = v.verifyIssues(ledger, ia, signatureProvider, attributes)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to verify issuers' signatures [%s]", anchor)
 	}
-	err = v.verifyTransfers(ledger, ta, signatureProvider)
+	err = v.verifyTransfers(ledger, ta, signatureProvider, attributes)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to verify senders' signatures [%s]", anchor)
 	}
@@ -121,7 +135,7 @@ func (v *Validator[P, T, TA, IA]) VerifyTokenRequest(ledger driver.Ledger, signa
 	for _, action := range ta {
 		actions = append(actions, action)
 	}
-	return actions, nil, nil
+	return actions, attributes, nil
 }
 
 func (v *Validator[P, T, TA, IA]) UnmarshalActions(raw []byte) ([]interface{}, error) {
@@ -145,7 +159,7 @@ func (v *Validator[P, T, TA, IA]) UnmarshalActions(raw []byte) ([]interface{}, e
 	return res, nil
 }
 
-func (v *Validator[P, T, TA, IA]) verifyAuditorSignature(signatureProvider driver.SignatureProvider) error {
+func (v *Validator[P, T, TA, IA]) verifyAuditorSignature(signatureProvider driver.SignatureProvider, attributes map[string][]byte) error {
 	if len(v.PublicParams.Auditors()) != 0 {
 		auditor := v.PublicParams.Auditors()[0]
 		verifier, err := v.Deserializer.GetAuditorVerifier(auditor)
@@ -158,16 +172,16 @@ func (v *Validator[P, T, TA, IA]) verifyAuditorSignature(signatureProvider drive
 	return nil
 }
 
-func (v *Validator[P, T, TA, IA]) verifyIssues(ledger driver.Ledger, issues []IA, signatureProvider driver.SignatureProvider) error {
+func (v *Validator[P, T, TA, IA]) verifyIssues(ledger driver.Ledger, issues []IA, signatureProvider driver.SignatureProvider, attributes map[string][]byte) error {
 	for _, issue := range issues {
-		if err := v.verifyIssue(issue, ledger, signatureProvider); err != nil {
+		if err := v.verifyIssue(issue, ledger, signatureProvider, attributes); err != nil {
 			return errors.Wrapf(err, "failed to verify transfer action")
 		}
 	}
 	return nil
 }
 
-func (v *Validator[P, T, TA, IA]) verifyIssue(tr IA, ledger driver.Ledger, signatureProvider driver.SignatureProvider) error {
+func (v *Validator[P, T, TA, IA]) verifyIssue(tr IA, ledger driver.Ledger, signatureProvider driver.SignatureProvider, attributes map[string][]byte) error {
 	context := &Context[P, T, TA, IA]{
 		PP:                v.PublicParams,
 		Deserializer:      v.Deserializer,
@@ -175,6 +189,7 @@ func (v *Validator[P, T, TA, IA]) verifyIssue(tr IA, ledger driver.Ledger, signa
 		Ledger:            ledger,
 		SignatureProvider: signatureProvider,
 		MetadataCounter:   map[string]int{},
+		Attributes:        attributes,
 	}
 	for _, v := range v.IssueValidators {
 		if err := v(context); err != nil {
@@ -197,18 +212,18 @@ func (v *Validator[P, T, TA, IA]) verifyIssue(tr IA, ledger driver.Ledger, signa
 	return nil
 }
 
-func (v *Validator[P, T, TA, IA]) verifyTransfers(ledger driver.Ledger, transferActions []TA, signatureProvider driver.SignatureProvider) error {
+func (v *Validator[P, T, TA, IA]) verifyTransfers(ledger driver.Ledger, transferActions []TA, signatureProvider driver.SignatureProvider, attributes map[string][]byte) error {
 	v.Logger.Debugf("check sender start...")
 	defer v.Logger.Debugf("check sender finished.")
 	for _, action := range transferActions {
-		if err := v.verifyTransfer(action, ledger, signatureProvider); err != nil {
+		if err := v.verifyTransfer(action, ledger, signatureProvider, attributes); err != nil {
 			return errors.Wrapf(err, "failed to verify transfer action")
 		}
 	}
 	return nil
 }
 
-func (v *Validator[P, T, TA, IA]) verifyTransfer(tr TA, ledger driver.Ledger, signatureProvider driver.SignatureProvider) error {
+func (v *Validator[P, T, TA, IA]) verifyTransfer(tr TA, ledger driver.Ledger, signatureProvider driver.SignatureProvider, attributes map[string][]byte) error {
 	context := &Context[P, T, TA, IA]{
 		PP:                v.PublicParams,
 		Deserializer:      v.Deserializer,
@@ -216,6 +231,7 @@ func (v *Validator[P, T, TA, IA]) verifyTransfer(tr TA, ledger driver.Ledger, si
 		Ledger:            ledger,
 		SignatureProvider: signatureProvider,
 		MetadataCounter:   map[string]int{},
+		Attributes:        attributes,
 	}
 	for _, v := range v.TransferValidators {
 		if err := v(context); err != nil {

--- a/token/core/fabtoken/validator.go
+++ b/token/core/fabtoken/validator.go
@@ -63,5 +63,6 @@ func NewValidator(pp *PublicParams, deserializer driver.Deserializer, extraValid
 		&ActionDeserializer{},
 		transferValidators,
 		issueValidators,
+		&common.Serializer{},
 	)
 }

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -69,5 +69,6 @@ func New(pp *crypto.PublicParams, deserializer driver.Deserializer, extraValidat
 		&ActionDeserializer{},
 		transferValidators,
 		issueValidators,
+		&common.Serializer{},
 	)
 }

--- a/token/driver/validator.go
+++ b/token/driver/validator.go
@@ -8,6 +8,12 @@ package driver
 
 import "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 
+// ValidationAttributeID is the type of validation attribute identifier
+type ValidationAttributeID = string
+
+// ValidationAttributes is a map containing attributes generated during validation
+type ValidationAttributes = map[ValidationAttributeID][]byte
+
 // GetStateFnc models a function that returns the value for the given key from the ledger
 type GetStateFnc = func(key string) ([]byte, error)
 
@@ -31,5 +37,5 @@ type Validator interface {
 	// VerifyTokenRequestFromRaw verifies the passed marshalled token request against the passed ledger and anchor.
 	// The function returns additionally a map that contains information about the token request. The content of this map
 	// is driver-dependant
-	VerifyTokenRequestFromRaw(getState GetStateFnc, anchor string, raw []byte) ([]interface{}, map[string][]byte, error)
+	VerifyTokenRequestFromRaw(getState GetStateFnc, anchor string, raw []byte) ([]interface{}, ValidationAttributes, error)
 }

--- a/token/services/network/fabric/tcc/mock/validator.go
+++ b/token/services/network/fabric/tcc/mock/validator.go
@@ -9,100 +9,106 @@ import (
 )
 
 type Validator struct {
-	UnmarshallAndVerifyStub        func(token.Ledger, string, []byte) ([]interface{}, error)
-	unmarshallAndVerifyMutex       sync.RWMutex
-	unmarshallAndVerifyArgsForCall []struct {
+	UnmarshallAndVerifyWithMetadataStub        func(token.Ledger, string, []byte) ([]interface{}, map[string][]byte, error)
+	unmarshallAndVerifyWithMetadataMutex       sync.RWMutex
+	unmarshallAndVerifyWithMetadataArgsForCall []struct {
 		arg1 token.Ledger
 		arg2 string
 		arg3 []byte
 	}
-	unmarshallAndVerifyReturns struct {
+	unmarshallAndVerifyWithMetadataReturns struct {
 		result1 []interface{}
-		result2 error
+		result2 map[string][]byte
+		result3 error
 	}
-	unmarshallAndVerifyReturnsOnCall map[int]struct {
+	unmarshallAndVerifyWithMetadataReturnsOnCall map[int]struct {
 		result1 []interface{}
-		result2 error
+		result2 map[string][]byte
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Validator) UnmarshallAndVerify(arg1 token.Ledger, arg2 string, arg3 []byte) ([]interface{}, error) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 token.Ledger, arg2 string, arg3 []byte) ([]interface{}, map[string][]byte, error) {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
 		copy(arg3Copy, arg3)
 	}
-	fake.unmarshallAndVerifyMutex.Lock()
-	ret, specificReturn := fake.unmarshallAndVerifyReturnsOnCall[len(fake.unmarshallAndVerifyArgsForCall)]
-	fake.unmarshallAndVerifyArgsForCall = append(fake.unmarshallAndVerifyArgsForCall, struct {
+	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
+	ret, specificReturn := fake.unmarshallAndVerifyWithMetadataReturnsOnCall[len(fake.unmarshallAndVerifyWithMetadataArgsForCall)]
+	fake.unmarshallAndVerifyWithMetadataArgsForCall = append(fake.unmarshallAndVerifyWithMetadataArgsForCall, struct {
 		arg1 token.Ledger
 		arg2 string
 		arg3 []byte
 	}{arg1, arg2, arg3Copy})
-	fake.recordInvocation("UnmarshallAndVerify", []interface{}{arg1, arg2, arg3Copy})
-	fake.unmarshallAndVerifyMutex.Unlock()
-	if fake.UnmarshallAndVerifyStub != nil {
-		return fake.UnmarshallAndVerifyStub(arg1, arg2, arg3)
+	stub := fake.UnmarshallAndVerifyWithMetadataStub
+	fakeReturns := fake.unmarshallAndVerifyWithMetadataReturns
+	fake.recordInvocation("UnmarshallAndVerifyWithMetadata", []interface{}{arg1, arg2, arg3Copy})
+	fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.unmarshallAndVerifyReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
-func (fake *Validator) UnmarshallAndVerifyCallCount() int {
-	fake.unmarshallAndVerifyMutex.RLock()
-	defer fake.unmarshallAndVerifyMutex.RUnlock()
-	return len(fake.unmarshallAndVerifyArgsForCall)
+func (fake *Validator) UnmarshallAndVerifyWithMetadataCallCount() int {
+	fake.unmarshallAndVerifyWithMetadataMutex.RLock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.RUnlock()
+	return len(fake.unmarshallAndVerifyWithMetadataArgsForCall)
 }
 
-func (fake *Validator) UnmarshallAndVerifyCalls(stub func(token.Ledger, string, []byte) ([]interface{}, error)) {
-	fake.unmarshallAndVerifyMutex.Lock()
-	defer fake.unmarshallAndVerifyMutex.Unlock()
-	fake.UnmarshallAndVerifyStub = stub
+func (fake *Validator) UnmarshallAndVerifyWithMetadataCalls(stub func(token.Ledger, string, []byte) ([]interface{}, map[string][]byte, error)) {
+	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
+	fake.UnmarshallAndVerifyWithMetadataStub = stub
 }
 
-func (fake *Validator) UnmarshallAndVerifyArgsForCall(i int) (token.Ledger, string, []byte) {
-	fake.unmarshallAndVerifyMutex.RLock()
-	defer fake.unmarshallAndVerifyMutex.RUnlock()
-	argsForCall := fake.unmarshallAndVerifyArgsForCall[i]
+func (fake *Validator) UnmarshallAndVerifyWithMetadataArgsForCall(i int) (token.Ledger, string, []byte) {
+	fake.unmarshallAndVerifyWithMetadataMutex.RLock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.RUnlock()
+	argsForCall := fake.unmarshallAndVerifyWithMetadataArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *Validator) UnmarshallAndVerifyReturns(result1 []interface{}, result2 error) {
-	fake.unmarshallAndVerifyMutex.Lock()
-	defer fake.unmarshallAndVerifyMutex.Unlock()
-	fake.UnmarshallAndVerifyStub = nil
-	fake.unmarshallAndVerifyReturns = struct {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataReturns(result1 []interface{}, result2 map[string][]byte, result3 error) {
+	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
+	fake.UnmarshallAndVerifyWithMetadataStub = nil
+	fake.unmarshallAndVerifyWithMetadataReturns = struct {
 		result1 []interface{}
-		result2 error
-	}{result1, result2}
+		result2 map[string][]byte
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *Validator) UnmarshallAndVerifyReturnsOnCall(i int, result1 []interface{}, result2 error) {
-	fake.unmarshallAndVerifyMutex.Lock()
-	defer fake.unmarshallAndVerifyMutex.Unlock()
-	fake.UnmarshallAndVerifyStub = nil
-	if fake.unmarshallAndVerifyReturnsOnCall == nil {
-		fake.unmarshallAndVerifyReturnsOnCall = make(map[int]struct {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataReturnsOnCall(i int, result1 []interface{}, result2 map[string][]byte, result3 error) {
+	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
+	fake.UnmarshallAndVerifyWithMetadataStub = nil
+	if fake.unmarshallAndVerifyWithMetadataReturnsOnCall == nil {
+		fake.unmarshallAndVerifyWithMetadataReturnsOnCall = make(map[int]struct {
 			result1 []interface{}
-			result2 error
+			result2 map[string][]byte
+			result3 error
 		})
 	}
-	fake.unmarshallAndVerifyReturnsOnCall[i] = struct {
+	fake.unmarshallAndVerifyWithMetadataReturnsOnCall[i] = struct {
 		result1 []interface{}
-		result2 error
-	}{result1, result2}
+		result2 map[string][]byte
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *Validator) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.unmarshallAndVerifyMutex.RLock()
-	defer fake.unmarshallAndVerifyMutex.RUnlock()
+	fake.unmarshallAndVerifyWithMetadataMutex.RLock()
+	defer fake.unmarshallAndVerifyWithMetadataMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -230,7 +230,7 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 	if err != nil {
 		return shim.Error("failed to add public params dependency:" + err.Error())
 	}
-	err = w.CommitTokenRequest(attributes[common.TokenRequestToSign], false)
+	err = w.CommitTokenRequest(attributes[common.TokenRequestToSign], true)
 	if err != nil {
 		return shim.Error("failed to write token request:" + err.Error())
 	}

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -14,10 +14,10 @@ import (
 	"runtime/debug"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/rws/translator"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/rws/translator"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	pb "github.com/hyperledger/fabric-protos-go/peer"
@@ -50,7 +50,7 @@ func (a *SetupAction) GetSetupParameters() ([]byte, error) {
 //go:generate counterfeiter -o mock/validator.go -fake-name Validator . Validator
 
 type Validator interface {
-	UnmarshallAndVerify(ledger token.Ledger, binding string, raw []byte) ([]interface{}, error)
+	UnmarshallAndVerifyWithMetadata(ledger token.Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error)
 }
 
 //go:generate counterfeiter -o mock/public_parameters_manager.go -fake-name PublicParametersManager . PublicParametersManager
@@ -212,7 +212,7 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 	}
 
 	// Verify
-	actions, err := validator.UnmarshallAndVerify(stub, stub.GetTxID(), raw)
+	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(stub, stub.GetTxID(), raw)
 	if err != nil {
 		return shim.Error("failed to verify token request: " + err.Error())
 	}
@@ -230,7 +230,7 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 	if err != nil {
 		return shim.Error("failed to add public params dependency:" + err.Error())
 	}
-	err = w.CommitTokenRequest(raw, false)
+	err = w.CommitTokenRequest(attributes[common.TokenRequestToSign], false)
 	if err != nil {
 		return shim.Error("failed to write token request:" + err.Error())
 	}

--- a/token/services/network/fabric/tcc/tcc_test.go
+++ b/token/services/network/fabric/tcc/tcc_test.go
@@ -73,7 +73,7 @@ var _ = Describe("ccvalidator", func() {
 				fakestub.GetTransientReturns(map[string][]byte{"token_request": []byte("token request")}, nil)
 				fakestub.GetStateReturnsOnCall(0, []byte("pp"), nil)
 				fakestub.GetStateReturnsOnCall(1, nil, nil)
-				fakeValidator.UnmarshallAndVerifyReturns([]interface{}{}, nil)
+				fakeValidator.UnmarshallAndVerifyWithMetadataReturns([]interface{}{}, nil, nil)
 			})
 			It("succeeds", func() {
 				response := chaincode.Invoke(fakestub)
@@ -90,7 +90,7 @@ var _ = Describe("ccvalidator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				fakestub.GetArgsReturns(args)
 				fakestub.GetTransientReturns(map[string][]byte{"token_request": []byte("token request")}, nil)
-				fakeValidator.UnmarshallAndVerifyReturns(nil, errors.Errorf("flying monkeys"))
+				fakeValidator.UnmarshallAndVerifyWithMetadataReturns(nil, nil, errors.Errorf("flying monkeys"))
 			})
 			It("fails", func() {
 				response := chaincode.Invoke(fakestub)

--- a/token/services/network/orion/approval.go
+++ b/token/services/network/orion/approval.go
@@ -12,6 +12,7 @@ import (
 	session2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault/rws/translator"
 	"github.com/pkg/errors"
@@ -121,7 +122,7 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 		return nil, errors.Wrapf(err, "failed to get query executor for orion network [%s]", request.Network)
 	}
 
-	actions, err := validator.UnmarshallAndVerify(
+	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(
 		&LedgerWrapper{qe: qe},
 		request.TxID,
 		request.Request,
@@ -147,7 +148,7 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 			return nil, errors.Wrapf(err, "failed to write action")
 		}
 	}
-	err = t.CommitTokenRequest(request.Request, false)
+	err = t.CommitTokenRequest(attributes[common.TokenRequestToSign], false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to commit token request")
 	}

--- a/token/services/network/orion/approval.go
+++ b/token/services/network/orion/approval.go
@@ -148,7 +148,7 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 			return nil, errors.Wrapf(err, "failed to write action")
 		}
 	}
-	err = t.CommitTokenRequest(attributes[common.TokenRequestToSign], false)
+	err = t.CommitTokenRequest(attributes[common.TokenRequestToSign], true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to commit token request")
 	}


### PR DESCRIPTION
The translation of the token request for fabric and orion contain the hash of the token request to later be checked again the local copy.