### PR TITLE
Centralize database initialization logic

### DIFF
--- a/token/services/auditdb/db/memory/memory.go
+++ b/token/services/auditdb/db/memory/memory.go
@@ -33,8 +33,9 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Audit
 
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
-		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
+		fmt.Sprintf("file:%x?mode=memory&cache=shared", h.Sum(nil)),
 		10,
+		false,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)

--- a/token/services/auditdb/db/sql/driver.go
+++ b/token/services/auditdb/db/sql/driver.go
@@ -7,22 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
-	"database/sql"
-	"fmt"
-	"os"
-	"sync"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	sqldb "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
-	"github.com/pkg/errors"
 )
-
-var logger = flogging.MustGetLogger("token-sdk.auditdb.sql")
 
 const (
 	// OptsKey is the key for the opts in the config
@@ -30,83 +20,20 @@ const (
 	EnvVarKey = "AUDITDB_DATASOURCE"
 )
 
-type Opts struct {
-	Driver       string
-	DataSource   string
-	TablePrefix  string
-	CreateSchema bool
-	MaxOpenConns int
-}
-
 type Driver struct {
-	mutex sync.RWMutex
-	dbs   map[string]*sql.DB
+	*sqldb.DBOpener
 }
 
 func NewDriver() *Driver {
-	return &Driver{dbs: make(map[string]*sql.DB)}
+	return &Driver{DBOpener: sqldb.NewSQLDBOpener(OptsKey, EnvVarKey)}
 }
 
 func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.AuditTransactionDB, error) {
-	opts := &Opts{}
-	tmsConfig, err := config.NewTokenSDK(view.GetConfigService(sp)).GetTMS(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	sqlDB, opts, err := d.DBOpener.Open(sp, tmsID)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to load configuration for tms [%s]", tmsID)
+		return nil, err
 	}
-	if err := tmsConfig.UnmarshalKey(OptsKey, opts); err != nil {
-		return nil, errors.Wrapf(err, "failed getting opts for vault")
-	}
-	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set", OptsKey))
-	}
-
-	dataSourceName := os.Getenv(EnvVarKey)
-	if dataSourceName == "" {
-		dataSourceName = opts.DataSource
-	}
-	if dataSourceName == "" {
-		return nil, errors.Errorf("either %s.dataSource in core.yaml or %s"+
-			"environment variable must be set to a dataSourceName that can be used with the %s golang driver",
-			OptsKey, EnvVarKey, opts.Driver)
-	}
-
-	sqlDB, err := d.OpenSQLDB(opts.Driver, opts.DataSource, opts.MaxOpenConns)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
-	}
-
-	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix+"_audit", opts.CreateSchema)
-}
-
-func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {
-	logger.Infof("connecting to [%s] database", driverName) // dataSource can contain a password
-
-	id := driverName + dataSourceName
-	var p *sql.DB
-	d.mutex.RLock()
-	p, ok := d.dbs[id]
-	if ok {
-		logger.Infof("reuse [%s] database (cached)", driverName)
-		d.mutex.RUnlock()
-		return p, nil
-	}
-	d.mutex.RUnlock()
-
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	// check again
-	p, ok = d.dbs[id]
-	if ok {
-		return p, nil
-	}
-	p, err := sql.Open(driverName, dataSourceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
-	}
-	p.SetMaxOpenConns(maxOpenConns)
-	d.dbs[id] = p
-	return p, nil
+	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix+"_aud", opts.CreateSchema)
 }
 
 func init() {

--- a/token/services/auditdb/db/sql/driver.go
+++ b/token/services/auditdb/db/sql/driver.go
@@ -33,7 +33,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.AuditT
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix+"_aud", opts.CreateSchema)
+	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix+"_aud", !opts.SkipCreateTable)
 }
 
 func init() {

--- a/token/services/db/sql/driver.go
+++ b/token/services/db/sql/driver.go
@@ -19,11 +19,12 @@ import (
 )
 
 type Opts struct {
-	Driver       string
-	DataSource   string
-	TablePrefix  string
-	CreateSchema bool
-	MaxOpenConns int
+	Driver          string
+	DataSource      string
+	TablePrefix     string
+	SkipCreateTable bool
+	SkipPragmas     bool
+	MaxOpenConns    int
 }
 
 type DBOpener struct {

--- a/token/services/db/sql/driver/driver.go
+++ b/token/services/db/sql/driver/driver.go
@@ -154,27 +154,27 @@ func (d *Driver) openSQLDB(driverName, dataSourceName string, maxOpenConns int) 
 	return p, nil
 }
 
-type TTXDBDriver struct {
+type TtxDBDriver struct {
 	*Driver
 }
 
-func (t *TTXDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.TokenTransactionDB, error) {
+func (t *TtxDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.TokenTransactionDB, error) {
 	return t.OpenTokenTransactionDB(sp, tmsID)
 }
 
-type TOKENDBDriver struct {
+type TokenDBDriver struct {
 	*Driver
 }
 
-func (t *TOKENDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.TokenDB, error) {
+func (t *TokenDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.TokenDB, error) {
 	return t.OpenTokenDB(sp, tmsID)
 }
 
-type AUDITDBDriver struct {
+type AuditDBDriver struct {
 	*Driver
 }
 
-func (t *AUDITDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.AuditTransactionDB, error) {
+func (t *AuditDBDriver) Open(sp view.ServiceProvider, tmsID token.TMSID) (auditdbd.AuditTransactionDB, error) {
 	return t.OpenAuditTransactionDB(sp, tmsID)
 }
 
@@ -192,8 +192,8 @@ func (t *IdentityDBDriver) OpenIdentityDB(sp view.ServiceProvider, tmsID token.T
 
 func init() {
 	root := NewDriver()
-	ttxdb.Register("unity", &TTXDBDriver{Driver: root})
-	tokendb.Register("unity", &TOKENDBDriver{Driver: root})
-	auditdb.Register("unity", &AUDITDBDriver{Driver: root})
+	ttxdb.Register("unity", &TtxDBDriver{Driver: root})
+	tokendb.Register("unity", &TokenDBDriver{Driver: root})
+	auditdb.Register("unity", &AuditDBDriver{Driver: root})
 	identitydb.Register("unity", &IdentityDBDriver{Driver: root})
 }

--- a/token/services/db/sql/identity_test.go
+++ b/token/services/db/sql/identity_test.go
@@ -7,32 +7,48 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
+	"fmt"
+	"path"
 	"reflect"
 	"testing"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/cache/secondcache"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 
 	"github.com/stretchr/testify/assert"
 )
 
+func initIdentityDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*IdentityDB, error) {
+	d := NewSQLDBOpener("", "")
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
+	if err != nil {
+		return nil, err
+	}
+	return NewIdentityDB(sqlDB, tablePrefix, true, secondcache.New(1000))
+}
+
 func TestIdentitySqlite(t *testing.T) {
 	tempDir := t.TempDir()
 
 	for _, c := range IdentityCases {
-		initSqlite(t, tempDir, c.Name)
+		db, err := initIdentityDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close() // TODO
-			c.Fn(xt, Identity)
+			c.Fn(xt, db)
 		})
 	}
 }
 
 func TestIdentitySqliteMemory(t *testing.T) {
 	for _, c := range IdentityCases {
-		initSqliteMemory(t, c.Name)
+		db, err := initIdentityDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close()
-			c.Fn(xt, Identity)
+			c.Fn(xt, db)
 		})
 	}
 }
@@ -42,10 +58,12 @@ func TestIdentityPostgres(t *testing.T) {
 	defer terminate()
 
 	for _, c := range IdentityCases {
-		initPostgres(t, pgConnStr, c.Name)
+		db, err := initIdentityDB("postgres", pgConnStr, c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Run(c.Name, func(xt *testing.T) {
-			defer Transactions.Close()
-			c.Fn(xt, Identity)
+			c.Fn(xt, db)
 		})
 	}
 }

--- a/token/services/db/sql/identity_test.go
+++ b/token/services/db/sql/identity_test.go
@@ -20,7 +20,7 @@ import (
 
 func initIdentityDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*IdentityDB, error) {
 	d := NewSQLDBOpener("", "")
-	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns, false)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func TestIdentitySqlite(t *testing.T) {
 	tempDir := t.TempDir()
 
 	for _, c := range IdentityCases {
-		db, err := initIdentityDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		db, err := initIdentityDB("sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -43,7 +43,7 @@ func TestIdentitySqlite(t *testing.T) {
 
 func TestIdentitySqliteMemory(t *testing.T) {
 	for _, c := range IdentityCases {
-		db, err := initIdentityDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		db, err := initIdentityDB("sqlite", "file:tmp?_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/token/services/db/sql/init.go
+++ b/token/services/db/sql/init.go
@@ -33,7 +33,7 @@ func initSchema(db *sql.DB, schemas ...string) (err error) {
 	}()
 	for _, schema := range schemas {
 		logger.Debug(schema)
-		if _, err = db.Exec(schema); err != nil {
+		if _, err = tx.Exec(schema); err != nil {
 			return errors.Wrap(err, "error creating schema")
 		}
 	}

--- a/token/services/db/sql/tokens_test.go
+++ b/token/services/db/sql/tokens_test.go
@@ -19,7 +19,7 @@ import (
 
 func initTokenDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*TokenDB, error) {
 	d := NewSQLDBOpener("", "")
-	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns, false)
 	if err != nil {
 		return nil, err
 	}
@@ -29,7 +29,7 @@ func initTokenDB(driverName, dataSourceName, tablePrefix string, maxOpenConns in
 func TestTokensSqlite(t *testing.T) {
 	tempDir := t.TempDir()
 	for _, c := range TokensCases {
-		db, err := initTokenDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		db, err := initTokenDB("sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -42,7 +42,7 @@ func TestTokensSqlite(t *testing.T) {
 
 func TestTokensSqliteMemory(t *testing.T) {
 	for _, c := range TokensCases {
-		db, err := initTokenDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		db, err := initTokenDB("sqlite", "file:tmp?_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/token/services/db/sql/transactions_test.go
+++ b/token/services/db/sql/transactions_test.go
@@ -16,7 +16,7 @@ import (
 
 func initTransactionsDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*TransactionDB, error) {
 	d := NewSQLDBOpener("", "")
-	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns, false)
 	if err != nil {
 		return nil, err
 	}
@@ -26,7 +26,7 @@ func initTransactionsDB(driverName, dataSourceName, tablePrefix string, maxOpenC
 func TestTransactionsSqlite(t *testing.T) {
 	tempDir := t.TempDir()
 	for _, c := range dbtest.Cases {
-		db, err := initTransactionsDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		db, err := initTransactionsDB("sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +40,7 @@ func TestTransactionsSqlite(t *testing.T) {
 
 func TestTransactionsSqliteMemory(t *testing.T) {
 	for _, c := range dbtest.Cases {
-		db, err := initTransactionsDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		db, err := initTransactionsDB("sqlite", "file:tmp?_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/token/services/db/sql/transactions_test.go
+++ b/token/services/db/sql/transactions_test.go
@@ -7,42 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
-	"database/sql"
 	"fmt"
 	"path"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb/db/dbtest"
-	"github.com/pkg/errors"
 )
 
 func initTransactionsDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*TransactionDB, error) {
-	db, err := sql.Open(driverName, dataSourceName)
+	d := NewSQLDBOpener("", "")
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
+		return nil, err
 	}
-	db.SetMaxOpenConns(maxOpenConns)
-
-	if err = db.Ping(); err != nil {
-		return nil, errors.Wrapf(err, "failed to ping db [%s]", driverName)
-	}
-	logger.Infof("connected to [%s:%s] database", driverName, tablePrefix)
-
-	tables, err := getTableNames(tablePrefix)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get table names")
-	}
-	transactions := newTransactionDB(db, transactionTables{
-		Movements:             tables.Movements,
-		Transactions:          tables.Transactions,
-		Requests:              tables.Requests,
-		Validations:           tables.Validations,
-		TransactionEndorseAck: tables.TransactionEndorseAck,
-	})
-	if err = initSchema(db, transactions.GetSchema()); err != nil {
-		return transactions, err
-	}
-	return transactions, nil
+	return NewTransactionDB(sqlDB, tablePrefix, true)
 }
 
 func TestTransactionsSqlite(t *testing.T) {

--- a/token/services/db/sql/wallet_test.go
+++ b/token/services/db/sql/wallet_test.go
@@ -17,7 +17,7 @@ import (
 
 func initWalletDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*WalletDB, error) {
 	d := NewSQLDBOpener("", "")
-	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns)
+	sqlDB, err := d.OpenSQLDB(driverName, dataSourceName, maxOpenConns, false)
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func TestWalletSqlite(t *testing.T) {
 	tempDir := t.TempDir()
 
 	for _, c := range WalletCases {
-		db, err := initWalletDB("sqlite", fmt.Sprintf("file:%s?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		db, err := initWalletDB("sqlite", fmt.Sprintf("file:%s?_pragma=busy_timeout(5000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,7 +40,7 @@ func TestWalletSqlite(t *testing.T) {
 
 func TestWalletSqliteMemory(t *testing.T) {
 	for _, c := range WalletCases {
-		db, err := initWalletDB("sqlite", "file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
+		db, err := initWalletDB("sqlite", "file:tmp?_pragma=busy_timeout(5000)&mode=memory&cache=shared", c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/token/services/identitydb/db/sql/driver.go
+++ b/token/services/identitydb/db/sql/driver.go
@@ -34,7 +34,7 @@ func (d *Driver) OpenIdentityDB(sp view.ServiceProvider, tmsID token.TMSID) (dri
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewIdentityDB(sqlDB, opts.TablePrefix, opts.CreateSchema, secondcache.New(1000))
+	return sqldb.NewIdentityDB(sqlDB, opts.TablePrefix, !opts.SkipCreateTable, secondcache.New(1000))
 }
 
 func (d *Driver) OpenWalletDB(sp view.ServiceProvider, tmsID token.TMSID) (driver.WalletDB, error) {
@@ -42,7 +42,7 @@ func (d *Driver) OpenWalletDB(sp view.ServiceProvider, tmsID token.TMSID) (drive
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewWalletDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
+	return sqldb.NewWalletDB(sqlDB, opts.TablePrefix, !opts.SkipCreateTable)
 }
 
 func init() {

--- a/token/services/identitydb/testdata/sqlite/core.yaml
+++ b/token/services/identitydb/testdata/sqlite/core.yaml
@@ -13,7 +13,7 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared
     grapes:
       network: grapes
       channel:
@@ -26,4 +26,4 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared

--- a/token/services/tokendb/db/memory/memory.go
+++ b/token/services/tokendb/db/memory/memory.go
@@ -33,8 +33,9 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
-		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
+		fmt.Sprintf("file:%x?mode=memory&cache=shared", h.Sum(nil)),
 		10,
+		false,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)

--- a/token/services/tokendb/db/sql/driver.go
+++ b/token/services/tokendb/db/sql/driver.go
@@ -7,22 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
-	"database/sql"
-	"fmt"
-	"os"
-	"sync"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	sqldb "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokendb"
-	"github.com/pkg/errors"
 )
-
-var logger = flogging.MustGetLogger("token-sdk.tokendb.sql")
 
 const (
 	// OptsKey is the key for the opts in the config
@@ -30,83 +20,20 @@ const (
 	EnvVarKey = "TOKENDB_DATASOURCE"
 )
 
-type Opts struct {
-	Driver       string
-	DataSource   string
-	TablePrefix  string
-	CreateSchema bool
-	MaxOpenConns int
-}
-
 type Driver struct {
-	mutex sync.RWMutex
-	dbs   map[string]*sql.DB
+	*sqldb.DBOpener
 }
 
 func NewDriver() *Driver {
-	return &Driver{dbs: make(map[string]*sql.DB)}
+	return &Driver{DBOpener: sqldb.NewSQLDBOpener(OptsKey, EnvVarKey)}
 }
 
 func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenDB, error) {
-	opts := &Opts{}
-	tmsConfig, err := config.NewTokenSDK(view.GetConfigService(sp)).GetTMS(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	sqlDB, opts, err := d.DBOpener.Open(sp, tmsID)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to load configuration for tms [%s]", tmsID)
+		return nil, err
 	}
-	if err := tmsConfig.UnmarshalKey(OptsKey, opts); err != nil {
-		return nil, errors.Wrapf(err, "failed getting opts for vault")
-	}
-	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set", OptsKey))
-	}
-
-	dataSourceName := os.Getenv(EnvVarKey)
-	if dataSourceName == "" {
-		dataSourceName = opts.DataSource
-	}
-	if dataSourceName == "" {
-		return nil, errors.Errorf("either %s.dataSource in core.yaml or %s"+
-			"environment variable must be set to a dataSourceName that can be used with the %s golang driver",
-			OptsKey, EnvVarKey, opts.Driver)
-	}
-
-	sqlDB, err := d.OpenSQLDB(opts.Driver, opts.DataSource, opts.MaxOpenConns)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
-	}
-
 	return sqldb.NewTokenDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
-}
-
-func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {
-	logger.Infof("connecting to [%s] database", driverName) // dataSource can contain a password
-
-	id := driverName + dataSourceName
-	var p *sql.DB
-	d.mutex.RLock()
-	p, ok := d.dbs[id]
-	if ok {
-		logger.Infof("reuse [%s] database (cached)", driverName)
-		d.mutex.RUnlock()
-		return p, nil
-	}
-	d.mutex.RUnlock()
-
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	// check again
-	p, ok = d.dbs[id]
-	if ok {
-		return p, nil
-	}
-	p, err := sql.Open(driverName, dataSourceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
-	}
-	p.SetMaxOpenConns(maxOpenConns)
-	d.dbs[id] = p
-	return p, nil
 }
 
 func init() {

--- a/token/services/tokendb/db/sql/driver.go
+++ b/token/services/tokendb/db/sql/driver.go
@@ -33,7 +33,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenD
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewTokenDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
+	return sqldb.NewTokenDB(sqlDB, opts.TablePrefix, !opts.SkipCreateTable)
 }
 
 func init() {

--- a/token/services/tokendb/testdata/sqlite/core.yaml
+++ b/token/services/tokendb/testdata/sqlite/core.yaml
@@ -13,7 +13,7 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared
     grapes:
       network: grapes
       channel:
@@ -26,4 +26,4 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared

--- a/token/services/ttxdb/db/memory/memory.go
+++ b/token/services/ttxdb/db/memory/memory.go
@@ -37,8 +37,9 @@ func (d *Driver) Open(sp view2.ServiceProvider, tmsID token.TMSID) (driver.Token
 
 	sqlDB, err := d.Driver.OpenSQLDB(
 		"sqlite",
-		fmt.Sprintf("file:%x?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared", h.Sum(nil)),
+		fmt.Sprintf("file:%x?mode=memory&cache=shared", h.Sum(nil)),
 		10,
+		false,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open memory db for [%s]", tmsID)

--- a/token/services/ttxdb/db/sql/driver.go
+++ b/token/services/ttxdb/db/sql/driver.go
@@ -33,7 +33,7 @@ func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenT
 	if err != nil {
 		return nil, err
 	}
-	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
+	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, !opts.SkipCreateTable)
 }
 
 func init() {

--- a/token/services/ttxdb/db/sql/driver.go
+++ b/token/services/ttxdb/db/sql/driver.go
@@ -7,22 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
-	"database/sql"
-	"fmt"
-	"os"
-	"sync"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	sqldb "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
-	"github.com/pkg/errors"
 )
-
-var logger = flogging.MustGetLogger("token-sdk.ttxdb.sql")
 
 const (
 	// OptsKey is the key for the opts in the config
@@ -30,83 +20,20 @@ const (
 	EnvVarKey = "TTXDB_DATASOURCE"
 )
 
-type Opts struct {
-	Driver       string
-	DataSource   string
-	TablePrefix  string
-	CreateSchema bool
-	MaxOpenConns int
-}
-
 type Driver struct {
-	mutex sync.RWMutex
-	dbs   map[string]*sql.DB
+	*sqldb.DBOpener
 }
 
 func NewDriver() *Driver {
-	return &Driver{dbs: make(map[string]*sql.DB)}
+	return &Driver{DBOpener: sqldb.NewSQLDBOpener(OptsKey, EnvVarKey)}
 }
 
 func (d *Driver) Open(sp view.ServiceProvider, tmsID token.TMSID) (driver.TokenTransactionDB, error) {
-	opts := &Opts{}
-	tmsConfig, err := config.NewTokenSDK(view.GetConfigService(sp)).GetTMS(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	sqlDB, opts, err := d.DBOpener.Open(sp, tmsID)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to load configuration for tms [%s]", tmsID)
+		return nil, err
 	}
-	if err := tmsConfig.UnmarshalKey(OptsKey, opts); err != nil {
-		return nil, errors.Wrapf(err, "failed getting opts for vault")
-	}
-	if opts.Driver == "" {
-		panic(fmt.Sprintf("%s.driver not set", OptsKey))
-	}
-
-	dataSourceName := os.Getenv(EnvVarKey)
-	if dataSourceName == "" {
-		dataSourceName = opts.DataSource
-	}
-	if dataSourceName == "" {
-		return nil, errors.Errorf("either %s.dataSource in core.yaml or %s"+
-			"environment variable must be set to a dataSourceName that can be used with the %s golang driver",
-			OptsKey, EnvVarKey, opts.Driver)
-	}
-
-	sqlDB, err := d.OpenSQLDB(opts.Driver, opts.DataSource, opts.MaxOpenConns)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db at [%s:%s:%s]", OptsKey, EnvVarKey, opts.Driver)
-	}
-
 	return sqldb.NewTransactionDB(sqlDB, opts.TablePrefix, opts.CreateSchema)
-}
-
-func (d *Driver) OpenSQLDB(driverName, dataSourceName string, maxOpenConns int) (*sql.DB, error) {
-	logger.Infof("connecting to [%s] database", driverName) // dataSource can contain a password
-
-	id := driverName + dataSourceName
-	var p *sql.DB
-	d.mutex.RLock()
-	p, ok := d.dbs[id]
-	if ok {
-		logger.Infof("reuse [%s] database (cached)", driverName)
-		d.mutex.RUnlock()
-		return p, nil
-	}
-	d.mutex.RUnlock()
-
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	// check again
-	p, ok = d.dbs[id]
-	if ok {
-		return p, nil
-	}
-	p, err := sql.Open(driverName, dataSourceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open db [%s]", driverName)
-	}
-	p.SetMaxOpenConns(maxOpenConns)
-	d.dbs[id] = p
-	return p, nil
 }
 
 func init() {

--- a/token/services/ttxdb/testdata/sqlite/core.yaml
+++ b/token/services/ttxdb/testdata/sqlite/core.yaml
@@ -13,7 +13,7 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared
     grapes:
       network: grapes
       channel:
@@ -26,4 +26,4 @@ token:
             tablePrefix: tsdk
             driver: sqlite
             maxOpenConns: 10
-            dataSource: db.sqlite?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)
+            dataSource: file:tmp?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&mode=memory&cache=shared


### PR DESCRIPTION
Simplifies opening of SQL databases by centralizing the configuration in the database package, similar to how identitydb was already doing it.