### PR TITLE
enforce foreign key constraints in token transaction db

### DIFF
--- a/token/services/auditdb/db.go
+++ b/token/services/auditdb/db.go
@@ -225,17 +225,8 @@ func (db *DB) NewHoldingsFilter() *HoldingsFilter {
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status
 func (d *DB) SetStatus(txID string, status TxStatus, message string) error {
 	logger.Debugf("set status [%s][%s]...", txID, status)
-
-	w, err := d.db.BeginAtomicWrite()
-	if err != nil {
-		return errors.WithMessagef(err, "begin update for txid [%s] failed", txID)
-	}
-	if err := w.SetStatus(txID, status, message); err != nil {
-		w.Rollback()
+	if err := d.db.SetStatus(txID, status, message); err != nil {
 		return errors.Wrapf(err, "failed setting status [%s][%s]", txID, driver.TxStatusMessage[status])
-	}
-	if err := w.Commit(); err != nil {
-		return errors.WithMessagef(err, "failed committing status [%s][%s]", txID, driver.TxStatusMessage[status])
 	}
 
 	// notify the listeners

--- a/token/services/db/dbtest/transactions.go
+++ b/token/services/db/dbtest/transactions.go
@@ -419,7 +419,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 	tr := []driver.TransactionRecord{
 		{
 			TxID:         "1",
-			Index:        0,
 			ActionType:   driver.Issue,
 			SenderEID:    "",
 			RecipientEID: "bob",
@@ -430,7 +429,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "2",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "bob",
 			RecipientEID: "alice",
@@ -441,7 +439,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "2",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "bob",
 			RecipientEID: "bob",
@@ -452,7 +449,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "3",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "bob",
 			RecipientEID: "alice",
@@ -463,7 +459,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "4",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "bob",
 			RecipientEID: "alice",
@@ -474,7 +469,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "5",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "bob",
 			RecipientEID: "alice",
@@ -485,7 +479,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "6",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "bob",
@@ -496,7 +489,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "7",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "bob",
@@ -507,7 +499,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "7",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "dan",
@@ -518,7 +509,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "8",
-			Index:        0,
 			ActionType:   driver.Redeem,
 			SenderEID:    "dan",
 			RecipientEID: "carlos",
@@ -529,7 +519,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "9",
-			Index:        0,
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "dan",
@@ -540,7 +529,6 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 		},
 		{
 			TxID:         "10",
-			Index:        0,
 			ActionType:   driver.Redeem,
 			SenderEID:    "alice",
 			RecipientEID: "",
@@ -796,10 +784,10 @@ func TEndorserAcks(t *testing.T, db driver.TokenTransactionDB) {
 func createTransaction(t *testing.T, db driver.TokenTransactionDB, txID string) {
 	w, err := db.BeginAtomicWrite()
 	if err != nil {
-		t.Fatalf("error creating transaction while trying to test something else: %w", err)
+		t.Fatalf("error creating transaction while trying to test something else: %s", err)
 	}
 	if err := w.AddTokenRequest(txID, []byte{}); err != nil {
-		t.Fatalf("error creating token request while trying to test something else: %w", err)
+		t.Fatalf("error creating token request while trying to test something else: %s", err)
 	}
 	tr1 := &driver.TransactionRecord{
 		TxID:         txID,
@@ -812,9 +800,9 @@ func createTransaction(t *testing.T, db driver.TokenTransactionDB, txID string) 
 		Status:       driver.Pending,
 	}
 	if err := w.AddTransaction(tr1); err != nil {
-		t.Fatalf("error creating transaction while trying to test something else: %w", err)
+		t.Fatalf("error creating transaction while trying to test something else: %s", err)
 	}
 	if err := w.Commit(); err != nil {
-		t.Fatalf("error committing transaction while trying to test something else: %w", err)
+		t.Fatalf("error committing transaction while trying to test something else: %s", err)
 	}
 }

--- a/token/services/db/driver/audit.go
+++ b/token/services/db/driver/audit.go
@@ -19,6 +19,10 @@ type AuditTransactionDB interface {
 	// BeginAtomicWrite opens an atomic database transaction. It must be committed or discarded.
 	BeginAtomicWrite() (AtomicWrite, error)
 
+	// SetStatus sets the status of a TokenRequest
+	// (and with that, the associated ValidationRecord, Movement and Transaction)
+	SetStatus(txID string, status TxStatus, message string) error
+
 	// GetStatus returns the status of a given transaction.
 	// It returns an error if the transaction is not found
 	GetStatus(txID string) (TxStatus, string, error)

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -99,8 +99,6 @@ type MovementRecord struct {
 type TransactionRecord struct {
 	// TxID is the transaction ID
 	TxID string
-	// Index is the action sequence number within the transaction
-	Index uint64
 	// ActionType is the type of action performed by this transaction record
 	ActionType ActionType
 	// SenderEID is the enrollment ID of the account that is sending tokens

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -99,6 +99,8 @@ type MovementRecord struct {
 type TransactionRecord struct {
 	// TxID is the transaction ID
 	TxID string
+	// Index is the action sequence number within the transaction
+	Index uint64
 	// ActionType is the type of action performed by this transaction record
 	ActionType ActionType
 	// SenderEID is the enrollment ID of the account that is sending tokens
@@ -113,6 +115,9 @@ type TransactionRecord struct {
 	Timestamp time.Time
 	// Status is the status of the transaction
 	Status TxStatus
+	// ApplicationMetadata is the metadata sent by the application in the
+	// transient field. It is not validated or recorded on the ledger.
+	ApplicationMetadata map[string][]byte
 }
 
 func (t *TransactionRecord) String() string {

--- a/token/services/db/driver/ttx.go
+++ b/token/services/db/driver/ttx.go
@@ -45,10 +45,6 @@ type AtomicWrite interface {
 	// AddValidationRecord adds a new validation records for the given params
 	// This operation _requires_ a TokenRequest with the same tx_id to exist
 	AddValidationRecord(txID string, meta map[string][]byte) error
-
-	// SetStatus sets the status of a TokenRequest
-	// (and with that, the associated ValidationRecord, Movement and Transaction)
-	SetStatus(txID string, status TxStatus, message string) error
 }
 
 type TransactionDB interface {
@@ -57,6 +53,10 @@ type TransactionDB interface {
 
 	// BeginAtomicWrite opens an atomic database transaction. It must be committed or discarded.
 	BeginAtomicWrite() (AtomicWrite, error)
+
+	// SetStatus sets the status of a TokenRequest
+	// (and with that, the associated ValidationRecord, Movement and Transaction)
+	SetStatus(txID string, status TxStatus, message string) error
 
 	// GetStatus returns the status of a given transaction.
 	// It returns an error if the transaction is not found

--- a/token/services/db/sql/driver.go
+++ b/token/services/db/sql/driver.go
@@ -24,7 +24,8 @@ const sqlitePragmas = `
 	PRAGMA busy_timeout = 5000;
 	PRAGMA synchronous = NORMAL;
 	PRAGMA cache_size = 1000000000;
-	PRAGMA temp_store = memory;`
+	PRAGMA temp_store = memory;
+	PRAGMA foreign_keys = ON;`
 
 type Opts struct {
 	Driver          string

--- a/token/services/db/sql/init.go
+++ b/token/services/db/sql/init.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"regexp"
 	"runtime/debug"
+	"strings"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/pkg/errors"
@@ -61,11 +62,14 @@ type tableNames struct {
 
 func getTableNames(prefix string) (tableNames, error) {
 	if prefix != "" {
+		if len(prefix) > 100 {
+			return tableNames{}, errors.New("table prefix must be shorter than 100 characters")
+		}
 		r := regexp.MustCompile("^[a-zA-Z_]+$")
 		if !r.MatchString(prefix) {
 			return tableNames{}, errors.New("illegal character in table prefix, only letters and underscores allowed")
 		}
-		prefix = prefix + "_"
+		prefix = strings.ToLower(prefix) + "_"
 	}
 
 	return tableNames{

--- a/token/services/db/sql/init_test.go
+++ b/token/services/db/sql/init_test.go
@@ -47,7 +47,7 @@ func TestGetTableNames(t *testing.T) {
 
 	names, err = getTableNames("Valid_Prefix")
 	assert.NoError(t, err)
-	assert.Equal(t, "Valid_Prefix_transactions", names.Transactions)
+	assert.Equal(t, "valid_prefix_transactions", names.Transactions)
 
 	names, err = getTableNames("valid")
 	assert.NoError(t, err)
@@ -63,12 +63,13 @@ func TestGetTableNames(t *testing.T) {
 		"\"invalid\"",
 		"in_valid1",
 		"Invalid-Prefix",
+		"too_long_abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij",
 	}
 
 	for _, inv := range invalid {
 		t.Run(fmt.Sprintf("Prefix: %s", inv), func(t *testing.T) {
 			names, err := getTableNames(inv)
-			assert.NotNil(t, err)
+			assert.Error(t, err)
 			assert.Equal(t, tableNames{}, names)
 		})
 	}

--- a/token/services/db/sql/querybuilder_test.go
+++ b/token/services/db/sql/querybuilder_test.go
@@ -28,7 +28,7 @@ func TestTransactionSql(t *testing.T) {
 		{
 			name:         "No params",
 			params:       driver.QueryTransactionsParams{},
-			expectedSql:  ";",
+			expectedSql:  "",
 			expectedArgs: []interface{}{},
 		},
 		{
@@ -36,7 +36,7 @@ func TestTransactionSql(t *testing.T) {
 			params: driver.QueryTransactionsParams{
 				Statuses: []driver.TxStatus{driver.Confirmed},
 			},
-			expectedSql:  "WHERE status = $1;",
+			expectedSql:  "WHERE status = $1",
 			expectedArgs: []interface{}{driver.Confirmed},
 		},
 		{
@@ -44,7 +44,7 @@ func TestTransactionSql(t *testing.T) {
 			params: driver.QueryTransactionsParams{
 				Statuses: []driver.TxStatus{driver.Pending, driver.Deleted},
 			},
-			expectedSql:  "WHERE (status = $1 OR status = $2);",
+			expectedSql:  "WHERE (status = $1 OR status = $2)",
 			expectedArgs: []interface{}{driver.Pending, driver.Deleted},
 		},
 		{
@@ -53,7 +53,7 @@ func TestTransactionSql(t *testing.T) {
 				SenderWallet: "alice",
 				Statuses:     []driver.TxStatus{driver.Confirmed},
 			},
-			expectedSql:  "WHERE status = $1;",
+			expectedSql:  "WHERE status = $1",
 			expectedArgs: []interface{}{driver.Confirmed},
 		},
 		{
@@ -62,7 +62,7 @@ func TestTransactionSql(t *testing.T) {
 				SenderWallet:    "alice",
 				RecipientWallet: "bob",
 			},
-			expectedSql:  "WHERE (sender_eid = $1 OR recipient_eid = $2);",
+			expectedSql:  "WHERE (sender_eid = $1 OR recipient_eid = $2)",
 			expectedArgs: []interface{}{"alice", "bob"},
 		},
 		{
@@ -72,7 +72,7 @@ func TestTransactionSql(t *testing.T) {
 				RecipientWallet: "alice",
 				From:            &lastYear,
 			},
-			expectedSql:  "WHERE stored_at >= $1 AND (sender_eid = $2 OR recipient_eid = $3);",
+			expectedSql:  "WHERE stored_at >= $1 AND (sender_eid = $2 OR recipient_eid = $3)",
 			expectedArgs: []interface{}{&lastYear, "alice", "alice"},
 		},
 		{
@@ -81,7 +81,7 @@ func TestTransactionSql(t *testing.T) {
 				To:   &now,
 				From: &lastYear,
 			},
-			expectedSql:  "WHERE stored_at >= $1 AND stored_at <= $2;",
+			expectedSql:  "WHERE stored_at >= $1 AND stored_at <= $2",
 			expectedArgs: []interface{}{&lastYear, &now},
 		},
 	}
@@ -107,7 +107,7 @@ func TestMovementConditions(t *testing.T) {
 			params: driver.QueryMovementsParams{
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE status != 'Deleted' ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE status != 3 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{},
 		},
 		{
@@ -116,7 +116,7 @@ func TestMovementConditions(t *testing.T) {
 				NumRecords:        5,
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE status != 'Deleted' ORDER BY stored_at DESC LIMIT 5;",
+			expectedSql:  "WHERE status != 3 ORDER BY stored_at DESC LIMIT 5",
 			expectedArgs: []interface{}{},
 		},
 		{
@@ -125,7 +125,7 @@ func TestMovementConditions(t *testing.T) {
 				EnrollmentIDs:     []string{"eid1", "eid2", "eid3"},
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE (enrollment_id = $1 OR enrollment_id = $2 OR enrollment_id = $3) AND status != 'Deleted' ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE (enrollment_id = $1 OR enrollment_id = $2 OR enrollment_id = $3) AND status != 3 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{"eid1", "eid2", "eid3"},
 		},
 		{
@@ -134,7 +134,7 @@ func TestMovementConditions(t *testing.T) {
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE status = $1 ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE status = $1 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{driver.Confirmed},
 		},
 		{
@@ -143,7 +143,7 @@ func TestMovementConditions(t *testing.T) {
 				TxStatuses:        []driver.TxStatus{driver.Pending, driver.Deleted},
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE (status = $1 OR status = $2) ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE (status = $1 OR status = $2) ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{driver.Pending, driver.Deleted},
 		},
 		{
@@ -153,7 +153,7 @@ func TestMovementConditions(t *testing.T) {
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE enrollment_id = $1 AND status = $2 ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE enrollment_id = $1 AND status = $2 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{"alice", driver.Confirmed},
 		},
 		{
@@ -164,7 +164,7 @@ func TestMovementConditions(t *testing.T) {
 				TokenTypes:        []string{"ABC", "XYZ"},
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE enrollment_id = $1 AND (token_type = $2 OR token_type = $3) AND status = $4 ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE enrollment_id = $1 AND (token_type = $2 OR token_type = $3) AND status = $4 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{"alice", "ABC", "XYZ", driver.Confirmed},
 		},
 		{
@@ -176,7 +176,7 @@ func TestMovementConditions(t *testing.T) {
 				NumRecords:        5,
 				MovementDirection: driver.All,
 			},
-			expectedSql:  "WHERE enrollment_id = $1 AND (token_type = $2 OR token_type = $3) AND status = $4 ORDER BY stored_at DESC LIMIT 5;",
+			expectedSql:  "WHERE enrollment_id = $1 AND (token_type = $2 OR token_type = $3) AND status = $4 ORDER BY stored_at DESC LIMIT 5",
 			expectedArgs: []interface{}{"alice", "ABC", "XYZ", driver.Confirmed},
 		},
 		{
@@ -186,7 +186,7 @@ func TestMovementConditions(t *testing.T) {
 				TokenTypes:        []string{"XYZ"},
 				MovementDirection: driver.Sent,
 			},
-			expectedSql:  "WHERE enrollment_id = $1 AND token_type = $2 AND status != 'Deleted' AND amount < 0 ORDER BY stored_at DESC;",
+			expectedSql:  "WHERE enrollment_id = $1 AND token_type = $2 AND status != 3 AND amount < 0 ORDER BY stored_at DESC",
 			expectedArgs: []interface{}{"alice", "XYZ"},
 		},
 		{
@@ -197,7 +197,7 @@ func TestMovementConditions(t *testing.T) {
 				MovementDirection: driver.Received,
 				NumRecords:        2,
 			},
-			expectedSql:  "WHERE status = $1 AND amount > 0 ORDER BY stored_at DESC LIMIT 2;",
+			expectedSql:  "WHERE status = $1 AND amount > 0 ORDER BY stored_at DESC LIMIT 2",
 			expectedArgs: []interface{}{driver.Pending},
 		},
 	}
@@ -260,7 +260,7 @@ func TestCertificationsQuerySql(t *testing.T) {
 	}
 	conditions, idStrs, err := certificationsQuerySql(ids)
 	assert.NoError(t, err)
-	assert.Equal(t, conditions, "token_id=$1 || token_id=$2;")
+	assert.Equal(t, conditions, "token_id=$1 || token_id=$2")
 	assert.Len(t, idStrs, len(ids))
 	for i := 0; i < len(ids); i++ {
 		assert.Equal(t, fmt.Sprintf("%s%d", ids[i].TxId, ids[i].Index), idStrs[i])
@@ -268,6 +268,11 @@ func TestCertificationsQuerySql(t *testing.T) {
 
 	conditions, idStrs, err = certificationsQuerySql(nil)
 	assert.NoError(t, err)
-	assert.Equal(t, ";", conditions)
+	assert.Equal(t, "", conditions)
 	assert.Nil(t, idStrs)
+}
+
+func TestJoin(t *testing.T) {
+	j := joinOnTxID("t1", "t2")
+	assert.Equal(t, "LEFT JOIN t2 ON t1.tx_id = t2.tx_id", j)
 }

--- a/token/services/db/sql/transactions.go
+++ b/token/services/db/sql/transactions.go
@@ -219,6 +219,23 @@ func (db *TransactionDB) Close() error {
 	return nil
 }
 
+func (db *TransactionDB) SetStatus(txID string, status driver.TxStatus, message string) (err error) {
+	var query string
+	if len(message) != 0 {
+		query = fmt.Sprintf("UPDATE %s SET status = $1, status_message = $2 WHERE tx_id = $3;", db.table.Requests)
+		logger.Debug(query)
+		_, err = db.db.Exec(query, status, message, txID)
+	} else {
+		query = fmt.Sprintf("UPDATE %s SET status = $1 WHERE tx_id = $2;", db.table.Requests)
+		logger.Debug(query)
+		_, err = db.db.Exec(query, status, txID)
+	}
+	if err != nil {
+		return errors.Wrapf(err, "error updating tx [%s]", txID)
+	}
+	return
+}
+
 func (db *TransactionDB) GetSchema() string {
 	return fmt.Sprintf(`
 		-- requests
@@ -490,26 +507,6 @@ func (w *AtomicWrite) AddValidationRecord(txID string, meta map[string][]byte) e
 
 	_, err = w.txn.Exec(query, txID, md, now)
 	return dbError(err)
-}
-
-func (w *AtomicWrite) SetStatus(txID string, status driver.TxStatus, message string) (err error) {
-	if w.txn == nil {
-		return errors.New("no db transaction in progress")
-	}
-	var query string
-	if len(message) != 0 {
-		query = fmt.Sprintf("UPDATE %s SET status = $1, status_message = $2 WHERE tx_id = $3;", w.db.table.Requests)
-		logger.Debug(query)
-		_, err = w.txn.Exec(query, status, message, txID)
-	} else {
-		query = fmt.Sprintf("UPDATE %s SET status = $1 WHERE tx_id = $2;", w.db.table.Requests)
-		logger.Debug(query)
-		_, err = w.txn.Exec(query, status, txID)
-	}
-	if err != nil {
-		return errors.Wrapf(err, "error updating tx [%s]", txID)
-	}
-	return
 }
 
 func dbError(err error) error {

--- a/token/services/db/sql/transactions.go
+++ b/token/services/db/sql/transactions.go
@@ -119,7 +119,7 @@ func (db *TransactionDB) QueryMovements(params driver.QueryMovementsParams) (res
 func (db *TransactionDB) QueryTransactions(params driver.QueryTransactionsParams) (driver.TransactionIterator, error) {
 	conditions, args := transactionsConditionsSql(params)
 	query := fmt.Sprintf(
-		"SELECT %s.tx_id, idx, action_type, sender_eid, recipient_eid, token_type, amount, %s.status, stored_at FROM %s %s %s",
+		"SELECT %s.tx_id, action_type, sender_eid, recipient_eid, token_type, amount, %s.status, stored_at FROM %s %s %s",
 		db.table.Transactions, db.table.Requests,
 		db.table.Transactions, joinOnTxID(db.table.Transactions, db.table.Requests), conditions)
 
@@ -250,7 +250,6 @@ func (db *TransactionDB) GetSchema() string {
 		CREATE TABLE IF NOT EXISTS %s (
 			id CHAR(36) NOT NULL PRIMARY KEY,
 			tx_id TEXT NOT NULL REFERENCES %s,
-			idx INT NOT NULL,
 			action_type INT NOT NULL,
 			sender_eid TEXT NOT NULL,
 			recipient_eid TEXT NOT NULL,
@@ -281,7 +280,7 @@ func (db *TransactionDB) GetSchema() string {
 		-- tea
 		CREATE TABLE IF NOT EXISTS %s (
 			id CHAR(36) NOT NULL PRIMARY KEY,
-			tx_id TEXT NOT NULL REFERENCES %s,
+			tx_id TEXT NOT NULL,
 			endorser BYTEA NOT NULL,
             sigma BYTEA NOT NULL,
 			stored_at TIMESTAMP NOT NULL
@@ -292,7 +291,7 @@ func (db *TransactionDB) GetSchema() string {
 		db.table.Transactions, db.table.Requests, db.table.Transactions, db.table.Transactions,
 		db.table.Movements, db.table.Requests, db.table.Movements, db.table.Movements,
 		db.table.Validations, db.table.Requests,
-		db.table.TransactionEndorseAck, db.table.Requests, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,
+		db.table.TransactionEndorseAck, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,
 	)
 }
 
@@ -324,10 +323,9 @@ func (t *TransactionIterator) Next() (*driver.TransactionRecord, error) {
 	var actionType int
 	var amount int64
 	var status int
-	// tx_id, idx, action_type, sender_eid, recipient_eid, token_type, amount, status, stored_at
+	// tx_id, action_type, sender_eid, recipient_eid, token_type, amount, status, stored_at
 	err := t.txs.Scan(
 		&r.TxID,
-		&r.Index,
 		&actionType,
 		&r.SenderEID,
 		&r.RecipientEID,
@@ -433,7 +431,7 @@ func (w *AtomicWrite) Rollback() {
 }
 
 func (w *AtomicWrite) AddTransaction(r *driver.TransactionRecord) error {
-	logger.Debugf("adding transaction record [%s:%d:%d,%s:%s:%s:%s]", r.TxID, r.Index, r.ActionType, r.TokenType, r.SenderEID, r.RecipientEID, r.Amount)
+	logger.Debugf("adding transaction record [%s:%d:%d,%s:%s:%s:%s]", r.TxID, r.ActionType, r.TokenType, r.SenderEID, r.RecipientEID, r.Amount)
 	if w.txn == nil {
 		return errors.New("no db transaction in progress")
 	}
@@ -447,8 +445,8 @@ func (w *AtomicWrite) AddTransaction(r *driver.TransactionRecord) error {
 		return errors.Wrapf(err, "error generating uuid")
 	}
 
-	query := fmt.Sprintf("INSERT INTO %s (id, tx_id, idx, action_type, sender_eid, recipient_eid, token_type, amount, stored_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);", w.db.table.Transactions)
-	args := []any{id, r.TxID, r.Index, actionType, r.SenderEID, r.RecipientEID, r.TokenType, amount, r.Timestamp.UTC()}
+	query := fmt.Sprintf("INSERT INTO %s (id, tx_id, action_type, sender_eid, recipient_eid, token_type, amount, stored_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);", w.db.table.Transactions)
+	args := []any{id, r.TxID, actionType, r.SenderEID, r.RecipientEID, r.TokenType, amount, r.Timestamp.UTC()}
 	logger.Debug(query, args)
 	_, err = w.txn.Exec(query, args...)
 

--- a/token/services/db/sql/transactions.go
+++ b/token/services/db/sql/transactions.go
@@ -175,7 +175,7 @@ func (db *TransactionDB) AddTransactionEndorsementAck(txID string, endorser view
 		return errors.Wrapf(err, "error generating uuid")
 	}
 	if _, err = db.db.Exec(query, id, txID, endorser, sigma, now); err != nil {
-		return errors.Wrapf(err, "failed to add endorsement ack")
+		return dbError(err)
 	}
 	return
 }
@@ -281,7 +281,7 @@ func (db *TransactionDB) GetSchema() string {
 		-- tea
 		CREATE TABLE IF NOT EXISTS %s (
 			id CHAR(36) NOT NULL PRIMARY KEY,
-			tx_id TEXT NOT NULL,
+			tx_id TEXT NOT NULL REFERENCES %s,
 			endorser BYTEA NOT NULL,
             sigma BYTEA NOT NULL,
 			stored_at TIMESTAMP NOT NULL
@@ -292,7 +292,7 @@ func (db *TransactionDB) GetSchema() string {
 		db.table.Transactions, db.table.Requests, db.table.Transactions, db.table.Transactions,
 		db.table.Movements, db.table.Requests, db.table.Movements, db.table.Movements,
 		db.table.Validations, db.table.Requests,
-		db.table.TransactionEndorseAck, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,
+		db.table.TransactionEndorseAck, db.table.Requests, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,
 	)
 }
 

--- a/token/services/db/sql/transactions_test.go
+++ b/token/services/db/sql/transactions_test.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb/db/dbtest"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/dbtest"
 )
 
 func initTransactionsDB(driverName, dataSourceName, tablePrefix string, maxOpenConns int) (*TransactionDB, error) {

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -353,7 +353,6 @@ func TransactionRecords(record *token.AuditRecord, timestamp time.Time) (txs []T
 
 				txs = append(txs, driver.TransactionRecord{
 					TxID:         record.Anchor,
-					Index:        uint64(actionIndex),
 					SenderEID:    inEID,
 					RecipientEID: outEID,
 					TokenType:    tokenType,

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -243,16 +243,8 @@ func (d *DB) AppendTransactionRecord(req *token.Request) error {
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status
 func (d *DB) SetStatus(txID string, status TxStatus, message string) error {
 	logger.Debugf("set status [%s][%s]...", txID, status)
-	w, err := d.db.BeginAtomicWrite()
-	if err != nil {
-		return errors.WithMessagef(err, "begin update for txid [%s] failed", txID)
-	}
-	if err := w.SetStatus(txID, status, message); err != nil {
-		w.Rollback()
+	if err := d.db.SetStatus(txID, status, message); err != nil {
 		return errors.Wrapf(err, "failed setting status [%s][%s]", txID, driver.TxStatusMessage[status])
-	}
-	if err := w.Commit(); err != nil {
-		return errors.WithMessagef(err, "failed committing status [%s][%s]", txID, driver.TxStatusMessage[status])
 	}
 
 	// notify the listeners

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -260,7 +260,7 @@ func (d *DB) SetStatus(txID string, status TxStatus, message string) error {
 		TxID:           txID,
 		ValidationCode: status,
 	})
-	logger.Debugf("Set status [%s][%s]...done without errors", txID, driver.TxStatusMessage[status])
+	logger.Debugf("set status [%s][%s] done", txID, driver.TxStatusMessage[status])
 	return nil
 }
 
@@ -272,7 +272,7 @@ func (d *DB) GetStatus(txID string) (TxStatus, string, error) {
 	if err != nil {
 		return Unknown, "", errors.Wrapf(err, "failed geting status [%s]", txID)
 	}
-	logger.Debugf("Got status [%s][%s]", txID, status)
+	logger.Debugf("got status [%s][%s]", txID, status)
 	return status, message, nil
 }
 
@@ -291,15 +291,15 @@ func (d *DB) GetTransactionEndorsementAcks(txID string) (map[string][]byte, erro
 	return d.db.GetTransactionEndorsementAcks(txID)
 }
 
-// AppendValidationRecord appends the given validation metadata related to the given token request and transaction id
-func (d *DB) AppendValidationRecord(txID string, tr []byte, meta map[string][]byte) error {
+// AppendValidationRecord appends the given validation metadata related to the given transaction id
+func (d *DB) AppendValidationRecord(txID string, meta map[string][]byte) error {
 	logger.Debugf("appending new validation record... [%s]", txID)
 
 	w, err := d.db.BeginAtomicWrite()
 	if err != nil {
 		return errors.WithMessagef(err, "begin update for txid [%s] failed", txID)
 	}
-	if err := w.AddValidationRecord(txID, tr, meta); err != nil {
+	if err := w.AddValidationRecord(txID, meta); err != nil {
 		return errors.WithMessagef(err, "append validation record for txid [%s] failed", txID)
 	}
 	if err := w.Commit(); err != nil {
@@ -361,6 +361,7 @@ func TransactionRecords(record *token.AuditRecord, timestamp time.Time) (txs []T
 
 				txs = append(txs, driver.TransactionRecord{
 					TxID:         record.Anchor,
+					Index:        uint64(actionIndex),
 					SenderEID:    inEID,
 					RecipientEID: outEID,
 					TokenType:    tokenType,

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -284,14 +284,19 @@ func (d *DB) GetTransactionEndorsementAcks(txID string) (map[string][]byte, erro
 }
 
 // AppendValidationRecord appends the given validation metadata related to the given transaction id
-func (d *DB) AppendValidationRecord(txID string, meta map[string][]byte) error {
+func (d *DB) AppendValidationRecord(txID string, tokenRequest []byte, meta map[string][]byte) error {
 	logger.Debugf("appending new validation record... [%s]", txID)
 
 	w, err := d.db.BeginAtomicWrite()
 	if err != nil {
 		return errors.WithMessagef(err, "begin update for txid [%s] failed", txID)
 	}
+	if err := w.AddTokenRequest(txID, tokenRequest); err != nil {
+		w.Rollback()
+		return errors.WithMessagef(err, "append token request for txid [%s] failed", txID)
+	}
 	if err := w.AddValidationRecord(txID, meta); err != nil {
+		w.Rollback()
 		return errors.WithMessagef(err, "append validation record for txid [%s] failed", txID)
 	}
 	if err := w.Commit(); err != nil {

--- a/token/services/ttxdb/db/memory/memory_test.go
+++ b/token/services/ttxdb/db/memory/memory_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb/db/dbtest"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/dbtest"
 )
 
 type MockServiceProvider struct{}


### PR DESCRIPTION
Business logic dictates that validations, transactions and movements all flow from a TokenRequest. This PR enforces that in the ttxdb database schema with foreign keys. It also uses JOINs to get the status and the request itself, instead of duplicating it across the tables.

<img width="436" alt="image" src="https://github.com/hyperledger-labs/fabric-token-sdk/assets/6328508/8e4d3f60-25d0-4ea2-9d63-46a5017e230f">

It doesn't yet include the foreign key constraint for the TransactionEndorseAck, because we don't use JOINs towards the request. But if these also should never exist without a TokenRequest, we should probably add that constraint as well.