### PR TITLE
fix data race in local membership

### DIFF
--- a/token/services/identity/msp/idemix/lm.go
+++ b/token/services/identity/msp/idemix/lm.go
@@ -111,6 +111,12 @@ func (l *LocalMembership) GetIdentifier(id driver.Identity) (string, error) {
 }
 
 func (l *LocalMembership) GetDefaultIdentifier() string {
+	l.resolversMutex.RLock()
+	defer l.resolversMutex.RUnlock()
+	return l.getDefaultIdentifier()
+}
+
+func (l *LocalMembership) getDefaultIdentifier() string {
 	for _, resolver := range l.resolvers {
 		if resolver.Default {
 			return resolver.Name
@@ -148,7 +154,7 @@ func (l *LocalMembership) RegisterIdentity(idConfig driver.IdentityConfiguration
 	l.resolversMutex.Lock()
 	defer l.resolversMutex.Unlock()
 
-	return l.registerIdentityConfiguration(idConfig, l.GetDefaultIdentifier() == "")
+	return l.registerIdentityConfiguration(idConfig, l.getDefaultIdentifier() == "")
 }
 
 func (l *LocalMembership) IDs() ([]string, error) {
@@ -187,7 +193,7 @@ func (l *LocalMembership) Load() error {
 	logger.Debugf("load identities from storage...done")
 
 	// if no default identity, use the first one
-	defaultIdentifier := l.GetDefaultIdentifier()
+	defaultIdentifier := l.getDefaultIdentifier()
 	if len(defaultIdentifier) == 0 {
 		logger.Warnf("no default identity, use the first one available")
 		if len(l.resolvers) > 0 {
@@ -385,7 +391,7 @@ func (l *LocalMembership) loadFromStorage() error {
 			URL:    entry.URL,
 			Config: entry.Config,
 			Raw:    entry.Raw,
-		}, l.GetDefaultIdentifier() == ""); err != nil {
+		}, l.getDefaultIdentifier() == ""); err != nil {
 			return err
 		}
 	}

--- a/token/services/identity/msp/x509/lm.go
+++ b/token/services/identity/msp/x509/lm.go
@@ -95,7 +95,7 @@ func (lm *LocalMembership) Load(identities []*config.Identity) error {
 	logger.Debugf("load identities from storage...done")
 
 	// if no default identity, use the first one
-	defaultIdentifier := lm.GetDefaultIdentifier()
+	defaultIdentifier := lm.getDefaultIdentifier()
 	if len(defaultIdentifier) == 0 {
 		logger.Warnf("no default identity, use the first one available")
 		if len(lm.resolvers) > 0 {
@@ -134,6 +134,12 @@ func (lm *LocalMembership) GetIdentifier(id driver.Identity) (string, error) {
 }
 
 func (lm *LocalMembership) GetDefaultIdentifier() string {
+	lm.resolversMutex.RLock()
+	defer lm.resolversMutex.RUnlock()
+	return lm.getDefaultIdentifier()
+}
+
+func (lm *LocalMembership) getDefaultIdentifier() string {
 	for _, resolver := range lm.resolvers {
 		if resolver.Default {
 			return resolver.Name
@@ -180,7 +186,7 @@ func (lm *LocalMembership) RegisterIdentity(idConfig driver.IdentityConfiguratio
 			return errors.Wrapf(err, "failed to load msp config [%s]", idConfig.ID)
 		}
 	}
-	return lm.registerIdentity(mspConfig, identityConfig, lm.GetDefaultIdentifier() == "")
+	return lm.registerIdentity(mspConfig, identityConfig, lm.getDefaultIdentifier() == "")
 }
 
 func (lm *LocalMembership) IDs() ([]string, error) {


### PR DESCRIPTION
Prevent some data race for the function `GetDefaultIdentifier` (reading list of resolvers) when called from `mapStringToID`