### PR TITLE
include wallet_id into tokens table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760
 	github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240902111918-657d39e795fe
+	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240906110529-b91207af4d1e
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.sum
+++ b/go.sum
@@ -1071,8 +1071,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240902111918-657d39e795fe h1:jSNYc0PaqvkxIPswJv/LPL97ixdee+fDqXGz4sllhEo=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240902111918-657d39e795fe/go.mod h1:9AELIfs/eawIhoHNKMSmYALaunmpDbs9bdWKyHuJs88=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240906110529-b91207af4d1e h1:34g3yH95u+VZ2BzUqVUKP3fbSnBYEix//HsaWPcYKc8=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20240906110529-b91207af4d1e/go.mod h1:9AELIfs/eawIhoHNKMSmYALaunmpDbs9bdWKyHuJs88=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -7,22 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package integration
 
 import (
-	"fmt"
-	"os"
-
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token"
 	"github.com/onsi/ginkgo/v2"
 )
 
 // TestPortRange represents a port range
-type TestPortRange int
+type TestPortRange integration.TestPortRange
 
 const (
-	basePort      = 20000
-	portsPerNode  = 150
-	portsPerSuite = 10 * portsPerNode
-
 	SimpleTokenSelector    = "simple"
 	SherdLockTokenSelector = "sherdlock"
 )
@@ -72,7 +66,7 @@ var (
 )
 
 const (
-	BasePort TestPortRange = basePort + portsPerSuite*iota
+	BasePort integration.TestPortRange = integration.BasePort + integration.PortsPerSuite*iota
 
 	ZKATDLogFungible
 	ZKATDLogFungibleStress
@@ -106,17 +100,3 @@ const (
 
 	Mixed
 )
-
-// StartPortForNode On linux, the default ephemeral port range is 32768-60999 and can be
-// allocated by the system for the client side of TCP connections or when
-// programs explicitly request one. Given linux is our default CI system,
-// we want to try avoid ports in that range.
-func (t TestPortRange) StartPortForNode() int {
-	const startEphemeral, endEphemeral = 32768, 60999
-
-	port := int(t) + portsPerNode*(ginkgo.GinkgoParallelProcess()-1)
-	if port >= startEphemeral-portsPerNode && port <= endEphemeral-portsPerNode {
-		fmt.Fprintf(os.Stderr, "WARNING: port %d is part of the default ephemeral port range on linux", port)
-	}
-	return port
-}

--- a/integration/token/common/support.go
+++ b/integration/token/common/support.go
@@ -9,6 +9,8 @@ package common
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/common"
+	topology2 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fabric/topology"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/endorser"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/integration/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common/views"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -28,4 +30,36 @@ func CheckFinality(network *integration.Infrastructure, id *token2.NodeReference
 	} else {
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
+
+func CheckEndorserFinality(network *integration.Infrastructure, id *token2.NodeReference, txID string, tmsID *token.TMSID, fail bool) {
+	if id == nil || len(id.Id()) == 0 {
+		return
+	}
+	var nw, channel string
+	if tmsID != nil {
+		nw, channel = tmsID.Network, tmsID.Channel
+	} else {
+		t := getFabricTopology(network)
+		nw, channel = t.Name(), t.Channels[0].Name
+	}
+	_, err := network.Client(id.ReplicaName()).CallView("EndorserFinality", common.JSONMarshall(&endorser.Finality{
+		TxID:    txID,
+		Network: nw,
+		Channel: channel,
+	}))
+	if fail {
+		Expect(err).To(HaveOccurred())
+	} else {
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+func getFabricTopology(network *integration.Infrastructure) *topology2.Topology {
+	for _, t := range network.Topologies {
+		if t.Type() == "fabric" {
+			return t.(*topology2.Topology)
+		}
+	}
+	panic("no fabric topology found")
 }

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -273,6 +273,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onAuditorRes
 	bob := sel.Get("bob")
 	charlie := sel.Get("charlie")
 	manager := sel.Get("manager")
+	endorsers := GetEndorsers(network, sel)
 	RegisterAuditor(network, auditor, nil)
 
 	// give some time to the nodes to get the public parameters
@@ -286,7 +287,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onAuditorRes
 	Eventually(DoesWalletExist).WithArguments(network, issuer, "pineapple", views.IssuerWallet).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(false))
 	Eventually(DoesWalletExist).WithArguments(network, alice, "", views.OwnerWallet).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(true))
 	Eventually(DoesWalletExist).WithArguments(network, alice, "mango", views.OwnerWallet).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(false))
-	IssueCash(network, "", "USD", 110, alice, auditor, true, issuer)
+	IssueSuccessfulCash(network, "", "USD", 110, alice, auditor, true, issuer, endorsers...)
 	t1 := time.Now()
 	CheckBalanceAndHolding(network, alice, "", "USD", 110, auditor)
 	CheckAuditedTransactions(network, auditor, AuditedTransactions[:1], nil, nil)
@@ -681,7 +682,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onAuditorRes
 	CheckBalanceAndHolding(network, bob, "", "EUR", 2820-sum, auditor)
 
 	// Transfer With TokenSelector
-	IssueCash(network, "", "YUAN", 17, alice, auditor, true, issuer)
+	IssueSuccessfulCash(network, "", "YUAN", 17, alice, auditor, true, issuer, endorsers...)
 	TransferCashWithSelector(network, alice, "", "YUAN", 10, bob, auditor)
 	CheckBalanceAndHolding(network, alice, "", "YUAN", 7, auditor)
 	CheckBalanceAndHolding(network, bob, "", "YUAN", 10, auditor)

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/monitoring"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/orion"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/endorser"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/tracing"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token"
 	common2 "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/common"
@@ -310,6 +311,7 @@ func Topology(opts common.Opts) []api.Topology {
 	if opts.FSCBasedEndorsement {
 		endorserTemplate := fscTopology.NewTemplate("endorser")
 		endorserTemplate.RegisterViewFactory("GetPublicParams", &views.GetPublicParamsViewFactory{})
+		endorserTemplate.RegisterViewFactory("EndorserFinality", &endorser.FinalityViewFactory{})
 		endorserTemplate.AddOptions(
 			fabric.WithOrganization("Org1"),
 			fabric2.WithEndorserRole(),

--- a/token/core/common/authrorization.go
+++ b/token/core/common/authrorization.go
@@ -16,7 +16,7 @@ import (
 type Authorization interface {
 	// IsMine returns true if the passed token is owned by an owner wallet.
 	// It returns the ID of the owner wallet and any additional owner identifier, if supported.
-	// It is possible that the wallet ID is empty an the additional owner identifier list is not.
+	// It is possible that the wallet ID is empty and the additional owner identifier list is not.
 	IsMine(tok *token2.Token) (string, []string, bool)
 	// AmIAnAuditor return true if the passed TMS contains an auditor wallet for any of the auditor identities
 	// defined in the public parameters of the passed TMS.
@@ -44,7 +44,7 @@ func NewTMSAuthorization(publicParameters driver.PublicParameters, walletService
 }
 
 // IsMine returns true if the passed token is owned by an owner wallet.
-// It returns the ID of the owner wallet and no additional owner identifiers
+// It returns the ID of the owner wallet and no additional owner identifiers.
 func (w *WalletBasedAuthorization) IsMine(tok *token2.Token) (string, []string, bool) {
 	wallet, err := w.WalletService.OwnerWallet(tok.Owner.Raw)
 	if err != nil {

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -37,9 +37,9 @@ type UnspentTokensIterator interface {
 	Next() (*token.UnspentToken, error)
 }
 
-type MinTokenInfoIterator interface {
+type SpendableTokensIterator interface {
 	Close()
-	Next() (*token.MinTokenInfo, error)
+	Next() (*token.UnspentTokenInWallet, error)
 }
 
 type Vault interface {
@@ -67,7 +67,7 @@ type QueryEngine interface {
 	UnspentTokensIterator() (UnspentTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.
 	// The token type can be empty. In that case, tokens of any type are returned.
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, walletID, tokenType string) (UnspentTokensIterator, error)
 	// ListUnspentTokens returns the list of unspent tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens associated to the passed ids

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -132,8 +132,10 @@ type WalletLookupID = any
 // Authorization defines method to check the relation between a token
 // and wallets (owner, auditor, etc.)
 type Authorization interface {
-	// IsMine returns true if the passed token is owned by an owner wallet in the passed TMS
-	IsMine(tok *token.Token) ([]string, bool)
+	// IsMine returns true if the passed token is owned by an owner wallet.
+	// It returns the ID of the owner wallet and any additional owner identifier, if supported.
+	// It is possible that the wallet ID is empty an the additional owner identifier list is not.
+	IsMine(tok *token.Token) (string, []string, bool)
 	// AmIAnAuditor return true if the passed TMS contains an auditor wallet for any of the auditor identities
 	// defined in the public parameters of the passed TMS.
 	AmIAnAuditor() bool

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -133,9 +133,11 @@ type WalletLookupID = any
 // and wallets (owner, auditor, etc.)
 type Authorization interface {
 	// IsMine returns true if the passed token is owned by an owner wallet.
-	// It returns the ID of the owner wallet and any additional owner identifier, if supported.
-	// It is possible that the wallet ID is empty an the additional owner identifier list is not.
-	IsMine(tok *token.Token) (string, []string, bool)
+	// It returns the ID of the owner wallet (walletID) and any additional owner identifier (additionalOwners), if supported.
+	// It is possible that walletID is empty additionalOwners is not.
+	// If walletID is not empty, this means that the corresponding wallet can spend the token directly.
+	// If walletID is empty, then additionalOwners must cooperate in some way in order to spend the token.
+	IsMine(tok *token.Token) (walletID string, additionalOwners []string, mine bool)
 	// AmIAnAuditor return true if the passed TMS contains an auditor wallet for any of the auditor identities
 	// defined in the public parameters of the passed TMS.
 	AmIAnAuditor() bool

--- a/token/services/db/dbtest/tokenlock.go
+++ b/token/services/db/dbtest/tokenlock.go
@@ -1,0 +1,34 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dbtest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/test-go/testify/assert"
+)
+
+// TokenLockDBCases collects test functions that db driver implementations can use for integration tests
+var TokenLockDBCases = []struct {
+	Name string
+	Fn   func(*testing.T, driver.TokenLockDB, driver.TokenTransactionDB)
+}{
+	{"TestFully", TestFully},
+}
+
+func TestFully(t *testing.T, tokenLockDB driver.TokenLockDB, tokenTransactionDB driver.TokenTransactionDB) {
+	tx, err := tokenTransactionDB.BeginAtomicWrite()
+	assert.NoError(t, err)
+	assert.NoError(t, tx.AddTokenRequest("apple", []byte("apple_tx_content"), nil))
+	assert.NoError(t, tx.Commit())
+
+	assert.NoError(t, tokenLockDB.Lock(&token.ID{TxId: "apple", Index: 0}, "pineapple"))
+	assert.NoError(t, tokenLockDB.Cleanup(1*time.Second))
+}

--- a/token/services/db/dbtest/transactions.go
+++ b/token/services/db/dbtest/transactions.go
@@ -20,8 +20,8 @@ import (
 	"github.com/test-go/testify/assert"
 )
 
-// This file exposes functions that db driver implementations can use for integration tests
-var Cases = []struct {
+// TokenTransactionDBCases collects test functions that db driver implementations can use for integration tests
+var TokenTransactionDBCases = []struct {
 	Name string
 	Fn   func(*testing.T, driver.TokenTransactionDB)
 }{

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -130,12 +130,12 @@ type TokenDB interface {
 	IsMine(txID string, index uint64) (bool, error)
 	// UnspentTokensIterator returns an iterator over all owned tokens
 	UnspentTokensIterator() (driver.UnspentTokensIterator, error)
-	// UnspentTokensIteratorBy returns an iterator over all tokens owned by the passed identifier of a given type
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
-	// MinTokenInfoIteratorBy returns the minimum information about the tokens needed for the selector
-	MinTokenInfoIteratorBy(ctx context.Context, ownerEID string, typ string) (driver.MinTokenInfoIterator, error)
+	// UnspentTokensIteratorBy returns an iterator over all tokens owned by the passed wallet identifier and of a given type
+	UnspentTokensIteratorBy(ctx context.Context, walletID, tokenType string) (driver.UnspentTokensIterator, error)
+	// SpendableTokensIteratorBy returns an iterator over all tokens owned solely by the passed wallet identifier and of a given type
+	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ string) (driver.SpendableTokensIterator, error)
 	// ListUnspentTokensBy returns the list of all tokens owned by the passed identifier of a given type
-	ListUnspentTokensBy(ownerEID, typ string) (*token.UnspentTokens, error)
+	ListUnspentTokensBy(walletID, typ string) (*token.UnspentTokens, error)
 	// ListUnspentTokens returns the list of all owned tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens for the passed ids

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -32,6 +32,8 @@ type TokenRecord struct {
 	OwnerType string
 	// OwnerIdentity is the deserialized Identity inside OwnerRaw
 	OwnerIdentity []byte
+	// OwnerWalletID is the identifier of the wallet that owns this token, it might be empty
+	OwnerWalletID string
 	// Ledger is the raw token as stored on the ledger
 	Ledger []byte
 	// LedgerMetadata is the metadata associated to the content of Ledger
@@ -77,8 +79,8 @@ type TokenDetails struct {
 
 // QueryTokenDetailsParams defines the parameters for querying token details
 type QueryTokenDetailsParams struct {
-	// OwnerEnrollmentID is the optional owner of the token
-	OwnerEnrollmentID string
+	// WalletID is the optional identifier of the wallet owning the token
+	WalletID string
 	// OwnerType is the type of owner, for instance 'idemix' or 'htlc'
 	OwnerType string
 	// TokenType (optional) is the type of token

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -199,6 +199,8 @@ type TokenLockDB interface {
 	// 1. The transaction that locked that token is valid or invalid;
 	// 2. The lock is too old.
 	Cleanup(evictionDelay time.Duration) error
+	// Close closes the database
+	Close() error
 }
 
 // TokenLockDBDriver is the interface for a token database driver

--- a/token/services/db/sql/common/querybuilder.go
+++ b/token/services/db/sql/common/querybuilder.go
@@ -154,7 +154,8 @@ func tokenQuerySql(params driver.QueryTokenDetailsParams, tokenTable, ownerTable
 	}
 	if params.WalletID != "" {
 		args = append(args, params.WalletID)
-		and = append(and, fmt.Sprintf("wallet_id = $%d", len(args)))
+		and = append(and, fmt.Sprintf("(wallet_id = $%d OR owner_wallet_id = $%d)", len(args), len(args)+1))
+		args = append(args, params.WalletID)
 	}
 
 	if params.TokenType != "" {
@@ -200,8 +201,7 @@ func tokenQuerySqlNoJoin(params driver.QueryTokenDetailsParams) (where string, a
 	}
 
 	if len(params.TransactionIDs) > 0 {
-		colTxID := "tx_id"
-		and = append(and, in(&args, colTxID, params.TransactionIDs))
+		and = append(and, in(&args, "tx_id", params.TransactionIDs))
 	}
 	if ids := whereTokenIDs(&args, params.IDs); ids != "" {
 		and = append(and, ids)

--- a/token/services/db/sql/common/querybuilder_test.go
+++ b/token/services/db/sql/common/querybuilder_test.go
@@ -254,43 +254,43 @@ func TestTokenSql(t *testing.T) {
 		},
 		{
 			name:         "owner unspent",
-			params:       driver.QueryTokenDetailsParams{OwnerEnrollmentID: "me"},
-			expectedSql:  "WHERE owner = true AND enrollment_id = $1 AND is_deleted = false",
+			params:       driver.QueryTokenDetailsParams{WalletID: "me"},
+			expectedSql:  "WHERE owner = true AND wallet_id = $1 AND is_deleted = false",
 			expectedArgs: []interface{}{"me"},
 		},
 		{
 			name: "owner with deleted",
 			params: driver.QueryTokenDetailsParams{
-				OwnerEnrollmentID: "me",
-				IncludeDeleted:    true,
+				WalletID:       "me",
+				IncludeDeleted: true,
 			},
-			expectedSql:  "WHERE owner = true AND enrollment_id = $1",
+			expectedSql:  "WHERE owner = true AND wallet_id = $1",
 			expectedArgs: []interface{}{"me"},
 		},
 		{
 			name: "owner and htlc with deleted",
 			params: driver.QueryTokenDetailsParams{
-				OwnerEnrollmentID: "me",
-				OwnerType:         "htlc",
-				IncludeDeleted:    true,
+				WalletID:       "me",
+				OwnerType:      "htlc",
+				IncludeDeleted: true,
 			},
-			expectedSql:  "WHERE owner = true AND owner_type = $1 AND enrollment_id = $2",
+			expectedSql:  "WHERE owner = true AND owner_type = $1 AND wallet_id = $2",
 			expectedArgs: []interface{}{"htlc", "me"},
 		},
 		{
 			name:         "owner and type",
-			params:       driver.QueryTokenDetailsParams{TokenType: "tok", OwnerEnrollmentID: "me"},
-			expectedSql:  "WHERE owner = true AND enrollment_id = $1 AND token_type = $2 AND is_deleted = false",
+			params:       driver.QueryTokenDetailsParams{TokenType: "tok", WalletID: "me"},
+			expectedSql:  "WHERE owner = true AND wallet_id = $1 AND token_type = $2 AND is_deleted = false",
 			expectedArgs: []interface{}{"me", "tok"},
 		},
 		{
 			name: "owner and type and id",
 			params: driver.QueryTokenDetailsParams{
-				TokenType:         "tok",
-				OwnerEnrollmentID: "me",
-				IDs:               []*token.ID{{TxId: "a", Index: 1}},
+				TokenType: "tok",
+				WalletID:  "me",
+				IDs:       []*token.ID{{TxId: "a", Index: 1}},
 			},
-			expectedSql:  "WHERE owner = true AND enrollment_id = $1 AND token_type = $2 AND (tx_id, idx) IN ( ($3, $4) ) AND is_deleted = false",
+			expectedSql:  "WHERE owner = true AND wallet_id = $1 AND token_type = $2 AND (tx_id, idx) IN ( ($3, $4) ) AND is_deleted = false",
 			expectedArgs: []interface{}{"me", "tok", "a", 1},
 		},
 		{
@@ -313,10 +313,10 @@ func TestTokenSql(t *testing.T) {
 	}
 	// with join
 	where, join, args := tokenQuerySql(driver.QueryTokenDetailsParams{
-		IDs:               []*token.ID{{TxId: "a", Index: 1}},
-		OwnerEnrollmentID: "me",
+		IDs:      []*token.ID{{TxId: "a", Index: 1}},
+		WalletID: "me",
 	}, "A", "B")
-	assert.Equal(t, "WHERE owner = true AND enrollment_id = $1 AND (A.tx_id, A.idx) IN ( ($2, $3) ) AND is_deleted = false", where, "join")
+	assert.Equal(t, "WHERE owner = true AND wallet_id = $1 AND (A.tx_id, A.idx) IN ( ($2, $3) ) AND is_deleted = false", where, "join")
 	assert.Equal(t, "LEFT JOIN B ON A.tx_id = B.tx_id AND A.idx = B.idx", join, "join")
 	assert.Len(t, args, 3)
 }

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -871,14 +871,14 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 	assert.Equal(t, false, res[2].IsSpent, "tx2-1 is not spent")
 
 	// alice
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{OwnerEnrollmentID: "alice"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "alice"})
 	assert.NoError(t, err)
 	assert.Len(t, res, 2)
 	assertEqual(t, tx1, res[0])
 	assertEqual(t, tx2, res[1])
 
 	// alice TST1
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{OwnerEnrollmentID: "alice", TokenType: "TST1"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "alice", TokenType: "TST1"})
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 	assertEqual(t, tx1, res[0])
@@ -887,7 +887,7 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 	assert.Equal(t, res[0].Amount, balance)
 
 	// alice TST
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{OwnerEnrollmentID: "alice", TokenType: "TST"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "alice", TokenType: "TST"})
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 	assertEqual(t, tx2, res[0])
@@ -896,7 +896,7 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 	assert.Equal(t, res[0].Amount, balance)
 
 	// bob TST
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{OwnerEnrollmentID: "bob", TokenType: "TST"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "bob", TokenType: "TST"})
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 	assertEqual(t, tx21, res[0])

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -284,6 +284,34 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.Len(t, unsp, 1)
 	assert.Equal(t, "0x02", unsp[0].Quantity)
 	assert.Equal(t, "ABC", unsp[0].Type)
+
+	tr = driver.TokenRecord{
+		TxID:           fmt.Sprintf("tx%d", 2000),
+		Index:          0,
+		IssuerRaw:      []byte{},
+		OwnerRaw:       []byte{1, 2, 3},
+		OwnerType:      "idemix",
+		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "pineapple",
+		Ledger:         []byte("ledger"),
+		LedgerMetadata: []byte{},
+		Quantity:       "0x02",
+		Type:           "ABC",
+		Amount:         2,
+		Owner:          true,
+		Auditor:        false,
+		Issuer:         false,
+	}
+	assert.NoError(t, db.StoreToken(tr, nil))
+	_, err = db.GetTokens(&token.ID{TxId: fmt.Sprintf("tx%d", 2000), Index: 0})
+	assert.NoError(t, err)
+
+	tx, err := db.NewTokenDBTransaction(context.TODO())
+	assert.NoError(t, err)
+	_, owners, err := tx.GetToken(context.TODO(), fmt.Sprintf("tx%d", 2000), 0, true)
+	assert.NoError(t, err)
+	assert.Len(t, owners, 1)
+	assert.NoError(t, tx.Rollback())
 }
 
 func getTokensBy(t *testing.T, db *TokenDB, ownerEID, typ string) []*token.UnspentToken {
@@ -391,6 +419,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{1, 2},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
@@ -407,6 +436,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{3, 4},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
@@ -423,6 +453,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{5, 6},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x03",
@@ -460,6 +491,7 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{1, 2},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		IssuerRaw:      []byte{11, 12},
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
@@ -477,6 +509,7 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{3, 4},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		IssuerRaw:      []byte{13, 14},
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
@@ -494,6 +527,7 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 		OwnerRaw:       []byte{5, 6},
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
+		OwnerWalletID:  "idemix",
 		IssuerRaw:      []byte{15, 16},
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},

--- a/token/services/db/sql/common/tokenlock.go
+++ b/token/services/db/sql/common/tokenlock.go
@@ -43,7 +43,13 @@ func NewTokenLockDB(db *sql.DB, opts NewDBOpts) (*TokenLockDB, error) {
 		return nil, errors.Wrapf(err, "failed to get table names")
 	}
 
-	tokenLockDB := newTokenLockDB(db, tokenLockTables{TokenLocks: tables.TokenLocks, Requests: tables.Requests})
+	tokenLockDB := newTokenLockDB(
+		db,
+		tokenLockTables{
+			TokenLocks: tables.TokenLocks,
+			Requests:   tables.Requests,
+		},
+	)
 	if opts.CreateSchema {
 		if err = common.InitSchema(db, []string{tokenLockDB.GetSchema()}...); err != nil {
 			return nil, err
@@ -80,4 +86,14 @@ func (db *TokenLockDB) GetSchema() string {
 		);`,
 		db.Table.TokenLocks,
 	)
+}
+
+func (db *TokenLockDB) Close() error {
+	logger.Info("closing database")
+	err := db.DB.Close()
+	if err != nil {
+		return errors.Wrap(err, "could not close DB")
+	}
+
+	return nil
 }

--- a/token/services/db/sql/common/transactions_test.go
+++ b/token/services/db/sql/common/transactions_test.go
@@ -35,7 +35,7 @@ func initTransactionsDB(driverName common.SQLDriverType, dataSourceName, tablePr
 
 func TestTransactionsSqlite(t *testing.T) {
 	tempDir := t.TempDir()
-	for _, c := range dbtest.Cases {
+	for _, c := range dbtest.TokenTransactionDBCases {
 		db, err := initTransactionsDB(sql2.SQLite, fmt.Sprintf("file:%s?_pragma=busy_timeout(20000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -49,7 +49,7 @@ func TestTransactionsSqlite(t *testing.T) {
 }
 
 func TestTransactionsSqliteMemory(t *testing.T) {
-	for _, c := range dbtest.Cases {
+	for _, c := range dbtest.TokenTransactionDBCases {
 		db, err := initTransactionsDB(sql2.SQLite, "file:tmp?_pragma=busy_timeout(20000)&mode=memory&cache=shared", c.Name, 10)
 		if err != nil {
 			t.Fatal(err)
@@ -65,7 +65,7 @@ func TestTransactionsPostgres(t *testing.T) {
 	terminate, pgConnStr := StartPostgresContainer(t)
 	defer terminate()
 
-	for _, c := range dbtest.Cases {
+	for _, c := range dbtest.TokenTransactionDBCases {
 		db, err := initTransactionsDB(sql2.Postgres, pgConnStr, c.Name, 10)
 		if err != nil {
 			t.Fatal(err)

--- a/token/services/db/sql/postgres/tokenlock_test.go
+++ b/token/services/db/sql/postgres/tokenlock_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"testing"
+
+	sql2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/dbtest"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql/common"
+)
+
+func initTokenLockDB(dataSourceName, tablePrefix string, maxOpenConns int) (driver.TokenLockDB, driver.TokenTransactionDB, error) {
+	d := common.NewSQLDBOpener("", "")
+	sqlDB, err := d.OpenSQLDB(sql2.Postgres, dataSourceName, maxOpenConns, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	tokenLockDB, err := NewTokenLockDB(sqlDB, common.NewDBOpts{
+		DataSource:   dataSourceName,
+		TablePrefix:  tablePrefix,
+		CreateSchema: true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	tokenTransactiokDB, err := NewTransactionDB(sqlDB, common.NewDBOpts{
+		DataSource:   dataSourceName,
+		TablePrefix:  tablePrefix,
+		CreateSchema: true,
+	})
+	if err != nil {
+		tokenLockDB.Close()
+		return nil, nil, err
+	}
+	return tokenLockDB, tokenTransactiokDB, err
+}
+
+func TestTokenLock(t *testing.T) {
+	terminate, pgConnStr := common.StartPostgresContainer(t)
+	defer terminate()
+
+	for _, c := range dbtest.TokenLockDBCases {
+		tokenLockDB, tokenTransactionDB, err := initTokenLockDB(pgConnStr, c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run(c.Name, func(xt *testing.T) {
+			defer tokenLockDB.Close()
+			defer tokenTransactionDB.Close()
+			c.Fn(xt, tokenLockDB, tokenTransactionDB)
+		})
+	}
+}

--- a/token/services/db/sql/sqlite/tokenlock_test.go
+++ b/token/services/db/sql/sqlite/tokenlock_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sqlite
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"testing"
+
+	sql2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/dbtest"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/sql/common"
+)
+
+func initTokenLockDB(dataSourceName, tablePrefix string, maxOpenConns int) (driver.TokenLockDB, driver.TokenTransactionDB, error) {
+	d := common.NewSQLDBOpener("", "")
+	sqlDB, err := d.OpenSQLDB(sql2.SQLite, dataSourceName, maxOpenConns, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	tokenLockDB, err := NewTokenLockDB(sqlDB, common.NewDBOpts{
+		DataSource:   dataSourceName,
+		TablePrefix:  tablePrefix,
+		CreateSchema: true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	tokenTransactionDB, err := NewTransactionDB(sqlDB, common.NewDBOpts{
+		DataSource:   dataSourceName,
+		TablePrefix:  tablePrefix,
+		CreateSchema: true,
+	})
+	if err != nil {
+		tokenLockDB.Close()
+		return nil, nil, err
+	}
+	return tokenLockDB, tokenTransactionDB, err
+}
+
+func TestTokenLock(t *testing.T) {
+	for _, c := range dbtest.TokenLockDBCases {
+		tempDir := filepath.Join(t.TempDir(), c.Name)
+		tokenLockDB, tokenTransactionDB, err := initTokenLockDB(fmt.Sprintf("file:%s?_pragma=busy_timeout(20000)", path.Join(tempDir, "db.sqlite")), c.Name, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Run(c.Name, func(xt *testing.T) {
+			defer tokenLockDB.Close()
+			defer tokenTransactionDB.Close()
+			c.Fn(xt, tokenLockDB, tokenTransactionDB)
+		})
+	}
+}

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -41,7 +41,7 @@ type tokenLocker interface {
 
 type selector struct {
 	logger    logging.Logger
-	cache     iterator[*token2.MinTokenInfo]
+	cache     iterator[*token2.UnspentTokenInWallet]
 	fetcher   tokenFetcher
 	locker    tokenLocker
 	precision uint64
@@ -82,7 +82,7 @@ func NewStubbornSelector(logger logging.Logger, tokenDB tokenFetcher, lockDB tok
 func NewSelector(logger logging.Logger, tokenDB tokenFetcher, lockDB tokenLocker, precision uint64) *selector {
 	return &selector{
 		logger:    logger,
-		cache:     collections.NewEmptyIterator[*token2.MinTokenInfo](),
+		cache:     collections.NewEmptyIterator[*token2.UnspentTokenInWallet](),
 		fetcher:   tokenDB,
 		locker:    lockDB,
 		precision: precision,

--- a/token/services/selector/testutils/testutils.go
+++ b/token/services/selector/testutils/testutils.go
@@ -126,23 +126,23 @@ func (q *MockQueryService) UnspentTokensIterator() (*token.UnspentTokensIterator
 	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.allKeys, 0}}, nil
 }
 
-func (q *MockQueryService) MinTokenInfoIteratorBy(ctx context.Context, ownerEID string, typ string) (driver.MinTokenInfoIterator, error) {
-	it, err := q.UnspentTokensIteratorBy(ctx, ownerEID, typ)
+func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, walletID string, typ string) (driver.SpendableTokensIterator, error) {
+	it, err := q.UnspentTokensIteratorBy(ctx, walletID, typ)
 	if err != nil {
 		return nil, err
 	}
-	return collections.Map(it, func(ut *token2.UnspentToken) (*token2.MinTokenInfo, error) {
-		return &token2.MinTokenInfo{
+	return collections.Map(it, func(ut *token2.UnspentToken) (*token2.UnspentTokenInWallet, error) {
+		return &token2.UnspentTokenInWallet{
 			Id:       ut.Id,
-			Owner:    string(ut.Owner.Raw),
+			WalletID: string(ut.Owner.Raw),
 			Type:     ut.Type,
 			Quantity: ut.Quantity,
 		}, nil
 	}), nil
 }
 
-func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, id, _ string) (driver.UnspentTokensIterator, error) {
-	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.cache[id], 0}}, nil
+func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, walletID, _ string) (driver.UnspentTokensIterator, error) {
+	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.cache[walletID], 0}}, nil
 }
 
 func (q *MockQueryService) GetTokens(inputs ...*token2.ID) ([]*token2.Token, error) {

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -68,6 +68,7 @@ type TokenToAppend struct {
 	tokenOnLedgerMetadata []byte
 	ownerType             string
 	ownerIdentity         token.Identity
+	ownerWalletID         string
 	owners                []string
 	issuer                token.Identity
 	precision             uint64
@@ -141,6 +142,7 @@ func (t *transaction) AppendToken(ctx context.Context, tta TokenToAppend) error 
 			OwnerRaw:       tta.tok.Owner.Raw,
 			OwnerType:      tta.ownerType,
 			OwnerIdentity:  tta.ownerIdentity,
+			OwnerWalletID:  tta.ownerWalletID,
 			Ledger:         tta.tokenOnLedger,
 			LedgerMetadata: tta.tokenOnLedgerMetadata,
 			Quantity:       tta.tok.Quantity,

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -262,7 +262,7 @@ func (t *Tokens) parse(auth driver.Authorization, txID string, md MetaData, is *
 		}
 
 		issuerFlag := !issuer.IsNone() && auth.Issued(issuer, tok)
-		ids, mine := auth.IsMine(tok)
+		ownerWalletID, ids, mine := auth.IsMine(tok)
 		if logger.IsEnabledFor(zapcore.DebugLevel) {
 			if mine {
 				logger.Debugf("transaction [%s], found a token and it is mine", txID)
@@ -293,6 +293,7 @@ func (t *Tokens) parse(auth driver.Authorization, txID string, md MetaData, is *
 			tokenOnLedgerMetadata: tokenOnLedgerMetadata,
 			ownerType:             ownerType,
 			ownerIdentity:         ownerIdentity,
+			ownerWalletID:         ownerWalletID,
 			owners:                ids,
 			issuer:                issuer,
 			precision:             precision,

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -27,8 +27,8 @@ type authMock struct{}
 func (a authMock) Issued(issuer driver.Identity, tok *token2.Token) bool {
 	return false
 }
-func (a authMock) IsMine(tok *token2.Token) ([]string, bool) {
-	return []string{string(tok.Owner.Raw)}, true
+func (a authMock) IsMine(tok *token2.Token) (string, []string, bool) {
+	return "", []string{string(tok.Owner.Raw)}, true
 }
 func (a authMock) AmIAnAuditor() bool {
 	return false

--- a/token/services/ttxdb/db/memory/memory_test.go
+++ b/token/services/ttxdb/db/memory/memory_test.go
@@ -24,7 +24,7 @@ func (sp mockConfigProvider) TranslatePath(path string) string                  
 func TestMemory(t *testing.T) {
 	d := NewDriver()
 
-	for _, c := range dbtest.Cases {
+	for _, c := range dbtest.TokenTransactionDBCases {
 		db, err := d.Driver.Open(new(mockConfigProvider), token.TMSID{Network: c.Name})
 		if err != nil {
 			t.Fatal(err)

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -87,14 +87,19 @@ func (it *IssuedTokens) Count() int {
 	return len(it.Tokens)
 }
 
-type MinTokenInfo struct {
-	Id       *ID
-	Owner    string
-	Type     string
+// UnspentTokenInWallet models an unspent token owner solely by a given wallet
+type UnspentTokenInWallet struct {
+	// Id is used to uniquely identify the token in the ledger
+	Id *ID
+	// WalletID is the ID of the wallet owning this token
+	WalletID string
+	// Type is the type of the token
+	Type string
+	// Quantity represents the number of units of Type that this unspent token holds.
 	Quantity string
 }
 
-// UnspentToken is used to specify a token returned by ListRequest
+// UnspentToken models an unspent token
 type UnspentToken struct {
 	// Id is used to uniquely identify the token in the ledger
 	Id *ID


### PR DESCRIPTION
This PR includes a new column into the tokens table to track the wallet id the token is bound to.
Notice that this can be empty depending on the nature of the token's owner (see the htlc script ownership, for an example).
In this way, we can avoid the join in the sql tokens db implementation when selecting tokens to spend.

This PR includes also unit-tests for the token lock db.