### PR TITLE
hide pkcs11 behind a build tag so that token sdk is pure go by default

### DIFF
--- a/ci/scripts/setup_softhsm.sh
+++ b/ci/scripts/setup_softhsm.sh
@@ -20,7 +20,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # softhsm2-util --delete-token --token "ForFSC" || true
 
     echo "Initializing tokens..."
-    softhsm2-util --init-token --slot 13 --label "ForFSC" --so-pin 1234 --pin 98765432
+    softhsm2-util --init-token --free --label "ForFSC" --so-pin 1234 --pin 98765432
 
 else
 

--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -102,18 +102,20 @@ token:
             path: /path/to/issuer-wallet
             # additional options that can be used to instantiated the wallet.
             # options are driver dependent. With `fabtoken` and `dlog` drivers,
-            # the following options apply
+            # the following options apply.
             opts:
               BCCSP:
                 Default: SW
+                SW:
+                  Hash: SHA2
+                  Security: 256
+                # The following only needs to be defined if the BCCSP Default is set to PKCS11.
+                # NOTE: in order to use pkcs11, you have to build the application with "go build -tags pkcs11"
                 PKCS11:
                   Hash: SHA2
                   Label: null
                   Library: null
                   Pin: null
-                  Security: 256
-                SW:
-                  Hash: SHA2
                   Security: 256
         # auditor wallets
         auditors:

--- a/docs/deployment/deployment.md
+++ b/docs/deployment/deployment.md
@@ -57,3 +57,9 @@ func main() {
 	})
 }
 ```
+
+## HSM Support
+
+In order to use a hardware HSM for x.509 identities, you have to build the application with
+`CGO_ENABLED=1 go build -tags pkcs11` and configure the PKCS11 settings in the configuration
+file (see [core-token.md](../core-token.md)).

--- a/fungible.mk
+++ b/fungible.mk
@@ -63,7 +63,7 @@ integration-tests-dloghsm-fabric: install-softhsm
 	@echo "Setup SoftHSM"
 	@./ci/scripts/setup_softhsm.sh
 	@echo "Start Integration Test"
-	cd ./integration/token/fungible/dloghsm; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --label-filter="$(TEST_FILTER)" .
+	cd ./integration/token/fungible/dloghsm; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --tags pkcs11 --label-filter="$(TEST_FILTER)" .
 
 .PHONY: integration-tests-fabtoken-fabric-t1
 integration-tests-fabtoken-fabric-t1:
@@ -87,7 +87,7 @@ integration-tests-fabtoken-fabric-t5:
 
 .PHONY: integration-tests-fabtoken-fabric
 integration-tests-fabtoken-fabric:
-	cd ./integration/token/fungible/fabtoken; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --label-filter="$(TEST_FILTER)" .
+	cd ./integration/token/fungible/fabtoken; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --tags pkcs11 --label-filter="$(TEST_FILTER)" .
 
 .PHONY: integration-tests-dlog-orion
 integration-tests-dlog-orion:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da
 	github.com/dgraph-io/badger/v3 v3.2103.2
 	github.com/hashicorp/go-uuid v1.0.2
-	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240724173042-088844238ec3
+	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240805090211-ae3778fa9aac
 	github.com/hyperledger-labs/fabric-token-sdk/txgen v0.0.0-00010101000000-000000000000
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/huin/goupnp v1.2.0 h1:uOKW26NG1hsSSbXIZ1IR7XP9Gjd1U8pnLaCMgntmkmY=
 github.com/huin/goupnp v1.2.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240724173042-088844238ec3 h1:XqxKaspPPyty8w4LlIIKUcMEp2zi5QCvnia+2YVW6ME=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240724173042-088844238ec3/go.mod h1:o/L/+Apv/hCHFVIQNIiYJcHh1Sl0LGSc2kAWJAeFLB0=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240805090211-ae3778fa9aac h1:tarUHl0o/9a9q5IcZn6CLWL7Qv/en1SZD2dJ2oD/Xb4=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240805090211-ae3778fa9aac/go.mod h1:o/L/+Apv/hCHFVIQNIiYJcHh1Sl0LGSc2kAWJAeFLB0=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/integration/nwo/token/generators/dlog/dlog_test.go
+++ b/integration/nwo/token/generators/dlog/dlog_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestDLogFabricCryptoMaterialGenerator_Setup(t *testing.T) {
 	gomega.RegisterTestingT(t)
-	buildServer := common.NewBuildServer()
+	buildServer := common.NewBuildServer("-tags", "pkcs11")
 	buildServer.Serve()
 	defer buildServer.Shutdown(true)
 

--- a/token/services/identity/msp/x509/msp/bccsp.go
+++ b/token/services/identity/msp/x509/msp/bccsp.go
@@ -10,8 +10,8 @@ import (
 	"encoding/hex"
 	"path/filepath"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/msp/x509/msp/pkcs11"
 	"github.com/hyperledger/fabric/bccsp"
-	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/hyperledger/fabric/bccsp/sw"
 	"github.com/pkg/errors"
 )
@@ -42,14 +42,12 @@ func GetPKCS11BCCSP(conf *BCCSP) (bccsp.BCCSP, bccsp.KeyStore, error) {
 		return nil, nil, errors.New("invalid BCCSP.PKCS11. missing configuration")
 	}
 
-	p11Opts := *conf.PKCS11
+	p11Opts := conf.PKCS11
 	ks := sw.NewDummyKeyStore()
-	mapper := skiMapper(p11Opts)
-	csp, err := pkcs11.New(*ToPKCS11OptsOpts(&p11Opts), ks, pkcs11.WithKeyMapper(mapper))
-	if err != nil {
-		return nil, nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", p11Opts)
-	}
-	return csp, ks, nil
+	opts := ToPKCS11OptsOpts(p11Opts)
+	csp, err := pkcs11.NewProvider(*opts, ks, skiMapper(*p11Opts))
+
+	return csp, ks, err
 }
 
 func skiMapper(p11Opts PKCS11) func([]byte) []byte {

--- a/token/services/identity/msp/x509/msp/pkcs11/disabled.go
+++ b/token/services/identity/msp/x509/msp/pkcs11/disabled.go
@@ -1,0 +1,45 @@
+//go:build !pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pkcs11
+
+import (
+	"github.com/hyperledger/fabric/bccsp"
+)
+
+type KeyIDMapping struct {
+	SKI string `yaml:"SKI,omitempty"`
+	ID  string `yaml:"ID,omitempty"`
+}
+
+type PKCS11Opts struct {
+	// Default algorithms when not specified (Deprecated?)
+	Security int    `yaml:"Security"`
+	Hash     string `yaml:"Hash"`
+
+	// PKCS11 options
+	Library        string         `yaml:"Library"`
+	Label          string         `yaml:"Label"`
+	Pin            string         `yaml:"Pin"`
+	SoftwareVerify bool           `yaml:"SoftwareVerify,omitempty"`
+	Immutable      bool           `yaml:"Immutable,omitempty"`
+	AltID          string         `yaml:"AltId,omitempty"`
+	KeyIDs         []KeyIDMapping `yaml:"KeyIds,omitempty" mapstructure:"KeyIds"`
+}
+
+func NewProvider(opts any, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (bccsp.BCCSP, error) {
+	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
+}
+
+func ToPKCS11OptsOpts(o any) *PKCS11Opts {
+	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
+}
+
+func FindPKCS11Lib() (lib, pin, label string, err error) {
+	panic("pkcs11 not included in build. Use: go build -tags pkcs11")
+}

--- a/token/services/identity/msp/x509/msp/pkcs11/pkcs11.go
+++ b/token/services/identity/msp/x509/msp/pkcs11/pkcs11.go
@@ -1,3 +1,5 @@
+//go:build pkcs11
+
 /*
 Copyright IBM Corp. All Rights Reserved.
 
@@ -9,6 +11,7 @@ package pkcs11
 import (
 	"os"
 
+	"github.com/hyperledger/fabric/bccsp"
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
@@ -24,6 +27,15 @@ type (
 	PKCS11Opts   = pkcs11.PKCS11Opts
 	KeyIDMapping = pkcs11.KeyIDMapping
 )
+
+// NewProvider returns a pkcs11 provider
+func NewProvider(opts PKCS11Opts, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (*pkcs11.Provider, error) {
+	csp, err := pkcs11.New(opts, ks, pkcs11.WithKeyMapper(mapper))
+	if err != nil {
+		return nil, errors.WithMessagef(err, "Failed initializing PKCS11 library with config [%+v]", opts)
+	}
+	return csp, nil
+}
 
 // FindPKCS11Lib attempts to find the PKCS11 library based on the given configuration
 func FindPKCS11Lib() (lib, pin, label string, err error) {


### PR DESCRIPTION
Companion PR to https://github.com/hyperledger-labs/fabric-smart-client/pull/621.

Goal is to make HSM support 'opt-in' by using a build tag: `CGO_ENABLED=1 go build -tags pkcs11`. If you don't supply the tag, it will not require CGO. This makes it easier to have cross-platform builds or to use alpine containers, for instance.
