### PR TITLE
remove query executor

### DIFF
--- a/docs/services/auditor.md
+++ b/docs/services/auditor.md
@@ -14,9 +14,10 @@ Key features and components:
     3. **Append**: Adds a transaction to the audit database and subscribes to transaction status changes on the network.
     4. **Release**: Releases locks acquired during auditing.
 - **Querying and status management:**
-    - **NewQueryExecutor**: Creates a QueryExecutor for filtering and retrieving audit data.
+    - **NewPaymentsFilter**: Creates a PaymentFilter to query movements from the database
+    - **NewHoldingsFilter**: Creates a HoldingsFilter to query holdings from the database
     - **SetStatus**: Sets the status of an audit record (Pending, Confirmed, Deleted).
     - **GetStatus**: Retrieves the status of a transaction.
     - **GetTokenRequest**: Retrieves the token request associated with a transaction ID.
 
-The auditor service is locate under [`token/services/auditor`](./../../token/services/auditor).
+The auditor service is located under [`token/services/auditor`](./../../token/services/auditor).

--- a/integration/token/fungible/views/history.go
+++ b/integration/token/fungible/views/history.go
@@ -66,9 +66,8 @@ func (p *ListAuditedTransactionsView) Call(context view.Context) (interface{}, e
 	// Get query executor
 	auditor, err := ttx.NewAuditor(context, w)
 	assert.NoError(err, "failed to get auditor instance")
-	aqe := auditor.NewQueryExecutor()
-	defer aqe.Done()
-	it, err := aqe.Transactions(ttxdb.QueryTransactionsParams{From: p.From, To: p.To})
+
+	it, err := auditor.Transactions(ttxdb.QueryTransactionsParams{From: p.From, To: p.To})
 	assert.NoError(err, "failed querying transactions")
 	defer it.Close()
 
@@ -111,9 +110,7 @@ type ListAcceptedTransactionsView struct {
 func (p *ListAcceptedTransactionsView) Call(context view.Context) (interface{}, error) {
 	// Get query executor
 	owner := ttx.NewOwner(context, token.GetManagementService(context))
-	aqe := owner.NewQueryExecutor()
-	defer aqe.Done()
-	it, err := aqe.Transactions(ttxdb.QueryTransactionsParams{
+	it, err := owner.Transactions(ttxdb.QueryTransactionsParams{
 		SenderWallet:    p.SenderWallet,
 		RecipientWallet: p.RecipientWallet,
 		From:            p.From,

--- a/token/services/auditdb/db.go
+++ b/token/services/auditdb/db.go
@@ -123,43 +123,6 @@ func (t *TransactionIterator) Next() (*TransactionRecord, error) {
 // QueryTransactionsParams defines the parameters for querying movements
 type QueryTransactionsParams = driver.QueryTransactionsParams
 
-// QueryExecutor executors queries against the DB
-type QueryExecutor struct {
-	db     *DB
-	closed bool
-}
-
-// NewPaymentsFilter returns a programmable filter over the payments sent or received by enrollment IDs.
-func (qe *QueryExecutor) NewPaymentsFilter() *PaymentsFilter {
-	return &PaymentsFilter{
-		db: qe.db,
-	}
-}
-
-// NewHoldingsFilter returns a programmable filter over the holdings owned by enrollment IDs.
-func (qe *QueryExecutor) NewHoldingsFilter() *HoldingsFilter {
-	return &HoldingsFilter{
-		db: qe.db,
-	}
-}
-
-// Transactions returns an iterators of transaction records filtered by the given params.
-func (qe *QueryExecutor) Transactions(params QueryTransactionsParams) (*TransactionIterator, error) {
-	it, err := qe.db.db.QueryTransactions(params)
-	if err != nil {
-		return nil, errors.Errorf("failed to query transactions: %s", err)
-	}
-	return &TransactionIterator{it: it}, nil
-}
-
-// Done closes the query executor. It must be called when the query executor is no longer needed.s
-func (qe *QueryExecutor) Done() {
-	if qe.closed {
-		return
-	}
-	qe.closed = true
-}
-
 // Wallet models a wallet
 type Wallet interface {
 	// ID returns the wallet ID
@@ -240,9 +203,23 @@ func (d *DB) Append(req *token.Request) error {
 	return nil
 }
 
-// NewQueryExecutor returns a new query executor
-func (d *DB) NewQueryExecutor() *QueryExecutor {
-	return &QueryExecutor{db: d}
+// Transactions returns an iterators of transaction records filtered by the given params.
+func (db *DB) Transactions(params QueryTransactionsParams) (driver.TransactionIterator, error) {
+	return db.db.QueryTransactions(params)
+}
+
+// NewPaymentsFilter returns a programmable filter over the payments sent or received by enrollment IDs.
+func (db *DB) NewPaymentsFilter() *PaymentsFilter {
+	return &PaymentsFilter{
+		db: db,
+	}
+}
+
+// NewHoldingsFilter returns a programmable filter over the holdings owned by enrollment IDs.
+func (db *DB) NewHoldingsFilter() *HoldingsFilter {
+	return &HoldingsFilter{
+		db: db,
+	}
 }
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -38,26 +38,6 @@ type Transaction interface {
 	Request() *token.Request
 }
 
-// QueryExecutor defines the interface for the query executor
-type QueryExecutor struct {
-	*auditdb.QueryExecutor
-}
-
-// NewPaymentsFilter returns a filter for payments
-func (a *QueryExecutor) NewPaymentsFilter() *auditdb.PaymentsFilter {
-	return a.QueryExecutor.NewPaymentsFilter()
-}
-
-// NewHoldingsFilter returns a filter for holdings
-func (a *QueryExecutor) NewHoldingsFilter() *auditdb.HoldingsFilter {
-	return a.QueryExecutor.NewHoldingsFilter()
-}
-
-// Done closes the query executor. It must be called when the query executor is no longer needed.
-func (a *QueryExecutor) Done() {
-	a.QueryExecutor.Done()
-}
-
 type NetworkProvider interface {
 	GetNetwork(network string, channel string) (*network.Network, error)
 }
@@ -119,11 +99,6 @@ func (a *Auditor) Append(tx Transaction) error {
 // Release releases the lock acquired of the passed transaction.
 func (a *Auditor) Release(tx Transaction) {
 	a.db.ReleaseLocks(tx.Request().Anchor)
-}
-
-// NewQueryExecutor returns a new query executor
-func (a *Auditor) NewQueryExecutor() *QueryExecutor {
-	return &QueryExecutor{QueryExecutor: a.db.NewQueryExecutor()}
 }
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status

--- a/token/services/auditor/manager.go
+++ b/token/services/auditor/manager.go
@@ -115,10 +115,7 @@ func (cm *Manager) restore(tmsID token.TMSID, walletID string) error {
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get auditor for [%s]", walletID)
 	}
-	qe := auditor.NewQueryExecutor()
-	defer qe.Done()
-
-	it, err := qe.Transactions(auditdb.QueryTransactionsParams{})
+	it, err := auditor.db.Transactions(auditdb.QueryTransactionsParams{})
 	if err != nil {
 		return errors.Errorf("failed to get tx iterator for [%s:%s]", tmsID, walletID)
 	}
@@ -180,7 +177,6 @@ func (cm *Manager) restore(tmsID token.TMSID, walletID string) error {
 		}
 	}
 	it.Close()
-	qe.Done()
 
 	for _, updated := range toBeUpdated {
 		if err := auditor.db.SetStatus(updated.TxID, updated.Status, updated.Message); err != nil {

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditor"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
 	"github.com/pkg/errors"
@@ -62,11 +63,19 @@ func (a *TxAuditor) Release(tx *Transaction) {
 	a.auditor.Release(tx)
 }
 
-// NewQueryExecutor returns a new query executor. The query executor is used to
-// execute queries against the auditor's DB.
-// The function `Done` on the query executor must be called when it is no longer needed.
-func (a *TxAuditor) NewQueryExecutor() *auditor.QueryExecutor {
-	return a.auditor.NewQueryExecutor()
+// Transactions returns an iterator of transaction records filtered by the given params.
+func (a *TxAuditor) Transactions(params QueryTransactionsParams) (driver.TransactionIterator, error) {
+	return a.auditDB.Transactions(params)
+}
+
+// NewPaymentsFilter returns a programmable filter over the payments sent or received by enrollment IDs.
+func (a *TxAuditor) NewPaymentsFilter() *auditdb.PaymentsFilter {
+	return a.auditDB.NewPaymentsFilter()
+}
+
+// NewHoldingsFilter returns a programmable filter over the holdings owned by enrollment IDs.
+func (a *TxAuditor) NewHoldingsFilter() *auditdb.HoldingsFilter {
+	return a.auditDB.NewHoldingsFilter()
 }
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status

--- a/token/services/ttx/db.go
+++ b/token/services/ttx/db.go
@@ -15,11 +15,6 @@ import (
 
 type QueryTransactionsParams = ttxdb.QueryTransactionsParams
 
-// QueryExecutor defines the interface for the query executor
-type QueryExecutor struct {
-	*ttxdb.QueryExecutor
-}
-
 type NetworkProvider interface {
 	GetNetwork(network string, channel string) (*network.Network, error)
 }
@@ -28,11 +23,6 @@ type NetworkProvider interface {
 type DB struct {
 	networkProvider NetworkProvider
 	db              *ttxdb.DB
-}
-
-// NewQueryExecutor returns a new query executor
-func (a *DB) NewQueryExecutor() *QueryExecutor {
-	return &QueryExecutor{QueryExecutor: a.db.NewQueryExecutor()}
 }
 
 // Append adds the passed transaction to the database

--- a/token/services/ttx/manager.go
+++ b/token/services/ttx/manager.go
@@ -91,10 +91,8 @@ func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get db for [%s:%s]", tmsID.Network, tmsID.Channel)
 	}
-	qe := db.NewQueryExecutor()
-	defer qe.Done()
 
-	it, err := qe.Transactions(ttxdb.QueryTransactionsParams{})
+	it, err := db.db.Transactions(ttxdb.QueryTransactionsParams{})
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get tx iterator for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID)
 	}
@@ -157,7 +155,6 @@ func (cm *Manager) RestoreTMS(tmsID token.TMSID) error {
 		}
 	}
 	it.Close()
-	qe.Done()
 
 	for _, updated := range toBeUpdated {
 		if err := db.db.SetStatus(updated.TxID, updated.Status, updated.Message); err != nil {

--- a/token/services/ttx/owner.go
+++ b/token/services/ttx/owner.go
@@ -10,6 +10,7 @@ import (
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 )
 
 type TxOwner struct {
@@ -30,16 +31,14 @@ func NewOwner(sp view2.ServiceProvider, tms *token.ManagementService) *TxOwner {
 	}
 }
 
-// NewQueryExecutor returns a new query executor.
-// The query executor is used to execute queries against the token transaction DB.
-// The function `Done` on the query executor must be called when it is no longer needed.
-func (a *TxOwner) NewQueryExecutor() *QueryExecutor {
-	return a.owner.NewQueryExecutor()
-}
-
 // Append adds a new transaction to the token transaction database.
 func (a *TxOwner) Append(tx *Transaction) error {
 	return a.owner.Append(tx)
+}
+
+// Transactions returns an iterators of transaction records filtered by the given params.
+func (a *TxOwner) Transactions(params QueryTransactionsParams) (driver.TransactionIterator, error) {
+	return a.owner.db.Transactions(params)
 }
 
 // TransactionInfo returns the transaction info for the given transaction ID.

--- a/token/services/ttxdb/README.md
+++ b/token/services/ttxdb/README.md
@@ -40,20 +40,11 @@ It is also possible to append just the transaction records corresponding to a gi
 
 ## Payments
 
-To get a list of payments filtered by given criteria, one must first obtain a `query executor` like
-this:
-
-```go
-    qe := ttxDB.NewQueryExecutor()
-    defer aqe.Done() // Don't forget to close the query executor
-```
-
-Now, we are ready to perform payment queries. 
 The following example shows how to retrieve the total amount of last 10 payments made by a given 
 business party, identified by the corresponding enrollment ID, for a given token type.
 
 ```go
-    filter := qe.NewPaymentsFilter()
+    filter := ttxDB.NewPaymentsFilter()
     filter, err = filter.ByEnrollmentId(eID).ByType(tokenType).Last(10).Execute()
     if err != nil {
         return errors.WithMessagef(err, "failed getting payments for enrollment id [%s] and token type [%s]", eID, tokenType)
@@ -68,7 +59,7 @@ Recall that the current holding is equal to the difference between inbound and o
 the entire history.
 
 ```go
-    filter := qe.NewHoldingsFilter()
+    filter := ttxDB.NewHoldingsFilter()
     filter, err = filter.ByEnrollmentId(eID).ByType(tokenType).Execute()
     if err != nil {
         return errors.WithMessagef(err, "failed getting holdings for enrollment id [%s] and token type [%s]", eID, tokenType)


### PR DESCRIPTION
Breaking API change: instead of opening and closing a query executor:

```
aqe := auditor.NewQueryExecutor()
defer aqe.Done()
 aqe.NewPaymentsFilter()
```
You have to directly:
```
auditor.NewPaymentsFilter()
```