### PR TITLE
fabric network adaptor: support for FSC-based endorsement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,6 +94,7 @@ jobs:
           dlog-fabric-t8,
           dlog-fabric-t9,
           dlog-fabric-t10,
+          dlog-fabric-t11,
           fabtoken-dlog-fabric,
           dloghsm-fabric-t1,
           dloghsm-fabric-t2,

--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -52,6 +52,28 @@ token:
             maxOpenConns: 10
             dataSource: /some/path/tokendb
 
+      services:
+        # This section contains network specific configuration
+        network:
+          # Configuration related to the Fabric network
+          fabric:
+            # In Fabric, the execution of the token chaincode can be endorsed by any node equipped with
+            # a proper endorsement key.
+            # Therefore, also FSC nodes equipped with proper endorsement keys can perform the same function.
+            # This section is dedicated to the configuration of the endorsement of the token chaincode by
+            # other FSC nodes.
+            endorsement:
+              # Is this node an endorser?: true/false
+              endorser: true
+              # If this node is an endorser, which Fabric identity should be used to sign the endorsement?
+              # If empty, the default identity will be used
+              id: 
+              # A list of FSC node identifiers that must be contacted to obtain the endorsement 
+              endorsers:
+              - endorser1
+              - endorser2
+              - endorser2
+
       # sections dedicated to the definition of the wallets
       wallets:
         # Default cache size reference that can be used by any wallet that support caching

--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -67,7 +67,11 @@ token:
               endorser: true
               # If this node is an endorser, which Fabric identity should be used to sign the endorsement?
               # If empty, the default identity will be used
-              id: 
+              id:
+              # This section is used to set the policy to be used to select the endorsers to contact.
+              # Available policies are: `1outn`, `all`. Default policy is `all`
+              policy:
+                type: 1outn
               # A list of FSC node identifiers that must be contacted to obtain the endorsement 
               endorsers:
               - endorser1

--- a/fungible.mk
+++ b/fungible.mk
@@ -38,6 +38,10 @@ integration-tests-dlog-fabric-t9:
 integration-tests-dlog-fabric-t10:
 	make integration-tests-dlog-fabric TEST_FILTER="T10"
 
+.PHONY: integration-tests-dlog-fabric-t11
+integration-tests-dlog-fabric-t11:
+	make integration-tests-dlog-fabric TEST_FILTER="T11"
+
 .PHONY: integration-tests-dlog-fabric
 integration-tests-dlog-fabric:
 	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --label-filter="$(TEST_FILTER)" .

--- a/integration/nwo/token/fabric/fabric.go
+++ b/integration/nwo/token/fabric/fabric.go
@@ -181,6 +181,10 @@ func (p *NetworkHandler) GenerateExtension(tms *topology2.TMS, node *sfcnode.Nod
 		"SQLDataSource":       func() string { return p.GetSQLDataSource(node.Options, uniqueName, tms) },
 		"TokensSQLDriver":     func() string { return GetTokenPersistenceDriver(node.Options) },
 		"TokensSQLDataSource": func() string { return p.GetTokensSQLDataSource(node.Options, uniqueName, tms) },
+		"Endorsement":         func() bool { return IsFSCEndorsementEnabled(tms) },
+		"Endorsers":           func() []string { return Endorsers(tms) },
+		"EndorserID":          func() string { return "" },
+		"Endorser":            func() bool { return topology2.ToOptions(node.Options).Endorser() },
 		"OnlyUnity":           func() bool { return common2.IsOnlyUnity(tms) },
 	}).Parse(Extension)
 	Expect(err).NotTo(HaveOccurred())

--- a/integration/nwo/token/fabric/opts.go
+++ b/integration/nwo/token/fabric/opts.go
@@ -6,9 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package fabric
 
-import "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
+	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+)
 
-// WithFabricCA notify the backend to activate fabric-ca for the issuance of identities
+// WithFabricCA notifies the backend to activate fabric-ca for the issuance of identities
 func WithFabricCA(tms *topology.TMS) {
 	tms.BackendParams["fabricca"] = true
 }
@@ -20,4 +23,34 @@ func IsFabricCA(tms *topology.TMS) bool {
 		return boxed.(bool)
 	}
 	return false
+}
+
+// WithFSCEndorsers tells the backend to use FSC-based endorsement for the passed TMS using the given FSC endorsers identifiers
+func WithFSCEndorsers(tms *topology.TMS, endorsers ...string) *topology.TMS {
+	tms.BackendParams["endorsements"] = true
+	tms.BackendParams["endorsers"] = endorsers
+	return tms
+}
+
+// IsFSCEndorsementEnabled returns true if the FSC-based endorsement for the given TMS is enabled, false otherwise
+func IsFSCEndorsementEnabled(tms *topology.TMS) bool {
+	v, ok := tms.BackendParams["endorsements"]
+	return ok && v.(bool)
+}
+
+// WithEndorserRole tells the backed that a node with this option plays the role of endorser
+func WithEndorserRole() node.Option {
+	return func(o *node.Options) error {
+		to := topology.ToOptions(o)
+		to.SetEndorser(true)
+		return nil
+	}
+}
+
+func Endorsers(tms *topology.TMS) []string {
+	v, ok := tms.BackendParams["endorsers"]
+	if !ok {
+		return nil
+	}
+	return v.([]string)
 }

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -32,6 +32,8 @@ token:
             fsc_endorsement:
               endorser: {{ Endorser }}
               id: {{ EndorserID }}
+              policy:
+                type: 1outn
               endorsers: {{ range Endorsers }}
               - {{ . }}{{ end }}
       {{ end }}

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -29,7 +29,7 @@ token:
       services:
         network:
           fabric:
-            endorsement:
+            fsc_endorsement:
               endorser: {{ Endorser }}
               id: {{ EndorserID }}
               endorsers: {{ range Endorsers }}

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -25,6 +25,16 @@ token:
         {{ if TMS.Certifiers }} interactive:
           ids: {{ range TMS.Certifiers }}
           - {{ . }}{{ end }}{{ end }}
+      {{ if Endorsement }}
+      services:
+        network:
+          fabric:
+            endorsement:
+              endorser: {{ Endorser }}
+              id: {{ EndorserID }}
+              endorsers: {{ range Endorsers }}
+              - {{ . }}{{ end }}
+      {{ end }}
       db:
         persistence:
           type: unity

--- a/integration/nwo/token/topology/options.go
+++ b/integration/nwo/token/topology/options.go
@@ -90,6 +90,18 @@ func (o *Options) SetAuditor(v bool) {
 	o.Mapping["Auditor"] = v
 }
 
+func (o *Options) Endorser() bool {
+	res := o.Mapping["Endorser"]
+	if res == nil {
+		return false
+	}
+	return res.(bool)
+}
+
+func (o *Options) SetEndorser(v bool) {
+	o.Mapping["Endorser"] = v
+}
+
 func (o *Options) UseHSMForIssuer(label string) {
 	o.Mapping["Issuers.HSM."+label] = true
 }

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -44,6 +44,8 @@ var (
 		ReplicationFactor: token.None,
 	}
 
+	WebSocketNoReplicationOnly = []*InfrastructureType{WebSocketNoReplication}
+
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
 		{

--- a/integration/token/common/sdk/fall/sdk.go
+++ b/integration/token/common/sdk/fall/sdk.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/node"
+	dig2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
 	fabtoken "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/driver"
 	dlog "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/driver"
 	tokensdk "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/dig"
@@ -23,11 +24,15 @@ import (
 )
 
 type SDK struct {
-	*tokensdk.SDK
+	dig2.SDK
 }
 
 func NewSDK(registry node.Registry) *SDK {
 	return &SDK{SDK: tokensdk.NewSDK(registry)}
+}
+
+func NewFrom(sdk dig2.SDK) *SDK {
+	return &SDK{SDK: sdk}
 }
 
 func (p *SDK) Install() error {

--- a/integration/token/common/sdk/fall/sdk_test.go
+++ b/integration/token/common/sdk/fall/sdk_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fall
+
+import (
+	"testing"
+
+	dig2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	fabricsdk "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"
+	orionsdk "github.com/hyperledger-labs/fabric-smart-client/platform/orion/sdk/dig"
+	sdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
+	tokensdk "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/dig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllWiring(t *testing.T) {
+	assert.NoError(t, sdk.DryRunWiring(
+		func(sdk dig2.SDK) *SDK { return NewFrom(tokensdk.NewFrom(orionsdk.NewFrom(fabricsdk.NewFrom(sdk)))) },
+		sdk.WithBool("token.enabled", true),
+		sdk.WithBool("orion.enabled", true),
+		sdk.WithBool("fabric.enabled", true),
+	))
+}

--- a/integration/token/common/topology.go
+++ b/integration/token/common/topology.go
@@ -20,20 +20,21 @@ type replicationOpts interface {
 }
 
 type Opts struct {
-	CommType        fsc.P2PCommunicationType
-	ReplicationOpts replicationOpts
-	Backend         string
-	TokenSDKDriver  string
-	AuditorAsIssuer bool
-	Aries           bool
-	FSCLogSpec      string
-	NoAuditor       bool
-	HSM             bool
-	SDKs            []api.SDK
-	WebEnabled      bool
-	Monitoring      bool
-	TokenSelector   string
-	OnlyUnity       bool
+	CommType            fsc.P2PCommunicationType
+	ReplicationOpts     replicationOpts
+	Backend             string
+	TokenSDKDriver      string
+	AuditorAsIssuer     bool
+	Aries               bool
+	FSCLogSpec          string
+	NoAuditor           bool
+	HSM                 bool
+	SDKs                []api.SDK
+	WebEnabled          bool
+	Monitoring          bool
+	TokenSelector       string
+	OnlyUnity           bool
+	FSCBasedEndorsement bool
 }
 
 func SetDefaultParams(tokenSDKDriver string, tms *topology.TMS, aries bool) {

--- a/integration/token/fungible/dlog/dlog_suite_test.go
+++ b/integration/token/fungible/dlog/dlog_suite_test.go
@@ -9,10 +9,9 @@ package dlog
 import (
 	"testing"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/integration"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/hyperledger-labs/fabric-token-sdk/integration"
 )
 
 func TestEndToEnd(t *testing.T) {

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -31,6 +31,7 @@ const (
 	NoAuditor
 	HSM
 	WebEnabled
+	WithEndorsers
 )
 
 var _ = Describe("EndToEnd", func() {
@@ -77,6 +78,13 @@ var _ = Describe("EndToEnd", func() {
 			AfterEach(ts.TearDown)
 			It("Malicious Transactions", Label("T9"), func() { fungible.TestMaliciousTransactions(ts.II, selector) })
 		})
+
+		Describe("T10 Fungible with Auditor ne Issuer and Endorsers", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries|WithEndorsers, t.ReplicationFactor, "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T10"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+		})
 	}
 
 	for _, tokenSelector := range integration2.TokenSelectors {
@@ -118,19 +126,19 @@ func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, token
 	opts, selector := token2.NewReplicationOptions(factor, names...)
 	ts := token2.NewTestSuite(opts.SQLConfigs, StartPortDlog, topology.Topology(
 		common.Opts{
-			Backend:         "fabric",
-			CommType:        commType,
-			TokenSDKDriver:  "dlog",
-			NoAuditor:       mask&NoAuditor > 0,
-			Aries:           mask&Aries > 0,
-			AuditorAsIssuer: mask&AuditorAsIssuer > 0,
-			HSM:             mask&HSM > 0,
-			WebEnabled:      mask&WebEnabled > 0,
-			SDKs:            []api.SDK{&fdlog.SDK{}},
-			Monitoring:      false,
-			ReplicationOpts: opts,
-			TokenSelector:   tokenSelector,
-			//FSCLogSpec:      "fabric-sdk=debug:token-sdk=debug:orion-sdk=debug:info",
+			Backend:             "fabric",
+			CommType:            commType,
+			TokenSDKDriver:      "dlog",
+			NoAuditor:           mask&NoAuditor > 0,
+			Aries:               mask&Aries > 0,
+			AuditorAsIssuer:     mask&AuditorAsIssuer > 0,
+			HSM:                 mask&HSM > 0,
+			WebEnabled:          mask&WebEnabled > 0,
+			SDKs:                []api.SDK{&fdlog.SDK{}},
+			Monitoring:          false,
+			ReplicationOpts:     opts,
+			FSCBasedEndorsement: mask&WithEndorsers > 0,
+			//FSCLogSpec:          "token-sdk=debug:fabric-sdk=debug:info",
 			OnlyUnity: true,
 		},
 	))

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -80,7 +80,7 @@ var _ = Describe("EndToEnd", func() {
 		})
 
 		Describe("T10 Fungible with Auditor ne Issuer and Endorsers", t.Label, func() {
-			ts, selector := newTestSuite(t.CommType, Aries|WithEndorsers, t.ReplicationFactor, "alice", "bob", "charlie")
+			ts, selector := newTestSuite(t.CommType, Aries|WithEndorsers, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
 			It("succeeded", Label("T10"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
@@ -88,11 +88,11 @@ var _ = Describe("EndToEnd", func() {
 	}
 
 	for _, tokenSelector := range integration2.TokenSelectors {
-		Describe("T10 TokenSelector Test", integration2.WebSocketNoReplication.Label, Label(tokenSelector), func() {
+		Describe("T11 TokenSelector Test", integration2.WebSocketNoReplication.Label, Label(tokenSelector), func() {
 			ts, replicaSelector := newTestSuite(integration2.WebSocketNoReplication.CommType, Aries, integration2.WebSocketNoReplication.ReplicationFactor, tokenSelector, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T10"), func() { fungible.TestSelector(ts.II, "auditor", replicaSelector) })
+			It("succeeded", Label("T11"), func() { fungible.TestSelector(ts.II, "auditor", replicaSelector) })
 		})
 	}
 })
@@ -139,7 +139,8 @@ func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, token
 			ReplicationOpts:     opts,
 			FSCBasedEndorsement: mask&WithEndorsers > 0,
 			//FSCLogSpec:          "token-sdk=debug:fabric-sdk=debug:info",
-			OnlyUnity: true,
+			OnlyUnity:     true,
+			TokenSelector: tokenSelector,
 		},
 	))
 	return ts, selector

--- a/integration/token/fungible/views/checks.go
+++ b/integration/token/fungible/views/checks.go
@@ -51,6 +51,8 @@ func (m *CheckTTXDBView) Call(context view.Context) (interface{}, error) {
 	assert.NotNil(net, "failed to get network [%s:%s]", tms.Network(), tms.Channel())
 	v, err := net.Vault(tms.Namespace())
 	assert.NoError(err, "failed to get vault [%s:%s:%s]", tms.Network(), tms.Channel(), tms.Namespace())
+	tv, err := net.TokenVault(tms.Namespace())
+	assert.NoError(err, "failed to get token vault [%s:%s:%s]", tms.Namespace(), tms.Channel(), tms.Namespace())
 	l, err := net.Ledger()
 	assert.NoError(err, "failed to get ledger [%s:%s:%s]", tms.Network(), tms.Channel(), tms.Namespace())
 
@@ -152,7 +154,7 @@ func (m *CheckTTXDBView) Call(context view.Context) (interface{}, error) {
 	}
 
 	// check unspent tokens
-	uit, err := v.QueryEngine().UnspentTokensIterator()
+	uit, err := tv.QueryEngine().UnspentTokensIterator()
 	assert.NoError(err, "failed to get unspent tokens")
 	defer uit.Close()
 	var unspentTokenIDs []*token2.ID
@@ -170,7 +172,7 @@ func (m *CheckTTXDBView) Call(context view.Context) (interface{}, error) {
 	} else {
 		assert.Equal(len(unspentTokenIDs), len(ledgerTokenContent))
 		index := 0
-		assert.NoError(v.QueryEngine().GetTokenOutputs(unspentTokenIDs, func(id *token2.ID, tokenRaw []byte) error {
+		assert.NoError(tv.QueryEngine().GetTokenOutputs(unspentTokenIDs, func(id *token2.ID, tokenRaw []byte) error {
 			if !bytes.Equal(ledgerTokenContent[index], tokenRaw) {
 				errorMessages = append(errorMessages, fmt.Sprintf("token content does not match at [%s][%d], [%s]!=[%s]",
 					id,
@@ -206,7 +208,7 @@ type PruneInvalidUnspentTokensView struct {
 func (p *PruneInvalidUnspentTokensView) Call(context view.Context) (interface{}, error) {
 	net := network.GetInstance(context, p.TMSID.Network, p.TMSID.Channel)
 	assert.NotNil(net, "cannot find network [%s:%s]", p.TMSID.Network, p.TMSID.Channel)
-	vault, err := net.Vault(p.TMSID.Namespace)
+	vault, err := net.TokenVault(p.TMSID.Namespace)
 	assert.NoError(err, "failed to get vault for [%s:%s:%s]", p.TMSID.Network, p.TMSID.Channel, p.TMSID.Namespace)
 
 	return vault.PruneInvalidUnspentTokens(context)
@@ -233,7 +235,7 @@ type ListVaultUnspentTokensView struct {
 func (l *ListVaultUnspentTokensView) Call(context view.Context) (interface{}, error) {
 	net := network.GetInstance(context, l.TMSID.Network, l.TMSID.Channel)
 	assert.NotNil(net, "cannot find network [%s:%s]", l.TMSID.Network, l.TMSID.Channel)
-	vault, err := net.Vault(l.TMSID.Namespace)
+	vault, err := net.TokenVault(l.TMSID.Namespace)
 	assert.NoError(err, "failed to get vault for [%s:%s:%s]", l.TMSID.Network, l.TMSID.Channel, l.TMSID.Namespace)
 
 	return vault.QueryEngine().ListUnspentTokens()
@@ -261,7 +263,7 @@ type CheckIfExistsInVaultView struct {
 func (c *CheckIfExistsInVaultView) Call(context view.Context) (interface{}, error) {
 	net := network.GetInstance(context, c.TMSID.Network, c.TMSID.Channel)
 	assert.NotNil(net, "cannot find network [%s:%s]", c.TMSID.Network, c.TMSID.Channel)
-	vault, err := net.Vault(c.TMSID.Namespace)
+	vault, err := net.TokenVault(c.TMSID.Namespace)
 	assert.NoError(err, "failed to get vault for [%s:%s:%s]", c.TMSID.Network, c.TMSID.Channel, c.TMSID.Namespace)
 	qe := vault.QueryEngine()
 	var IDs []*token2.ID

--- a/integration/token/fungible/views/info.go
+++ b/integration/token/fungible/views/info.go
@@ -109,7 +109,7 @@ type WhoDeletedTokenView struct {
 func (w *WhoDeletedTokenView) Call(context view.Context) (interface{}, error) {
 	net := network.GetInstance(context, w.TMSID.Network, w.TMSID.Channel)
 	assert.NotNil(net, "cannot find network [%s:%s]", w.TMSID.Network, w.TMSID.Channel)
-	vault, err := net.Vault(w.TMSID.Namespace)
+	vault, err := net.TokenVault(w.TMSID.Namespace)
 	assert.NoError(err, "failed to get vault for [%s:%s:%s]", w.TMSID.Network, w.TMSID.Channel, w.TMSID.Namespace)
 
 	who, deleted, err := vault.QueryEngine().WhoDeletedTokens(w.TokenIDs...)

--- a/integration/token/test_utils.go
+++ b/integration/token/test_utils.go
@@ -123,6 +123,20 @@ func NewTestSuite(sqlConfigs map[string]*sql.PostgresConfig, startPort func() in
 	}
 }
 
+// NewLocalTestSuite returns a new test suite that stores configuration data in `./testdata` and does not remove it when
+// the test is done.
+func NewLocalTestSuite(sqlConfigs map[string]*sql.PostgresConfig, startPort func() int, topologies []api.Topology) *TestSuite {
+	return &TestSuite{
+		sqlConfigs: sqlConfigs,
+		generator: func() (*integration.Infrastructure, error) {
+			i, err := integration.New(startPort(), "./testdata", integration.ReplaceTemplate(topologies)...)
+			i.DeleteOnStop = false
+			return i, err
+		},
+		closeFunc: func() {},
+	}
+}
+
 type TestSuite struct {
 	sqlConfigs map[string]*sql.PostgresConfig
 	generator  func() (*integration.Infrastructure, error)

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -76,7 +76,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 	if n == nil {
 		return nil, errors.Errorf("network [%s] does not exists", networkID)
 	}
-	v, err := n.Vault(namespace)
+	v, err := n.TokenVault(namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "vault [%s:%s] does not exists", networkID, namespace)
 	}

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -78,7 +78,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 		return nil, errors.Errorf("network [%s] does not exists", networkID)
 	}
 	networkLocalMembership := n.LocalMembership()
-	v, err := n.Vault(namespace)
+	v, err := n.TokenVault(namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "vault [%s:%s] does not exists", networkID, namespace)
 	}

--- a/token/driver/config.go
+++ b/token/driver/config.go
@@ -17,6 +17,8 @@ type Configuration interface {
 	UnmarshalKey(key string, rawVal interface{}) error
 	// GetString returns the value associated with the key as a string
 	GetString(key string) string
+	// GetBool returns the value associated with the key as a bool
+	GetBool(key string) bool
 	// TranslatePath translates the passed path relative to the config path
 	TranslatePath(path string) string
 }

--- a/token/sdk/dig/sdk_test.go
+++ b/token/sdk/dig/sdk_test.go
@@ -13,11 +13,11 @@ import (
 	fabricsdk "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"
 	orionsdk "github.com/hyperledger-labs/fabric-smart-client/platform/orion/sdk/dig"
 	sdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFabricWiring(t *testing.T) {
-	assert.NoError(sdk.DryRunWiring(
+	assert.NoError(t, sdk.DryRunWiring(
 		func(sdk dig2.SDK) *SDK { return NewFrom(fabricsdk.NewFrom(sdk)) },
 		sdk.WithBool("token.enabled", true),
 		sdk.WithBool("fabric.enabled", true),
@@ -25,7 +25,7 @@ func TestFabricWiring(t *testing.T) {
 }
 
 func TestOrionWiring(t *testing.T) {
-	assert.NoError(sdk.DryRunWiring(
+	assert.NoError(t, sdk.DryRunWiring(
 		func(sdk dig2.SDK) *SDK { return NewFrom(orionsdk.NewFrom(sdk)) },
 		sdk.WithBool("token.enabled", true),
 		sdk.WithBool("orion.enabled", true),
@@ -33,7 +33,7 @@ func TestOrionWiring(t *testing.T) {
 }
 
 func TestFabricOrionWiring(t *testing.T) {
-	assert.NoError(sdk.DryRunWiring(
+	assert.NoError(t, sdk.DryRunWiring(
 		func(sdk dig2.SDK) *SDK { return NewFrom(fabricsdk.NewFrom(orionsdk.NewFrom(sdk))) },
 		sdk.WithBool("token.enabled", true),
 		sdk.WithBool("fabric.enabled", true),
@@ -42,7 +42,7 @@ func TestFabricOrionWiring(t *testing.T) {
 }
 
 func TestOrionFabricWiring(t *testing.T) {
-	assert.NoError(sdk.DryRunWiring(
+	assert.NoError(t, sdk.DryRunWiring(
 		func(sdk dig2.SDK) *SDK { return NewFrom(orionsdk.NewFrom(fabricsdk.NewFrom(sdk))) },
 		sdk.WithBool("token.enabled", true),
 		sdk.WithBool("orion.enabled", true),

--- a/token/sdk/vault/adaptors.go
+++ b/token/sdk/vault/adaptors.go
@@ -12,6 +12,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+type Vault struct {
+	*network.TokenVault
+}
+
+func (v *Vault) QueryEngine() driver.QueryEngine {
+	return v.TokenVault.QueryEngine()
+}
+
+func (v *Vault) CertificationStorage() driver.CertificationStorage {
+	return v.TokenVault.CertificationStorage()
+}
+
 type ProviderAdaptor struct {
 	Provider *network.Provider
 }
@@ -21,11 +33,11 @@ func (p *ProviderAdaptor) Vault(networkID string, channel string, namespace stri
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get network for [%s:%s:%s]", networkID, channel, namespace)
 	}
-	v, err := net.Vault(namespace)
+	v, err := net.TokenVault(namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get vault for [%s:%s:%s]", networkID, channel, namespace)
 	}
-	return v, nil
+	return &Vault{TokenVault: v}, nil
 }
 
 type PublicParamsProvider struct {
@@ -37,7 +49,7 @@ func (p *PublicParamsProvider) PublicParams(networkID string, channel string, na
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get network for [%s:%s:%s]", networkID, channel, namespace)
 	}
-	v, err := net.Vault(namespace)
+	v, err := net.TokenVault(namespace)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get vault for [%s:%s:%s]", networkID, channel, namespace)
 	}

--- a/token/services/config/config.go
+++ b/token/services/config/config.go
@@ -68,6 +68,10 @@ func (m *configuration) GetString(key string) string {
 	return m.cp.GetString("token.tms." + m.keyID + "." + key)
 }
 
+func (m *configuration) GetBool(key string) bool {
+	return m.cp.GetBool("token.tms." + m.keyID + "." + key)
+}
+
 func (m *configuration) IsSet(key string) bool {
 	return m.cp.IsSet("token.tms." + m.keyID + "." + key)
 }

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -34,10 +34,10 @@ type TokenVault interface {
 
 // OwnerWallet is a combination of a wallet and a query service
 type OwnerWallet struct {
-	wallet       *token.OwnerWallet
-	queryService QueryEngine
-	vault        TokenVault
-	bufferSize   int
+	wallet      *token.OwnerWallet
+	queryEngine QueryEngine
+	vault       TokenVault
+	bufferSize  int
 }
 
 // ListTokensAsSender returns a list of non-expired htlc-tokens whose sender id is in this wallet
@@ -297,7 +297,7 @@ func (w *OwnerWallet) filterIterator(tokenType string, sender bool, selector Sel
 	} else {
 		walletID = recipientWallet(w.wallet)
 	}
-	it, err := w.queryService.UnspentTokensIteratorBy(walletID, tokenType)
+	it, err := w.queryEngine.UnspentTokensIteratorBy(walletID, tokenType)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get iterator over unspent tokens")
 	}
@@ -323,17 +323,17 @@ func Wallet(sp token.ServiceProvider, wallet *token.OwnerWallet) *OwnerWallet {
 	if nw == nil {
 		return nil
 	}
-	vault, err := nw.Vault(tms.Namespace())
+	vault, err := nw.TokenVault(tms.Namespace())
 	if err != nil {
 		logger.Errorf("failed to get vault for [%s:%s:%s]", tms.Network(), tms.Channel(), tms.Namespace())
 		return nil
 	}
 
 	return &OwnerWallet{
-		wallet:       wallet,
-		vault:        vault,
-		queryService: vault.QueryEngine(),
-		bufferSize:   100,
+		wallet:      wallet,
+		vault:       vault,
+		queryEngine: vault.QueryEngine(),
+		bufferSize:  100,
 	}
 }
 

--- a/token/services/network/common/normalizer.go
+++ b/token/services/network/common/normalizer.go
@@ -6,11 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 
 package common
 
-// NamespaceFinder models a namespace finder
-type NamespaceFinder interface {
+import "github.com/hyperledger-labs/fabric-token-sdk/token/services/config"
+
+// Configuration models the configuration provider
+type Configuration interface {
 	// LookupNamespace searches for a TMS configuration that matches the given network and channel, and
 	// return its namespace.
 	// If no matching configuration is found, an error is returned.
 	// If multiple matching configurations are found, an error is returned.
 	LookupNamespace(network, channel string) (string, error)
+
+	ConfigurationFor(network, channel, namespace string) (config.Configuration, error)
 }

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -50,6 +50,8 @@ type Network interface {
 	// the argument is ignored.
 	Vault(namespace string) (Vault, error)
 
+	TokenVault(namespace string) (TokenVault, error)
+
 	// Broadcast sends the passed blob to the network
 	Broadcast(context context.Context, blob interface{}) error
 

--- a/token/services/network/driver/vault.go
+++ b/token/services/network/driver/vault.go
@@ -22,24 +22,33 @@ const (
 	Unknown                // Transaction is unknown
 )
 
-// UnspentTokensIterator models an iterator of unspent tokens
-type UnspentTokensIterator = driver2.UnspentTokensIterator
+type (
+	// UnspentTokensIterator models an iterator of unspent tokens
+	UnspentTokensIterator = driver2.UnspentTokensIterator
+	QueryEngine           = vault.QueryEngine
+	CertificationStorage  = vault.CertificationStorage
+)
 
 // TokenVault models the token vault
 type TokenVault interface {
 	// QueryEngine returns the query engine over this vault
-	QueryEngine() vault.QueryEngine
+	QueryEngine() QueryEngine
 
 	// CertificationStorage returns the certification storage over this vault
-	CertificationStorage() vault.CertificationStorage
+	CertificationStorage() CertificationStorage
 
 	// DeleteTokens delete the passed tokens in the passed namespace
 	DeleteTokens(ids ...*token.ID) error
 }
 
+type QueryExecutor interface {
+	GetState(key string) ([]byte, error)
+	Done()
+}
+
 // Vault models the vault service
 type Vault interface {
-	TokenVault
+	NewQueryExecutor() (QueryExecutor, error)
 
 	// GetLastTxID returns the last transaction ID committed into the vault
 	GetLastTxID() (string, error)

--- a/token/services/network/fabric/driver.go
+++ b/token/services/network/fabric/driver.go
@@ -9,6 +9,7 @@ package fabric
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	vault2 "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/vault"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/config"
@@ -26,7 +27,7 @@ type Driver struct {
 	tokensManager    *tokens.Manager
 	configService    *config.Service
 	viewManager      *view.Manager
-	viewRegistry     *view.Registry
+	viewRegistry     driver2.Registry
 	filterProvider   *common.AcceptTxInDBFilterProvider
 	tmsProvider      *token.ManagementServiceProvider
 	identityProvider *view.IdentityProvider
@@ -38,7 +39,7 @@ func NewDriver(
 	tokensManager *tokens.Manager,
 	configService *config.Service,
 	viewManager *view.Manager,
-	viewRegistry *view.Registry,
+	viewRegistry driver2.Registry,
 	filterProvider *common.AcceptTxInDBFilterProvider,
 	tmsProvider *token.ManagementServiceProvider,
 ) driver.NamedDriver {

--- a/token/services/network/fabric/driver.go
+++ b/token/services/network/fabric/driver.go
@@ -30,7 +30,7 @@ type Driver struct {
 	viewRegistry     driver2.Registry
 	filterProvider   *common.AcceptTxInDBFilterProvider
 	tmsProvider      *token.ManagementServiceProvider
-	identityProvider *view.IdentityProvider
+	identityProvider driver2.IdentityProvider
 }
 
 func NewDriver(
@@ -42,18 +42,20 @@ func NewDriver(
 	viewRegistry driver2.Registry,
 	filterProvider *common.AcceptTxInDBFilterProvider,
 	tmsProvider *token.ManagementServiceProvider,
+	identityProvider driver2.IdentityProvider,
 ) driver.NamedDriver {
 	return driver.NamedDriver{
 		Name: "fabric",
 		Driver: &Driver{
-			fnsProvider:    fnsProvider,
-			vaultProvider:  vaultProvider,
-			tokensManager:  tokensManager,
-			configService:  configService,
-			viewManager:    viewManager,
-			viewRegistry:   viewRegistry,
-			filterProvider: filterProvider,
-			tmsProvider:    tmsProvider,
+			fnsProvider:      fnsProvider,
+			vaultProvider:    vaultProvider,
+			tokensManager:    tokensManager,
+			configService:    configService,
+			viewManager:      viewManager,
+			viewRegistry:     viewRegistry,
+			filterProvider:   filterProvider,
+			tmsProvider:      tmsProvider,
+			identityProvider: identityProvider,
 		},
 	}
 }

--- a/token/services/network/fabric/endorsement/chaincode.go
+++ b/token/services/network/fabric/endorsement/chaincode.go
@@ -1,0 +1,49 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorsement
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/chaincode"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+)
+
+const InvokeFunction = "invoke"
+
+type chaincodeEndorsementService struct {
+	tmsID token2.TMSID
+}
+
+func newChaincodeEndorsementService(tmsID token2.TMSID) *chaincodeEndorsementService {
+	return &chaincodeEndorsementService{tmsID: tmsID}
+}
+
+func (e *chaincodeEndorsementService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
+	env, err := chaincode.NewEndorseView(
+		e.tmsID.Namespace,
+		InvokeFunction,
+	).WithNetwork(
+		e.tmsID.Network,
+	).WithChannel(
+		e.tmsID.Channel,
+	).WithSignerIdentity(
+		signer,
+	).WithTransientEntry(
+		"token_request", requestRaw,
+	).WithTxID(
+		fabric.TxID{
+			Nonce:   txID.Nonce,
+			Creator: txID.Creator,
+		},
+	).Endorse(context)
+	if err != nil {
+		return nil, err
+	}
+	return env, nil
+}

--- a/token/services/network/fabric/endorsement/fsc.go
+++ b/token/services/network/fabric/endorsement/fsc.go
@@ -16,7 +16,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newFSCService(nw *fabric.NetworkService, tms *token.ManagementService, configuration tdriver.Configuration, viewRegistry ViewRegistry, viewManager ViewManager, identityProvider IdentityProvider) (*fscService, error) {
+func newFSCService(
+	nw *fabric.NetworkService,
+	tms *token.ManagementService,
+	configuration tdriver.Configuration,
+	viewRegistry ViewRegistry,
+	viewManager ViewManager,
+	identityProvider IdentityProvider,
+) (*fscService, error) {
 	tmsID := tms.ID()
 	ch, err := nw.Channel(tmsID.Channel)
 	if err != nil {

--- a/token/services/network/fabric/endorsement/fsc.go
+++ b/token/services/network/fabric/endorsement/fsc.go
@@ -1,0 +1,78 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorsement
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	tdriver "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/fts"
+	"github.com/pkg/errors"
+)
+
+func newFSCService(nw *fabric.NetworkService, tms *token.ManagementService, configuration tdriver.Configuration, viewRegistry ViewRegistry, viewManager ViewManager, identityProvider IdentityProvider) (*fscService, error) {
+	tmsID := tms.ID()
+	ch, err := nw.Channel(tmsID.Channel)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting channel [%s]", tmsID.Channel)
+	}
+	committer := ch.Committer()
+	if configuration.GetBool("services.network.fabric.endorsement.endorser") {
+		logger.Info("this node is an endorser, prepare it...")
+		if err := committer.ProcessNamespace(tmsID.Namespace); err != nil {
+			return nil, errors.WithMessagef(err, "failed to add namespace to committer [%s]", tmsID.Namespace)
+		}
+		if err := viewRegistry.RegisterResponder(&fts.RequestApprovalResponderView{}, &fts.RequestApprovalView{}); err != nil {
+			return nil, errors.WithMessagef(err, "failed to register approval view for [%s]", tmsID)
+		}
+	}
+
+	var endorserIDs []string
+	if err := configuration.UnmarshalKey("services.network.fabric.endorsement.endorsers", &endorserIDs); err != nil {
+		return nil, errors.WithMessage(err, "failed to load endorsers")
+	}
+	logger.Infof("defined [%s] as endorsers for [%s]", endorserIDs, tmsID)
+	if len(endorserIDs) == 0 {
+		return nil, errors.Errorf("no endorsers found for [%s]", tmsID)
+	}
+	endorsers := make([]view.Identity, 0, len(endorserIDs))
+	for _, id := range endorserIDs {
+		if endorserID := identityProvider.Identity(id); endorserID.IsNone() {
+			return nil, errors.Errorf("cannot find identity for endorser [%s]", id)
+		} else {
+			endorsers = append(endorsers, endorserID)
+		}
+	}
+
+	return &fscService{endorsers: endorsers, tms: tms, viewManager: viewManager}, nil
+}
+
+type fscService struct {
+	tms         *token.ManagementService
+	endorsers   []view.Identity
+	viewManager ViewManager
+}
+
+func (e *fscService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
+	logger.Debugf("request approval via fts endrosers...")
+	envBoxed, err := e.viewManager.InitiateView(&fts.RequestApprovalView{
+		TMS:        e.tms,
+		RequestRaw: requestRaw,
+		TxID:       txID,
+		Endorsers:  e.endorsers,
+	}, context.Context())
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to request approval")
+	}
+	env, ok := envBoxed.(driver.Envelope)
+	if !ok {
+		return nil, errors.Errorf("expected driver.Envelope, got [%T]", envBoxed)
+	}
+	return env, nil
+}

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package endorsement
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+
+	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils"
+	"github.com/pkg/errors"
+)
+
+var (
+	logger = flogging.MustGetLogger("token-sdk.network.fabric.endorsement")
+)
+
+type IdentityProvider interface {
+	Identity(string) view.Identity
+}
+
+type ViewManager interface {
+	InitiateView(view view2.View, ctx context.Context) (interface{}, error)
+}
+
+type ViewRegistry interface {
+	RegisterResponder(responder view2.View, initiatedBy interface{}) error
+}
+
+type ServiceProvider struct {
+	utils.LazyProvider[token2.TMSID, Service]
+}
+
+func NewServiceProvider(
+	fns *fabric.NetworkService,
+	configService common.Configuration,
+	viewManager ViewManager,
+	viewRegistry ViewRegistry,
+	identityProvider IdentityProvider,
+	tmsProvider *token2.ManagementServiceProvider,
+) *ServiceProvider {
+	l := &loader{
+		fns:              fns,
+		configService:    configService,
+		viewManager:      viewManager,
+		viewRegistry:     viewRegistry,
+		identityProvider: identityProvider,
+		tmsProvider:      tmsProvider,
+	}
+	return &ServiceProvider{LazyProvider: utils.NewLazyProviderWithKeyMapper(key, l.load)}
+}
+
+type Service interface {
+	Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error)
+}
+
+type loader struct {
+	fns              *fabric.NetworkService
+	configService    common.Configuration
+	viewManager      ViewManager
+	viewRegistry     ViewRegistry
+	identityProvider IdentityProvider
+	tmsProvider      *token2.ManagementServiceProvider
+}
+
+func (l *loader) load(tmsID token2.TMSID) (Service, error) {
+	// if I'm an endorser, I need to process all token transactions
+	configuration, err := l.configService.ConfigurationFor(tmsID.Network, tmsID.Channel, tmsID.Namespace)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get configuration for [%s]", tmsID)
+	}
+
+	if !configuration.IsSet("services.network.fabric.endorsement") {
+		return newChaincodeEndorsementService(tmsID), nil
+	}
+
+	tms, err := l.tmsProvider.GetManagementService(token2.WithTMSID(tmsID))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get tms for [%s]", tmsID)
+	}
+	return newFSCService(l.fns, tms, configuration, l.viewRegistry, l.viewManager, l.identityProvider)
+}
+
+func key(tmsID token2.TMSID) string {
+	return tmsID.Network + tmsID.Channel + tmsID.Namespace
+}

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -10,8 +10,8 @@ import (
 	"context"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/flogging"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -33,9 +33,7 @@ type ViewManager interface {
 	InitiateView(view view2.View, ctx context.Context) (interface{}, error)
 }
 
-type ViewRegistry interface {
-	RegisterResponder(responder view2.View, initiatedBy interface{}) error
-}
+type ViewRegistry = driver2.Registry
 
 type ServiceProvider struct {
 	utils.LazyProvider[token2.TMSID, Service]

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -21,6 +21,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	FSCEndorsementKey = "services.network.fabric.fsc_endorsement"
+)
+
 var (
 	logger = flogging.MustGetLogger("token-sdk.network.fabric.endorsement")
 )
@@ -78,10 +82,12 @@ func (l *loader) load(tmsID token2.TMSID) (Service, error) {
 		return nil, errors.WithMessagef(err, "failed to get configuration for [%s]", tmsID)
 	}
 
-	if !configuration.IsSet("services.network.fabric.endorsement") {
+	if !configuration.IsSet(FSCEndorsementKey) {
+		logger.Infof("chaincode endorsement enabled...")
 		return newChaincodeEndorsementService(tmsID), nil
 	}
 
+	logger.Infof("FSC endorsement enabled...")
 	tms, err := l.tmsProvider.GetManagementService(token2.WithTMSID(tmsID))
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to get tms for [%s]", tmsID)

--- a/token/services/network/fabric/fts/approval.go
+++ b/token/services/network/fabric/fts/approval.go
@@ -1,0 +1,274 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fts
+
+import (
+	"time"
+
+	fabric2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/endorser"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
+	"github.com/pkg/errors"
+)
+
+const (
+	InvokeFunction = "invoke"
+)
+
+var logger = logging.MustGetLogger("token-sdk.network.fabric.fts")
+
+type RequestApprovalView struct {
+	TMS        *token2.ManagementService
+	TxID       driver.TxID
+	RequestRaw []byte
+	// RequestAnchor, if not nil it will instruct the approver to verify the token request using this anchor and not the transaction it.
+	// This is to be used only for testing.
+	RequestAnchor string
+	// Nonce, if not nil it will be appended to the messages to sign.
+	// This is to be used only for testing.
+	Nonce []byte
+	// Endorsers are the identities of the FSC node that play the role of endorser
+	Endorsers []view.Identity
+}
+
+func (r *RequestApprovalView) Call(context view.Context) (interface{}, error) {
+	_, tx, err := endorser.NewTransaction(
+		context,
+		fabric2.WithCreator(r.TxID.Creator),
+		fabric2.WithNonce(r.TxID.Nonce),
+	)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to create endorser transaction")
+	}
+
+	tx.SetProposal(r.TMS.Namespace(), "", InvokeFunction)
+	if err := tx.EndorseProposal(); err != nil {
+		return nil, errors.WithMessagef(err, "failed to endorse proposal")
+	}
+	if err := tx.SetTransientState("tmsID", r.TMS.ID()); err != nil {
+		return nil, errors.WithMessagef(err, "failed to set TMS ID transient")
+	}
+	if err := tx.SetTransient("token_request", r.RequestRaw); err != nil {
+		return nil, errors.WithMessagef(err, "failed to set token request transient")
+	}
+	if len(r.RequestAnchor) != 0 {
+		if err := tx.SetTransient("RequestAnchor", []byte(r.RequestAnchor)); err != nil {
+			return nil, errors.WithMessagef(err, "failed to set token request transient")
+		}
+	}
+	if len(r.Nonce) != 0 {
+		if err := tx.SetTransient("Nonce", r.Nonce); err != nil {
+			return nil, errors.WithMessagef(err, "failed to set token request transient")
+		}
+	}
+
+	logger.Debugf("Request Endorsement on tx [%s] to [%v]...", tx.ID(), r.Endorsers)
+	_, err = context.RunView(endorser.NewParallelCollectEndorsementsOnProposalView(
+		tx,
+		r.Endorsers...,
+	).WithTimeout(2 * time.Minute))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to collect endorsements")
+	}
+	logger.Debugf("Request Endorsement on tx [%s] to [%v]...done", tx.ID(), r.Endorsers)
+
+	rws, err := tx.RWSet()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get rws")
+	}
+	rws.Done()
+	logger.Debugf("[%s] found [%d] nss [%v]", tx.ID(), len(rws.Namespaces()), rws.Namespaces())
+
+	// Return envelope
+	return tx.Envelope()
+}
+
+type RequestApprovalResponderView struct{}
+
+func (r *RequestApprovalResponderView) Call(context view.Context) (interface{}, error) {
+	// When the borrower runs the CollectEndorsementsView, at some point, the borrower sends the assembled transaction
+	// to the approver. Therefore, the approver waits to receive the transaction.
+	tx, err := endorser.ReceiveTransaction(context)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to received transaction for approval")
+	}
+	raw, err := tx.Bytes()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to marshal transaction [%s]", tx.ID())
+	}
+
+	logger.Debugf("Respond to request of approval for tx [%s][%s]", tx.ID(), hash.Hashable(raw).String())
+
+	var tmsID token2.TMSID
+	if err := tx.GetTransientState("tmsID", &tmsID); err != nil {
+		return nil, errors.WithMessagef(err, "failed to get TMS ID from transient [%s]", tx.ID())
+	}
+	requestRaw := tx.GetTransient("token_request")
+	if len(requestRaw) == 0 {
+		return nil, errors.Errorf("failed to get token request from transient [%s], it is empty", tx.ID())
+	}
+	requestAnchor := string(tx.GetTransient("RequestAnchor"))
+	if len(requestAnchor) == 0 {
+		requestAnchor = tx.ID()
+	}
+
+	logger.Debugf("evaluate token request on TMS [%s]", tmsID)
+	tms := token2.GetManagementService(context, token2.WithTMSID(tmsID))
+	if tms == nil {
+		return nil, errors.Errorf("cannot find TMS for [%s]", tmsID)
+	}
+
+	rws, err := tx.RWSet()
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get rws for tx [%s]", tx.ID())
+	}
+	defer rws.Done()
+
+	fns, err := fabric2.GetFabricNetworkService(context, tms.Network())
+	if err != nil {
+		return nil, errors.WithMessagef(err, "cannot find fabric network for [%s]", tms.Network())
+	}
+
+	// validate token request
+	v, err := network.GetInstance(context, tx.Network(), tx.Channel()).Vault(tms.Namespace())
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get vault")
+	}
+	actions, validationMetadata, err := r.validate(context, tms, tx, requestAnchor, requestRaw, v)
+	if err != nil {
+		return nil, err
+	}
+
+	// endorse
+	endorserID, err := r.endorserID(tms, fns)
+	if err != nil {
+		return nil, err
+	}
+
+	// write actions into the transaction
+	err = r.translate(tms, tx, validationMetadata, rws, actions...)
+	if err != nil {
+		return nil, err
+	}
+
+	endorsementResult, err := context.RunView(endorser.NewEndorsementOnProposalResponderView(tx, endorserID))
+	if err != nil {
+		logger.Errorf("failed to respond to endorsement [%s]", err)
+	}
+	return endorsementResult, err
+}
+
+func (r *RequestApprovalResponderView) translate(
+	tms *token2.ManagementService,
+	tx *endorser.Transaction,
+	validationMetadata map[string][]byte,
+	rws *fabric2.RWSet,
+	actions ...any,
+) error {
+	// prepare the rws as usual
+	w := translator.New(tx.ID(), &rwsWrapper{stub: rws}, tms.Namespace())
+	for _, action := range actions {
+		if err := w.Write(action); err != nil {
+			return errors.Wrapf(err, "failed to write token action for tx [%s]", tx.ID())
+		}
+	}
+	err := w.AddPublicParamsDependency()
+	if err != nil {
+		return errors.Wrapf(err, "failed to add public params dependency")
+	}
+	err = w.CommitTokenRequest(validationMetadata[common.TokenRequestToSign], true)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write token request")
+	}
+	return nil
+}
+
+func (r *RequestApprovalResponderView) validate(
+	context view.Context,
+	tms *token2.ManagementService,
+	tx *endorser.Transaction,
+	anchor string,
+	requestRaw []byte,
+	vault *network.Vault,
+) ([]any, map[string][]byte, error) {
+	validator, err := tms.Validator()
+	if err != nil {
+		return nil, nil, errors.WithMessagef(err, "failed to get validator [%s:%s]", tms.Network(), tms.Channel())
+	}
+	qe, err := vault.NewQueryExecutor()
+	if err != nil {
+		return nil, nil, errors.WithMessagef(err, "failed to get query executor")
+	}
+	defer qe.Done()
+	actions, meta, err := validator.UnmarshallAndVerifyWithMetadata(context.Context(), qe, anchor, requestRaw)
+	if err != nil {
+		return nil, nil, errors.WithMessagef(err, "failed to verify token request for [%s]", tx.ID())
+	}
+	db, err := ttxdb.GetByTMSId(context, tms.ID())
+	if err != nil {
+		return nil, nil, errors.WithMessagef(err, "failed to retrieve db [%s]", tms.ID())
+	}
+	if err := db.AppendValidationRecord(tx.ID(), requestRaw, meta); err != nil {
+		return nil, nil, errors.WithMessagef(err, "failed to append metadata for [%s]", tx.ID())
+	}
+	return actions, meta, nil
+}
+
+func (r *RequestApprovalResponderView) endorserID(tms *token2.ManagementService, fns *fabric2.NetworkService) (view.Identity, error) {
+	var endorserIDLabel string
+	if err := tms.Configuration().UnmarshalKey("services.network.fabric.endorsement.id", &endorserIDLabel); err != nil {
+		return nil, errors.WithMessage(err, "failed to load endorserID")
+	}
+	var endorserID view.Identity
+	if len(endorserIDLabel) == 0 {
+		endorserID = fns.LocalMembership().DefaultIdentity()
+	} else {
+		var err error
+		endorserID, err = fns.LocalMembership().GetIdentityByID(endorserIDLabel)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "cannot find local endorser identity for [%s]", endorserIDLabel)
+		}
+	}
+	if endorserID.IsNone() {
+		return nil, errors.Errorf("cannot find local endorser identity for [%s]", endorserIDLabel)
+	}
+	if _, err := fns.SignerService().GetSigner(endorserID); err != nil {
+		return nil, errors.WithMessagef(err, "cannot find fabric signer for identity [%s:%s]", endorserIDLabel, endorserID)
+	}
+	return endorserID, nil
+}
+
+type rwsWrapper struct {
+	stub *fabric2.RWSet
+}
+
+func (rwset *rwsWrapper) SetState(namespace string, key string, value []byte) error {
+	return rwset.stub.SetState(namespace, key, value)
+}
+
+func (rwset *rwsWrapper) GetState(namespace string, key string) ([]byte, error) {
+	return rwset.stub.GetState(namespace, key)
+}
+
+func (rwset *rwsWrapper) DeleteState(namespace string, key string) error {
+	return rwset.stub.DeleteState(namespace, key)
+}
+
+func (rwset *rwsWrapper) Bytes() ([]byte, error) {
+	return nil, nil
+}
+
+func (rwset *rwsWrapper) Done() {
+}

--- a/token/services/network/fabric/fts/approval.go
+++ b/token/services/network/fabric/fts/approval.go
@@ -228,7 +228,7 @@ func (r *RequestApprovalResponderView) validate(
 
 func (r *RequestApprovalResponderView) endorserID(tms *token2.ManagementService, fns *fabric2.NetworkService) (view.Identity, error) {
 	var endorserIDLabel string
-	if err := tms.Configuration().UnmarshalKey("services.network.fabric.endorsement.id", &endorserIDLabel); err != nil {
+	if err := tms.Configuration().UnmarshalKey("services.network.fabric.fsc_endorsement.id", &endorserIDLabel); err != nil {
 		return nil, errors.WithMessage(err, "failed to load endorserID")
 	}
 	var endorserID view.Identity

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -272,6 +272,11 @@ func (n *Network) Connect(ns string) ([]token2.ServiceOption, error) {
 	if len(ppRaw) != 0 {
 		return []token2.ServiceOption{token2.WithTMSID(tmsID), token2.WithPublicParameter(ppRaw)}, nil
 	}
+	// Let the endorsement service initialize itself, if needed
+	_, err = n.endorsementServiceProvider.Get(tmsID)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "failed to get endorsement service at [%s]", tmsID)
+	}
 	return []token2.ServiceOption{token2.WithTMSID(tmsID)}, nil
 }
 

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -133,10 +133,6 @@ func (l *ledger) Status(id string) (driver.ValidationCode, error) {
 	}
 }
 
-type IdentityProvider interface {
-	Identity(string) view.Identity
-}
-
 type ViewManager interface {
 	InitiateView(view view2.View, ctx context.Context) (interface{}, error)
 }
@@ -146,16 +142,14 @@ type ViewRegistry interface {
 }
 
 type Network struct {
-	n                *fabric.NetworkService
-	ch               *fabric.Channel
-	tmsProvider      *token2.ManagementServiceProvider
-	viewManager      ViewManager
-	viewRegistry     ViewRegistry
-	ledger           *ledger
-	configuration    common2.Configuration
-	filterProvider   common2.TransactionFilterProvider[*common2.AcceptTxInDBsFilter]
-	tokensProvider   *tokens2.Manager
-	identityProvider IdentityProvider
+	n              *fabric.NetworkService
+	ch             *fabric.Channel
+	tmsProvider    *token2.ManagementServiceProvider
+	viewManager    ViewManager
+	ledger         *ledger
+	configuration  common2.Configuration
+	filterProvider common2.TransactionFilterProvider[*common2.AcceptTxInDBsFilter]
+	tokensProvider *tokens2.Manager
 
 	vaultLazyCache      utils.LazyProvider[string, driver.Vault]
 	tokenVaultLazyCache utils.LazyProvider[string, driver.TokenVault]
@@ -168,13 +162,10 @@ func NewNetwork(
 	n *fabric.NetworkService,
 	ch *fabric.Channel,
 	newVault NewVaultFunc,
-	nsFinder common2.NamespaceFinder,
 	configuration common2.Configuration,
 	filterProvider common2.TransactionFilterProvider[*common2.AcceptTxInDBsFilter],
 	tokensProvider *tokens2.Manager,
-	identityProvider IdentityProvider,
 	viewManager ViewManager,
-	viewRegistry ViewRegistry,
 	tmsProvider *token2.ManagementServiceProvider,
 	endorsementServiceProvider *endorsement.ServiceProvider,
 ) *Network {
@@ -187,28 +178,16 @@ func NewNetwork(
 	return &Network{
 		n:                          n,
 		ch:                         ch,
+		tmsProvider:                tmsProvider,
+		viewManager:                viewManager,
+		ledger:                     &ledger{l: ch.Ledger()},
 		configuration:              configuration,
 		filterProvider:             filterProvider,
 		tokensProvider:             tokensProvider,
-		tmsProvider:                tmsProvider,
-		viewManager:                viewManager,
-		viewRegistry:               viewRegistry,
-		ledger:                     &ledger{ch.Ledger()},
-		subscribers:                events.NewSubscribers(),
 		vaultLazyCache:             utils.NewLazyProvider(loader.loadVault),
 		tokenVaultLazyCache:        utils.NewLazyProvider(loader.loadTokenVault),
-		endorsementServiceProvider: endorsementServiceProvider,
-		identityProvider:           identityProvider,
-		n:                          n,
-		ch:                         ch,
-		nsFinder:                   nsFinder,
-		filterProvider:             filterProvider,
-		tokensProvider:             tokensProvider,
-		tmsProvider:                tmsProvider,
-		viewManager:                viewManager,
-		ledger:                     &ledger{ch.Ledger()},
 		subscribers:                events.NewSubscribers(),
-		vaultLazyCache:             utils.NewLazyProvider(loader.load),
+		endorsementServiceProvider: endorsementServiceProvider,
 	}
 }
 

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -138,7 +138,7 @@ type ViewManager interface {
 }
 
 type ViewRegistry interface {
-	RegisterResponder(responder view2.View, initiatedBy interface{}) error
+	RegisterResponder(responder view.View, initiatedBy interface{}) error
 }
 
 type Network struct {

--- a/token/services/network/fabric/processor.go
+++ b/token/services/network/fabric/processor.go
@@ -9,14 +9,11 @@ package fabric
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/keys"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
-
-var logger = logging.MustGetLogger("token-sdk.vault.processor")
 
 type GetTokensFunc = func() (*tokens.Tokens, error)
 type GetTMSProviderFunc = func() *token.ManagementServiceProvider


### PR DESCRIPTION
This PR does the following: It allows the developer to configure FSC nodes as endorsers of the Token Chaincode.
In this case, the FSC node will not run directly the chaincode but its logic directly.