### PR TITLE
db extensions

### DIFF
--- a/token/sdk/dig/providers.go
+++ b/token/sdk/dig/providers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db"
 	dbdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql/driver/unity"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql/ext"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identitydb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
@@ -86,8 +87,11 @@ type DBDriverResult struct {
 	IdentityDBDriver  db.NamedDriver[dbdriver.IdentityDBDriver]  `group:"identitydb-drivers"`
 }
 
-func NewDBDrivers() DBDriverResult {
-	ttxDBDriver, tokenDBDriver, tokenLockDBDriver, auditDBDriver, identityDBDriver := unity.NewDBDrivers()
+func NewDBDrivers(in struct {
+	dig.In
+	TokenDBExtensions []ext.Factory[ext.TokenDBExtension] `group:"tokendb-extensions"`
+}) DBDriverResult {
+	ttxDBDriver, tokenDBDriver, tokenLockDBDriver, auditDBDriver, identityDBDriver := unity.NewDBDrivers(in.TokenDBExtensions)
 	return DBDriverResult{
 		TTXDBDriver:       ttxDBDriver,
 		TokenDBDriver:     tokenDBDriver,

--- a/token/sdk/dig/sdk.go
+++ b/token/sdk/dig/sdk.go
@@ -41,6 +41,7 @@ import (
 	kvs2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identitydb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc/db/sql"
 	logging2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	_ "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric"
@@ -118,6 +119,7 @@ func (p *SDK) Install() error {
 		p.Container().Provide(digutils.Identity[*auditdb.Manager](), dig.As(new(auditor.AuditDBProvider))),
 		p.Container().Provide(NewIdentityDBManager),
 		p.Container().Provide(NewTokenLockDBManager),
+		p.Container().Provide(sql.NewHTLCTokenDBExtensionFactory, dig.Group("tokendb-extensions")),
 		p.Container().Provide(digutils.Identity[*kvs.KVS](), dig.As(new(kvs2.KVS))),
 		p.Container().Provide(identity.NewDBStorageProvider),
 		p.Container().Provide(auditor.NewManager),

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package driver
 
 import (
+	"database/sql"
 	"errors"
 	"time"
 
@@ -105,6 +106,7 @@ type CertificationDB interface {
 }
 
 type TokenDBTransaction interface {
+	Tx() *sql.Tx
 	// GetToken returns the owned tokens and their identifier keys for the passed ids.
 	GetToken(txID string, index uint64, includeDeleted bool) (*token.Token, []string, error)
 	// Delete marks the passed token as deleted by a given identifier (idempotent)

--- a/token/services/db/sql/ext/driver.go
+++ b/token/services/db/sql/ext/driver.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package ext
 
 import (

--- a/token/services/db/sql/ext/driver.go
+++ b/token/services/db/sql/ext/driver.go
@@ -10,6 +10,7 @@ import (
 	"database/sql"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Extension interface {
@@ -20,4 +21,5 @@ type TokenDBExtension interface {
 	Extension
 	Delete(tx *sql.Tx, txID string, index uint64, deletedBy string) error
 	StoreToken(tx *sql.Tx, tr driver.TokenRecord, owners []string) error
+	DeleteTokens(tx *sql.Tx, deletedBy string, ids ...*token.ID) error
 }

--- a/token/services/db/sql/ext/driver.go
+++ b/token/services/db/sql/ext/driver.go
@@ -1,0 +1,17 @@
+package ext
+
+import (
+	"database/sql"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+)
+
+type Extension interface {
+	GetSchema() string
+}
+
+type TokenDBExtension interface {
+	Extension
+	Delete(tx *sql.Tx, txID string, index uint64, deletedBy string) error
+	StoreToken(tx *sql.Tx, tr driver.TokenRecord, owners []string) error
+}

--- a/token/services/db/sql/ext/driver.go
+++ b/token/services/db/sql/ext/driver.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Extension interface {
-	GetSchema() string
+	GetSchema(tablePrefix string) string
 }
 
 type TokenDBExtension interface {
@@ -22,4 +22,8 @@ type TokenDBExtension interface {
 	Delete(tx *sql.Tx, txID string, index uint64, deletedBy string) error
 	StoreToken(tx *sql.Tx, tr driver.TokenRecord, owners []string) error
 	DeleteTokens(tx *sql.Tx, deletedBy string, ids ...*token.ID) error
+}
+
+type Factory[T Extension] interface {
+	NewExtension(prefix string) (T, error)
 }

--- a/token/services/db/sql/identity.go
+++ b/token/services/db/sql/identity.go
@@ -64,7 +64,7 @@ func NewIdentityDB(db *sql.DB, tablePrefix string, createSchema bool, signerInfo
 		Signers:                tables.Signers,
 	}, signerInfoCache)
 	if createSchema {
-		if err = initSchema(db, identityDB.GetSchema()); err != nil {
+		if err = initSchema(db, identityDB.GetSchema(tablePrefix)); err != nil {
 			return nil, err
 		}
 	}
@@ -267,7 +267,7 @@ func (w *IdentityConfigurationIterator) Next() (driver.IdentityConfiguration, er
 	return c, err
 }
 
-func (db *IdentityDB) GetSchema() string {
+func (db *IdentityDB) GetSchema(string) string {
 	return fmt.Sprintf(`
 		-- IdentityConfigurations
 		CREATE TABLE IF NOT EXISTS %s (

--- a/token/services/db/sql/tokenlock.go
+++ b/token/services/db/sql/tokenlock.go
@@ -41,7 +41,7 @@ func NewTokenLockDB(db *sql.DB, tablePrefix string, createSchema bool) (driver.T
 
 	identityDB := newTokenLockDB(db, tokenLockTables{TokenLocks: tables.TokenLocks})
 	if createSchema {
-		if err = initSchema(db, identityDB.GetSchema()); err != nil {
+		if err = initSchema(db, identityDB.GetSchema(tablePrefix)); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +64,7 @@ func (db *TokenLockDB) UnlockByTxID(consumerTxID transaction.ID) error {
 	return err
 }
 
-func (db *TokenLockDB) GetSchema() string {
+func (db *TokenLockDB) GetSchema(string) string {
 	return fmt.Sprintf(`
 		-- TokenLocks
 		CREATE TABLE IF NOT EXISTS %s (

--- a/token/services/db/sql/transactions.go
+++ b/token/services/db/sql/transactions.go
@@ -57,7 +57,7 @@ func NewTransactionDB(db *sql.DB, tablePrefix string, createSchema bool) (driver
 		TransactionEndorseAck: tables.TransactionEndorseAck,
 	})
 	if createSchema {
-		if err = initSchema(db, transactionsDB.GetSchema()); err != nil {
+		if err = initSchema(db, transactionsDB.GetSchema(tablePrefix)); err != nil {
 			return nil, err
 		}
 	}
@@ -253,7 +253,7 @@ func (db *TransactionDB) SetStatus(txID string, status driver.TxStatus, message 
 	return
 }
 
-func (db *TransactionDB) GetSchema() string {
+func (db *TransactionDB) GetSchema(string) string {
 	return fmt.Sprintf(`
 		-- requests
 		CREATE TABLE IF NOT EXISTS %s (

--- a/token/services/db/sql/wallet.go
+++ b/token/services/db/sql/wallet.go
@@ -40,7 +40,7 @@ func NewWalletDB(db *sql.DB, tablePrefix string, createSchema bool) (driver.Wall
 
 	walletDB := newWalletDB(db, walletTables{Wallets: tables.Wallets})
 	if createSchema {
-		if err = initSchema(db, walletDB.GetSchema()); err != nil {
+		if err = initSchema(db, walletDB.GetSchema(tablePrefix)); err != nil {
 			return nil, errors.Wrapf(err, "failed to create schema")
 		}
 	}
@@ -127,7 +127,7 @@ func (db *WalletDB) IdentityExists(identity token.Identity, wID driver.WalletID,
 	return result != ""
 }
 
-func (db *WalletDB) GetSchema() string {
+func (db *WalletDB) GetSchema(string) string {
 	return fmt.Sprintf(`
 		-- Wallets
 		CREATE TABLE IF NOT EXISTS %s (

--- a/token/services/interop/htlc/db/sql/tokendbext.go
+++ b/token/services/interop/htlc/db/sql/tokendbext.go
@@ -1,0 +1,91 @@
+package sql
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/pkg/errors"
+)
+
+var logger = logging.MustGetLogger("token-sdk.sql.htlc")
+
+type htlcTokenDBExtensionTables struct {
+	Tokens string
+}
+
+type HTLCTokenDBExtension struct {
+	table htlcTokenDBExtensionTables
+}
+
+func NewHTLCTokenDBExtension(table htlcTokenDBExtensionTables) *HTLCTokenDBExtension {
+	return &HTLCTokenDBExtension{table: table}
+}
+
+func (e *HTLCTokenDBExtension) GetSchema() string {
+	return fmt.Sprintf(`
+		-- Tokens
+		CREATE TABLE IF NOT EXISTS %s (
+			tx_id TEXT NOT NULL,
+			idx INT NOT NULL,
+			sender_raw BYTEA NOT NULL,
+			recipient_raw BYTEA NOT NULL,
+			deadline TIMESTAMP NOT NULL,
+			hash BYTEA NOT NULL,
+			hash_function INT NOT NULL,
+			hash_encoding INT NOT NULL,
+			PRIMARY KEY (tx_id, idx)
+		);
+		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
+		`,
+		e.table.Tokens,
+		e.table.Tokens,
+	)
+}
+
+func (e *HTLCTokenDBExtension) Delete(tx *sql.Tx, txID string, index uint64, deletedBy string) error {
+	return nil
+}
+
+func (e *HTLCTokenDBExtension) StoreToken(tx *sql.Tx, tr driver.TokenRecord, owners []string) error {
+	if tr.OwnerType != htlc.ScriptType {
+		// nothing to store here
+		return nil
+	}
+	script := &htlc.Script{}
+	if err := json.Unmarshal(tr.OwnerIdentity, script); err != nil {
+		return errors.Wrapf(err, "failed to unmrshal HTLC script")
+	}
+	// store the script
+	logger.Debugf("store htlc record [%s:%d,%v] in table [%s]", tr.TxID, tr.Index, owners, e.table.Tokens)
+
+	// Store token
+	query := fmt.Sprintf("INSERT INTO %s (tx_id, idx, sender_raw, recipient_raw, deadline, hash, hash_function, hash_encoding) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)", e.table.Tokens)
+	logger.Debug(query,
+		tr.TxID,
+		tr.Index,
+		script.Sender,
+		script.Recipient,
+		script.Deadline,
+		script.HashInfo.Hash,
+		script.HashInfo.HashFunc,
+		script.HashInfo.HashEncoding)
+	if _, err := tx.Exec(query,
+		tr.TxID,
+		tr.Index,
+		script.Sender,
+		script.Recipient,
+		script.Deadline,
+		script.HashInfo.Hash,
+		script.HashInfo.HashFunc,
+		script.HashInfo.HashEncoding); err != nil {
+		logger.Errorf("error storing htlc token [%s] in table [%s]: [%s][%s]", tr.TxID, e.table.Tokens, err, string(debug.Stack()))
+		return errors.Wrapf(err, "error storing htlc token [%s] in table [%s]", tr.TxID, e.table.Tokens)
+	}
+
+	return nil
+}

--- a/token/services/interop/htlc/db/sql/tokendbext.go
+++ b/token/services/interop/htlc/db/sql/tokendbext.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sql
 
 import (
@@ -43,7 +49,7 @@ func (e *HTLCTokenDBExtension) GetSchema() string {
 		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
 		`,
 		e.table.Tokens,
-		e.table.Tokens,
+		e.table.Tokens, e.table.Tokens,
 	)
 }
 

--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	utils2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
+	dbdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/testutils"
 	_ "github.com/lib/pq"
@@ -74,7 +75,9 @@ func createManager(pgConnStr string, backoff time.Duration) (testutils.EnhancedM
 		return nil, err
 	}
 
-	tokenDB, err := initDB("postgres", pgConnStr, "test", 10, sql.NewTokenDB)
+	tokenDB, err := initDB("postgres", pgConnStr, "test", 10, func(db *sql2.DB, tablePrefix string, createSchema bool) (dbdriver.TokenDB, error) {
+		return sql.NewTokenDB(db, tablePrefix, createSchema)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/tokendb/db/memory/memory.go
+++ b/token/services/tokendb/db/memory/memory.go
@@ -7,16 +7,20 @@ SPDX-License-Identifier: Apache-2.0
 package memory
 
 import (
+	"database/sql"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db"
 	dbdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	sqldb "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokendb/db/sql"
+	sql2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/tokendb/db/sql"
 	_ "modernc.org/sqlite"
 )
 
 func NewDriver() db.NamedDriver[dbdriver.TokenDBDriver] {
 	return db.NamedDriver[dbdriver.TokenDBDriver]{
-		Name:   "memory",
-		Driver: db.NewMemoryDriver(sql.NewSQLDBOpener(), sqldb.NewTokenDB),
+		Name: "memory",
+		Driver: db.NewMemoryDriver(sql2.NewSQLDBOpener(), func(db *sql.DB, tablePrefix string, createSchema bool) (dbdriver.TokenDB, error) {
+			return sqldb.NewTokenDB(db, tablePrefix, createSchema)
+		}),
 	}
 }

--- a/token/services/tokendb/db/sql/driver.go
+++ b/token/services/tokendb/db/sql/driver.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package sql
 
 import (
+	"database/sql"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db"
 	dbdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	sqldb "github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql"
@@ -24,7 +26,9 @@ func NewSQLDBOpener() *sqldb.DBOpener {
 
 func NewDriver() db.NamedDriver[dbdriver.TokenDBDriver] {
 	return db.NamedDriver[dbdriver.TokenDBDriver]{
-		Name:   "sql",
-		Driver: db.NewSQLDriver(NewSQLDBOpener(), sqldb.NewTokenDB),
+		Name: "sql",
+		Driver: db.NewSQLDriver(NewSQLDBOpener(), func(db *sql.DB, tablePrefix string, createSchema bool) (dbdriver.TokenDB, error) {
+			return sqldb.NewTokenDB(db, tablePrefix, createSchema)
+		}),
 	}
 }


### PR DESCRIPTION
This PR introduces a mechanism to extend the TokenDB to store additional information about a token. 
For example, when a token's owner field contains an HTLC (`service/interop/htlc`) script, it would be convenient to store script-related information for more targeted queries and data analysis.