### PR TITLE
cleaup service provider's use in services

### DIFF
--- a/token/services/auditdb/db.go
+++ b/token/services/auditdb/db.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
@@ -368,7 +367,7 @@ var (
 
 // GetByTMSId returns the DB for the given TMS id.
 // Nil might be returned if the wallet is not found or an error occurred.
-func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
+func GetByTMSId(sp token.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	s, err := GetProvider(sp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")
@@ -380,7 +379,7 @@ func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	return c, nil
 }
 
-func GetProvider(sp view.ServiceProvider) (*Manager, error) {
+func GetProvider(sp token.ServiceProvider) (*Manager, error) {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")

--- a/token/services/auditor/manager.go
+++ b/token/services/auditor/manager.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
@@ -166,7 +165,7 @@ var (
 )
 
 // Get returns the Auditor instance for the passed auditor wallet
-func Get(sp view.ServiceProvider, w *token.AuditorWallet) *Auditor {
+func Get(sp token.ServiceProvider, w *token.AuditorWallet) *Auditor {
 	if w == nil {
 		logger.Debugf("no wallet provided")
 		return nil
@@ -175,7 +174,7 @@ func Get(sp view.ServiceProvider, w *token.AuditorWallet) *Auditor {
 }
 
 // GetByTMSID returns the Auditor instance for the passed auditor wallet
-func GetByTMSID(sp view.ServiceProvider, tmsID token.TMSID) *Auditor {
+func GetByTMSID(sp token.ServiceProvider, tmsID token.TMSID) *Auditor {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		logger.Errorf("failed to get manager service: [%s]", err)
@@ -190,6 +189,6 @@ func GetByTMSID(sp view.ServiceProvider, tmsID token.TMSID) *Auditor {
 }
 
 // New returns the Auditor instance for the passed auditor wallet
-func New(sp view.ServiceProvider, w *token.AuditorWallet) *Auditor {
+func New(sp token.ServiceProvider, w *token.AuditorWallet) *Auditor {
 	return Get(sp, w)
 }

--- a/token/services/identity/storage.go
+++ b/token/services/identity/storage.go
@@ -9,7 +9,6 @@ package identity
 import (
 	"reflect"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/pkg/errors"
@@ -31,7 +30,7 @@ var (
 )
 
 // GetStorageProvider returns the registered instance of StorageProvider from the passed service provider
-func GetStorageProvider(sp view.ServiceProvider) (StorageProvider, error) {
+func GetStorageProvider(sp token.ServiceProvider) (StorageProvider, error) {
 	s, err := sp.GetService(storageProviderType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get token vault provider")

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -9,7 +9,6 @@ package htlc
 import (
 	"encoding/json"
 
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -309,12 +308,12 @@ func (w *OwnerWallet) filterIterator(tokenType string, sender bool, selector Sel
 }
 
 // GetWallet returns the wallet whose id is the passed id
-func GetWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption) *token.OwnerWallet {
+func GetWallet(sp token.ServiceProvider, id string, opts ...token.ServiceOption) *token.OwnerWallet {
 	return ttx.GetWallet(sp, id, opts...)
 }
 
 // Wallet returns an OwnerWallet which contains a wallet and a query service
-func Wallet(sp view2.ServiceProvider, wallet *token.OwnerWallet) *OwnerWallet {
+func Wallet(sp token.ServiceProvider, wallet *token.OwnerWallet) *OwnerWallet {
 	if wallet == nil {
 		return nil
 	}

--- a/token/services/network/driver/driver.go
+++ b/token/services/network/driver/driver.go
@@ -6,10 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+import "github.com/hyperledger-labs/fabric-token-sdk/token"
 
 // Driver models the network driver factory
 type Driver interface {
 	// New returns a new network instance for the passed network and channel (if applicable)
-	New(sp view.ServiceProvider, network, channel string) (Network, error)
+	New(sp token.ServiceProvider, network, channel string) (Network, error)
 }

--- a/token/services/network/fabric/driver.go
+++ b/token/services/network/fabric/driver.go
@@ -8,7 +8,7 @@ package fabric
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
@@ -17,7 +17,7 @@ import (
 
 type Driver struct{}
 
-func (d *Driver) New(sp view.ServiceProvider, network, channel string) (driver.Network, error) {
+func (d *Driver) New(sp token.ServiceProvider, network, channel string) (driver.Network, error) {
 	n, err := fabric.GetFabricNetworkService(sp, network)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "fabric network [%s] not found", network)

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -113,7 +113,7 @@ type Network struct {
 	subscribers    *events.Subscribers
 }
 
-func NewNetwork(sp view2.ServiceProvider, n *fabric.NetworkService, ch *fabric.Channel, newVault NewVaultFunc) *Network {
+func NewNetwork(sp token2.ServiceProvider, n *fabric.NetworkService, ch *fabric.Channel, newVault NewVaultFunc) *Network {
 	return &Network{
 		n:           n,
 		ch:          ch,

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -14,14 +14,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
-
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	api2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -391,14 +389,14 @@ func (n *Network) ProcessNamespace(namespace string) error {
 
 // Provider returns an instance of network provider
 type Provider struct {
-	sp view2.ServiceProvider
+	sp token.ServiceProvider
 
 	lock     sync.Mutex
 	networks map[string]*Network
 }
 
 // NewProvider returns a new instance of network provider
-func NewProvider(sp view2.ServiceProvider) *Provider {
+func NewProvider(sp token.ServiceProvider) *Provider {
 	ms := &Provider{
 		sp:       sp,
 		networks: map[string]*Network{},
@@ -445,7 +443,7 @@ func (np *Provider) newNetwork(network string, channel string) (*Network, error)
 }
 
 // GetInstance returns a network instance for the given network and channel
-func GetInstance(sp view2.ServiceProvider, network, channel string) *Network {
+func GetInstance(sp token.ServiceProvider, network, channel string) *Network {
 	n, err := GetProvider(sp).GetNetwork(network, channel)
 	if err != nil {
 		logger.Errorf("Failed to get network [%s:%s]: %s", network, channel, err)
@@ -454,7 +452,7 @@ func GetInstance(sp view2.ServiceProvider, network, channel string) *Network {
 	return n
 }
 
-func GetProvider(sp view2.ServiceProvider) *Provider {
+func GetProvider(sp token.ServiceProvider) *Provider {
 	s, err := sp.GetService(&Provider{})
 	if err != nil {
 		panic(fmt.Sprintf("Failed to get service: %s", err))

--- a/token/services/network/orion/driver.go
+++ b/token/services/network/orion/driver.go
@@ -9,6 +9,7 @@ package orion
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/vault"
@@ -17,7 +18,7 @@ import (
 
 type Driver struct{}
 
-func (d *Driver) New(sp view.ServiceProvider, network, channel string) (driver.Network, error) {
+func (d *Driver) New(sp token.ServiceProvider, network, channel string) (driver.Network, error) {
 	n, err := orion.GetOrionNetworkService(sp, network)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "network [%s] not found", network)

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -33,7 +33,7 @@ type IdentityProvider interface {
 }
 
 type Network struct {
-	sp          view2.ServiceProvider
+	sp          token2.ServiceProvider
 	viewManager *view2.Manager
 	tmsProvider *token2.ManagementServiceProvider
 	n           *orion.NetworkService
@@ -46,7 +46,7 @@ type Network struct {
 	subscribers    *events.Subscribers
 }
 
-func NewNetwork(sp view2.ServiceProvider, ip IdentityProvider, n *orion.NetworkService, newVault NewVaultFunc) *Network {
+func NewNetwork(sp token2.ServiceProvider, ip IdentityProvider, n *orion.NetworkService, newVault NewVaultFunc) *Network {
 	net := &Network{
 		sp:          sp,
 		ip:          ip,

--- a/token/services/network/orion/publicparams.go
+++ b/token/services/network/orion/publicparams.go
@@ -9,13 +9,13 @@ package orion
 import (
 	"time"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
-
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	session2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/pkg/errors"
 )
 
@@ -115,7 +115,7 @@ func (v *PublicParamsRequestResponderView) Call(context view.Context) (interface
 	return nil, nil
 }
 
-func ReadPublicParameters(context view2.ServiceProvider, network, namespace string) ([]byte, error) {
+func ReadPublicParameters(context token.ServiceProvider, network, namespace string) ([]byte, error) {
 	ons, err := orion.GetOrionNetworkService(context, network)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get orion network service for network [%s]", network)

--- a/token/services/nfttx/qe.go
+++ b/token/services/nfttx/qe.go
@@ -9,7 +9,6 @@ package nfttx
 import (
 	"encoding/base64"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/marshaller"
@@ -37,7 +36,7 @@ type QueryExecutor struct {
 	precision uint64
 }
 
-func NewQueryExecutor(sp view.ServiceProvider, wallet string, precision uint64, opts ...token.ServiceOption) (*QueryExecutor, error) {
+func NewQueryExecutor(sp token.ServiceProvider, wallet string, precision uint64, opts ...token.ServiceOption) (*QueryExecutor, error) {
 	tms := token.GetManagementService(sp, opts...)
 	qe := tms.Vault().NewQueryEngine()
 	return &QueryExecutor{

--- a/token/services/nfttx/wallet.go
+++ b/token/services/nfttx/wallet.go
@@ -7,15 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package nfttx
 
 import (
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-	"github.com/pkg/errors"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/pkg/errors"
 )
 
 type OwnerWallet struct {
-	view2.ServiceProvider
+	token.ServiceProvider
 	*token.OwnerWallet
 	Precision uint64
 }
@@ -38,7 +36,7 @@ func WithType(tokenType string) token.ListTokensOption {
 }
 
 // MyWallet returns the default wallet, nil if not found.
-func MyWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *OwnerWallet {
+func MyWallet(sp token.ServiceProvider, opts ...token.ServiceOption) *OwnerWallet {
 	tms := token.GetManagementService(sp, opts...)
 	w := tms.WalletManager().OwnerWallet("")
 	if w == nil {
@@ -49,7 +47,7 @@ func MyWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *OwnerWalle
 
 // MyWalletFromTx returns the default wallet for the tuple (network, channel, namespace) as identified by the passed
 // transaction. Returns nil if no wallet is found.
-func MyWalletFromTx(sp view2.ServiceProvider, tx *Transaction) *OwnerWallet {
+func MyWalletFromTx(sp token.ServiceProvider, tx *Transaction) *OwnerWallet {
 	tms := token.GetManagementService(
 		sp,
 		token.WithNetwork(tx.Network()),
@@ -66,7 +64,7 @@ func MyWalletFromTx(sp view2.ServiceProvider, tx *Transaction) *OwnerWallet {
 // GetWallet returns the wallet whose id is the passed id.
 // If the passed id is empty, GetWallet has the same behaviour of MyWallet.
 // It returns nil, if no wallet is found.
-func GetWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption) *OwnerWallet {
+func GetWallet(sp token.ServiceProvider, id string, opts ...token.ServiceOption) *OwnerWallet {
 	tms := token.GetManagementService(sp, opts...)
 	w := tms.WalletManager().OwnerWallet(id)
 	if w == nil {
@@ -78,7 +76,7 @@ func GetWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption)
 // GetWalletForChannel returns the wallet whose id is the passed id for the passed channel.
 // If the passed id is empty, GetWalletForChannel has the same behaviour of MyWalletFromTx.
 // It returns nil, if no wallet is found.
-func GetWalletForChannel(sp view2.ServiceProvider, channel, id string, opts ...token.ServiceOption) *OwnerWallet {
+func GetWalletForChannel(sp token.ServiceProvider, channel, id string, opts ...token.ServiceOption) *OwnerWallet {
 	tms := token.GetManagementService(sp, append(opts, token.WithChannel(channel))...)
 	w := tms.WalletManager().OwnerWallet(id)
 	if w == nil {
@@ -99,7 +97,7 @@ func MyIssuerWallet(context view.Context, opts ...token.ServiceOption) *token.Is
 // GetIssuerWallet returns the issuer wallet whose id is the passed id.
 // If the passed id is empty, GetIssuerWallet has the same behaviour of MyIssuerWallet.
 // It returns nil, if no wallet is found.
-func GetIssuerWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption) *token.IssuerWallet {
+func GetIssuerWallet(sp token.ServiceProvider, id string, opts ...token.ServiceOption) *token.IssuerWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().IssuerWallet(id)
 	if w == nil {
 		return nil
@@ -110,7 +108,7 @@ func GetIssuerWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceO
 // GetIssuerWalletForChannel returns the issuer wallet whose id is the passed id for the passed channel.
 // If the passed id is empty, GetIssuerWalletForChannel has the same behaviour of MyIssuerWallet.
 // It returns nil, if no wallet is found.
-func GetIssuerWalletForChannel(sp view2.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.IssuerWallet {
+func GetIssuerWalletForChannel(sp token.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.IssuerWallet {
 	w := token.GetManagementService(sp, append(opts, token.WithChannel(channel))...).WalletManager().IssuerWallet(id)
 	if w == nil {
 		return nil
@@ -119,7 +117,7 @@ func GetIssuerWalletForChannel(sp view2.ServiceProvider, channel, id string, opt
 }
 
 // MyAuditorWallet returns the default auditor wallet, nil if not found.
-func MyAuditorWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
+func MyAuditorWallet(sp token.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().AuditorWallet("")
 	if w == nil {
 		return nil

--- a/token/services/tokendb/db.go
+++ b/token/services/tokendb/db.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
@@ -131,7 +130,7 @@ var (
 
 // GetByTMSId returns the DB for the given TMS id.
 // Nil might be returned if the wallet is not found or an error occurred.
-func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
+func GetByTMSId(sp token.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	s, err := GetProvider(sp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")
@@ -143,7 +142,7 @@ func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	return c, nil
 }
 
-func GetProvider(sp view.ServiceProvider) (*Manager, error) {
+func GetProvider(sp token.ServiceProvider) (*Manager, error) {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")

--- a/token/services/tokens/manager.go
+++ b/token/services/tokens/manager.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/events"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
@@ -106,7 +105,7 @@ var (
 )
 
 // GetService returns the Tokens instance for the passed TMS
-func GetService(sp view.ServiceProvider, tmsID token.TMSID) (*Tokens, error) {
+func GetService(sp token.ServiceProvider, tmsID token.TMSID) (*Tokens, error) {
 	s, err := GetProvider(sp)
 	if err != nil {
 		return nil, err
@@ -118,7 +117,7 @@ func GetService(sp view.ServiceProvider, tmsID token.TMSID) (*Tokens, error) {
 	return tokens, nil
 }
 
-func GetProvider(sp view.ServiceProvider) (*Manager, error) {
+func GetProvider(sp token.ServiceProvider) (*Manager, error) {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -24,14 +24,13 @@ import (
 )
 
 type TxAuditor struct {
-	sp                      view2.ServiceProvider
 	w                       *token.AuditorWallet
 	auditor                 *auditor.Auditor
 	auditDB                 *auditdb.DB
 	transactionInfoProvider *TransactionInfoProvider
 }
 
-func NewAuditor(sp view2.ServiceProvider, w *token.AuditorWallet) (*TxAuditor, error) {
+func NewAuditor(sp token.ServiceProvider, w *token.AuditorWallet) (*TxAuditor, error) {
 	backend := auditor.New(sp, w)
 	auditDB, err := auditdb.GetByTMSId(sp, w.TMS().ID())
 	if err != nil {
@@ -42,11 +41,10 @@ func NewAuditor(sp view2.ServiceProvider, w *token.AuditorWallet) (*TxAuditor, e
 		return nil, err
 	}
 	return &TxAuditor{
-		sp:                      sp,
 		w:                       w,
 		auditor:                 backend,
 		auditDB:                 auditDB,
-		transactionInfoProvider: newTransactionInfoProvider(sp, w.TMS(), ttxDB),
+		transactionInfoProvider: newTransactionInfoProvider(w.TMS(), ttxDB),
 	}, nil
 }
 
@@ -80,7 +78,7 @@ func (a *TxAuditor) NewHoldingsFilter() *auditdb.HoldingsFilter {
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status
 func (a *TxAuditor) SetStatus(txID string, status TxStatus, message string) error {
-	return a.auditDB.SetStatus(txID, auditdb.TxStatus(status), message)
+	return a.auditDB.SetStatus(txID, status, message)
 }
 
 func (a *TxAuditor) GetTokenRequest(txID string) ([]byte, error) {

--- a/token/services/ttx/info.go
+++ b/token/services/ttx/info.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package ttx
 
 import (
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
@@ -30,13 +29,12 @@ type TransactionInfo struct {
 
 // TransactionInfoProvider allows the retrieval of the transaction info
 type TransactionInfoProvider struct {
-	sp    view.ServiceProvider
 	tms   *token.ManagementService
 	ttxDB TokenTransactionDB
 }
 
-func newTransactionInfoProvider(sp view.ServiceProvider, tms *token.ManagementService, ttxDB TokenTransactionDB) *TransactionInfoProvider {
-	return &TransactionInfoProvider{sp: sp, tms: tms, ttxDB: ttxDB}
+func newTransactionInfoProvider(tms *token.ManagementService, ttxDB TokenTransactionDB) *TransactionInfoProvider {
+	return &TransactionInfoProvider{tms: tms, ttxDB: ttxDB}
 }
 
 // TransactionInfo returns the transaction info for the given transaction ID.

--- a/token/services/ttx/manager.go
+++ b/token/services/ttx/manager.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
@@ -142,7 +141,7 @@ var (
 )
 
 // Get returns the DB instance for the passed TMS
-func Get(sp view.ServiceProvider, tms *token.ManagementService) *DB {
+func Get(sp token.ServiceProvider, tms *token.ManagementService) *DB {
 	if tms == nil {
 		logger.Debugf("no TMS provided")
 		return nil
@@ -161,6 +160,6 @@ func Get(sp view.ServiceProvider, tms *token.ManagementService) *DB {
 }
 
 // New returns the DB instance for the passed TMS
-func New(sp view.ServiceProvider, tms *token.ManagementService) *DB {
+func New(sp token.ServiceProvider, tms *token.ManagementService) *DB {
 	return Get(sp, tms)
 }

--- a/token/services/ttx/metrics.go
+++ b/token/services/ttx/metrics.go
@@ -9,8 +9,8 @@ package ttx
 import (
 	"reflect"
 
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 )
 
 var (
@@ -53,7 +53,7 @@ func NewMetrics(p metrics.Provider) *Metrics {
 	}
 }
 
-func GetMetrics(sp view2.ServiceProvider) *Metrics {
+func GetMetrics(sp token.ServiceProvider) *Metrics {
 	s, err := sp.GetService(spKey)
 	if err != nil {
 		panic(err)

--- a/token/services/ttx/owner.go
+++ b/token/services/ttx/owner.go
@@ -7,27 +7,24 @@ SPDX-License-Identifier: Apache-2.0
 package ttx
 
 import (
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 )
 
 type TxOwner struct {
-	sp                      view2.ServiceProvider
 	tms                     *token.ManagementService
 	owner                   *DB
 	transactionInfoProvider *TransactionInfoProvider
 }
 
 // NewOwner returns a new owner service.
-func NewOwner(sp view2.ServiceProvider, tms *token.ManagementService) *TxOwner {
+func NewOwner(sp token.ServiceProvider, tms *token.ManagementService) *TxOwner {
 	backend := New(sp, tms)
 	return &TxOwner{
-		sp:                      sp,
 		tms:                     tms,
 		owner:                   backend,
-		transactionInfoProvider: newTransactionInfoProvider(sp, tms, backend),
+		transactionInfoProvider: newTransactionInfoProvider(tms, backend),
 	}
 }
 

--- a/token/services/ttx/wallet.go
+++ b/token/services/ttx/wallet.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package ttx
 
 import (
-	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 )
@@ -22,7 +21,7 @@ func WithType(tokenType string) token.ListTokensOption {
 }
 
 // MyWallet returns the default wallet, nil if not found.
-func MyWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *token.OwnerWallet {
+func MyWallet(sp token.ServiceProvider, opts ...token.ServiceOption) *token.OwnerWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().OwnerWallet("")
 	if w == nil {
 		return nil
@@ -32,7 +31,7 @@ func MyWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *token.Owne
 
 // MyWalletFromTx returns the default wallet for the tuple (network, channel, namespace) as identified by the passed
 // transaction. Returns nil if no wallet is found.
-func MyWalletFromTx(sp view2.ServiceProvider, tx *Transaction) *token.OwnerWallet {
+func MyWalletFromTx(sp token.ServiceProvider, tx *Transaction) *token.OwnerWallet {
 	w := token.GetManagementService(
 		sp,
 		token.WithNetwork(tx.Network()),
@@ -48,7 +47,7 @@ func MyWalletFromTx(sp view2.ServiceProvider, tx *Transaction) *token.OwnerWalle
 // GetWallet returns the wallet whose id is the passed id.
 // If the passed id is empty, GetWallet has the same behaviour of MyWallet.
 // It returns nil, if no wallet is found.
-func GetWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption) *token.OwnerWallet {
+func GetWallet(sp token.ServiceProvider, id string, opts ...token.ServiceOption) *token.OwnerWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().OwnerWallet(id)
 	if w == nil {
 		return nil
@@ -59,7 +58,7 @@ func GetWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption)
 // GetWalletForChannel returns the wallet whose id is the passed id for the passed channel.
 // If the passed id is empty, GetWalletForChannel has the same behaviour of MyWalletFromTx.
 // It returns nil, if no wallet is found.
-func GetWalletForChannel(sp view2.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.OwnerWallet {
+func GetWalletForChannel(sp token.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.OwnerWallet {
 	w := token.GetManagementService(sp, append(opts, token.WithChannel(channel))...).WalletManager().OwnerWallet(id)
 	if w == nil {
 		return nil
@@ -79,7 +78,7 @@ func MyIssuerWallet(context view.Context, opts ...token.ServiceOption) *token.Is
 // GetIssuerWallet returns the issuer wallet whose id is the passed id.
 // If the passed id is empty, GetIssuerWallet has the same behaviour of MyIssuerWallet.
 // It returns nil, if no wallet is found.
-func GetIssuerWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceOption) *token.IssuerWallet {
+func GetIssuerWallet(sp token.ServiceProvider, id string, opts ...token.ServiceOption) *token.IssuerWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().IssuerWallet(id)
 	if w == nil {
 		return nil
@@ -90,7 +89,7 @@ func GetIssuerWallet(sp view2.ServiceProvider, id string, opts ...token.ServiceO
 // GetIssuerWalletForChannel returns the issuer wallet whose id is the passed id for the passed channel.
 // If the passed id is empty, GetIssuerWalletForChannel has the same behaviour of MyIssuerWallet.
 // It returns nil, if no wallet is found.
-func GetIssuerWalletForChannel(sp view2.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.IssuerWallet {
+func GetIssuerWalletForChannel(sp token.ServiceProvider, channel, id string, opts ...token.ServiceOption) *token.IssuerWallet {
 	w := token.GetManagementService(sp, append(opts, token.WithChannel(channel))...).WalletManager().IssuerWallet(id)
 	if w == nil {
 		return nil
@@ -99,7 +98,7 @@ func GetIssuerWalletForChannel(sp view2.ServiceProvider, channel, id string, opt
 }
 
 // MyAuditorWallet returns the default auditor wallet, nil if not found.
-func MyAuditorWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
+func MyAuditorWallet(sp token.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().AuditorWallet("")
 	if w == nil {
 		return nil
@@ -110,7 +109,7 @@ func MyAuditorWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *tok
 // GetAuditorWallet returns the wallet whose id is the passed id.
 // If the passed id is empty, GetAuditorWallet has the same behaviour of MyAuditorWallet.
 // It returns nil, if no wallet is found.
-func GetAuditorWallet(sp view2.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
+func GetAuditorWallet(sp token.ServiceProvider, opts ...token.ServiceOption) *token.AuditorWallet {
 	w := token.GetManagementService(sp, opts...).WalletManager().AuditorWallet("")
 	if w == nil {
 		return nil

--- a/token/services/ttxdb/db.go
+++ b/token/services/ttxdb/db.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -497,7 +496,7 @@ var (
 
 // GetByTMSId returns the DB for the given TMS id.
 // Nil might be returned if the wallet is not found or an error occurred.
-func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
+func GetByTMSId(sp token.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	s, err := GetProvider(sp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")
@@ -509,7 +508,7 @@ func GetByTMSId(sp view.ServiceProvider, tmsID token.TMSID) (*DB, error) {
 	return c, nil
 }
 
-func GetProvider(sp view.ServiceProvider) (*Manager, error) {
+func GetProvider(sp token.ServiceProvider) (*Manager, error) {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get manager service")

--- a/token/services/vault/vault.go
+++ b/token/services/vault/vault.go
@@ -9,7 +9,7 @@ package vault
 import (
 	"reflect"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	db "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -52,7 +52,7 @@ var (
 )
 
 // GetProvider returns the registered instance of Provider from the passed service provider
-func GetProvider(sp view.ServiceProvider) (Provider, error) {
+func GetProvider(sp token2.ServiceProvider) (Provider, error) {
 	s, err := sp.GetService(managerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get token vault provider")


### PR DESCRIPTION
This PR does the following:
- Use token.ServiceProvider rather than view.ServiceProvider.
- Remove ServiceProvider as a field where possible.