### PR TITLE
add an option to stop the htlc scan for preimage when all blocks are …

### DIFF
--- a/integration/token/interop/support.go
+++ b/integration/token/interop/support.go
@@ -390,7 +390,7 @@ func fastExchange(network *integration.Infrastructure, id string, recipient stri
 	time.Sleep(10 * time.Second)
 }
 
-func scan(network *integration.Infrastructure, id string, hash []byte, hashFunc crypto.Hash, startingTransactionID string, opts ...token.ServiceOption) {
+func scan(network *integration.Infrastructure, id string, hash []byte, hashFunc crypto.Hash, startingTransactionID string, stopOnLastTx bool, opts ...token.ServiceOption) {
 	options, err := token.CompileServiceOptions(opts...)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -400,11 +400,12 @@ func scan(network *integration.Infrastructure, id string, hash []byte, hashFunc 
 		Hash:                  hash,
 		HashFunc:              hashFunc,
 		StartingTransactionID: startingTransactionID,
+		StopOnLastTx:          stopOnLastTx,
 	}))
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func scanWithError(network *integration.Infrastructure, id string, hash []byte, hashFunc crypto.Hash, startingTransactionID string, errorMsgs []string, opts ...token.ServiceOption) {
+func scanWithError(network *integration.Infrastructure, id string, hash []byte, hashFunc crypto.Hash, startingTransactionID string, errorMsgs []string, stopOnLastTx bool, opts ...token.ServiceOption) {
 	options, err := token.CompileServiceOptions(opts...)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -414,6 +415,7 @@ func scanWithError(network *integration.Infrastructure, id string, hash []byte, 
 		Hash:                  hash,
 		HashFunc:              hashFunc,
 		StartingTransactionID: startingTransactionID,
+		StopOnLastTx:          stopOnLastTx,
 	}))
 	Expect(err).To(HaveOccurred())
 	for _, msg := range errorMsgs {

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -82,8 +82,8 @@ type Network interface {
 	RemoveFinalityListener(id string, listener FinalityListener) error
 
 	// LookupTransferMetadataKey searches for a transfer metadata key containing the passed sub-key starting from the passed transaction id in the given namespace.
-	// The operation gets canceled if the passed timeout elapses.
-	LookupTransferMetadataKey(namespace string, startingTxID string, subKey string, timeout time.Duration) ([]byte, error)
+	// The operation gets canceled if the passed timeout elapses or, if stopOnLastTx is true, when the last transaction in the vault is reached.
+	LookupTransferMetadataKey(namespace string, startingTxID string, subKey string, timeout time.Duration, stopOnLastTx bool) ([]byte, error)
 
 	// Ledger gives access to the remote ledger
 	Ledger() (Ledger, error)

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -372,9 +372,9 @@ func (n *Network) RemoveFinalityListener(id string, listener FinalityListener) e
 }
 
 // LookupTransferMetadataKey searches for a transfer metadata key containing the passed sub-key starting from the passed transaction id in the given namespace.
-// The operation gets canceled if the passed timeout gets reached.
-func (n *Network) LookupTransferMetadataKey(namespace, startingTxID, key string, timeout time.Duration, opts ...token.ServiceOption) ([]byte, error) {
-	return n.n.LookupTransferMetadataKey(namespace, startingTxID, key, timeout)
+// The operation gets canceled if the passed timeout gets reached or, if stopOnLastTx is true, when the last transaction in the vault is reached.
+func (n *Network) LookupTransferMetadataKey(namespace, startingTxID, key string, timeout time.Duration, stopOnLastTx bool, opts ...token.ServiceOption) ([]byte, error) {
+	return n.n.LookupTransferMetadataKey(namespace, startingTxID, key, timeout, stopOnLastTx)
 }
 
 func (n *Network) Ledger() (*Ledger, error) {

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -225,7 +225,7 @@ func (n *Network) RemoveFinalityListener(txID string, listener driver.FinalityLi
 	return n.n.Committer().RemoveFinalityListener(txID, wrapper.(*FinalityListener))
 }
 
-func (n *Network) LookupTransferMetadataKey(namespace string, startingTxID string, key string, timeout time.Duration) ([]byte, error) {
+func (n *Network) LookupTransferMetadataKey(namespace string, startingTxID string, key string, timeout time.Duration, _ bool) ([]byte, error) {
 	k, err := keys.CreateTransferActionMetadataKey(key)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to generate transfer action metadata key from [%s]", key)


### PR DESCRIPTION
…searched until the tip of the blockchain.

Can be used for a better experience if triggered by a user and you want to show them immediately whether the preimage is available on the current ledger, instead of having to wait until timing out.
