### PR TITLE
observable token services with context

### DIFF
--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -220,13 +220,13 @@ func TestGenFailure(t *testing.T) {
 	testGenRun(gt, tokengen, []string{"gen", "fabtoken", "--output", tempOutput})
 	raw, err := os.ReadFile(filepath.Join(tempOutput, "fabtoken_pp.json"))
 	gt.Expect(err).NotTo(HaveOccurred())
-	_, _, err = token.NewServicesFromPublicParams(raw)
+	_, _, err = token.NewServicesFromPublicParams(nil, token.TMSID{}, raw)
 	gt.Expect(err).NotTo(HaveOccurred())
 
 	testGenRun(gt, tokengen, []string{"gen", "dlog", "--idemix", "./testdata/idemix", "--output", tempOutput})
 	raw, err = os.ReadFile(filepath.Join(tempOutput, "zkatdlog_pp.json"))
 	gt.Expect(err).NotTo(HaveOccurred())
-	_, _, err = token.NewServicesFromPublicParams(raw)
+	_, _, err = token.NewServicesFromPublicParams(nil, token.TMSID{}, raw)
 	gt.Expect(err).NotTo(HaveOccurred())
 }
 

--- a/token/core/common/observables/audit.go
+++ b/token/core/common/observables/audit.go
@@ -43,8 +43,8 @@ func NewObservableAuditorService(auditService driver.AuditorService, metrics *au
 	return &ObservableAuditorService{AuditService: auditService, Metrics: metrics}
 }
 
-func (o *ObservableAuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
-	newContext, span := o.Metrics.auditTracer.Start(context, "check")
+func (o *ObservableAuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
+	newContext, span := o.Metrics.auditTracer.Start(ctx, "check")
 	defer span.End()
 
 	err := o.AuditService.AuditorCheck(newContext, request, metadata, anchor)

--- a/token/core/common/observables/audit.go
+++ b/token/core/common/observables/audit.go
@@ -44,10 +44,10 @@ func NewObservableAuditorService(auditService driver.AuditorService, metrics *au
 }
 
 func (o *ObservableAuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
-	_, span := o.Metrics.auditTracer.Start(context, "check")
+	newContext, span := o.Metrics.auditTracer.Start(context, "check")
 	defer span.End()
 
-	err := o.AuditService.AuditorCheck(context, request, metadata, anchor)
+	err := o.AuditService.AuditorCheck(newContext, request, metadata, anchor)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return err
 }

--- a/token/core/common/observables/audit.go
+++ b/token/core/common/observables/audit.go
@@ -39,11 +39,15 @@ type ObservableAuditorService struct {
 	Metrics      *auditMetrics
 }
 
-func (o *ObservableAuditorService) AuditorCheck(request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
-	_, span := o.Metrics.auditTracer.Start(context.Background(), "check")
+func NewObservableAuditorService(auditService driver.AuditorService, metrics *auditMetrics) *ObservableAuditorService {
+	return &ObservableAuditorService{AuditService: auditService, Metrics: metrics}
+}
+
+func (o *ObservableAuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
+	_, span := o.Metrics.auditTracer.Start(context, "check")
 	defer span.End()
 
-	err := o.AuditService.AuditorCheck(request, metadata, anchor)
+	err := o.AuditService.AuditorCheck(context, request, metadata, anchor)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return err
 }

--- a/token/core/common/observables/issue.go
+++ b/token/core/common/observables/issue.go
@@ -38,8 +38,8 @@ func NewObservableIssueService(issueService driver.IssueService, metrics *issueM
 	return &ObservableIssueService{IssueService: issueService, Metrics: metrics}
 }
 
-func (o *ObservableIssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
-	newContext, span := o.Metrics.issueTracer.Start(context, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
+func (o *ObservableIssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+	newContext, span := o.Metrics.issueTracer.Start(ctx, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
 	defer span.End()
 
 	action, meta, err := o.IssueService.Issue(newContext, issuerIdentity, tokenType, values, owners, opts)

--- a/token/core/common/observables/issue.go
+++ b/token/core/common/observables/issue.go
@@ -38,11 +38,11 @@ func NewObservableIssueService(issueService driver.IssueService, metrics *issueM
 	return &ObservableIssueService{IssueService: issueService, Metrics: metrics}
 }
 
-func (o *ObservableIssueService) Issue(issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
-	_, span := o.Metrics.issueTracer.Start(context.Background(), "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
+func (o *ObservableIssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+	_, span := o.Metrics.issueTracer.Start(context, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
 	defer span.End()
 
-	action, meta, err := o.IssueService.Issue(issuerIdentity, tokenType, values, owners, opts)
+	action, meta, err := o.IssueService.Issue(context, issuerIdentity, tokenType, values, owners, opts)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return action, meta, err
 }

--- a/token/core/common/observables/issue.go
+++ b/token/core/common/observables/issue.go
@@ -39,10 +39,10 @@ func NewObservableIssueService(issueService driver.IssueService, metrics *issueM
 }
 
 func (o *ObservableIssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
-	_, span := o.Metrics.issueTracer.Start(context, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
+	newContext, span := o.Metrics.issueTracer.Start(context, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
 	defer span.End()
 
-	action, meta, err := o.IssueService.Issue(context, issuerIdentity, tokenType, values, owners, opts)
+	action, meta, err := o.IssueService.Issue(newContext, issuerIdentity, tokenType, values, owners, opts)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return action, meta, err
 }

--- a/token/core/common/observables/transfer.go
+++ b/token/core/common/observables/transfer.go
@@ -40,10 +40,10 @@ func NewObservableTransferService(transferService driver.TransferService, metric
 }
 
 func (o *ObservableTransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, ids []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
-	_, span := o.Metrics.transferTracer.Start(context, "transfer")
+	newContext, span := o.Metrics.transferTracer.Start(context, "transfer")
 	defer span.End()
 
-	action, meta, err := o.TransferService.Transfer(context, txID, wallet, ids, Outputs, opts)
+	action, meta, err := o.TransferService.Transfer(newContext, txID, wallet, ids, Outputs, opts)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return action, meta, err
 }

--- a/token/core/common/observables/transfer.go
+++ b/token/core/common/observables/transfer.go
@@ -39,11 +39,11 @@ func NewObservableTransferService(transferService driver.TransferService, metric
 	return &ObservableTransferService{TransferService: transferService, Metrics: metrics}
 }
 
-func (o *ObservableTransferService) Transfer(txID string, wallet driver.OwnerWallet, ids []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
-	_, span := o.Metrics.transferTracer.Start(context.Background(), "transfer")
+func (o *ObservableTransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, ids []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+	_, span := o.Metrics.transferTracer.Start(context, "transfer")
 	defer span.End()
 
-	action, meta, err := o.TransferService.Transfer(txID, wallet, ids, Outputs, opts)
+	action, meta, err := o.TransferService.Transfer(context, txID, wallet, ids, Outputs, opts)
 	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
 	return action, meta, err
 }

--- a/token/core/common/observables/transfer.go
+++ b/token/core/common/observables/transfer.go
@@ -39,8 +39,8 @@ func NewObservableTransferService(transferService driver.TransferService, metric
 	return &ObservableTransferService{TransferService: transferService, Metrics: metrics}
 }
 
-func (o *ObservableTransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, ids []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
-	newContext, span := o.Metrics.transferTracer.Start(context, "transfer")
+func (o *ObservableTransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, ids []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+	newContext, span := o.Metrics.transferTracer.Start(ctx, "transfer")
 	defer span.End()
 
 	action, meta, err := o.TransferService.Transfer(newContext, txID, wallet, ids, Outputs, opts)

--- a/token/core/common/observables/validator.go
+++ b/token/core/common/observables/validator.go
@@ -1,0 +1,52 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package observables
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/metrics"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type validatorMetrics struct {
+	validatorTracer trace.Tracer
+}
+
+func NewValidator(p trace.TracerProvider) *validatorMetrics {
+	return &validatorMetrics{
+		validatorTracer: p.Tracer("validator", tracing.WithMetricsOpts(tracing.MetricsOpts{
+			Namespace:  "token_sdk",
+			LabelNames: metrics.AllLabelNames(SuccessfulLabel),
+		})),
+	}
+}
+
+type ObservableValidator struct {
+	Validator driver.Validator
+	Metrics   *validatorMetrics
+}
+
+func NewObservableValidator(validator driver.Validator, metrics *validatorMetrics) *ObservableValidator {
+	return &ObservableValidator{Validator: validator, Metrics: metrics}
+}
+
+func (o *ObservableValidator) UnmarshalActions(raw []byte) ([]interface{}, error) {
+	return o.Validator.UnmarshalActions(raw)
+}
+
+func (o *ObservableValidator) VerifyTokenRequestFromRaw(ctx context.Context, getState driver.GetStateFnc, anchor string, raw []byte) ([]interface{}, driver.ValidationAttributes, error) {
+	newContext, span := o.Metrics.validatorTracer.Start(ctx, "validate")
+	defer span.End()
+
+	action, meta, err := o.Validator.VerifyTokenRequestFromRaw(newContext, getState, anchor, raw)
+	span.SetAttributes(attribute.Bool(SuccessfulLabel, err == nil))
+	return action, meta, err
+}

--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"context"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/pkg/errors"
@@ -74,7 +76,7 @@ func NewValidator[P driver.PublicParameters, T any, TA driver.TransferAction, IA
 	}
 }
 
-func (v *Validator[P, T, TA, IA]) VerifyTokenRequestFromRaw(getState driver.GetStateFnc, anchor string, raw []byte) ([]interface{}, driver.ValidationAttributes, error) {
+func (v *Validator[P, T, TA, IA]) VerifyTokenRequestFromRaw(ctx context.Context, getState driver.GetStateFnc, anchor string, raw []byte) ([]interface{}, driver.ValidationAttributes, error) {
 	if len(raw) == 0 {
 		return nil, nil, errors.New("empty token request")
 	}

--- a/token/core/fabtoken/auditor.go
+++ b/token/core/fabtoken/auditor.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package fabtoken
 
-import "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+)
 
 type AuditorService struct{}
 
@@ -17,6 +21,6 @@ func NewAuditorService() *AuditorService {
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
 // fabtoken does not make use of AuditorCheck as the token request contains token
 // information in the clear
-func (s *AuditorService) AuditorCheck(tokenRequest *driver.TokenRequest, tokenRequestMetadata *driver.TokenRequestMetadata, txID string) error {
+func (s *AuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
 	return nil
 }

--- a/token/core/fabtoken/auditor.go
+++ b/token/core/fabtoken/auditor.go
@@ -21,6 +21,6 @@ func NewAuditorService() *AuditorService {
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
 // fabtoken does not make use of AuditorCheck as the token request contains token
 // information in the clear
-func (s *AuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
+func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
 	return nil
 }

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -8,10 +8,14 @@ package driver
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	tracing2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/metrics"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/observables"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/tracing"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/config"
@@ -130,6 +134,8 @@ func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, ch
 		return nil, errors.Wrapf(err, "failed to initiliaze public params manager")
 	}
 	deserializer := NewDeserializer()
+	metricsProvider := metrics.NewTMSProvider(tmsID, metrics.GetProvider(sp))
+	tracerProvider := tracing2.NewTracerProviderWithBackingProvider(tracing.GetProvider(sp), metricsProvider)
 	ws := common.NewWalletService(
 		logger,
 		ip,
@@ -148,9 +154,18 @@ func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, ch
 		common.NewSerializer(),
 		deserializer,
 		tmsConfig,
-		fabtoken.NewIssueService(publicParamsManager, ws, deserializer),
-		fabtoken.NewTransferService(logger, publicParamsManager, ws, common.NewVaultTokenLoader(qe), deserializer),
-		fabtoken.NewAuditorService(),
+		observables.NewObservableIssueService(
+			fabtoken.NewIssueService(publicParamsManager, ws, deserializer),
+			observables.NewIssue(tracerProvider),
+		),
+		observables.NewObservableTransferService(
+			fabtoken.NewTransferService(logger, publicParamsManager, ws, common.NewVaultTokenLoader(qe), deserializer),
+			observables.NewTransfer(tracerProvider),
+		),
+		observables.NewObservableAuditorService(
+			fabtoken.NewAuditorService(),
+			observables.NewAudit(tracerProvider),
+		),
 		fabtoken.NewTokensService(),
 	)
 	if err != nil {

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -27,7 +27,7 @@ func NewIssueService(publicParamsManager driver.PublicParamsManager, walletServi
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization OutputMetadata associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
+	"context"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
@@ -25,7 +27,7 @@ func NewIssueService(publicParamsManager driver.PublicParamsManager, walletServi
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization OutputMetadata associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -43,7 +43,7 @@ func NewTransferService(
 
 // Transfer returns a TransferAction as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	// select inputs
 	inputIDs, inputTokens, err := s.TokenLoader.GetTokens(tokenIDs)
 	if err != nil {

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
+	"context"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/meta"
@@ -41,7 +43,7 @@ func NewTransferService(
 
 // Transfer returns a TransferAction as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	// select inputs
 	inputIDs, inputTokens, err := s.TokenLoader.GetTokens(tokenIDs)
 	if err != nil {

--- a/token/core/validator.go
+++ b/token/core/validator.go
@@ -13,10 +13,10 @@ import (
 
 // NewValidator returns a new instance of driver.Validator for the passed parameters.
 // If no driver is registered for the public params' identifier, it returns an error.
-func NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
+func NewValidator(sp driver.ServiceProvider, tmsID driver.TMSID, pp driver.PublicParameters) (driver.Validator, error) {
 	d, ok := holder.Drivers[pp.Identifier()]
 	if !ok {
 		return nil, errors.Errorf("cannot load public paramenters, driver [%s] not found", pp.Identifier())
 	}
-	return d.NewValidator(pp)
+	return d.NewValidator(sp, tmsID, pp)
 }

--- a/token/core/zkatdlog/crypto/validator/validator_test.go
+++ b/token/core/zkatdlog/crypto/validator/validator_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package validator_test
 
 import (
+	"context"
 	"encoding/asn1"
 	"encoding/json"
 	"os"
@@ -133,7 +134,7 @@ var _ = Describe("validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("succeeds", func() {
-				actions, _, err := engine.VerifyTokenRequestFromRaw(fakeLedger.GetStateStub, "1", raw)
+				actions, _, err := engine.VerifyTokenRequestFromRaw(context.TODO(), fakeLedger.GetStateStub, "1", raw)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(actions)).To(Equal(1))
 			})
@@ -168,7 +169,7 @@ var _ = Describe("validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 			It("succeeds", func() {
-				actions, _, err := engine.VerifyTokenRequestFromRaw(getState, "1", raw)
+				actions, _, err := engine.VerifyTokenRequestFromRaw(context.TODO(), getState, "1", raw)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(actions)).To(Equal(1))
 			})
@@ -203,7 +204,7 @@ var _ = Describe("validator", func() {
 
 			})
 			It("succeeds", func() {
-				actions, _, err := engine.VerifyTokenRequestFromRaw(getState, "1", raw)
+				actions, _, err := engine.VerifyTokenRequestFromRaw(context.TODO(), getState, "1", raw)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(actions)).To(Equal(1))
 			})
@@ -240,7 +241,7 @@ var _ = Describe("validator", func() {
 
 			})
 			It("succeeds", func() {
-				actions, _, err := engine.VerifyTokenRequestFromRaw(getState, "2", raw)
+				actions, _, err := engine.VerifyTokenRequestFromRaw(context.TODO(), getState, "2", raw)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(actions)).To(Equal(1))
 			})
@@ -260,7 +261,7 @@ var _ = Describe("validator", func() {
 
 				})
 				It("fails", func() {
-					_, _, err := engine.VerifyTokenRequestFromRaw(getState, "2", raw)
+					_, _, err := engine.VerifyTokenRequestFromRaw(context.TODO(), getState, "2", raw)
 					Expect(err.Error()).To(ContainSubstring("pseudonym signature invalid"))
 
 				})

--- a/token/core/zkatdlog/nogh/auditor.go
+++ b/token/core/zkatdlog/nogh/auditor.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package nogh
 
 import (
+	"context"
+
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
@@ -42,10 +44,10 @@ func NewAuditorService(
 }
 
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
-func (s *AuditorService) AuditorCheck(tokenRequest *driver.TokenRequest, tokenRequestMetadata *driver.TokenRequestMetadata, txID string) error {
-	s.Logger.Debugf("[%s] check token request validity, number of transfer actions [%d]...", txID, len(tokenRequestMetadata.Transfers))
+func (s *AuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, txID string) error {
+	s.Logger.Debugf("[%s] check token request validity, number of transfer actions [%d]...", txID, len(metadata.Transfers))
 	var inputTokens [][]*token.Token
-	for i, transfer := range tokenRequestMetadata.Transfers {
+	for i, transfer := range metadata.Transfers {
 		s.Logger.Debugf("[%s] transfer action [%d] contains [%d] inputs", txID, i, len(transfer.TokenIDs))
 		inputs, err := s.TokenCommitmentLoader.GetTokenOutputs(transfer.TokenIDs)
 		if err != nil {
@@ -65,8 +67,8 @@ func (s *AuditorService) AuditorCheck(tokenRequest *driver.TokenRequest, tokenRe
 		math.Curves[pp.Curve],
 	)
 	err := auditor.Check(
-		tokenRequest,
-		tokenRequestMetadata,
+		request,
+		metadata,
 		inputTokens,
 		txID,
 	)

--- a/token/core/zkatdlog/nogh/auditor.go
+++ b/token/core/zkatdlog/nogh/auditor.go
@@ -44,7 +44,7 @@ func NewAuditorService(
 }
 
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
-func (s *AuditorService) AuditorCheck(context context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, txID string) error {
+func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, txID string) error {
 	s.Logger.Debugf("[%s] check token request validity, number of transfer actions [%d]...", txID, len(metadata.Transfers))
 	var inputTokens [][]*token.Token
 	for i, transfer := range metadata.Transfers {

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -185,12 +185,15 @@ func (d *Driver) NewTokenService(sp driver.ServiceProvider, networkID string, ch
 			),
 			observables.NewTransfer(tracerProvider),
 		),
-		zkatdlog.NewAuditorService(
-			logger,
-			ppm,
-			common.NewLedgerTokenLoader[*token3.Token](logger, qe, tokDeserializer),
-			deserializer,
-			driverMetrics,
+		observables.NewObservableAuditorService(
+			zkatdlog.NewAuditorService(
+				logger,
+				ppm,
+				common.NewLedgerTokenLoader[*token3.Token](logger, qe, tokDeserializer),
+				deserializer,
+				driverMetrics,
+			),
+			observables.NewAudit(tracerProvider),
 		),
 		zkatdlog.NewTokensService(ppm),
 	)

--- a/token/core/zkatdlog/nogh/issue.go
+++ b/token/core/zkatdlog/nogh/issue.go
@@ -42,7 +42,7 @@ func NewIssueService(
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization TokenInformation associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/zkatdlog/nogh/issue.go
+++ b/token/core/zkatdlog/nogh/issue.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package nogh
 
 import (
+	"context"
 	"time"
 
 	common2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
@@ -41,7 +42,7 @@ func NewIssueService(
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization TokenInformation associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(context context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package nogh
 
 import (
+	"context"
 	"time"
 
 	math "github.com/IBM/mathlib"
@@ -50,7 +51,7 @@ func NewTransferService(
 
 // Transfer returns a TransferActionMetadata as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(txID string, wallet driver.OwnerWallet, tokenIDs []*token3.ID, outputTokens []*token3.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token3.ID, outputTokens []*token3.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	s.Logger.Debugf("Prepare Transfer Action [%s,%v]", txID, tokenIDs)
 	// load tokens with the passed token identifiers
 	inputIDs, tokens, inputInf, senders, err := s.TokenLoader.LoadTokens(tokenIDs)

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -51,7 +51,7 @@ func NewTransferService(
 
 // Transfer returns a TransferActionMetadata as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(context context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token3.ID, outputTokens []*token3.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token3.ID, outputTokens []*token3.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	s.Logger.Debugf("Prepare Transfer Action [%s,%v]", txID, tokenIDs)
 	// load tokens with the passed token identifiers
 	inputIDs, tokens, inputInf, senders, err := s.TokenLoader.LoadTokens(tokenIDs)

--- a/token/driver/auditor.go
+++ b/token/driver/auditor.go
@@ -6,8 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import "context"
+
 // AuditorService models the auditor service
 type AuditorService interface {
 	// AuditorCheck verifies the well-formedness of the passed request with the respect to the passed metadata and anchor
-	AuditorCheck(request *TokenRequest, metadata *TokenRequestMetadata, anchor string) error
+	AuditorCheck(context context.Context, request *TokenRequest, metadata *TokenRequestMetadata, anchor string) error
 }

--- a/token/driver/auditor.go
+++ b/token/driver/auditor.go
@@ -11,5 +11,5 @@ import "context"
 // AuditorService models the auditor service
 type AuditorService interface {
 	// AuditorCheck verifies the well-formedness of the passed request with the respect to the passed metadata and anchor
-	AuditorCheck(context context.Context, request *TokenRequest, metadata *TokenRequestMetadata, anchor string) error
+	AuditorCheck(ctx context.Context, request *TokenRequest, metadata *TokenRequestMetadata, anchor string) error
 }

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -21,7 +21,7 @@ type Driver interface {
 	// NewPublicParametersManager returns a new PublicParametersManager instance from the passed public parameters
 	NewPublicParametersManager(pp PublicParameters) (PublicParamsManager, error)
 	// NewValidator returns a new Validator instance from the passed public parameters
-	NewValidator(pp PublicParameters) (Validator, error)
+	NewValidator(sp ServiceProvider, tmsID TMSID, pp PublicParameters) (Validator, error)
 }
 
 // ExtendedDriver is the interface that models additional services a token driver may offer

--- a/token/driver/issue.go
+++ b/token/driver/issue.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import "context"
+
 // IssueOptions models the options that can be passed to the issue command
 type IssueOptions struct {
 	// Attributes is a container of generic options that might be driver specific
@@ -20,7 +22,7 @@ type IssueService interface {
 	// The function returns an IssuerAction, the associated metadata, and the identity of the issuer (depending on the implementation, it can be different from
 	// the one passed in input).
 	// The metadata is an array with an entry for each output created by the action.
-	Issue(issuerIdentity Identity, tokenType string, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
+	Issue(context context.Context, issuerIdentity Identity, tokenType string, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
 
 	// VerifyIssue checks the well-formedness of the passed IssuerAction with the respect to the passed metadata
 	VerifyIssue(tr IssueAction, metadata [][]byte) error

--- a/token/driver/issue.go
+++ b/token/driver/issue.go
@@ -22,7 +22,7 @@ type IssueService interface {
 	// The function returns an IssuerAction, the associated metadata, and the identity of the issuer (depending on the implementation, it can be different from
 	// the one passed in input).
 	// The metadata is an array with an entry for each output created by the action.
-	Issue(context context.Context, issuerIdentity Identity, tokenType string, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
+	Issue(ctx context.Context, issuerIdentity Identity, tokenType string, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
 
 	// VerifyIssue checks the well-formedness of the passed IssuerAction with the respect to the passed metadata
 	VerifyIssue(tr IssueAction, metadata [][]byte) error

--- a/token/driver/mock/ts.go
+++ b/token/driver/mock/ts.go
@@ -2,6 +2,7 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -22,14 +23,15 @@ type TransferService struct {
 		result1 driver.TransferAction
 		result2 error
 	}
-	TransferStub        func(string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)
+	TransferStub        func(context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)
 	transferMutex       sync.RWMutex
 	transferArgsForCall []struct {
-		arg1 string
-		arg2 driver.OwnerWallet
-		arg3 []*token.ID
-		arg4 []*token.Token
-		arg5 *driver.TransferOptions
+		arg1 context.Context
+		arg2 string
+		arg3 driver.OwnerWallet
+		arg4 []*token.ID
+		arg5 []*token.Token
+		arg6 *driver.TransferOptions
 	}
 	transferReturns struct {
 		result1 driver.TransferAction
@@ -126,32 +128,33 @@ func (fake *TransferService) DeserializeTransferActionReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *TransferService) Transfer(arg1 string, arg2 driver.OwnerWallet, arg3 []*token.ID, arg4 []*token.Token, arg5 *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
-	var arg3Copy []*token.ID
-	if arg3 != nil {
-		arg3Copy = make([]*token.ID, len(arg3))
-		copy(arg3Copy, arg3)
-	}
-	var arg4Copy []*token.Token
+func (fake *TransferService) Transfer(arg1 context.Context, arg2 string, arg3 driver.OwnerWallet, arg4 []*token.ID, arg5 []*token.Token, arg6 *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+	var arg4Copy []*token.ID
 	if arg4 != nil {
-		arg4Copy = make([]*token.Token, len(arg4))
+		arg4Copy = make([]*token.ID, len(arg4))
 		copy(arg4Copy, arg4)
+	}
+	var arg5Copy []*token.Token
+	if arg5 != nil {
+		arg5Copy = make([]*token.Token, len(arg5))
+		copy(arg5Copy, arg5)
 	}
 	fake.transferMutex.Lock()
 	ret, specificReturn := fake.transferReturnsOnCall[len(fake.transferArgsForCall)]
 	fake.transferArgsForCall = append(fake.transferArgsForCall, struct {
-		arg1 string
-		arg2 driver.OwnerWallet
-		arg3 []*token.ID
-		arg4 []*token.Token
-		arg5 *driver.TransferOptions
-	}{arg1, arg2, arg3Copy, arg4Copy, arg5})
+		arg1 context.Context
+		arg2 string
+		arg3 driver.OwnerWallet
+		arg4 []*token.ID
+		arg5 []*token.Token
+		arg6 *driver.TransferOptions
+	}{arg1, arg2, arg3, arg4Copy, arg5Copy, arg6})
 	stub := fake.TransferStub
 	fakeReturns := fake.transferReturns
-	fake.recordInvocation("Transfer", []interface{}{arg1, arg2, arg3Copy, arg4Copy, arg5})
+	fake.recordInvocation("Transfer", []interface{}{arg1, arg2, arg3, arg4Copy, arg5Copy, arg6})
 	fake.transferMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -165,17 +168,17 @@ func (fake *TransferService) TransferCallCount() int {
 	return len(fake.transferArgsForCall)
 }
 
-func (fake *TransferService) TransferCalls(stub func(string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)) {
+func (fake *TransferService) TransferCalls(stub func(context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)) {
 	fake.transferMutex.Lock()
 	defer fake.transferMutex.Unlock()
 	fake.TransferStub = stub
 }
 
-func (fake *TransferService) TransferArgsForCall(i int) (string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) {
+func (fake *TransferService) TransferArgsForCall(i int) (context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) {
 	fake.transferMutex.RLock()
 	defer fake.transferMutex.RUnlock()
 	argsForCall := fake.transferArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *TransferService) TransferReturns(result1 driver.TransferAction, result2 *driver.TransferMetadata, result3 error) {

--- a/token/driver/mock/validator.go
+++ b/token/driver/mock/validator.go
@@ -2,6 +2,7 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -21,12 +22,13 @@ type Validator struct {
 		result1 []interface{}
 		result2 error
 	}
-	VerifyTokenRequestFromRawStub        func(func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)
+	VerifyTokenRequestFromRawStub        func(context.Context, func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)
 	verifyTokenRequestFromRawMutex       sync.RWMutex
 	verifyTokenRequestFromRawArgsForCall []struct {
-		arg1 func(key string) ([]byte, error)
-		arg2 string
-		arg3 []byte
+		arg1 context.Context
+		arg2 func(key string) ([]byte, error)
+		arg3 string
+		arg4 []byte
 	}
 	verifyTokenRequestFromRawReturns struct {
 		result1 []interface{}
@@ -111,25 +113,26 @@ func (fake *Validator) UnmarshalActionsReturnsOnCall(i int, result1 []interface{
 	}{result1, result2}
 }
 
-func (fake *Validator) VerifyTokenRequestFromRaw(arg1 func(key string) ([]byte, error), arg2 string, arg3 []byte) ([]interface{}, map[string][]byte, error) {
-	var arg3Copy []byte
-	if arg3 != nil {
-		arg3Copy = make([]byte, len(arg3))
-		copy(arg3Copy, arg3)
+func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func(key string) ([]byte, error), arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	ret, specificReturn := fake.verifyTokenRequestFromRawReturnsOnCall[len(fake.verifyTokenRequestFromRawArgsForCall)]
 	fake.verifyTokenRequestFromRawArgsForCall = append(fake.verifyTokenRequestFromRawArgsForCall, struct {
-		arg1 func(key string) ([]byte, error)
-		arg2 string
-		arg3 []byte
-	}{arg1, arg2, arg3Copy})
+		arg1 context.Context
+		arg2 func(key string) ([]byte, error)
+		arg3 string
+		arg4 []byte
+	}{arg1, arg2, arg3, arg4Copy})
 	stub := fake.VerifyTokenRequestFromRawStub
 	fakeReturns := fake.verifyTokenRequestFromRawReturns
-	fake.recordInvocation("VerifyTokenRequestFromRaw", []interface{}{arg1, arg2, arg3Copy})
+	fake.recordInvocation("VerifyTokenRequestFromRaw", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.verifyTokenRequestFromRawMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -143,17 +146,17 @@ func (fake *Validator) VerifyTokenRequestFromRawCallCount() int {
 	return len(fake.verifyTokenRequestFromRawArgsForCall)
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)) {
+func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(context.Context, func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)) {
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	defer fake.verifyTokenRequestFromRawMutex.Unlock()
 	fake.VerifyTokenRequestFromRawStub = stub
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (func(key string) ([]byte, error), string, []byte) {
+func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (context.Context, func(key string) ([]byte, error), string, []byte) {
 	fake.verifyTokenRequestFromRawMutex.RLock()
 	defer fake.verifyTokenRequestFromRawMutex.RUnlock()
 	argsForCall := fake.verifyTokenRequestFromRawArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *Validator) VerifyTokenRequestFromRawReturns(result1 []interface{}, result2 map[string][]byte, result3 error) {

--- a/token/driver/transfer.go
+++ b/token/driver/transfer.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package driver
 
 import (
+	"context"
+
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
@@ -23,7 +25,7 @@ type TransferService interface {
 	// Transfer generates a TransferAction that spend the passed token ids and created the passed outputs.
 	// In addition, a set of options can be specified to further customize the transfer command.
 	// The function returns an TransferAction and the associated metadata.
-	Transfer(txID string, wallet OwnerWallet, ids []*token2.ID, Outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
+	Transfer(context context.Context, txID string, wallet OwnerWallet, ids []*token2.ID, Outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
 
 	// VerifyTransfer checks the well-formedness of the passed TransferAction with the respect to the passed output metadata
 	VerifyTransfer(tr TransferAction, tokenInfos [][]byte) error

--- a/token/driver/transfer.go
+++ b/token/driver/transfer.go
@@ -25,7 +25,7 @@ type TransferService interface {
 	// Transfer generates a TransferAction that spend the passed token ids and created the passed outputs.
 	// In addition, a set of options can be specified to further customize the transfer command.
 	// The function returns an TransferAction and the associated metadata.
-	Transfer(context context.Context, txID string, wallet OwnerWallet, ids []*token2.ID, Outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
+	Transfer(ctx context.Context, txID string, wallet OwnerWallet, ids []*token2.ID, Outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
 
 	// VerifyTransfer checks the well-formedness of the passed TransferAction with the respect to the passed output metadata
 	VerifyTransfer(tr TransferAction, tokenInfos [][]byte) error

--- a/token/driver/validator.go
+++ b/token/driver/validator.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import "context"
+
 // ValidationAttributeID is the type of validation attribute identifier
 type ValidationAttributeID = string
 
@@ -42,5 +44,5 @@ type Validator interface {
 	// VerifyTokenRequestFromRaw verifies the passed marshalled token request against the passed ledger and anchor.
 	// The function returns additionally a map that contains information about the token request. The content of this map
 	// is driver-dependant
-	VerifyTokenRequestFromRaw(getState GetStateFnc, anchor string, raw []byte) ([]interface{}, ValidationAttributes, error)
+	VerifyTokenRequestFromRaw(ctx context.Context, getState GetStateFnc, anchor string, raw []byte) ([]interface{}, ValidationAttributes, error)
 }

--- a/token/request.go
+++ b/token/request.go
@@ -219,7 +219,7 @@ func (r *Request) ID() string {
 // Issue appends an issue action to the request. The action will be prepared using the provided issuer wallet.
 // The action issues to the receiver a token of the passed type and quantity.
 // Additional options can be passed to customize the action.
-func (r *Request) Issue(context context.Context, wallet *IssuerWallet, receiver Identity, typ string, q uint64, opts ...IssueOption) (*IssueAction, error) {
+func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Identity, typ string, q uint64, opts ...IssueOption) (*IssueAction, error) {
 	if wallet == nil {
 		return nil, errors.Errorf("wallet is nil")
 	}
@@ -250,7 +250,7 @@ func (r *Request) Issue(context context.Context, wallet *IssuerWallet, receiver 
 
 	// Compute Issue
 	action, meta, err := r.TokenService.tms.IssueService().Issue(
-		context,
+		ctx,
 		id,
 		typ,
 		[]uint64{q},
@@ -278,7 +278,7 @@ func (r *Request) Issue(context context.Context, wallet *IssuerWallet, receiver 
 // The action transfers tokens of the passed types to the receivers for the passed quantities.
 // In other words, owners[0] will receives values[0], and so on.
 // Additional options can be passed to customize the action.
-func (r *Request) Transfer(context context.Context, wallet *OwnerWallet, typ string, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
+func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ string, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
 	for _, v := range values {
 		if v == 0 {
 			return nil, errors.Errorf("value is zero")
@@ -299,7 +299,7 @@ func (r *Request) Transfer(context context.Context, wallet *OwnerWallet, typ str
 
 	// Compute transfer
 	transfer, transferMetadata, err := ts.Transfer(
-		context,
+		ctx,
 		r.Anchor,
 		wallet.w,
 		tokenIDs,
@@ -332,7 +332,7 @@ func (r *Request) Transfer(context context.Context, wallet *OwnerWallet, typ str
 // Redeem appends a redeem action to the request. The action will be prepared using the provided owner wallet.
 // The action redeems tokens of the passed type for a total amount matching the passed value.
 // Additional options can be passed to customize the action.
-func (r *Request) Redeem(context context.Context, wallet *OwnerWallet, typ string, value uint64, opts ...TransferOption) error {
+func (r *Request) Redeem(ctx context.Context, wallet *OwnerWallet, typ string, value uint64, opts ...TransferOption) error {
 	opt, err := compileTransferOptions(opts...)
 	if err != nil {
 		return errors.WithMessagef(err, "failed compiling options [%v]", opts)
@@ -348,7 +348,7 @@ func (r *Request) Redeem(context context.Context, wallet *OwnerWallet, typ strin
 
 	// Compute redeem, it is a transfer with owner set to nil
 	transfer, transferMetadata, err := ts.Transfer(
-		context,
+		ctx,
 		r.Anchor,
 		wallet.w,
 		tokenIDs,
@@ -975,13 +975,13 @@ func (r *Request) Transfers() []*Transfer {
 
 // AuditCheck performs the audit check of the request in addition to
 // the checks of the token request itself via IsValid.
-func (r *Request) AuditCheck(context context.Context) error {
+func (r *Request) AuditCheck(ctx context.Context) error {
 	r.TokenService.logger.Debugf("audit check request [%s] on tms [%s]", r.Anchor, r.TokenService.ID())
 	if err := r.IsValid(); err != nil {
 		return err
 	}
 	return r.TokenService.tms.AuditorService().AuditorCheck(
-		context,
+		ctx,
 		r.Actions,
 		r.Metadata,
 		r.Anchor,

--- a/token/request.go
+++ b/token/request.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
+	"context"
 	"encoding/asn1"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/meta"
@@ -218,7 +219,7 @@ func (r *Request) ID() string {
 // Issue appends an issue action to the request. The action will be prepared using the provided issuer wallet.
 // The action issues to the receiver a token of the passed type and quantity.
 // Additional options can be passed to customize the action.
-func (r *Request) Issue(wallet *IssuerWallet, receiver Identity, typ string, q uint64, opts ...IssueOption) (*IssueAction, error) {
+func (r *Request) Issue(context context.Context, wallet *IssuerWallet, receiver Identity, typ string, q uint64, opts ...IssueOption) (*IssueAction, error) {
 	if wallet == nil {
 		return nil, errors.Errorf("wallet is nil")
 	}
@@ -249,6 +250,7 @@ func (r *Request) Issue(wallet *IssuerWallet, receiver Identity, typ string, q u
 
 	// Compute Issue
 	action, meta, err := r.TokenService.tms.IssueService().Issue(
+		context,
 		id,
 		typ,
 		[]uint64{q},
@@ -276,7 +278,7 @@ func (r *Request) Issue(wallet *IssuerWallet, receiver Identity, typ string, q u
 // The action transfers tokens of the passed types to the receivers for the passed quantities.
 // In other words, owners[0] will receives values[0], and so on.
 // Additional options can be passed to customize the action.
-func (r *Request) Transfer(wallet *OwnerWallet, typ string, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
+func (r *Request) Transfer(context context.Context, wallet *OwnerWallet, typ string, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
 	for _, v := range values {
 		if v == 0 {
 			return nil, errors.Errorf("value is zero")
@@ -297,6 +299,7 @@ func (r *Request) Transfer(wallet *OwnerWallet, typ string, values []uint64, own
 
 	// Compute transfer
 	transfer, transferMetadata, err := ts.Transfer(
+		context,
 		r.Anchor,
 		wallet.w,
 		tokenIDs,
@@ -329,7 +332,7 @@ func (r *Request) Transfer(wallet *OwnerWallet, typ string, values []uint64, own
 // Redeem appends a redeem action to the request. The action will be prepared using the provided owner wallet.
 // The action redeems tokens of the passed type for a total amount matching the passed value.
 // Additional options can be passed to customize the action.
-func (r *Request) Redeem(wallet *OwnerWallet, typ string, value uint64, opts ...TransferOption) error {
+func (r *Request) Redeem(context context.Context, wallet *OwnerWallet, typ string, value uint64, opts ...TransferOption) error {
 	opt, err := compileTransferOptions(opts...)
 	if err != nil {
 		return errors.WithMessagef(err, "failed compiling options [%v]", opts)
@@ -345,6 +348,7 @@ func (r *Request) Redeem(wallet *OwnerWallet, typ string, value uint64, opts ...
 
 	// Compute redeem, it is a transfer with owner set to nil
 	transfer, transferMetadata, err := ts.Transfer(
+		context,
 		r.Anchor,
 		wallet.w,
 		tokenIDs,
@@ -971,12 +975,13 @@ func (r *Request) Transfers() []*Transfer {
 
 // AuditCheck performs the audit check of the request in addition to
 // the checks of the token request itself via IsValid.
-func (r *Request) AuditCheck() error {
+func (r *Request) AuditCheck(context context.Context) error {
 	r.TokenService.logger.Debugf("audit check request [%s] on tms [%s]", r.Anchor, r.TokenService.ID())
 	if err := r.IsValid(); err != nil {
 		return err
 	}
 	return r.TokenService.tms.AuditorService().AuditorCheck(
+		context,
 		r.Actions,
 		r.Metadata,
 		r.Anchor,

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package auditor
 
 import (
+	"context"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
@@ -56,8 +58,8 @@ type Auditor struct {
 }
 
 // Validate validates the passed token request
-func (a *Auditor) Validate(request *token.Request) error {
-	return request.AuditCheck()
+func (a *Auditor) Validate(context context.Context, request *token.Request) error {
+	return request.AuditCheck(context)
 }
 
 // Audit extracts the list of inputs and outputs from the passed transaction.

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -180,6 +180,7 @@ func (t *Transaction) Lock(wallet *token.OwnerWallet, sender view.Identity, typ 
 		return nil, err
 	}
 	_, err = t.TokenRequest.Transfer(
+		t.Transaction.Context,
 		wallet,
 		typ,
 		[]uint64{value},

--- a/token/services/network/fabric/tcc/main/main.go
+++ b/token/services/network/fabric/tcc/main/main.go
@@ -65,7 +65,7 @@ func main() {
 		err := shim.Start(
 			&tcc.TokenChaincode{
 				TokenServicesFactory: func(bytes []byte) (tcc.PublicParameters, tcc.Validator, error) {
-					ppm, v, err := token.NewServicesFromPublicParams(bytes)
+					ppm, v, err := token.NewServicesFromPublicParams(nil, token.TMSID{}, bytes)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -105,7 +105,7 @@ func main() {
 			Address: config.CCaddress,
 			CC: &tcc.TokenChaincode{
 				TokenServicesFactory: func(bytes []byte) (tcc.PublicParameters, tcc.Validator, error) {
-					ppm, v, err := token.NewServicesFromPublicParams(bytes)
+					ppm, v, err := token.NewServicesFromPublicParams(nil, token.TMSID{}, bytes)
 					if err != nil {
 						return nil, nil, err
 					}

--- a/token/services/network/fabric/tcc/mock/validator.go
+++ b/token/services/network/fabric/tcc/mock/validator.go
@@ -2,19 +2,21 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/tcc"
 )
 
 type Validator struct {
-	UnmarshallAndVerifyWithMetadataStub        func(token.Ledger, string, []byte) ([]interface{}, map[string][]byte, error)
+	UnmarshallAndVerifyWithMetadataStub        func(context.Context, driver.ValidatorLedger, string, []byte) ([]interface{}, map[string][]byte, error)
 	unmarshallAndVerifyWithMetadataMutex       sync.RWMutex
 	unmarshallAndVerifyWithMetadataArgsForCall []struct {
-		arg1 token.Ledger
-		arg2 string
-		arg3 []byte
+		arg1 context.Context
+		arg2 driver.ValidatorLedger
+		arg3 string
+		arg4 []byte
 	}
 	unmarshallAndVerifyWithMetadataReturns struct {
 		result1 []interface{}
@@ -30,25 +32,26 @@ type Validator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 token.Ledger, arg2 string, arg3 []byte) ([]interface{}, map[string][]byte, error) {
-	var arg3Copy []byte
-	if arg3 != nil {
-		arg3Copy = make([]byte, len(arg3))
-		copy(arg3Copy, arg3)
+func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 context.Context, arg2 driver.ValidatorLedger, arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
+	var arg4Copy []byte
+	if arg4 != nil {
+		arg4Copy = make([]byte, len(arg4))
+		copy(arg4Copy, arg4)
 	}
 	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
 	ret, specificReturn := fake.unmarshallAndVerifyWithMetadataReturnsOnCall[len(fake.unmarshallAndVerifyWithMetadataArgsForCall)]
 	fake.unmarshallAndVerifyWithMetadataArgsForCall = append(fake.unmarshallAndVerifyWithMetadataArgsForCall, struct {
-		arg1 token.Ledger
-		arg2 string
-		arg3 []byte
-	}{arg1, arg2, arg3Copy})
+		arg1 context.Context
+		arg2 driver.ValidatorLedger
+		arg3 string
+		arg4 []byte
+	}{arg1, arg2, arg3, arg4Copy})
 	stub := fake.UnmarshallAndVerifyWithMetadataStub
 	fakeReturns := fake.unmarshallAndVerifyWithMetadataReturns
-	fake.recordInvocation("UnmarshallAndVerifyWithMetadata", []interface{}{arg1, arg2, arg3Copy})
+	fake.recordInvocation("UnmarshallAndVerifyWithMetadata", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
@@ -62,17 +65,17 @@ func (fake *Validator) UnmarshallAndVerifyWithMetadataCallCount() int {
 	return len(fake.unmarshallAndVerifyWithMetadataArgsForCall)
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadataCalls(stub func(token.Ledger, string, []byte) ([]interface{}, map[string][]byte, error)) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataCalls(stub func(context.Context, driver.ValidatorLedger, string, []byte) ([]interface{}, map[string][]byte, error)) {
 	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
 	defer fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
 	fake.UnmarshallAndVerifyWithMetadataStub = stub
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadataArgsForCall(i int) (token.Ledger, string, []byte) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataArgsForCall(i int) (context.Context, driver.ValidatorLedger, string, []byte) {
 	fake.unmarshallAndVerifyWithMetadataMutex.RLock()
 	defer fake.unmarshallAndVerifyWithMetadataMutex.RUnlock()
 	argsForCall := fake.unmarshallAndVerifyWithMetadataArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *Validator) UnmarshallAndVerifyWithMetadataReturns(result1 []interface{}, result2 map[string][]byte, result3 error) {

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package tcc
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -50,7 +51,7 @@ func (a *SetupAction) GetSetupParameters() ([]byte, error) {
 //go:generate counterfeiter -o mock/validator.go -fake-name Validator . Validator
 
 type Validator interface {
-	UnmarshallAndVerifyWithMetadata(ledger token.Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error)
+	UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger token.Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error)
 }
 
 //go:generate counterfeiter -o mock/public_parameters_manager.go -fake-name PublicParametersManager . PublicParametersManager
@@ -216,7 +217,7 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 	}
 
 	// Verify
-	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(stub, stub.GetTxID(), raw)
+	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(context.Background(), stub, stub.GetTxID(), raw)
 	if err != nil {
 		return shim.Error("failed to verify token request: " + err.Error())
 	}

--- a/token/services/network/orion/approval.go
+++ b/token/services/network/orion/approval.go
@@ -97,7 +97,14 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read public parameters")
 	}
-	_, validator, err := token.NewServicesFromPublicParams(ppRaw)
+	_, validator, err := token.NewServicesFromPublicParams(
+		context,
+		token.TMSID{
+			Network:   request.Network,
+			Namespace: request.Namespace,
+		},
+		ppRaw,
+	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create validator")
 	}
@@ -122,6 +129,7 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 	}
 
 	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(
+		context.Context(),
 		&LedgerWrapper{qe: qe},
 		request.TxID,
 		request.Request,

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -49,7 +49,7 @@ func NewAuditor(sp token.ServiceProvider, w *token.AuditorWallet) (*TxAuditor, e
 }
 
 func (a *TxAuditor) Validate(tx *Transaction) error {
-	return a.auditor.Validate(tx.TokenRequest)
+	return a.auditor.Validate(tx.Context, tx.TokenRequest)
 }
 
 func (a *TxAuditor) Audit(tx *Transaction) (*token.InputStream, *token.OutputStream, error) {

--- a/token/services/ttx/support.go
+++ b/token/services/ttx/support.go
@@ -16,7 +16,7 @@ func StoreTransactionRecords(context view.Context, tx *Transaction) error {
 	return NewOwner(context, tx.TokenRequest.TokenService).Append(tx)
 }
 
-// RunView runs passed view within the passed context and using the passed options in a separate goroutine
+// RunView runs passed view within the passed Context and using the passed options in a separate goroutine
 func RunView(context view.Context, view view.View, opts ...view.RunViewOption) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/token/tms.go
+++ b/token/tms.go
@@ -303,7 +303,7 @@ func GetManagementService(sp ServiceProvider, opts ...ServiceOption) *Management
 
 // NewServicesFromPublicParams uses the passed marshalled public parameters to create an instance
 // of PublicParametersManager and a new instance of Validator.
-func NewServicesFromPublicParams(params []byte) (*PublicParametersManager, *Validator, error) {
+func NewServicesFromPublicParams(sp ServiceProvider, tmsID TMSID, params []byte) (*PublicParametersManager, *Validator, error) {
 	logger.Debugf("unmarshall public parameters...")
 	pp, err := core.PublicParametersFromBytes(params)
 	if err != nil {
@@ -317,7 +317,7 @@ func NewServicesFromPublicParams(params []byte) (*PublicParametersManager, *Vali
 	}
 
 	logger.Debugf("instantiate validator...")
-	validator, err := core.NewValidator(pp)
+	validator, err := core.NewValidator(sp, tmsID, pp)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed instantiating validator")
 	}

--- a/token/validator.go
+++ b/token/validator.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
+	"context"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 )
 
@@ -24,8 +26,8 @@ func (c *Validator) UnmarshalActions(raw []byte) ([]interface{}, error) {
 }
 
 // UnmarshallAndVerify unmarshalls the token request and verifies it against the passed ledger and anchor
-func (c *Validator) UnmarshallAndVerify(ledger Ledger, anchor string, raw []byte) ([]interface{}, error) {
-	actions, _, err := c.backend.VerifyTokenRequestFromRaw(ledger.GetState, anchor, raw)
+func (c *Validator) UnmarshallAndVerify(ctx context.Context, ledger Ledger, anchor string, raw []byte) ([]interface{}, error) {
+	actions, _, err := c.backend.VerifyTokenRequestFromRaw(ctx, ledger.GetState, anchor, raw)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +39,8 @@ func (c *Validator) UnmarshallAndVerify(ledger Ledger, anchor string, raw []byte
 
 // UnmarshallAndVerifyWithMetadata behaves as UnmarshallAndVerify. In addition, it returns the metadata extracts from the token request
 // in the form of map.
-func (c *Validator) UnmarshallAndVerifyWithMetadata(ledger Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error) {
-	actions, meta, err := c.backend.VerifyTokenRequestFromRaw(ledger.GetState, anchor, raw)
+func (c *Validator) UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error) {
+	actions, meta, err := c.backend.VerifyTokenRequestFromRaw(ctx, ledger.GetState, anchor, raw)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/token/validator_test.go
+++ b/token/validator_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/mock"
@@ -43,7 +44,7 @@ func TestValidator_UnmarshallAndVerify(t *testing.T) {
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(expectedActions, nil, nil)
 
-	actions, err := validator.UnmarshallAndVerify(mockLedger, anchor, raw)
+	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, anchor, raw)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedActions, actions)
@@ -61,7 +62,7 @@ func TestValidator_UnmarshallAndVerifyWithMetadata(t *testing.T) {
 	expectedMetadata := map[string][]byte{"key1": []byte("value1"), "key2": []byte("value2")}
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(expectedActions, expectedMetadata, nil)
-	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(mockLedger, anchor, raw)
+	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, anchor, raw)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedActions, actions)
@@ -94,7 +95,7 @@ func TestValidator_UnmarshallAndVerify_Error(t *testing.T) {
 
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(nil, nil, errors.New("mocked error"))
-	actions, err := validator.UnmarshallAndVerify(mockLedger, anchor, raw)
+	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, anchor, raw)
 
 	assert.Error(t, err)
 	assert.Nil(t, actions)
@@ -110,7 +111,7 @@ func TestValidator_UnmarshallAndVerifyWithMetadata_Error(t *testing.T) {
 
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(nil, nil, errors.New("mocked error"))
-	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(mockLedger, anchor, raw)
+	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, anchor, raw)
 	assert.Error(t, err)
 	assert.Nil(t, actions)
 	assert.Nil(t, metadata)


### PR DESCRIPTION
This PR does the following:
- Adding context to the token driver issue, transfer, and audit service
- Install observable services for both fabtoken and dlog