### PR TITLE
Separate token parsing from storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ clean:
 	docker container prune -f
 	rm -rf ./integration/token/fungible/dlog/cmd/
 	rm -rf ./integration/token/fungible/dloghsm/cmd/
+	rm -rf ./integration/token/fungible/dlogstress/cmd/
 	rm -rf ./integration/token/fungible/fabtoken/cmd/
 	rm -rf ./integration/token/fungible/odlog/cmd/
 	rm -rf ./integration/token/fungible/ofabtoken/cmd/

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -105,12 +105,8 @@ type CertificationDB interface {
 }
 
 type TokenDBTransaction interface {
-	// TransactionExists returns true if a token with that transaction id exists in the db
-	TransactionExists(id string) (bool, error)
 	// GetToken returns the owned tokens and their identifier keys for the passed ids.
 	GetToken(txID string, index uint64, includeDeleted bool) (*token.Token, []string, error)
-	// OwnersOf returns the list of owner of a given token
-	OwnersOf(txID string, index uint64) ([]string, error)
 	// Delete marks the passed token as deleted by a given identifier (idempotent)
 	Delete(txID string, index uint64, deletedBy string) error
 	// StoreToken stores the passed token record in relation to the passed owner identifiers, if any
@@ -155,6 +151,8 @@ type TokenDB interface {
 	GetTokens(inputs ...*token.ID) ([]string, []*token.Token, error)
 	// WhoDeletedTokens for each id, the function return if it was deleted and by who as per the Delete function
 	WhoDeletedTokens(inputs ...*token.ID) ([]string, []bool, error)
+	// TransactionExists returns true if a token with that transaction id exists in the db
+	TransactionExists(id string) (bool, error)
 	// StorePublicParams stores the public parameters
 	StorePublicParams(raw []byte) error
 	// PublicParams returns the stored public parameters

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tokens
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/test-go/testify/assert"
+)
+
+type qsMock struct{}
+
+func (qs qsMock) IsMine(id *token2.ID) (bool, error) {
+	return true, nil
+}
+
+type authMock struct{}
+
+func (a authMock) IsMine(_ *token.ManagementService, tok *token2.Token) ([]string, bool) {
+	return []string{string(tok.Owner.Raw)}, true
+}
+func (a authMock) AmIAnAuditor(_ *token.ManagementService) bool {
+	return false
+}
+
+// OwnerType returns the type of owner (e.g. 'idemix' or 'htlc') and the identity bytes
+func (a authMock) OwnerType(raw []byte) (string, []byte, error) {
+	return "idemix", raw, nil
+}
+
+type mdMock struct{}
+
+func (md mdMock) SpentTokenID() []*token2.ID {
+	// only called if graphHiding is true
+	return []*token2.ID{}
+}
+
+// The second return is the issuer.
+func (md mdMock) GetToken(raw []byte) (*token2.Token, token.Identity, []byte, error) {
+	var parsed []string
+	if len(raw) == 0 {
+		parsed = []string{"eid", "typ", "0x0"}
+	} else {
+		parsed = strings.Split(string(raw), ",")
+	}
+	return &token2.Token{
+		Owner: &token2.Owner{
+			Raw: []byte(parsed[0]),
+		},
+		Type:     parsed[1],
+		Quantity: parsed[2],
+	}, []byte{}, []byte{}, nil
+}
+
+func TestParse(t *testing.T) {
+	tokens := &Tokens{
+		TMSProvider: nil,
+		Ownership:   &authMock{},
+		Issued:      nil,
+		Storage:     &DBStorage{},
+	}
+	md := mdMock{}
+
+	// simple transfer
+	input1 := &token.Input{
+		Id: &token2.ID{
+			TxId:  "in",
+			Index: 0,
+		},
+		ActionIndex:  0,
+		EnrollmentID: "alice",
+		Type:         "TOK",
+		Quantity:     token2.NewQuantityFromUInt64(10),
+	}
+	output1 := &token.Output{
+		ActionIndex:  0,
+		Index:        0,
+		EnrollmentID: "bob",
+		Type:         "TOK",
+		LedgerOutput: []byte("bob,TOK,0x0"),
+		Quantity:     token2.NewQuantityFromUInt64(10),
+	}
+	is := token.NewInputStream(qsMock{}, []*token.Input{input1}, 64)
+	os := token.NewOutputStream([]*token.Output{output1}, 64)
+
+	spend, store := tokens.parse(nil, "tx1", md, is, os, false, 64, false)
+
+	assert.Len(t, spend, 1)
+	assert.Equal(t, "in", spend[0].TxId)
+	assert.Equal(t, uint64(0), spend[0].Index)
+
+	assert.Len(t, store, 1)
+	assert.Equal(t, "tx1", store[0].txID)
+	assert.Equal(t, output1.Index, store[0].index)
+	assert.Equal(t, output1.LedgerOutput, store[0].tokenOnLedger)
+	assert.Equal(t, true, store[0].flags.Mine)
+	assert.Equal(t, false, store[0].flags.Auditor)
+	assert.Equal(t, false, store[0].flags.Issuer)
+	assert.Equal(t, uint64(64), store[0].precision)
+	assert.Equal(t, output1.Type, store[0].tok.Type)
+
+	// no ledger output -> spend
+	output1.LedgerOutput = []byte{}
+	os = token.NewOutputStream([]*token.Output{output1}, 64)
+	spend, store = tokens.parse(nil, "tx1", md, is, os, false, 64, false)
+	assert.Len(t, spend, 2)
+	assert.Len(t, store, 0)
+
+	// transfer with several inputs and outputs
+	input1 = &token.Input{
+		Id: &token2.ID{
+			TxId:  "in1",
+			Index: 1,
+		},
+		ActionIndex:  0,
+		EnrollmentID: "alice",
+		Type:         "TOK",
+		Quantity:     token2.NewQuantityFromUInt64(50),
+	}
+	input2 := &token.Input{
+		Id: &token2.ID{
+			TxId:  "in2",
+			Index: 2,
+		},
+		ActionIndex:  0,
+		EnrollmentID: "alice",
+		Type:         "TOK",
+		Quantity:     token2.NewQuantityFromUInt64(50),
+	}
+	output1 = &token.Output{
+		ActionIndex:  0,
+		Index:        0,
+		EnrollmentID: "bob",
+		Type:         "TOK",
+		LedgerOutput: []byte("bob,TOK,0x0"),
+		Quantity:     token2.NewQuantityFromUInt64(10),
+	}
+	output2 := &token.Output{
+		ActionIndex:  0,
+		Index:        1,
+		EnrollmentID: "alice",
+		Type:         "TOK",
+		LedgerOutput: []byte("bob,TOK,0x0"),
+		Quantity:     token2.NewQuantityFromUInt64(90),
+	}
+	is = token.NewInputStream(qsMock{}, []*token.Input{input1, input2}, 64)
+	os = token.NewOutputStream([]*token.Output{output1, output2}, 64)
+
+	spend, store = tokens.parse(nil, "tx2", md, is, os, false, 64, false)
+	assert.Len(t, spend, 2)
+	assert.Equal(t, "in1", spend[0].TxId)
+	assert.Equal(t, uint64(1), spend[0].Index)
+	assert.Equal(t, "in2", spend[1].TxId)
+	assert.Equal(t, uint64(2), spend[1].Index)
+
+	assert.Len(t, store, 2)
+	assert.Equal(t, output1.LedgerOutput, store[0].tokenOnLedger)
+	assert.Equal(t, "tx2", store[0].txID)
+	assert.Equal(t, output1.Index, store[0].index)
+	assert.Equal(t, output1.Type, store[0].tok.Type)
+
+	assert.Equal(t, output2.LedgerOutput, store[1].tokenOnLedger)
+	assert.Equal(t, "tx2", store[1].txID)
+	assert.Equal(t, output2.Index, store[1].index)
+	assert.Equal(t, output2.Type, store[1].tok.Type)
+}


### PR DESCRIPTION
The existing implementation opens up a database transaction and then starts parsing the token request. This operation indirectly, via other structs, does a few database calls outside of the open db transaction. This causes failures when performing a large amount of concurrent transactions in specific configurations; specifically with sqlite as backend or with a low maximum of open database connections.

This PR splits out the parsing from the storing/deleting operations, to leave the db transaction open for as short as possible and free up resources again. As a bonus it improves the testability of the parsing.