### PR TITLE
dbs must be agnostic to any backend implementation

### DIFF
--- a/integration/token/fungible/views/utils.go
+++ b/integration/token/fungible/views/utils.go
@@ -28,14 +28,14 @@ func AssertTokens(sp token.ServiceProvider, tx *ttx.Transaction, outputs *token.
 		tokenID := output.ID(tx.ID())
 		if output.Owner.Equal(id) || tx.TokenService().SigService().IsMe(output.Owner) {
 			// check it exists
-			_, toks, err := db.GetTokens(tokenID)
+			toks, err := db.GetTokens(tokenID)
 			assert.NoError(err, "failed to retrieve token [%s]", tokenID)
 			assert.Equal(1, len(toks), "expected one token")
 			assert.Equal(output.Quantity.Hex(), toks[0].Quantity, "token quantity mismatch")
 			assert.Equal(output.Type, toks[0].Type, "token type mismatch")
 		} else {
 			// check it does not exist
-			_, _, err := db.GetTokens(tokenID)
+			_, err := db.GetTokens(tokenID)
 			assert.Error(err, "token [%s] should not exist", tokenID)
 			assert.True(strings.Contains(err.Error(), "token not found"))
 		}

--- a/token/actions.go
+++ b/token/actions.go
@@ -6,7 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package token
 
-import "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+import (
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
 
 // IssueAction represents an action that issues tokens.
 type IssueAction struct {
@@ -74,8 +77,12 @@ func (t *TransferAction) SerializeOutputAt(i int) ([]byte, error) {
 }
 
 // GetInputs returns the input ids used in the action.
-func (t *TransferAction) GetInputs() ([]string, error) {
+func (t *TransferAction) GetInputs() ([]*token.ID, error) {
 	return t.a.GetInputs()
+}
+
+func (t *TransferAction) GetSerialNumbers() []string {
+	return t.a.GetSerialNumbers()
 }
 
 // IsGraphHiding returns true if the action supports graph hiding.

--- a/token/actions_test.go
+++ b/token/actions_test.go
@@ -9,6 +9,8 @@ package token
 import (
 	"testing"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -113,7 +115,7 @@ func TestTransferAction_SerializeOutputAt(t *testing.T) {
 
 func TestTransferAction_GetInputs(t *testing.T) {
 	mockTransferAction := &mock.TransferAction{}
-	mockInputs := []string{"input1", "input2"}
+	mockInputs := []*token.ID{{TxId: "input1"}, {TxId: "input2"}}
 	mockTransferAction.GetInputsReturns(mockInputs, nil)
 	transferAction := &TransferAction{a: mockTransferAction}
 	inputs, err := transferAction.GetInputs()

--- a/token/core/common/backend.go
+++ b/token/core/common/backend.go
@@ -8,6 +8,7 @@ package common
 
 import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -38,8 +39,8 @@ func (b *Backend) HasBeenSignedBy(id driver.Identity, verifier driver.Verifier) 
 	return sigma, verifier.Verify(b.Message, sigma)
 }
 
-func (b *Backend) GetState(key string) ([]byte, error) {
-	return b.Ledger(key)
+func (b *Backend) GetState(id token.ID) ([]byte, error) {
+	return b.Ledger(id)
 }
 
 func (b *Backend) Signatures() [][]byte {

--- a/token/core/common/loaders.go
+++ b/token/core/common/loaders.go
@@ -122,12 +122,12 @@ func NewVaultLedgerTokenAndMetadataLoader[T LedgerToken, M any](tokenVault Token
 // matching the token identifiers, the corresponding zkatdlog tokens, the information of the
 // tokens in clear text and the identities of their owners
 // LoadToken returns an error in case of failure
-func (s *VaultLedgerTokenAndMetadataLoader[T, M]) LoadTokens(ctx context.Context, ids []*token.ID) ([]string, []T, []M, []driver.Identity, error) {
+func (s *VaultLedgerTokenAndMetadataLoader[T, M]) LoadTokens(ctx context.Context, ids []*token.ID) ([]T, []M, []driver.Identity, error) {
 	span := trace.SpanFromContext(ctx)
 	// return token outputs and the corresponding opening
-	inputIDs, comms, infos, err := s.TokenVault.GetTokenInfoAndOutputs(ctx, ids)
+	comms, infos, err := s.TokenVault.GetTokenInfoAndOutputs(ctx, ids)
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	span.AddEvent("iterate_tokens")
@@ -136,27 +136,27 @@ func (s *VaultLedgerTokenAndMetadataLoader[T, M]) LoadTokens(ctx context.Context
 	signerIds := make([]driver.Identity, len(ids))
 	for i, id := range ids {
 		if len(comms[i]) == 0 {
-			return nil, nil, nil, nil, errors.Errorf("failed getting state for id [%v], nil comm value", id)
+			return nil, nil, nil, errors.Errorf("failed getting state for id [%v], nil comm value", id)
 		}
 		if len(infos[i]) == 0 {
-			return nil, nil, nil, nil, errors.Errorf("failed getting state for id [%v], nil info value", id)
+			return nil, nil, nil, errors.Errorf("failed getting state for id [%v], nil info value", id)
 		}
 		span.AddEvent("deserialize_token")
 		tok, err := s.Deserializer.DeserializeToken(comms[i])
 		if err != nil {
-			return nil, nil, nil, nil, errors.Wrapf(err, "failed deserializing token for id [%v][%s]", id, string(comms[i]))
+			return nil, nil, nil, errors.Wrapf(err, "failed deserializing token for id [%v][%s]", id, string(comms[i]))
 		}
 		span.AddEvent("deserialize_metadata")
 		ti, err := s.Deserializer.DeserializeMetadata(infos[i])
 		if err != nil {
-			return nil, nil, nil, nil, errors.Wrapf(err, "failed deserializeing token info for id [%v]", id)
+			return nil, nil, nil, errors.Wrapf(err, "failed deserializeing token info for id [%v]", id)
 		}
 		tokens[i] = tok
 		inputInf[i] = ti
 		signerIds[i] = tok.GetOwner()
 	}
 
-	return inputIDs, tokens, inputInf, signerIds, nil
+	return tokens, inputInf, signerIds, nil
 }
 
 type VaultTokenInfoLoader[M any] struct {
@@ -195,7 +195,7 @@ func NewVaultTokenLoader(tokenVault driver.QueryEngine) *VaultTokenLoader {
 
 // GetTokens takes an array of token identifiers (txID, index) and returns the keys of the identified tokens
 // in the vault and the content of the tokens
-func (s *VaultTokenLoader) GetTokens(ids []*token.ID) ([]string, []*token.Token, error) {
+func (s *VaultTokenLoader) GetTokens(ids []*token.ID) ([]*token.Token, error) {
 	return s.TokenVault.GetTokens(ids...)
 }
 

--- a/token/core/common/ws.go
+++ b/token/core/common/ws.go
@@ -24,7 +24,7 @@ var (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([]string, [][]byte, [][]byte, error)
+	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, error)
 	GetTokenOutputs(ids []*token.ID, callback driver.QueryCallbackFunc) error
 	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)

--- a/token/core/fabtoken/actions.go
+++ b/token/core/fabtoken/actions.go
@@ -115,7 +115,7 @@ func (i *IssueAction) GetMetadata() map[string][]byte {
 // TransferAction encodes a fabtoken transfer
 type TransferAction struct {
 	// identifier of token to be transferred
-	Inputs []string
+	Inputs []*token.ID
 	// outputs to be created as a result of the transfer
 	Outputs []*Output
 	// Metadata contains the transfer action's metadata
@@ -180,8 +180,12 @@ func (t *TransferAction) SerializeOutputAt(index int) ([]byte, error) {
 }
 
 // GetInputs returns inputs of the TransferAction
-func (t *TransferAction) GetInputs() ([]string, error) {
+func (t *TransferAction) GetInputs() ([]*token.ID, error) {
 	return t.Inputs, nil
+}
+
+func (t *TransferAction) GetSerialNumbers() []string {
+	return nil
 }
 
 // Deserialize un-marshals TransferAction

--- a/token/core/fabtoken/service.go
+++ b/token/core/fabtoken/service.go
@@ -14,7 +14,7 @@ import (
 )
 
 type TokenLoader interface {
-	GetTokens(ids []*token.ID) ([]string, []*token.Token, error)
+	GetTokens(ids []*token.ID) ([]*token.Token, error)
 }
 
 type Service struct {

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -45,7 +45,7 @@ func NewTransferService(
 // It also returns the corresponding TransferMetadata
 func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	// select inputs
-	inputIDs, inputTokens, err := s.TokenLoader.GetTokens(tokenIDs)
+	inputTokens, err := s.TokenLoader.GetTokens(tokenIDs)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load tokens")
 	}
@@ -73,7 +73,7 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 
 	// assemble transfer action
 	transfer := &TransferAction{
-		Inputs:   inputIDs,
+		Inputs:   tokenIDs,
 		Outputs:  outs,
 		Metadata: meta.TransferActionMetadata(opts.Attributes),
 	}

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -179,7 +179,7 @@ func RetrieveInputsFromTransferAction(t *TransferAction, ledger driver.Ledger) (
 		return nil, errors.Wrap(err, "failed to retrieve input IDs")
 	}
 	for _, in := range inputs {
-		bytes, err := ledger.GetState(in)
+		bytes, err := ledger.GetState(*in)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to retrieve input to spend [%s]", in)
 		}

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -392,7 +392,7 @@ func GetAuditInfoForTransfers(transfers [][]byte, metadata []driver.TransferMeta
 			}
 			auditableInputs[k] = append(auditableInputs[k], ai)
 		}
-		ta := &transfer.TransferAction{}
+		ta := &transfer.Action{}
 		err := json.Unmarshal(transfers[k], ta)
 		if err != nil {
 			return nil, nil, err

--- a/token/core/zkatdlog/crypto/audit/auditor_test.go
+++ b/token/core/zkatdlog/crypto/audit/auditor_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"time"
 
+	token3 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
 	mem "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/memory"
@@ -117,7 +119,7 @@ var _ = Describe("Auditor", func() {
 	})
 })
 
-func createTransfer(pp *crypto.PublicParams) (*transfer2.TransferAction, driver.TransferMetadata, [][]*token.Token) {
+func createTransfer(pp *crypto.PublicParams) (*transfer2.Action, driver.TransferMetadata, [][]*token.Token) {
 	id, auditInfo := getIdemixInfo("./testdata/idemix")
 	transfer, inf, inputs := prepareTransfer(pp, id)
 
@@ -152,7 +154,7 @@ func createTransfer(pp *crypto.PublicParams) (*transfer2.TransferAction, driver.
 	return transfer, metadata, tokns
 }
 
-func createTransferWithBogusOutput(pp *crypto.PublicParams) (*transfer2.TransferAction, driver.TransferMetadata, [][]*token.Token) {
+func createTransferWithBogusOutput(pp *crypto.PublicParams) (*transfer2.Action, driver.TransferMetadata, [][]*token.Token) {
 	id, auditInfo := getIdemixInfo("./testdata/idemix")
 	transfer, inf, inputs := prepareTransfer(pp, id)
 
@@ -296,11 +298,12 @@ func createInputs(pp *crypto.PublicParams, id driver.Identity) ([]*token.Token, 
 	return inputs, infos
 }
 
-func prepareTransfer(pp *crypto.PublicParams, id driver.Identity) (*transfer2.TransferAction, []*token.Metadata, []*token.Token) {
+func prepareTransfer(pp *crypto.PublicParams, id driver.Identity) (*transfer2.Action, []*token.Metadata, []*token.Token) {
 	inputs, tokenInfos := createInputs(pp, id)
 
 	fakeSigner := &mock.SigningIdentity{}
-	sender, err := transfer2.NewSender([]driver.Signer{fakeSigner, fakeSigner}, inputs, []string{"0", "1"}, tokenInfos, pp)
+
+	sender, err := transfer2.NewSender([]driver.Signer{fakeSigner, fakeSigner}, inputs, []*token3.ID{{TxId: "0"}, {TxId: "1"}}, tokenInfos, pp)
 	Expect(err).NotTo(HaveOccurred())
 	transfer, inf, err := sender.GenerateZKTransfer(context.TODO(), []uint64{40, 20}, [][]byte{id, id})
 	Expect(err).NotTo(HaveOccurred())

--- a/token/core/zkatdlog/crypto/transfer/sender_test.go
+++ b/token/core/zkatdlog/crypto/transfer/sender_test.go
@@ -8,6 +8,8 @@ package transfer_test
 import (
 	"context"
 
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
@@ -25,7 +27,7 @@ var _ = Describe("Sender", func() {
 		signers             []driver.Signer
 		pp                  *crypto.PublicParams
 
-		transfer *transfer2.TransferAction
+		transfer *transfer2.Action
 		sender   *transfer2.Sender
 
 		invalues  []*math.Zr
@@ -34,7 +36,7 @@ var _ = Describe("Sender", func() {
 		tokens    []*token.Token
 
 		owners [][]byte
-		ids    []string
+		ids    []*token2.ID
 	)
 	BeforeEach(func() {
 		var err error
@@ -69,10 +71,10 @@ var _ = Describe("Sender", func() {
 		outvalues[0] = 65
 		outvalues[1] = 35
 
-		ids = make([]string, 3)
-		ids[0] = "0"
-		ids[1] = "1"
-		ids[2] = "3"
+		ids = make([]*token2.ID, 3)
+		ids[0] = &token2.ID{TxId: "0"}
+		ids[1] = &token2.ID{TxId: "1"}
+		ids[2] = &token2.ID{TxId: "3"}
 
 		inputs := PrepareTokens(invalues, inBF, "ABC", pp.PedersenGenerators, c)
 		tokens = make([]*token.Token, 3)

--- a/token/core/zkatdlog/crypto/transfer/transfer.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Proof is a zero-knowledge proof that shows that a TransferAction is valid
+// Proof is a zero-knowledge proof that shows that a Action is valid
 type Proof struct {
 	// proof that inputs and outputs in a Transfer Action are well-formed
 	// inputs and outputs have the same total value
@@ -27,19 +27,19 @@ type Proof struct {
 	RangeCorrectness *rp.RangeCorrectness
 }
 
-// Verifier verifies if a TransferAction is valid
+// Verifier verifies if a Action is valid
 type Verifier struct {
 	TypeAndSum       *TypeAndSumVerifier
 	RangeCorrectness *rp.RangeCorrectnessVerifier
 }
 
-// Prover produces a proof that a TransferAction is valid
+// Prover produces a proof that a Action is valid
 type Prover struct {
 	TypeAndSum       *TypeAndSumProver
 	RangeCorrectness *rp.RangeCorrectnessProver
 }
 
-// NewProver returns a TransferAction Prover that corresponds to the passed arguments
+// NewProver returns a Action Prover that corresponds to the passed arguments
 func NewProver(inputWitness, outputWitness []*token.TokenDataWitness, inputs, outputs []*math.G1, pp *crypto.PublicParams) (*Prover, error) {
 	c := math.Curves[pp.Curve]
 	p := &Prover{}
@@ -88,7 +88,7 @@ func NewProver(inputWitness, outputWitness []*token.TokenDataWitness, inputs, ou
 	return p, nil
 }
 
-// NewVerifier returns a TransferAction Verifier as a function of the passed parameters
+// NewVerifier returns a Action Verifier as a function of the passed parameters
 func NewVerifier(inputs, outputs []*math.G1, pp *crypto.PublicParams) *Verifier {
 	v := &Verifier{}
 	v.TypeAndSum = NewTypeAndSumVerifier(pp.PedersenGenerators, inputs, outputs, math.Curves[pp.Curve])

--- a/token/core/zkatdlog/crypto/validator/ledger.go
+++ b/token/core/zkatdlog/crypto/validator/ledger.go
@@ -5,8 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 */
 package validator
 
+import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 //go:generate counterfeiter -o mock/ledger.go -fake-name Ledger . Ledger
 
 type Ledger interface {
-	GetState(key string) ([]byte, error)
+	GetState(id token.ID) ([]byte, error)
 }

--- a/token/core/zkatdlog/crypto/validator/mock/ledger.go
+++ b/token/core/zkatdlog/crypto/validator/mock/ledger.go
@@ -5,13 +5,14 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/validator"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Ledger struct {
-	GetStateStub        func(key string) ([]byte, error)
+	GetStateStub        func(token.ID) ([]byte, error)
 	getStateMutex       sync.RWMutex
 	getStateArgsForCall []struct {
-		key string
+		arg1 token.ID
 	}
 	getStateReturns struct {
 		result1 []byte
@@ -25,21 +26,23 @@ type Ledger struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Ledger) GetState(key string) ([]byte, error) {
+func (fake *Ledger) GetState(arg1 token.ID) ([]byte, error) {
 	fake.getStateMutex.Lock()
 	ret, specificReturn := fake.getStateReturnsOnCall[len(fake.getStateArgsForCall)]
 	fake.getStateArgsForCall = append(fake.getStateArgsForCall, struct {
-		key string
-	}{key})
-	fake.recordInvocation("GetState", []interface{}{key})
+		arg1 token.ID
+	}{arg1})
+	stub := fake.GetStateStub
+	fakeReturns := fake.getStateReturns
+	fake.recordInvocation("GetState", []interface{}{arg1})
 	fake.getStateMutex.Unlock()
-	if fake.GetStateStub != nil {
-		return fake.GetStateStub(key)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getStateReturns.result1, fake.getStateReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Ledger) GetStateCallCount() int {
@@ -48,13 +51,22 @@ func (fake *Ledger) GetStateCallCount() int {
 	return len(fake.getStateArgsForCall)
 }
 
-func (fake *Ledger) GetStateArgsForCall(i int) string {
+func (fake *Ledger) GetStateCalls(stub func(token.ID) ([]byte, error)) {
+	fake.getStateMutex.Lock()
+	defer fake.getStateMutex.Unlock()
+	fake.GetStateStub = stub
+}
+
+func (fake *Ledger) GetStateArgsForCall(i int) token.ID {
 	fake.getStateMutex.RLock()
 	defer fake.getStateMutex.RUnlock()
-	return fake.getStateArgsForCall[i].key
+	argsForCall := fake.getStateArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *Ledger) GetStateReturns(result1 []byte, result2 error) {
+	fake.getStateMutex.Lock()
+	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	fake.getStateReturns = struct {
 		result1 []byte
@@ -63,6 +75,8 @@ func (fake *Ledger) GetStateReturns(result1 []byte, result2 error) {
 }
 
 func (fake *Ledger) GetStateReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.getStateMutex.Lock()
+	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = nil
 	if fake.getStateReturnsOnCall == nil {
 		fake.getStateReturnsOnCall = make(map[int]struct {

--- a/token/core/zkatdlog/crypto/validator/validator.go
+++ b/token/core/zkatdlog/crypto/validator/validator.go
@@ -16,15 +16,15 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 )
 
-type ValidateTransferFunc = common.ValidateTransferFunc[*crypto.PublicParams, *token.Token, *transfer.TransferAction, *issue.IssueAction]
+type ValidateTransferFunc = common.ValidateTransferFunc[*crypto.PublicParams, *token.Token, *transfer.Action, *issue.IssueAction]
 
-type ValidateIssueFunc = common.ValidateIssueFunc[*crypto.PublicParams, *token.Token, *transfer.TransferAction, *issue.IssueAction]
+type ValidateIssueFunc = common.ValidateIssueFunc[*crypto.PublicParams, *token.Token, *transfer.Action, *issue.IssueAction]
 
-type Context = common.Context[*crypto.PublicParams, *token.Token, *transfer.TransferAction, *issue.IssueAction]
+type Context = common.Context[*crypto.PublicParams, *token.Token, *transfer.Action, *issue.IssueAction]
 
 type ActionDeserializer struct{}
 
-func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*issue.IssueAction, []*transfer.TransferAction, error) {
+func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*issue.IssueAction, []*transfer.Action, error) {
 	issueActions := make([]*issue.IssueAction, len(tr.Issues))
 	for i := 0; i < len(tr.Issues); i++ {
 		ia := &issue.IssueAction{}
@@ -34,9 +34,9 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*iss
 		issueActions[i] = ia
 	}
 
-	transferActions := make([]*transfer.TransferAction, len(tr.Transfers))
+	transferActions := make([]*transfer.Action, len(tr.Transfers))
 	for i := 0; i < len(tr.Transfers); i++ {
-		ta := &transfer.TransferAction{}
+		ta := &transfer.Action{}
 		if err := ta.Deserialize(tr.Transfers[i]); err != nil {
 			return nil, nil, err
 		}
@@ -46,7 +46,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*iss
 	return issueActions, transferActions, nil
 }
 
-type Validator = common.Validator[*crypto.PublicParams, *token.Token, *transfer.TransferAction, *issue.IssueAction]
+type Validator = common.Validator[*crypto.PublicParams, *token.Token, *transfer.Action, *issue.IssueAction]
 
 func New(logger logging.Logger, pp *crypto.PublicParams, deserializer driver.Deserializer, extraValidators ...ValidateTransferFunc) *Validator {
 	transferValidators := []ValidateTransferFunc{
@@ -60,7 +60,7 @@ func New(logger logging.Logger, pp *crypto.PublicParams, deserializer driver.Des
 		IssueValidate,
 	}
 
-	return common.NewValidator[*crypto.PublicParams, *token.Token, *transfer.TransferAction, *issue.IssueAction](
+	return common.NewValidator[*crypto.PublicParams, *token.Token, *transfer.Action, *issue.IssueAction](
 		logger,
 		pp,
 		deserializer,

--- a/token/core/zkatdlog/crypto/validator/validator_test.go
+++ b/token/core/zkatdlog/crypto/validator/validator_test.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"time"
 
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
 	mem "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/memory"
@@ -479,9 +481,9 @@ func prepareTransfer(pp *crypto.PublicParams, signer driver.SigningIdentity, aud
 	outvalues[0] = 65
 	outvalues[1] = 35
 
-	ids := make([]string, 2)
-	ids[0] = "0"
-	ids[1] = "1"
+	ids := make([]*token2.ID, 2)
+	ids[0] = &token2.ID{TxId: "0"}
+	ids[1] = &token2.ID{TxId: "1"}
 
 	inputs := prepareTokens(invalues, inBF, "ABC", pp.PedersenGenerators, c)
 	tokens := make([]*tokn.Token, 2)
@@ -547,6 +549,6 @@ func prepareTransfer(pp *crypto.PublicParams, signer driver.SigningIdentity, aud
 	return sender, tr, transferMetadata, tokens
 }
 
-func getState(key string) ([]byte, error) {
-	return fakeLedger.GetState(key)
+func getState(id token2.ID) ([]byte, error) {
+	return fakeLedger.GetState(id)
 }

--- a/token/core/zkatdlog/crypto/validator/validator_transfer.go
+++ b/token/core/zkatdlog/crypto/validator/validator_transfer.go
@@ -30,7 +30,7 @@ func TransferSignatureValidate(ctx *Context) error {
 	}
 	for i, in := range inputs {
 		ctx.Logger.Debugf("load token [%d][%s]", i, in)
-		bytes, err := ctx.Ledger.GetState(in)
+		bytes, err := ctx.Ledger.GetState(*in)
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve input to spend [%s]", in)
 		}

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -25,7 +25,7 @@ type TokenCommitmentLoader interface {
 }
 
 type TokenLoader interface {
-	LoadTokens(ctx context.Context, ids []*token2.ID) ([]string, []*token.Token, []*token.Metadata, []driver.Identity, error)
+	LoadTokens(ctx context.Context, ids []*token2.ID) ([]*token.Token, []*token.Metadata, []driver.Identity, error)
 }
 
 type Service struct {

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -65,14 +65,14 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 	s.Logger.Debugf("Prepare Transfer Action [%s,%v]", txID, tokenIDs)
 	// load tokens with the passed token identifiers
 	span.AddEvent("load_tokens")
-	inputIDs, tokens, inputInf, senders, err := s.TokenLoader.LoadTokens(newCtx, tokenIDs)
+	tokens, inputInf, senders, err := s.TokenLoader.LoadTokens(newCtx, tokenIDs)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load tokens")
 	}
 	pp := s.PublicParametersManager.PublicParams()
 
 	// get sender
-	sender, err := transfer.NewSender(nil, tokens, inputIDs, inputInf, pp)
+	sender, err := transfer.NewSender(nil, tokens, tokenIDs, inputInf, pp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -195,7 +195,7 @@ func (s *TransferService) VerifyTransfer(action driver.TransferAction, outputsMe
 	if action == nil {
 		return errors.New("failed to verify transfer: nil transfer action")
 	}
-	tr, ok := action.(*transfer.TransferAction)
+	tr, ok := action.(*transfer.Action)
 	if !ok {
 		return errors.New("failed to verify transfer: expected *zkatdlog.TransferActionMetadata")
 	}
@@ -230,7 +230,7 @@ func (s *TransferService) VerifyTransfer(action driver.TransferAction, outputsMe
 // DeserializeTransferAction un-marshals a TransferActionMetadata from the passed array of bytes.
 // DeserializeTransferAction returns an error, if the un-marshalling fails.
 func (s *TransferService) DeserializeTransferAction(raw []byte) (driver.TransferAction, error) {
-	transferAction := &transfer.TransferAction{}
+	transferAction := &transfer.Action{}
 	err := transferAction.Deserialize(raw)
 	if err != nil {
 		return nil, err

--- a/token/driver/action.go
+++ b/token/driver/action.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
+import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 // SetupAction is the action used to update the public parameters
 type SetupAction interface {
 	GetSetupParameters() ([]byte, error)
@@ -56,7 +58,9 @@ type TransferAction interface {
 	// SerializeOutputAt returns the serialized output at the passed index
 	SerializeOutputAt(index int) ([]byte, error)
 	// GetInputs returns the identifiers of the inputs in the action.
-	GetInputs() ([]string, error)
+	GetInputs() ([]*token.ID, error)
+	// GetSerialNumbers returns the serial numbers of the inputs if this action supports graph hiding
+	GetSerialNumbers() []string
 	// IsGraphHiding returns true if the action is graph hiding
 	IsGraphHiding() bool
 	// GetMetadata returns the action's metadata

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -39,23 +39,21 @@ type QueryEngine struct {
 		result2 string
 		result3 error
 	}
-	GetTokenInfoAndOutputsStub        func(context.Context, []*token.ID) ([]string, [][]byte, [][]byte, error)
+	GetTokenInfoAndOutputsStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, error)
 	getTokenInfoAndOutputsMutex       sync.RWMutex
 	getTokenInfoAndOutputsArgsForCall []struct {
 		arg1 context.Context
 		arg2 []*token.ID
 	}
 	getTokenInfoAndOutputsReturns struct {
-		result1 []string
+		result1 [][]byte
 		result2 [][]byte
-		result3 [][]byte
-		result4 error
+		result3 error
 	}
 	getTokenInfoAndOutputsReturnsOnCall map[int]struct {
-		result1 []string
+		result1 [][]byte
 		result2 [][]byte
-		result3 [][]byte
-		result4 error
+		result3 error
 	}
 	GetTokenInfosStub        func([]*token.ID) ([][]byte, error)
 	getTokenInfosMutex       sync.RWMutex
@@ -82,20 +80,18 @@ type QueryEngine struct {
 	getTokenOutputsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetTokensStub        func(...*token.ID) ([]string, []*token.Token, error)
+	GetTokensStub        func(...*token.ID) ([]*token.Token, error)
 	getTokensMutex       sync.RWMutex
 	getTokensArgsForCall []struct {
 		arg1 []*token.ID
 	}
 	getTokensReturns struct {
-		result1 []string
-		result2 []*token.Token
-		result3 error
+		result1 []*token.Token
+		result2 error
 	}
 	getTokensReturnsOnCall map[int]struct {
-		result1 []string
-		result2 []*token.Token
-		result3 error
+		result1 []*token.Token
+		result2 error
 	}
 	IsMineStub        func(*token.ID) (bool, error)
 	isMineMutex       sync.RWMutex
@@ -350,7 +346,7 @@ func (fake *QueryEngine) GetStatusReturnsOnCall(i int, result1 int, result2 stri
 	}{result1, result2, result3}
 }
 
-func (fake *QueryEngine) GetTokenInfoAndOutputs(arg1 context.Context, arg2 []*token.ID) ([]string, [][]byte, [][]byte, error) {
+func (fake *QueryEngine) GetTokenInfoAndOutputs(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, error) {
 	var arg2Copy []*token.ID
 	if arg2 != nil {
 		arg2Copy = make([]*token.ID, len(arg2))
@@ -370,9 +366,9 @@ func (fake *QueryEngine) GetTokenInfoAndOutputs(arg1 context.Context, arg2 []*to
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3, ret.result4
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *QueryEngine) GetTokenInfoAndOutputsCallCount() int {
@@ -381,7 +377,7 @@ func (fake *QueryEngine) GetTokenInfoAndOutputsCallCount() int {
 	return len(fake.getTokenInfoAndOutputsArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokenInfoAndOutputsCalls(stub func(context.Context, []*token.ID) ([]string, [][]byte, [][]byte, error)) {
+func (fake *QueryEngine) GetTokenInfoAndOutputsCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, error)) {
 	fake.getTokenInfoAndOutputsMutex.Lock()
 	defer fake.getTokenInfoAndOutputsMutex.Unlock()
 	fake.GetTokenInfoAndOutputsStub = stub
@@ -394,36 +390,33 @@ func (fake *QueryEngine) GetTokenInfoAndOutputsArgsForCall(i int) (context.Conte
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *QueryEngine) GetTokenInfoAndOutputsReturns(result1 []string, result2 [][]byte, result3 [][]byte, result4 error) {
+func (fake *QueryEngine) GetTokenInfoAndOutputsReturns(result1 [][]byte, result2 [][]byte, result3 error) {
 	fake.getTokenInfoAndOutputsMutex.Lock()
 	defer fake.getTokenInfoAndOutputsMutex.Unlock()
 	fake.GetTokenInfoAndOutputsStub = nil
 	fake.getTokenInfoAndOutputsReturns = struct {
-		result1 []string
+		result1 [][]byte
 		result2 [][]byte
-		result3 [][]byte
-		result4 error
-	}{result1, result2, result3, result4}
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *QueryEngine) GetTokenInfoAndOutputsReturnsOnCall(i int, result1 []string, result2 [][]byte, result3 [][]byte, result4 error) {
+func (fake *QueryEngine) GetTokenInfoAndOutputsReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 error) {
 	fake.getTokenInfoAndOutputsMutex.Lock()
 	defer fake.getTokenInfoAndOutputsMutex.Unlock()
 	fake.GetTokenInfoAndOutputsStub = nil
 	if fake.getTokenInfoAndOutputsReturnsOnCall == nil {
 		fake.getTokenInfoAndOutputsReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 [][]byte
 			result2 [][]byte
-			result3 [][]byte
-			result4 error
+			result3 error
 		})
 	}
 	fake.getTokenInfoAndOutputsReturnsOnCall[i] = struct {
-		result1 []string
+		result1 [][]byte
 		result2 [][]byte
-		result3 [][]byte
-		result4 error
-	}{result1, result2, result3, result4}
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *QueryEngine) GetTokenInfos(arg1 []*token.ID) ([][]byte, error) {
@@ -562,7 +555,7 @@ func (fake *QueryEngine) GetTokenOutputsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *QueryEngine) GetTokens(arg1 ...*token.ID) ([]string, []*token.Token, error) {
+func (fake *QueryEngine) GetTokens(arg1 ...*token.ID) ([]*token.Token, error) {
 	fake.getTokensMutex.Lock()
 	ret, specificReturn := fake.getTokensReturnsOnCall[len(fake.getTokensArgsForCall)]
 	fake.getTokensArgsForCall = append(fake.getTokensArgsForCall, struct {
@@ -576,9 +569,9 @@ func (fake *QueryEngine) GetTokens(arg1 ...*token.ID) ([]string, []*token.Token,
 		return stub(arg1...)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *QueryEngine) GetTokensCallCount() int {
@@ -587,7 +580,7 @@ func (fake *QueryEngine) GetTokensCallCount() int {
 	return len(fake.getTokensArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokensCalls(stub func(...*token.ID) ([]string, []*token.Token, error)) {
+func (fake *QueryEngine) GetTokensCalls(stub func(...*token.ID) ([]*token.Token, error)) {
 	fake.getTokensMutex.Lock()
 	defer fake.getTokensMutex.Unlock()
 	fake.GetTokensStub = stub
@@ -600,33 +593,30 @@ func (fake *QueryEngine) GetTokensArgsForCall(i int) []*token.ID {
 	return argsForCall.arg1
 }
 
-func (fake *QueryEngine) GetTokensReturns(result1 []string, result2 []*token.Token, result3 error) {
+func (fake *QueryEngine) GetTokensReturns(result1 []*token.Token, result2 error) {
 	fake.getTokensMutex.Lock()
 	defer fake.getTokensMutex.Unlock()
 	fake.GetTokensStub = nil
 	fake.getTokensReturns = struct {
-		result1 []string
-		result2 []*token.Token
-		result3 error
-	}{result1, result2, result3}
+		result1 []*token.Token
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *QueryEngine) GetTokensReturnsOnCall(i int, result1 []string, result2 []*token.Token, result3 error) {
+func (fake *QueryEngine) GetTokensReturnsOnCall(i int, result1 []*token.Token, result2 error) {
 	fake.getTokensMutex.Lock()
 	defer fake.getTokensMutex.Unlock()
 	fake.GetTokensStub = nil
 	if fake.getTokensReturnsOnCall == nil {
 		fake.getTokensReturnsOnCall = make(map[int]struct {
-			result1 []string
-			result2 []*token.Token
-			result3 error
+			result1 []*token.Token
+			result2 error
 		})
 	}
 	fake.getTokensReturnsOnCall[i] = struct {
-		result1 []string
-		result2 []*token.Token
-		result3 error
-	}{result1, result2, result3}
+		result1 []*token.Token
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *QueryEngine) IsMine(arg1 *token.ID) (bool, error) {

--- a/token/driver/mock/ta.go
+++ b/token/driver/mock/ta.go
@@ -5,19 +5,20 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type TransferAction struct {
-	GetInputsStub        func() ([]string, error)
+	GetInputsStub        func() ([]*token.ID, error)
 	getInputsMutex       sync.RWMutex
 	getInputsArgsForCall []struct {
 	}
 	getInputsReturns struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}
 	getInputsReturnsOnCall map[int]struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}
 	GetMetadataStub        func() map[string][]byte
@@ -39,6 +40,16 @@ type TransferAction struct {
 	}
 	getOutputsReturnsOnCall map[int]struct {
 		result1 []driver.Output
+	}
+	GetSerialNumbersStub        func() []string
+	getSerialNumbersMutex       sync.RWMutex
+	getSerialNumbersArgsForCall []struct {
+	}
+	getSerialNumbersReturns struct {
+		result1 []string
+	}
+	getSerialNumbersReturnsOnCall map[int]struct {
+		result1 []string
 	}
 	GetSerializedOutputsStub        func() ([][]byte, error)
 	getSerializedOutputsMutex       sync.RWMutex
@@ -112,7 +123,7 @@ type TransferAction struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TransferAction) GetInputs() ([]string, error) {
+func (fake *TransferAction) GetInputs() ([]*token.ID, error) {
 	fake.getInputsMutex.Lock()
 	ret, specificReturn := fake.getInputsReturnsOnCall[len(fake.getInputsArgsForCall)]
 	fake.getInputsArgsForCall = append(fake.getInputsArgsForCall, struct {
@@ -136,34 +147,34 @@ func (fake *TransferAction) GetInputsCallCount() int {
 	return len(fake.getInputsArgsForCall)
 }
 
-func (fake *TransferAction) GetInputsCalls(stub func() ([]string, error)) {
+func (fake *TransferAction) GetInputsCalls(stub func() ([]*token.ID, error)) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = stub
 }
 
-func (fake *TransferAction) GetInputsReturns(result1 []string, result2 error) {
+func (fake *TransferAction) GetInputsReturns(result1 []*token.ID, result2 error) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = nil
 	fake.getInputsReturns = struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *TransferAction) GetInputsReturnsOnCall(i int, result1 []string, result2 error) {
+func (fake *TransferAction) GetInputsReturnsOnCall(i int, result1 []*token.ID, result2 error) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = nil
 	if fake.getInputsReturnsOnCall == nil {
 		fake.getInputsReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 []*token.ID
 			result2 error
 		})
 	}
 	fake.getInputsReturnsOnCall[i] = struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}{result1, result2}
 }
@@ -271,6 +282,59 @@ func (fake *TransferAction) GetOutputsReturnsOnCall(i int, result1 []driver.Outp
 	}
 	fake.getOutputsReturnsOnCall[i] = struct {
 		result1 []driver.Output
+	}{result1}
+}
+
+func (fake *TransferAction) GetSerialNumbers() []string {
+	fake.getSerialNumbersMutex.Lock()
+	ret, specificReturn := fake.getSerialNumbersReturnsOnCall[len(fake.getSerialNumbersArgsForCall)]
+	fake.getSerialNumbersArgsForCall = append(fake.getSerialNumbersArgsForCall, struct {
+	}{})
+	stub := fake.GetSerialNumbersStub
+	fakeReturns := fake.getSerialNumbersReturns
+	fake.recordInvocation("GetSerialNumbers", []interface{}{})
+	fake.getSerialNumbersMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *TransferAction) GetSerialNumbersCallCount() int {
+	fake.getSerialNumbersMutex.RLock()
+	defer fake.getSerialNumbersMutex.RUnlock()
+	return len(fake.getSerialNumbersArgsForCall)
+}
+
+func (fake *TransferAction) GetSerialNumbersCalls(stub func() []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = stub
+}
+
+func (fake *TransferAction) GetSerialNumbersReturns(result1 []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = nil
+	fake.getSerialNumbersReturns = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *TransferAction) GetSerialNumbersReturnsOnCall(i int, result1 []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = nil
+	if fake.getSerialNumbersReturnsOnCall == nil {
+		fake.getSerialNumbersReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.getSerialNumbersReturnsOnCall[i] = struct {
+		result1 []string
 	}{result1}
 }
 
@@ -626,6 +690,8 @@ func (fake *TransferAction) Invocations() map[string][][]interface{} {
 	defer fake.getMetadataMutex.RUnlock()
 	fake.getOutputsMutex.RLock()
 	defer fake.getOutputsMutex.RUnlock()
+	fake.getSerialNumbersMutex.RLock()
+	defer fake.getSerialNumbersMutex.RUnlock()
 	fake.getSerializedOutputsMutex.RLock()
 	defer fake.getSerializedOutputsMutex.RUnlock()
 	fake.isGraphHidingMutex.RLock()

--- a/token/driver/mock/validator.go
+++ b/token/driver/mock/validator.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Validator struct {
@@ -22,11 +23,11 @@ type Validator struct {
 		result1 []interface{}
 		result2 error
 	}
-	VerifyTokenRequestFromRawStub        func(context.Context, func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)
+	VerifyTokenRequestFromRawStub        func(context.Context, func(id token.ID) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)
 	verifyTokenRequestFromRawMutex       sync.RWMutex
 	verifyTokenRequestFromRawArgsForCall []struct {
 		arg1 context.Context
-		arg2 func(key string) ([]byte, error)
+		arg2 func(id token.ID) ([]byte, error)
 		arg3 string
 		arg4 []byte
 	}
@@ -113,7 +114,7 @@ func (fake *Validator) UnmarshalActionsReturnsOnCall(i int, result1 []interface{
 	}{result1, result2}
 }
 
-func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func(key string) ([]byte, error), arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
+func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func(id token.ID) ([]byte, error), arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
 	var arg4Copy []byte
 	if arg4 != nil {
 		arg4Copy = make([]byte, len(arg4))
@@ -123,7 +124,7 @@ func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func
 	ret, specificReturn := fake.verifyTokenRequestFromRawReturnsOnCall[len(fake.verifyTokenRequestFromRawArgsForCall)]
 	fake.verifyTokenRequestFromRawArgsForCall = append(fake.verifyTokenRequestFromRawArgsForCall, struct {
 		arg1 context.Context
-		arg2 func(key string) ([]byte, error)
+		arg2 func(id token.ID) ([]byte, error)
 		arg3 string
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
@@ -146,13 +147,13 @@ func (fake *Validator) VerifyTokenRequestFromRawCallCount() int {
 	return len(fake.verifyTokenRequestFromRawArgsForCall)
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(context.Context, func(key string) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)) {
+func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(context.Context, func(id token.ID) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)) {
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	defer fake.verifyTokenRequestFromRawMutex.Unlock()
 	fake.VerifyTokenRequestFromRawStub = stub
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (context.Context, func(key string) ([]byte, error), string, []byte) {
+func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (context.Context, func(id token.ID) ([]byte, error), string, []byte) {
 	fake.verifyTokenRequestFromRawMutex.RLock()
 	defer fake.verifyTokenRequestFromRawMutex.RUnlock()
 	argsForCall := fake.verifyTokenRequestFromRawArgsForCall[i]

--- a/token/driver/mock/validator_ledger.go
+++ b/token/driver/mock/validator_ledger.go
@@ -5,13 +5,14 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type ValidatorLedger struct {
-	GetStateStub        func(string) ([]byte, error)
+	GetStateStub        func(token.ID) ([]byte, error)
 	getStateMutex       sync.RWMutex
 	getStateArgsForCall []struct {
-		arg1 string
+		arg1 token.ID
 	}
 	getStateReturns struct {
 		result1 []byte
@@ -25,11 +26,11 @@ type ValidatorLedger struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ValidatorLedger) GetState(arg1 string) ([]byte, error) {
+func (fake *ValidatorLedger) GetState(arg1 token.ID) ([]byte, error) {
 	fake.getStateMutex.Lock()
 	ret, specificReturn := fake.getStateReturnsOnCall[len(fake.getStateArgsForCall)]
 	fake.getStateArgsForCall = append(fake.getStateArgsForCall, struct {
-		arg1 string
+		arg1 token.ID
 	}{arg1})
 	stub := fake.GetStateStub
 	fakeReturns := fake.getStateReturns
@@ -50,13 +51,13 @@ func (fake *ValidatorLedger) GetStateCallCount() int {
 	return len(fake.getStateArgsForCall)
 }
 
-func (fake *ValidatorLedger) GetStateCalls(stub func(string) ([]byte, error)) {
+func (fake *ValidatorLedger) GetStateCalls(stub func(token.ID) ([]byte, error)) {
 	fake.getStateMutex.Lock()
 	defer fake.getStateMutex.Unlock()
 	fake.GetStateStub = stub
 }
 
-func (fake *ValidatorLedger) GetStateArgsForCall(i int) string {
+func (fake *ValidatorLedger) GetStateArgsForCall(i int) token.ID {
 	fake.getStateMutex.RLock()
 	defer fake.getStateMutex.RUnlock()
 	argsForCall := fake.getStateArgsForCall[i]

--- a/token/driver/validator.go
+++ b/token/driver/validator.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
 
 // ValidationAttributeID is the type of validation attribute identifier
 type ValidationAttributeID = string
@@ -15,12 +19,12 @@ type ValidationAttributeID = string
 type ValidationAttributes = map[ValidationAttributeID][]byte
 
 // GetStateFnc models a function that returns the value for the given key from the ledger
-type GetStateFnc = func(key string) ([]byte, error)
+type GetStateFnc = func(id token.ID) ([]byte, error)
 
 // Ledger models a read-only ledger
 type Ledger interface {
 	// GetState returns the value for the given key
-	GetState(key string) ([]byte, error)
+	GetState(id token.ID) ([]byte, error)
 }
 
 type SignatureProvider interface {
@@ -34,7 +38,7 @@ type SignatureProvider interface {
 //go:generate counterfeiter -o mock/validator_ledger.go -fake-name ValidatorLedger . ValidatorLedger
 
 type ValidatorLedger interface {
-	GetState(key string) ([]byte, error)
+	GetState(id token.ID) ([]byte, error)
 }
 
 // Validator models a token request validator

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -83,9 +83,9 @@ type QueryEngine interface {
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
 	// GetTokenInfoAndOutputs retrieves both the token output and information for the passed ids.
-	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([]string, [][]byte, [][]byte, error)
+	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, error)
 	// GetTokens returns the list of tokens with their respective vault keys
-	GetTokens(inputs ...*token.ID) ([]string, []*token.Token, error)
+	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.
 	// The bool array is an indicator used to tell if the token at a given position has been deleted or not
 	WhoDeletedTokens(inputs ...*token.ID) ([]string, []bool, error)

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -148,11 +148,11 @@ type TokenDB interface {
 	GetTokenInfos(ids []*token.ID) ([][]byte, error)
 	// GetTokenInfoAndOutputs returns both value and metadata of the tokens for the passed ids.
 	// For each token, the call-back function is invoked. The call-back function is invoked respecting the order of the passed ids.
-	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([]string, [][]byte, [][]byte, error)
+	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, error)
 	// GetAllTokenInfos returns the token metadata for the passed ids
 	GetAllTokenInfos(ids []*token.ID) ([][]byte, error)
 	// GetTokens returns the owned tokens and their identifier keys for the passed ids.
-	GetTokens(inputs ...*token.ID) ([]string, []*token.Token, error)
+	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens for each id, the function return if it was deleted and by who as per the Delete function
 	WhoDeletedTokens(inputs ...*token.ID) ([]string, []bool, error)
 	// TransactionExists returns true if a token with that transaction id exists in the db

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -279,13 +279,11 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	tokens = getTokensBy(t, db, "alice", "ABC")
 	assert.Len(t, tokens, 1, "unspentTokensIteratorBy: expected only Alice ABC tokens to be returned")
 
-	keys, unsp, err := db.GetTokens(&token.ID{TxId: "tx101", Index: 0})
+	unsp, err := db.GetTokens(&token.ID{TxId: "tx101", Index: 0})
 	assert.NoError(t, err)
-	assert.Len(t, keys, 1)
 	assert.Len(t, unsp, 1)
 	assert.Equal(t, "0x02", unsp[0].Quantity)
 	assert.Equal(t, "ABC", unsp[0].Type)
-	assert.Equal(t, keys[0], "\x00ztoken\x00tx101\x000\x00")
 }
 
 func getTokensBy(t *testing.T, db *TokenDB, ownerEID, typ string) []*token.UnspentToken {
@@ -627,7 +625,7 @@ func TGetTokenInfos(t *testing.T, db *TokenDB) {
 	assert.Equal(t, "tx101", string(infos[2]))
 
 	// infos and outputs
-	keys, toks, infos, err := db.GetTokenInfoAndOutputs(context.TODO(), ids)
+	toks, infos, err := db.GetTokenInfoAndOutputs(context.TODO(), ids)
 	assert.NoError(t, err)
 	assert.Len(t, infos, 3)
 	assert.Equal(t, "tx102", string(infos[0]))
@@ -637,7 +635,6 @@ func TGetTokenInfos(t *testing.T, db *TokenDB) {
 	assert.Equal(t, "tx102l", string(toks[0]))
 	assert.Equal(t, "tx102l", string(toks[1]))
 	assert.Equal(t, "tx101l", string(toks[2]))
-	assert.Equal(t, "\x00ztoken\x00tx101\x000\x00", string(keys[2]))
 }
 
 func TDeleteMultiple(t *testing.T, db *TokenDB) {

--- a/token/services/network/common/rws/translator/action.go
+++ b/token/services/network/common/rws/translator/action.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package translator
 
+import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+
 type SetupAction interface {
 	GetSetupParameters() ([]byte, error)
 }
@@ -36,7 +38,9 @@ type TransferAction interface {
 	// SerializeOutputAt returns the serialized output at the passed index
 	SerializeOutputAt(index int) ([]byte, error)
 	// GetInputs returns the identifiers of the inputs in the action.
-	GetInputs() ([]string, error)
+	GetInputs() ([]*token.ID, error)
+	// GetSerialNumbers returns the serial numbers of the inputs if this action supports graph hiding
+	GetSerialNumbers() []string
 	// IsGraphHiding returns true if the action is graph hiding
 	IsGraphHiding() bool
 	// GetMetadata returns the action's metadata

--- a/token/services/network/common/rws/translator/mock/transfer_action.go
+++ b/token/services/network/common/rws/translator/mock/transfer_action.go
@@ -5,19 +5,20 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type TransferAction struct {
-	GetInputsStub        func() ([]string, error)
+	GetInputsStub        func() ([]*token.ID, error)
 	getInputsMutex       sync.RWMutex
 	getInputsArgsForCall []struct {
 	}
 	getInputsReturns struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}
 	getInputsReturnsOnCall map[int]struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}
 	GetMetadataStub        func() map[string][]byte
@@ -29,6 +30,16 @@ type TransferAction struct {
 	}
 	getMetadataReturnsOnCall map[int]struct {
 		result1 map[string][]byte
+	}
+	GetSerialNumbersStub        func() []string
+	getSerialNumbersMutex       sync.RWMutex
+	getSerialNumbersArgsForCall []struct {
+	}
+	getSerialNumbersReturns struct {
+		result1 []string
+	}
+	getSerialNumbersReturnsOnCall map[int]struct {
+		result1 []string
 	}
 	GetSerializedOutputsStub        func() ([][]byte, error)
 	getSerializedOutputsMutex       sync.RWMutex
@@ -102,7 +113,7 @@ type TransferAction struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TransferAction) GetInputs() ([]string, error) {
+func (fake *TransferAction) GetInputs() ([]*token.ID, error) {
 	fake.getInputsMutex.Lock()
 	ret, specificReturn := fake.getInputsReturnsOnCall[len(fake.getInputsArgsForCall)]
 	fake.getInputsArgsForCall = append(fake.getInputsArgsForCall, struct {
@@ -126,34 +137,34 @@ func (fake *TransferAction) GetInputsCallCount() int {
 	return len(fake.getInputsArgsForCall)
 }
 
-func (fake *TransferAction) GetInputsCalls(stub func() ([]string, error)) {
+func (fake *TransferAction) GetInputsCalls(stub func() ([]*token.ID, error)) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = stub
 }
 
-func (fake *TransferAction) GetInputsReturns(result1 []string, result2 error) {
+func (fake *TransferAction) GetInputsReturns(result1 []*token.ID, result2 error) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = nil
 	fake.getInputsReturns = struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *TransferAction) GetInputsReturnsOnCall(i int, result1 []string, result2 error) {
+func (fake *TransferAction) GetInputsReturnsOnCall(i int, result1 []*token.ID, result2 error) {
 	fake.getInputsMutex.Lock()
 	defer fake.getInputsMutex.Unlock()
 	fake.GetInputsStub = nil
 	if fake.getInputsReturnsOnCall == nil {
 		fake.getInputsReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 []*token.ID
 			result2 error
 		})
 	}
 	fake.getInputsReturnsOnCall[i] = struct {
-		result1 []string
+		result1 []*token.ID
 		result2 error
 	}{result1, result2}
 }
@@ -208,6 +219,59 @@ func (fake *TransferAction) GetMetadataReturnsOnCall(i int, result1 map[string][
 	}
 	fake.getMetadataReturnsOnCall[i] = struct {
 		result1 map[string][]byte
+	}{result1}
+}
+
+func (fake *TransferAction) GetSerialNumbers() []string {
+	fake.getSerialNumbersMutex.Lock()
+	ret, specificReturn := fake.getSerialNumbersReturnsOnCall[len(fake.getSerialNumbersArgsForCall)]
+	fake.getSerialNumbersArgsForCall = append(fake.getSerialNumbersArgsForCall, struct {
+	}{})
+	stub := fake.GetSerialNumbersStub
+	fakeReturns := fake.getSerialNumbersReturns
+	fake.recordInvocation("GetSerialNumbers", []interface{}{})
+	fake.getSerialNumbersMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *TransferAction) GetSerialNumbersCallCount() int {
+	fake.getSerialNumbersMutex.RLock()
+	defer fake.getSerialNumbersMutex.RUnlock()
+	return len(fake.getSerialNumbersArgsForCall)
+}
+
+func (fake *TransferAction) GetSerialNumbersCalls(stub func() []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = stub
+}
+
+func (fake *TransferAction) GetSerialNumbersReturns(result1 []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = nil
+	fake.getSerialNumbersReturns = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *TransferAction) GetSerialNumbersReturnsOnCall(i int, result1 []string) {
+	fake.getSerialNumbersMutex.Lock()
+	defer fake.getSerialNumbersMutex.Unlock()
+	fake.GetSerialNumbersStub = nil
+	if fake.getSerialNumbersReturnsOnCall == nil {
+		fake.getSerialNumbersReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.getSerialNumbersReturnsOnCall[i] = struct {
+		result1 []string
 	}{result1}
 }
 
@@ -561,6 +625,8 @@ func (fake *TransferAction) Invocations() map[string][][]interface{} {
 	defer fake.getInputsMutex.RUnlock()
 	fake.getMetadataMutex.RLock()
 	defer fake.getMetadataMutex.RUnlock()
+	fake.getSerialNumbersMutex.RLock()
+	defer fake.getSerialNumbersMutex.RUnlock()
 	fake.getSerializedOutputsMutex.RLock()
 	defer fake.getSerializedOutputsMutex.RUnlock()
 	fake.isGraphHidingMutex.RLock()

--- a/token/services/network/common/rws/translator/translator.go
+++ b/token/services/network/common/rws/translator/translator.go
@@ -202,12 +202,20 @@ func (w *Translator) checkIssue(issue IssueAction) error {
 }
 
 func (w *Translator) checkTransfer(t TransferAction) error {
-	keys, err := t.GetInputs()
+	inputs, err := t.GetInputs()
 	if err != nil {
 		return errors.Wrapf(err, "invalid transfer: failed getting input IDs")
 	}
 	if !t.IsGraphHiding() {
-		for _, key := range keys {
+		rwsetKeys := make([]string, len(inputs))
+		for i, input := range inputs {
+			rwsetKeys[i], err = keys.CreateTokenKey(input.TxId, input.Index)
+			if err != nil {
+				return errors.Wrapf(err, "invalid transfer: failed creating output ID [%v]", input)
+			}
+		}
+
+		for _, key := range rwsetKeys {
 			bytes, err := w.RWSet.GetState(w.namespace, key)
 			if err != nil {
 				return errors.Wrapf(err, "invalid transfer: failed getting state [%s]", key)
@@ -217,7 +225,7 @@ func (w *Translator) checkTransfer(t TransferAction) error {
 			}
 		}
 	} else {
-		for _, key := range keys {
+		for _, key := range t.GetSerialNumbers() {
 			bytes, err := w.RWSet.GetState(w.namespace, key)
 			if err != nil {
 				return errors.Wrapf(err, "invalid transfer: failed getting state [%s]", key)
@@ -382,11 +390,7 @@ func (w *Translator) commitTransferAction(transferAction TransferAction) error {
 	}
 
 	// store inputs
-	ids, err := transferAction.GetInputs()
-	if err != nil {
-		return err
-	}
-	err = w.spendTokens(ids, transferAction.IsGraphHiding())
+	err := w.spendTokens(transferAction)
 	if err != nil {
 		return err
 	}
@@ -414,9 +418,21 @@ func (w *Translator) commitTransferAction(transferAction TransferAction) error {
 	return nil
 }
 
-func (w *Translator) spendTokens(ids []string, graphHiding bool) error {
-	if !graphHiding {
-		for _, id := range ids {
+func (w *Translator) spendTokens(transferAction TransferAction) error {
+	if !transferAction.IsGraphHiding() {
+		ids, err := transferAction.GetInputs()
+		if err != nil {
+			return err
+		}
+		rwsetKeys := make([]string, len(ids))
+		for i, input := range ids {
+			rwsetKeys[i], err = keys.CreateTokenKey(input.TxId, input.Index)
+			if err != nil {
+				return errors.Wrapf(err, "invalid transfer: failed creating output ID [%v]", input)
+			}
+		}
+
+		for _, id := range rwsetKeys {
 			logger.Debugf("Delete state %s\n", id)
 			err := w.RWSet.DeleteState(w.namespace, id)
 			if err != nil {
@@ -427,6 +443,7 @@ func (w *Translator) spendTokens(ids []string, graphHiding bool) error {
 			}
 		}
 	} else {
+		ids := transferAction.GetSerialNumbers()
 		for _, id := range ids {
 			logger.Debugf("add serial number %s\n", id)
 			k, err := keys.CreateSNKey(id)

--- a/token/services/network/common/rws/translator/translator_test.go
+++ b/token/services/network/common/rws/translator/translator_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/keys"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator/mock"
-
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -115,7 +115,7 @@ var _ = Describe("Translator", func() {
 			faketransfer.IsRedeemAtReturnsOnCall(0, false)
 			faketransfer.SerializeOutputAtReturnsOnCall(1, []byte("output-2"), nil)
 			faketransfer.IsRedeemAtReturnsOnCall(1, false)
-			faketransfer.GetInputsReturns([]string{"key1", "key2", "key3"}, nil)
+			faketransfer.GetInputsReturns([]*token.ID{{TxId: "key1"}, {TxId: "key2"}, {TxId: "key3"}}, nil)
 			faketransfer.NumOutputsReturns(2)
 			fakeRWSet.GetStateReturnsOnCall(0, []byte("token-1"), nil)
 			fakeRWSet.GetStateReturnsOnCall(1, []byte("token-2"), nil)
@@ -189,7 +189,8 @@ var _ = Describe("Translator", func() {
 			fakeRWSet.GetStateReturnsOnCall(0, nil, nil)
 			fakeRWSet.GetStateReturnsOnCall(1, nil, nil)
 			fakeRWSet.GetStateReturnsOnCall(2, nil, nil)
-			faketransfer.GetInputsReturns(sn, nil)
+			faketransfer.GetInputsReturns([]*token.ID{{TxId: "key1"}, {TxId: "key2"}, {TxId: "key3"}}, nil)
+			faketransfer.GetSerialNumbersReturns(sn)
 			faketransfer.NumOutputsReturns(2)
 			faketransfer.IsGraphHidingReturns(true)
 		})

--- a/token/services/network/driver/vault.go
+++ b/token/services/network/driver/vault.go
@@ -42,7 +42,7 @@ type TokenVault interface {
 }
 
 type QueryExecutor interface {
-	GetState(key string) ([]byte, error)
+	GetState(id token.ID) ([]byte, error)
 	Done()
 }
 

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -68,7 +68,11 @@ type qe struct {
 	ns string
 }
 
-func (q *qe) GetState(key string) ([]byte, error) {
+func (q *qe) GetState(id token.ID) ([]byte, error) {
+	key, err := keys.CreateTokenKey(id.TxId, id.Index)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting token key for [%v]", id)
+	}
 	return q.QueryExecutor.GetState(q.ns, key)
 }
 

--- a/token/services/network/fabric/tcc/shim.go
+++ b/token/services/network/fabric/tcc/shim.go
@@ -3,6 +3,7 @@ Copyright IBM Corp. All Rights Reserved.
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package tcc
 
 import (

--- a/token/services/network/orion/approval.go
+++ b/token/services/network/orion/approval.go
@@ -9,6 +9,8 @@ package orion
 import (
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/keys"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/orion"
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	session2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
@@ -20,6 +22,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	driver2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -266,6 +269,10 @@ type LedgerWrapper struct {
 	qe *orion.SessionQueryExecutor
 }
 
-func (l *LedgerWrapper) GetState(key string) ([]byte, error) {
+func (l *LedgerWrapper) GetState(id token2.ID) ([]byte, error) {
+	key, err := keys.CreateTokenKey(id.TxId, id.Index)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed getting token key for [%v]", id)
+	}
 	return l.qe.Get(orionKey(key))
 }

--- a/token/vault.go
+++ b/token/vault.go
@@ -123,7 +123,7 @@ func (q *QueryEngine) PublicParams() ([]byte, error) {
 
 // GetTokens returns the tokens stored in the vault matching the given ids
 func (q *QueryEngine) GetTokens(inputs ...*token.ID) ([]*token.Token, error) {
-	_, tokens, err := q.qe.GetTokens(inputs...)
+	tokens, err := q.qe.GetTokens(inputs...)
 	return tokens, err
 }
 

--- a/token/vault_test.go
+++ b/token/vault_test.go
@@ -200,7 +200,7 @@ func TestQueryEngine_GetTokens(t *testing.T) {
 		Type:     "some_type",
 		Quantity: "some_quantity",
 	}}
-	mockQE.GetTokensReturns(nil, expectedTokens, nil)
+	mockQE.GetTokensReturns(expectedTokens, nil)
 
 	queryEngine := NewQueryEngine(logging.MustGetLogger("test"), mockQE, 3, time.Second)
 	tokens, err := queryEngine.GetTokens(nil)
@@ -212,7 +212,7 @@ func TestQueryEngine_GetTokens_Error(t *testing.T) {
 	mockQE := &mock.QueryEngine{}
 
 	expectedErr := errors.New("mock error")
-	mockQE.GetTokensReturns(nil, nil, expectedErr)
+	mockQE.GetTokensReturns(nil, expectedErr)
 
 	queryEngine := NewQueryEngine(logging.MustGetLogger("test"), mockQE, 3, time.Second)
 	tokens, err := queryEngine.GetTokens(nil)


### PR DESCRIPTION
This PR does the following: It removes from the db implementation any reference to the generation of keys used to store tokens in the rwset. The dbs must be agnostic to any backend implementation