### PR TITLE
spendable tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.6
 require (
 	github.com/IBM/idemix v0.0.2-0.20240816143710-3dce4618d760
 	github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760
-	github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5
+	github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.6
 require (
 	github.com/IBM/idemix v0.0.2-0.20240816143710-3dce4618d760
 	github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760
-	github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381
+	github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d h
 github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d/go.mod h1:FC0vVgNI6bv8GH0VTwjup+arwJ8Tau1iEhroWZ1oPwU=
 github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760 h1:4tcdWj0MONt4JtiqNESWMuWSb5rDInIFzlUSbncHlCM=
 github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760/go.mod h1:4bYvi+a50aXxmHf1vwuvR+Wd8YXZ6AhT+0p5oK4xdOA=
-github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5 h1:wfksZZMeYfPeqsXwiotUsbnOqGGpth6t8Ij4tJ/91kw=
-github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
+github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381 h1:FHobdbIHiODoLuYhuUlJvGbEKsrmolJBMxZ/18L+Z3s=
+github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d h
 github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d/go.mod h1:FC0vVgNI6bv8GH0VTwjup+arwJ8Tau1iEhroWZ1oPwU=
 github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760 h1:4tcdWj0MONt4JtiqNESWMuWSb5rDInIFzlUSbncHlCM=
 github.com/IBM/idemix/bccsp/types v0.0.0-20240816143710-3dce4618d760/go.mod h1:4bYvi+a50aXxmHf1vwuvR+Wd8YXZ6AhT+0p5oK4xdOA=
-github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381 h1:FHobdbIHiODoLuYhuUlJvGbEKsrmolJBMxZ/18L+Z3s=
-github.com/IBM/mathlib v0.0.3-0.20241119052826-7fdf2555b381/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
+github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5 h1:wfksZZMeYfPeqsXwiotUsbnOqGGpth6t8Ij4tJ/91kw=
+github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/integration/token/dvp/tests.go
+++ b/integration/token/dvp/tests.go
@@ -82,7 +82,7 @@ func sellHouse(network *integration.Infrastructure, houseID string, seller *toke
 	common2.CheckFinality(network, buyer, common.JSONUnmarshalString(txIDBoxed), nil, false)
 }
 
-func checkBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected uint64) {
+func checkBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64) {
 	res, err := network.Client(ref.ReplicaName()).CallView("balance", common.JSONMarshall(&views2.BalanceQuery{
 		Wallet: wallet,
 		Type:   typ,

--- a/integration/token/dvp/tests.go
+++ b/integration/token/dvp/tests.go
@@ -21,6 +21,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	USD = token2.TokenType("USD")
+)
+
 func TestAll(network *integration.Infrastructure, sel *token3.ReplicaSelector) {
 	cashIssuer := sel.Get("cash_issuer")
 	buyer := sel.Get("buyer")
@@ -33,16 +37,16 @@ func TestAll(network *integration.Infrastructure, sel *token3.ReplicaSelector) {
 	// Ready to go
 	registerAuditor(network)
 	issueCash(network, cashIssuer, buyer)
-	checkBalance(network, buyer, "", "USD", 10)
-	checkBalance(network, seller, "", "USD", 0)
+	checkBalance(network, buyer, "", USD, 10)
+	checkBalance(network, seller, "", USD, 0)
 	houseID := issueHouse(network, 4, houseIssuer, seller)
 	queryHouse(network, seller, houseID, "5th Avenue")
 	queryHouse(network, buyer, houseID, "5th Avenue", "failed loading house with id")
 	sellHouse(network, houseID, seller, buyer)
 	queryHouse(network, buyer, houseID, "5th Avenue")
 	queryHouse(network, seller, houseID, "5th Avenue", "failed loading house with id")
-	checkBalance(network, buyer, "", "USD", 6)
-	checkBalance(network, seller, "", "USD", 4)
+	checkBalance(network, buyer, "", USD, 6)
+	checkBalance(network, seller, "", USD, 4)
 }
 
 func registerAuditor(network *integration.Infrastructure) {
@@ -53,7 +57,7 @@ func registerAuditor(network *integration.Infrastructure) {
 func issueCash(network *integration.Infrastructure, issuer *token3.NodeReference, buyer *token3.NodeReference) {
 	_, err := network.Client(issuer.ReplicaName()).CallView("issue_cash", common.JSONMarshall(cash.IssueCash{
 		IssuerWallet: "",
-		TokenType:    "USD",
+		TokenType:    USD,
 		Quantity:     10,
 		Recipient:    buyer.Id(),
 	}))

--- a/integration/token/dvp/tests.go
+++ b/integration/token/dvp/tests.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	USD = token2.TokenType("USD")
+	USD = token2.Type("USD")
 )
 
 func TestAll(network *integration.Infrastructure, sel *token3.ReplicaSelector) {
@@ -86,7 +86,7 @@ func sellHouse(network *integration.Infrastructure, houseID string, seller *toke
 	common2.CheckFinality(network, buyer, common.JSONUnmarshalString(txIDBoxed), nil, false)
 }
 
-func checkBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64) {
+func checkBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token2.Type, expected uint64) {
 	res, err := network.Client(ref.ReplicaName()).CallView("balance", common.JSONMarshall(&views2.BalanceQuery{
 		Wallet: wallet,
 		Type:   typ,

--- a/integration/token/dvp/views/balance.go
+++ b/integration/token/dvp/views/balance.go
@@ -13,16 +13,17 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type BalanceQuery struct {
 	TMSID  token.TMSID
 	Wallet string
-	Type   string
+	Type   token2.TokenType
 }
 
 type Balance struct {
-	Type     string
+	Type     token2.TokenType
 	Quantity string
 }
 

--- a/integration/token/dvp/views/balance.go
+++ b/integration/token/dvp/views/balance.go
@@ -19,11 +19,11 @@ import (
 type BalanceQuery struct {
 	TMSID  token.TMSID
 	Wallet string
-	Type   token2.TokenType
+	Type   token2.Type
 }
 
 type Balance struct {
-	Type     token2.TokenType
+	Type     token2.Type
 	Quantity string
 }
 

--- a/integration/token/dvp/views/buyer.go
+++ b/integration/token/dvp/views/buyer.go
@@ -46,7 +46,7 @@ func (b *BuyHouseView) Call(context view.Context) (interface{}, error) {
 	// check action
 	assert.Equal(otherCash, action.Recipient, "recipient mismatch")
 	assert.True(action.Amount > 0, "amount must be greater than 0")
-	assert.Equal(token2.TokenType("USD"), action.Type, "currency must be USD")
+	assert.Equal(token2.Type("USD"), action.Type, "currency must be USD")
 	assert.Equal(meCash, action.From, "sender mismatch")
 
 	// check house and action match

--- a/integration/token/dvp/views/buyer.go
+++ b/integration/token/dvp/views/buyer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/dvp/views/house"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type BuyHouseView struct{}
@@ -45,7 +46,7 @@ func (b *BuyHouseView) Call(context view.Context) (interface{}, error) {
 	// check action
 	assert.Equal(otherCash, action.Recipient, "recipient mismatch")
 	assert.True(action.Amount > 0, "amount must be greater than 0")
-	assert.Equal("USD", action.Type, "currency must be USD")
+	assert.Equal(token2.TokenType("USD"), action.Type, "currency must be USD")
 	assert.Equal(meCash, action.From, "sender mismatch")
 
 	// check house and action match

--- a/integration/token/dvp/views/cash/history.go
+++ b/integration/token/dvp/views/cash/history.go
@@ -21,7 +21,7 @@ type ListIssuedTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType token2.TokenType
+	TokenType token2.Type
 }
 
 type ListIssuedTokensView struct {

--- a/integration/token/dvp/views/cash/history.go
+++ b/integration/token/dvp/views/cash/history.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 )
@@ -20,7 +21,7 @@ type ListIssuedTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType string
+	TokenType token2.TokenType
 }
 
 type ListIssuedTokensView struct {

--- a/integration/token/dvp/views/cash/issue.go
+++ b/integration/token/dvp/views/cash/issue.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // IssueCash contains the input information to issue a token
@@ -20,7 +21,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType string
+	TokenType token.TokenType
 	// Quantity represent the number of units of a certain token type stored in the token
 	Quantity uint64
 	// Recipient is an identifier of the recipient identity

--- a/integration/token/dvp/views/cash/issue.go
+++ b/integration/token/dvp/views/cash/issue.go
@@ -21,7 +21,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType token.TokenType
+	TokenType token.Type
 	// Quantity represent the number of units of a certain token type stored in the token
 	Quantity uint64
 	// Recipient is an identifier of the recipient identity

--- a/integration/token/dvp/views/cash/list.go
+++ b/integration/token/dvp/views/cash/list.go
@@ -22,7 +22,7 @@ type ListUnspentTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType token2.TokenType
+	TokenType token2.Type
 }
 
 type ListUnspentTokensView struct {

--- a/integration/token/dvp/views/cash/list.go
+++ b/integration/token/dvp/views/cash/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 )
@@ -21,7 +22,7 @@ type ListUnspentTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType string
+	TokenType token2.TokenType
 }
 
 type ListUnspentTokensView struct {

--- a/integration/token/fungible/mixed/topology.go
+++ b/integration/token/fungible/mixed/topology.go
@@ -134,7 +134,8 @@ func Topology(opts common.Opts) []api.Topology {
 		RegisterViewFactory("ListVaultUnspentTokens", &views.ListVaultUnspentTokensViewFactory{}).
 		RegisterViewFactory("TxFinality", &views2.TxFinalityViewFactory{}).
 		RegisterViewFactory("MaliciousTransfer", &views.MaliciousTransferViewFactory{}).
-		RegisterViewFactory("TxStatus", &views.TxStatusViewFactory{})
+		RegisterViewFactory("TxStatus", &views.TxStatusViewFactory{}).
+		RegisterViewFactory("SetSpendableFlag", &views.SetSpendableFlagViewFactory{})
 
 	bob := fscTopology.AddNodeByName("bob").AddOptions(
 		fabric.WithOrganization("Org2"),

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -79,19 +79,19 @@ func getFabricTopology(network *integration.Infrastructure) *topology2.Topology 
 	return nil
 }
 
-func IssueCash(network *integration.Infrastructure, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func IssueCash(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
 	return IssueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, expectedErrorMsgs...)
 }
 
-func IssueSuccessfulCash(network *integration.Infrastructure, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, finalities ...*token3.NodeReference) string {
+func IssueSuccessfulCash(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, finalities ...*token3.NodeReference) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, finalities, []string{})
 }
 
-func IssueCashForTMSID(network *integration.Infrastructure, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func IssueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, tmsId, []*token3.NodeReference{}, expectedErrorMsgs)
 }
 
-func issueCashForTMSID(network *integration.Infrastructure, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, endorsers []*token3.NodeReference, expectedErrorMsgs []string) string {
+func issueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, endorsers []*token3.NodeReference, expectedErrorMsgs []string) string {
 	targetAuditor := auditor.Id()
 	if auditor.Id() == "issuer" || auditor.Id() == "newIssuer" {
 		// the issuer is the auditor, choose default identity
@@ -227,21 +227,21 @@ func matchTransactionRecord(tx *ttxdb.TransactionRecord, txExpected TransactionR
 	return nil
 }
 
-func CheckBalanceAndHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected uint64, auditor *token3.NodeReference) {
+func CheckBalanceAndHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, auditor *token3.NodeReference) {
 	CheckBalance(network, ref, wallet, typ, expected)
 	CheckHolding(network, ref, wallet, typ, int64(expected), auditor)
 }
 
-func CheckBalanceAndHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func CheckBalanceAndHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	CheckBalanceForTMSID(network, ref, wallet, typ, expected, tmsID)
 	CheckHoldingForTMSID(network, ref, wallet, typ, int64(expected), auditor, tmsID)
 }
 
-func CheckBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected uint64) {
+func CheckBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64) {
 	CheckBalanceForTMSID(network, ref, wallet, typ, expected, nil)
 }
 
-func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected uint64, tmsID *token2.TMSID) {
+func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, tmsID *token2.TMSID) {
 	res, err := network.Client(ref.ReplicaName()).CallView("balance", common.JSONMarshall(&views.BalanceQuery{
 		Wallet: wallet,
 		Type:   typ,
@@ -257,11 +257,11 @@ func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeR
 	Expect(expectedQ.Cmp(q)).To(BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
 }
 
-func CheckHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected int64, auditor *token3.NodeReference) {
+func CheckHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected int64, auditor *token3.NodeReference) {
 	CheckHoldingForTMSID(network, ref, wallet, typ, expected, auditor, nil)
 }
 
-func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ string, expected int64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected int64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	eIDBoxed, err := network.Client(ref.ReplicaName()).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
 		Wallet: wallet,
 		TMSID:  tmsID,
@@ -278,11 +278,11 @@ func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeR
 	Expect(holding).To(Equal(int(expected)))
 }
 
-func CheckSpending(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType string, auditor *token3.NodeReference, expected uint64) {
+func CheckSpending(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.TokenType, auditor *token3.NodeReference, expected uint64) {
 	CheckSpendingForTMSID(network, id, wallet, tokenType, auditor, expected, nil)
 }
 
-func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType string, auditor *token3.NodeReference, expected uint64, tmsId *token2.TMSID) {
+func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.TokenType, auditor *token3.NodeReference, expected uint64, tmsId *token2.TMSID) {
 	// check spending
 	// first get the enrollment id
 	eIDBoxed, err := network.Client(id.ReplicaName()).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
@@ -302,11 +302,11 @@ func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeR
 	Expect(spending).To(Equal(expected))
 }
 
-func ListIssuerHistory(network *integration.Infrastructure, wallet, typ string, issuer *token3.NodeReference) *token.IssuedTokens {
+func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ token.TokenType, issuer *token3.NodeReference) *token.IssuedTokens {
 	return ListIssuerHistoryForTMSID(network, wallet, typ, issuer, nil)
 }
 
-func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet, typ string, issuer *token3.NodeReference, tmsId *token2.TMSID) *token.IssuedTokens {
+func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, issuer *token3.NodeReference, tmsId *token2.TMSID) *token.IssuedTokens {
 	res, err := network.Client(issuer.ReplicaName()).CallView("historyIssuedToken", common.JSONMarshall(&views.ListIssuedTokens{
 		Wallet:    wallet,
 		TokenType: typ,
@@ -319,11 +319,11 @@ func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet, typ 
 	return issuedTokens
 }
 
-func ListUnspentTokens(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ string) *token.UnspentTokens {
+func ListUnspentTokens(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType) *token.UnspentTokens {
 	return ListUnspentTokensForTMSID(network, id, wallet, typ, nil)
 }
 
-func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ string, tmsId *token2.TMSID) *token.UnspentTokens {
+func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, tmsId *token2.TMSID) *token.UnspentTokens {
 	res, err := network.Client(id.ReplicaName()).CallView("history", common.JSONMarshall(&views.ListUnspentTokens{
 		Wallet:    wallet,
 		TokenType: typ,
@@ -336,11 +336,11 @@ func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.N
 	return unspentTokens
 }
 
-func TransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	return TransferCashForTMSID(network, sender, wallet, typ, amount, receiver, auditor, nil, expectedErrorMsgs...)
 }
 
-func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	txidBoxed, err := network.Client(sender.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -378,7 +378,7 @@ func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.No
 	return ""
 }
 
-func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
+func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
 	_, err := network.Client(sender.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -390,7 +390,7 @@ func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *to
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 	// start the call as a stream
@@ -446,7 +446,7 @@ func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *Wa
 	return ""
 }
 
-func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient data for the recipient and register it
 	recipientData := wmp.RecipientData(receiver.Id(), receiverWallet)
 	RegisterRecipientData(network, receiver, receiverWallet, recipientData)
@@ -492,7 +492,7 @@ func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *Wall
 	return ""
 }
 
-func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 
@@ -554,7 +554,7 @@ func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wm
 	return ""
 }
 
-func TransferCashMultiActions(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amounts []uint64, receivers []*token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) string {
+func TransferCashMultiActions(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amounts []uint64, receivers []*token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) string {
 	Expect(len(amounts) > 1).To(BeTrue())
 	Expect(len(receivers)).To(BeEquivalentTo(len(amounts)))
 	transfer := &views.Transfer{
@@ -610,7 +610,7 @@ func TransferCashMultiActions(network *integration.Infrastructure, sender *token
 	return strErr[s+4 : e]
 }
 
-func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	txidBoxed, err := network.Client(id.ReplicaName()).CallView("MaliciousTransfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -635,7 +635,7 @@ func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeR
 	return ""
 }
 
-func PrepareTransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) (string, []byte) {
+func PrepareTransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) (string, []byte) {
 	transferInput := &views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -759,7 +759,7 @@ func TransferCashByIDs(network *integration.Infrastructure, ref *token3.NodeRefe
 	}
 }
 
-func TransferCashWithSelector(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ string, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) {
+func TransferCashWithSelector(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) {
 	txIDBoxed, err := network.Client(sender.ReplicaName()).CallView("transferWithSelector", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -782,11 +782,11 @@ func TransferCashWithSelector(network *integration.Infrastructure, sender *token
 	}
 }
 
-func RedeemCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ string, amount uint64, auditor *token3.NodeReference) {
+func RedeemCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference) {
 	RedeemCashForTMSID(network, id, wallet, typ, amount, auditor, nil)
 }
 
-func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ string, amount uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
 		Auditor: auditor.Id(),
 		Wallet:  wallet,
@@ -810,7 +810,7 @@ func RedeemCashByIDs(network *integration.Infrastructure, id *token3.NodeReferen
 	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), nil, false)
 }
 
-func SwapCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typeLeft string, amountLeft uint64, typRight string, amountRight uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
+func SwapCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typeLeft token.TokenType, amountLeft uint64, typRight token.TokenType, amountRight uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
 	txid, err := network.Client(id.ReplicaName()).CallView("swap", common.JSONMarshall(&views.Swap{
 		Auditor:         auditor.Id(),
 		AliceWallet:     wallet,
@@ -1161,7 +1161,7 @@ func SetSpendableFlag(network *integration.Infrastructure, user *token3.NodeRefe
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ string, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
 	var recipientData *token2.RecipientData
 	if wpm != nil {
 		recipientData = wpm.RecipientData(user.Id(), wallet)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -207,7 +207,7 @@ func CheckAcceptedTransactions(network *integration.Infrastructure, id *token3.N
 
 func matchTransactionRecord(tx *ttxdb.TransactionRecord, txExpected TransactionRecord, i int) error {
 	if tx.TokenType != txExpected.TokenType {
-		return errors.Errorf("tx [%d] tx.TokenType: %s, txExpected.TokenType: %s", i, tx.TokenType, txExpected.TokenType)
+		return errors.Errorf("tx [%d] tx.TokenFormat: %s, txExpected.TokenFormat: %s", i, tx.TokenType, txExpected.TokenType)
 	}
 	if !strings.HasPrefix(tx.SenderEID, txExpected.SenderEID) {
 		return errors.Errorf("tx [%d] tx.SenderEID: %s, txExpected.SenderEID: %s", i, tx.SenderEID, txExpected.SenderEID)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -79,19 +79,19 @@ func getFabricTopology(network *integration.Infrastructure) *topology2.Topology 
 	return nil
 }
 
-func IssueCash(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func IssueCash(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
 	return IssueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, expectedErrorMsgs...)
 }
 
-func IssueSuccessfulCash(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, finalities ...*token3.NodeReference) string {
+func IssueSuccessfulCash(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, finalities ...*token3.NodeReference) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, nil, finalities, []string{})
 }
 
-func IssueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func IssueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	return issueCashForTMSID(network, wallet, typ, amount, receiver, auditor, anonymous, issuer, tmsId, []*token3.NodeReference{}, expectedErrorMsgs)
 }
 
-func issueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, endorsers []*token3.NodeReference, expectedErrorMsgs []string) string {
+func issueCashForTMSID(network *integration.Infrastructure, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, anonymous bool, issuer *token3.NodeReference, tmsId *token2.TMSID, endorsers []*token3.NodeReference, expectedErrorMsgs []string) string {
 	targetAuditor := auditor.Id()
 	if auditor.Id() == "issuer" || auditor.Id() == "newIssuer" {
 		// the issuer is the auditor, choose default identity
@@ -227,21 +227,21 @@ func matchTransactionRecord(tx *ttxdb.TransactionRecord, txExpected TransactionR
 	return nil
 }
 
-func CheckBalanceAndHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, auditor *token3.NodeReference) {
+func CheckBalanceAndHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64, auditor *token3.NodeReference) {
 	CheckBalance(network, ref, wallet, typ, expected)
 	CheckHolding(network, ref, wallet, typ, int64(expected), auditor)
 }
 
-func CheckBalanceAndHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func CheckBalanceAndHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	CheckBalanceForTMSID(network, ref, wallet, typ, expected, tmsID)
 	CheckHoldingForTMSID(network, ref, wallet, typ, int64(expected), auditor, tmsID)
 }
 
-func CheckBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64) {
+func CheckBalance(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64) {
 	CheckBalanceForTMSID(network, ref, wallet, typ, expected, nil)
 }
 
-func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected uint64, tmsID *token2.TMSID) {
+func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected uint64, tmsID *token2.TMSID) {
 	res, err := network.Client(ref.ReplicaName()).CallView("balance", common.JSONMarshall(&views.BalanceQuery{
 		Wallet: wallet,
 		Type:   typ,
@@ -257,11 +257,11 @@ func CheckBalanceForTMSID(network *integration.Infrastructure, ref *token3.NodeR
 	Expect(expectedQ.Cmp(q)).To(BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
 }
 
-func CheckHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected int64, auditor *token3.NodeReference) {
+func CheckHolding(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected int64, auditor *token3.NodeReference) {
 	CheckHoldingForTMSID(network, ref, wallet, typ, expected, auditor, nil)
 }
 
-func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.TokenType, expected int64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeReference, wallet string, typ token.Type, expected int64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	eIDBoxed, err := network.Client(ref.ReplicaName()).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
 		Wallet: wallet,
 		TMSID:  tmsID,
@@ -278,11 +278,11 @@ func CheckHoldingForTMSID(network *integration.Infrastructure, ref *token3.NodeR
 	Expect(holding).To(Equal(int(expected)))
 }
 
-func CheckSpending(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.TokenType, auditor *token3.NodeReference, expected uint64) {
+func CheckSpending(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.Type, auditor *token3.NodeReference, expected uint64) {
 	CheckSpendingForTMSID(network, id, wallet, tokenType, auditor, expected, nil)
 }
 
-func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.TokenType, auditor *token3.NodeReference, expected uint64, tmsId *token2.TMSID) {
+func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, tokenType token.Type, auditor *token3.NodeReference, expected uint64, tmsId *token2.TMSID) {
 	// check spending
 	// first get the enrollment id
 	eIDBoxed, err := network.Client(id.ReplicaName()).CallView("GetEnrollmentID", common.JSONMarshall(&views.GetEnrollmentID{
@@ -302,11 +302,11 @@ func CheckSpendingForTMSID(network *integration.Infrastructure, id *token3.NodeR
 	Expect(spending).To(Equal(expected))
 }
 
-func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ token.TokenType, issuer *token3.NodeReference) *token.IssuedTokens {
+func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ token.Type, issuer *token3.NodeReference) *token.IssuedTokens {
 	return ListIssuerHistoryForTMSID(network, wallet, typ, issuer, nil)
 }
 
-func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet string, typ token.TokenType, issuer *token3.NodeReference, tmsId *token2.TMSID) *token.IssuedTokens {
+func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet string, typ token.Type, issuer *token3.NodeReference, tmsId *token2.TMSID) *token.IssuedTokens {
 	res, err := network.Client(issuer.ReplicaName()).CallView("historyIssuedToken", common.JSONMarshall(&views.ListIssuedTokens{
 		Wallet:    wallet,
 		TokenType: typ,
@@ -319,11 +319,11 @@ func ListIssuerHistoryForTMSID(network *integration.Infrastructure, wallet strin
 	return issuedTokens
 }
 
-func ListUnspentTokens(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType) *token.UnspentTokens {
+func ListUnspentTokens(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type) *token.UnspentTokens {
 	return ListUnspentTokensForTMSID(network, id, wallet, typ, nil)
 }
 
-func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, tmsId *token2.TMSID) *token.UnspentTokens {
+func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, tmsId *token2.TMSID) *token.UnspentTokens {
 	res, err := network.Client(id.ReplicaName()).CallView("history", common.JSONMarshall(&views.ListUnspentTokens{
 		Wallet:    wallet,
 		TokenType: typ,
@@ -336,11 +336,11 @@ func ListUnspentTokensForTMSID(network *integration.Infrastructure, id *token3.N
 	return unspentTokens
 }
 
-func TransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	return TransferCashForTMSID(network, sender, wallet, typ, amount, receiver, auditor, nil, expectedErrorMsgs...)
 }
 
-func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	txidBoxed, err := network.Client(sender.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -378,7 +378,7 @@ func TransferCashForTMSID(network *integration.Infrastructure, sender *token3.No
 	return ""
 }
 
-func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
+func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
 	_, err := network.Client(sender.ReplicaName()).CallView("transfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -390,7 +390,7 @@ func TransferCashNoFinalityCheck(network *integration.Infrastructure, sender *to
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 	// start the call as a stream
@@ -446,7 +446,7 @@ func TransferCashFromExternalWallet(network *integration.Infrastructure, wmp *Wa
 	return ""
 }
 
-func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient data for the recipient and register it
 	recipientData := wmp.RecipientData(receiver.Id(), receiverWallet)
 	RegisterRecipientData(network, receiver, receiverWallet, recipientData)
@@ -492,7 +492,7 @@ func TransferCashToExternalWallet(network *integration.Infrastructure, wmp *Wall
 	return ""
 }
 
-func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
+func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wmp *WalletManagerProvider, websSocket bool, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, receiverWallet string, auditor *token3.NodeReference, expectedErrorMsgs ...string) string {
 	// obtain the recipient for the rest
 	restRecipient := wmp.RecipientData(sender.Id(), wallet)
 
@@ -554,7 +554,7 @@ func TransferCashFromAndToExternalWallet(network *integration.Infrastructure, wm
 	return ""
 }
 
-func TransferCashMultiActions(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amounts []uint64, receivers []*token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) string {
+func TransferCashMultiActions(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amounts []uint64, receivers []*token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) string {
 	Expect(len(amounts) > 1).To(BeTrue())
 	Expect(len(receivers)).To(BeEquivalentTo(len(amounts)))
 	transfer := &views.Transfer{
@@ -610,7 +610,7 @@ func TransferCashMultiActions(network *integration.Infrastructure, sender *token
 	return strErr[s+4 : e]
 }
 
-func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
+func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tmsId *token2.TMSID, expectedErrorMsgs ...string) string {
 	txidBoxed, err := network.Client(id.ReplicaName()).CallView("MaliciousTransfer", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -635,7 +635,7 @@ func MaliciousTransferCash(network *integration.Infrastructure, id *token3.NodeR
 	return ""
 }
 
-func PrepareTransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) (string, []byte) {
+func PrepareTransferCash(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, tokenID *token.ID, expectedErrorMsgs ...string) (string, []byte) {
 	transferInput := &views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -759,7 +759,7 @@ func TransferCashByIDs(network *integration.Infrastructure, ref *token3.NodeRefe
 	}
 }
 
-func TransferCashWithSelector(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) {
+func TransferCashWithSelector(network *integration.Infrastructure, sender *token3.NodeReference, wallet string, typ token.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, expectedErrorMsgs ...string) {
 	txIDBoxed, err := network.Client(sender.ReplicaName()).CallView("transferWithSelector", common.JSONMarshall(&views.Transfer{
 		Auditor:      auditor.Id(),
 		Wallet:       wallet,
@@ -782,11 +782,11 @@ func TransferCashWithSelector(network *integration.Infrastructure, sender *token
 	}
 }
 
-func RedeemCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference) {
+func RedeemCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference) {
 	RedeemCashForTMSID(network, id, wallet, typ, amount, auditor, nil)
 }
 
-func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
+func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, tmsID *token2.TMSID) {
 	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
 		Auditor: auditor.Id(),
 		Wallet:  wallet,
@@ -810,7 +810,7 @@ func RedeemCashByIDs(network *integration.Infrastructure, id *token3.NodeReferen
 	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), nil, false)
 }
 
-func SwapCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typeLeft token.TokenType, amountLeft uint64, typRight token.TokenType, amountRight uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
+func SwapCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typeLeft token.Type, amountLeft uint64, typRight token.Type, amountRight uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) {
 	txid, err := network.Client(id.ReplicaName()).CallView("swap", common.JSONMarshall(&views.Swap{
 		Auditor:         auditor.Id(),
 		AliceWallet:     wallet,
@@ -1161,7 +1161,7 @@ func SetSpendableFlag(network *integration.Infrastructure, user *token3.NodeRefe
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ token.TokenType, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
+func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
 	var recipientData *token2.RecipientData
 	if wpm != nil {
 		recipientData = wpm.RecipientData(user.Id(), wallet)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -1152,6 +1152,15 @@ func SetKVSEntry(network *integration.Infrastructure, user *token3.NodeReference
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func SetSpendableFlag(network *integration.Infrastructure, user *token3.NodeReference, tokenID token.ID, value bool) {
+	_, err := network.Client(user.ReplicaName()).CallView("SetSpendableFlag", common.JSONMarshall(&views.SetSpendableFlag{
+		TMSID:     token2.TMSID{},
+		TokenID:   tokenID,
+		Spendable: value,
+	}))
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func Withdraw(network *integration.Infrastructure, wpm *WalletManagerProvider, user *token3.NodeReference, wallet string, typ string, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, expectedErrorMsgs ...string) string {
 	var recipientData *token2.RecipientData
 	if wpm != nil {

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -789,6 +789,16 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	CheckBalanceAndHolding(network, bob, "", "Pineapples", 0, auditor)
 	CheckBalanceAndHolding(network, charlie, "", "Pineapples", 0, auditor)
 	CheckAuditorDB(network, auditor, "", nil)
+
+	// test spendable token
+	txIssueSpendableToken := IssueCash(network, "", "Spendable", 3, alice, auditor, true, issuer)
+	SetSpendableFlag(network, alice, token2.ID{TxId: txIssueSpendableToken, Index: 0}, false)
+	TransferCash(network, alice, "", "Spendable", 2, bob, auditor, "failed selecting tokens")
+	SetSpendableFlag(network, alice, token2.ID{TxId: txIssueSpendableToken, Index: 0}, true)
+	TransferCash(network, alice, "", "Spendable", 2, bob, auditor)
+	CheckBalanceAndHolding(network, alice, "", "Spendable", 1, auditor)
+	CheckBalanceAndHolding(network, bob, "", "Spendable", 2, auditor)
+	CheckAuditorDB(network, auditor, "", nil)
 }
 
 func TestSelector(network *integration.Infrastructure, auditorId string, sel *token3.ReplicaSelector) {

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -208,6 +208,7 @@ func Topology(opts common.Opts) []api.Topology {
 	alice.RegisterViewFactory("TxFinality", &views2.TxFinalityViewFactory{})
 	alice.RegisterViewFactory("MaliciousTransfer", &views.MaliciousTransferViewFactory{})
 	alice.RegisterViewFactory("TxStatus", &views.TxStatusViewFactory{})
+	alice.RegisterViewFactory("SetSpendableFlag", &views.SetSpendableFlagViewFactory{})
 
 	bob := fscTopology.AddNodeByName("bob").AddOptions(
 		fabric.WithOrganization("Org2"),
@@ -361,7 +362,7 @@ func Topology(opts common.Opts) []api.Topology {
 	}
 	if opts.Monitoring {
 		monitoringTopology := monitoring.NewTopology()
-		//monitoringTopology.EnableHyperledgerExplorer()
+		// monitoringTopology.EnableHyperledgerExplorer()
 		monitoringTopology.EnablePrometheusGrafana()
 		return []api.Topology{
 			backendNetwork, tokenTopology, fscTopology,

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -208,7 +208,7 @@ func (p *RegisterAuditorViewFactory) NewView(in []byte) (view.View, error) {
 
 type CurrentHolding struct {
 	EnrollmentID string
-	TokenType    token2.TokenType
+	TokenType    token2.Type
 	TMSID        token.TMSID
 }
 
@@ -247,9 +247,9 @@ func (p *CurrentHoldingViewFactory) NewView(in []byte) (view.View, error) {
 }
 
 type CurrentSpending struct {
-	EnrollmentID string           `json:"enrollment_id"`
-	TokenType    token2.TokenType `json:"token_type"`
-	TMSID        *token.TMSID     `json:"tmsid"`
+	EnrollmentID string       `json:"enrollment_id"`
+	TokenType    token2.Type  `json:"token_type"`
+	TMSID        *token.TMSID `json:"tmsid"`
 }
 
 // CurrentSpendingView is used to retrieve the current spending of token type of the passed enrollment id

--- a/integration/token/fungible/views/auditor.go
+++ b/integration/token/fungible/views/auditor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -207,7 +208,7 @@ func (p *RegisterAuditorViewFactory) NewView(in []byte) (view.View, error) {
 
 type CurrentHolding struct {
 	EnrollmentID string
-	TokenType    string
+	TokenType    token2.TokenType
 	TMSID        token.TMSID
 }
 
@@ -246,9 +247,9 @@ func (p *CurrentHoldingViewFactory) NewView(in []byte) (view.View, error) {
 }
 
 type CurrentSpending struct {
-	EnrollmentID string       `json:"enrollment_id"`
-	TokenType    string       `json:"token_type"`
-	TMSID        *token.TMSID `json:"tmsid"`
+	EnrollmentID string           `json:"enrollment_id"`
+	TokenType    token2.TokenType `json:"token_type"`
+	TMSID        *token.TMSID     `json:"tmsid"`
 }
 
 // CurrentSpendingView is used to retrieve the current spending of token type of the passed enrollment id

--- a/integration/token/fungible/views/balance.go
+++ b/integration/token/fungible/views/balance.go
@@ -21,11 +21,11 @@ type BalanceQuery struct {
 	TMSID     *token.TMSID
 	SkipCheck bool
 	Wallet    string
-	Type      token2.TokenType
+	Type      token2.Type
 }
 
 type Balance struct {
-	Type     token2.TokenType
+	Type     token2.Type
 	Quantity string
 }
 

--- a/integration/token/fungible/views/balance.go
+++ b/integration/token/fungible/views/balance.go
@@ -21,11 +21,11 @@ type BalanceQuery struct {
 	TMSID     *token.TMSID
 	SkipCheck bool
 	Wallet    string
-	Type      string
+	Type      token2.TokenType
 }
 
 type Balance struct {
-	Type     string
+	Type     token2.TokenType
 	Quantity string
 }
 

--- a/integration/token/fungible/views/history.go
+++ b/integration/token/fungible/views/history.go
@@ -24,7 +24,7 @@ type ListIssuedTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// The TMS to pick in case of multiple TMSIDs
 	TMSID *token.TMSID
 }

--- a/integration/token/fungible/views/history.go
+++ b/integration/token/fungible/views/history.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -23,7 +24,7 @@ type ListIssuedTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType string
+	TokenType token2.TokenType
 	// The TMS to pick in case of multiple TMSIDs
 	TMSID *token.TMSID
 }

--- a/integration/token/fungible/views/issue.go
+++ b/integration/token/fungible/views/issue.go
@@ -29,7 +29,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType string
+	TokenType token2.TokenType
 	// Quantity represent the number of units of a certain token type stored in the token
 	Quantity uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/fungible/views/issue.go
+++ b/integration/token/fungible/views/issue.go
@@ -29,7 +29,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// Quantity represent the number of units of a certain token type stored in the token
 	Quantity uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/fungible/views/list.go
+++ b/integration/token/fungible/views/list.go
@@ -22,7 +22,7 @@ type ListUnspentTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// The TMS to pick in case of multiple TMSIDs
 	TMSID *token.TMSID
 }

--- a/integration/token/fungible/views/list.go
+++ b/integration/token/fungible/views/list.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -21,7 +22,7 @@ type ListUnspentTokens struct {
 	// Wallet whose identities own the token
 	Wallet string
 	// TokenType is the token type to select
-	TokenType string
+	TokenType token2.TokenType
 	// The TMS to pick in case of multiple TMSIDs
 	TMSID *token.TMSID
 }

--- a/integration/token/fungible/views/redeem.go
+++ b/integration/token/fungible/views/redeem.go
@@ -26,7 +26,7 @@ type Redeem struct {
 	// TokenIDs contains a list of token ids to redeem. If empty, tokens are selected on the spot.
 	TokenIDs []*token.ID
 	// Type of tokens to redeem
-	Type token.TokenType
+	Type token.Type
 	// Amount to redeem
 	Amount uint64
 	// The TMS to pick in case of multiple TMSIDs

--- a/integration/token/fungible/views/redeem.go
+++ b/integration/token/fungible/views/redeem.go
@@ -26,7 +26,7 @@ type Redeem struct {
 	// TokenIDs contains a list of token ids to redeem. If empty, tokens are selected on the spot.
 	TokenIDs []*token.ID
 	// Type of tokens to redeem
-	Type string
+	Type token.TokenType
 	// Amount to redeem
 	Amount uint64
 	// The TMS to pick in case of multiple TMSIDs

--- a/integration/token/fungible/views/swap.go
+++ b/integration/token/fungible/views/swap.go
@@ -24,11 +24,11 @@ type Swap struct {
 	// AliceWallet is the wallet Alice will use
 	AliceWallet string
 	// FromAliceType is the token type Alice will transfer
-	FromAliceType token.TokenType
+	FromAliceType token.Type
 	// FromAliceAmount is the amount Alice will transfer
 	FromAliceAmount uint64
 	// FromBobType is the token type Bob will transfer
-	FromBobType token.TokenType
+	FromBobType token.Type
 	// FromBobAmount is the amount Bob will transfer
 	FromBobAmount uint64
 	// Bob is the identity of the Bob's FSC node

--- a/integration/token/fungible/views/swap.go
+++ b/integration/token/fungible/views/swap.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // Swap contains the input information for a swap
@@ -23,11 +24,11 @@ type Swap struct {
 	// AliceWallet is the wallet Alice will use
 	AliceWallet string
 	// FromAliceType is the token type Alice will transfer
-	FromAliceType string
+	FromAliceType token.TokenType
 	// FromAliceAmount is the amount Alice will transfer
 	FromAliceAmount uint64
 	// FromBobType is the token type Bob will transfer
-	FromBobType string
+	FromBobType token.TokenType
 	// FromBobAmount is the amount Bob will transfer
 	FromBobAmount uint64
 	// Bob is the identity of the Bob's FSC node

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -40,7 +40,7 @@ type Transfer struct {
 	// TokenIDs contains a list of token ids to transfer. If empty, tokens are selected on the spot.
 	TokenIDs []*token.ID
 	// Type of tokens to transfer
-	Type token.TokenType
+	Type token.Type
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/fungible/views/transfer.go
+++ b/integration/token/fungible/views/transfer.go
@@ -40,7 +40,7 @@ type Transfer struct {
 	// TokenIDs contains a list of token ids to transfer. If empty, tokens are selected on the spot.
 	TokenIDs []*token.ID
 	// Type of tokens to transfer
-	Type string
+	Type token.TokenType
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/fungible/views/withdraw.go
+++ b/integration/token/fungible/views/withdraw.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Withdrawal struct {
@@ -25,7 +26,7 @@ type Withdrawal struct {
 	// Amount represent the number of units of a certain token type stored in the token
 	Amount uint64
 	// TokenType is the type of token to issue
-	TokenType string
+	TokenType token2.TokenType
 	// Issuer identifies the issuer
 	Issuer string
 	// Recipient information

--- a/integration/token/fungible/views/withdraw.go
+++ b/integration/token/fungible/views/withdraw.go
@@ -26,7 +26,7 @@ type Withdrawal struct {
 	// Amount represent the number of units of a certain token type stored in the token
 	Amount uint64
 	// TokenType is the type of token to issue
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// Issuer identifies the issuer
 	Issuer string
 	// Recipient information

--- a/integration/token/interop/support.go
+++ b/integration/token/interop/support.go
@@ -37,7 +37,7 @@ func RegisterAuditor(network *integration.Infrastructure, opts ...token.ServiceO
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func IssueCash(network *integration.Infrastructure, wallet string, typ token2.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) string {
+func IssueCash(network *integration.Infrastructure, wallet string, typ token2.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) string {
 	txid, err := network.Client("issuer").CallView("issue", common.JSONMarshall(&views.IssueCash{
 		IssuerWallet: wallet,
 		TokenType:    typ,
@@ -51,7 +51,7 @@ func IssueCash(network *integration.Infrastructure, wallet string, typ token2.To
 	return common.JSONUnmarshalString(txid)
 }
 
-func IssueCashWithTMS(network *integration.Infrastructure, tmsID token.TMSID, issuer *token3.NodeReference, wallet string, typ token2.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) string {
+func IssueCashWithTMS(network *integration.Infrastructure, tmsID token.TMSID, issuer *token3.NodeReference, wallet string, typ token2.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference) string {
 	txid, err := network.Client(issuer.ReplicaName()).CallView("issue", common.JSONMarshall(&views2.IssueCash{
 		TMSID:        tmsID,
 		IssuerWallet: wallet,
@@ -66,7 +66,7 @@ func IssueCashWithTMS(network *integration.Infrastructure, tmsID token.TMSID, is
 	return txID
 }
 
-func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ token2.TokenType) *token2.IssuedTokens {
+func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ token2.Type) *token2.IssuedTokens {
 	res, err := network.Client("issuer").CallView("history", common.JSONMarshall(&views.ListIssuedTokens{
 		Wallet:    wallet,
 		TokenType: typ,
@@ -78,7 +78,7 @@ func ListIssuerHistory(network *integration.Infrastructure, wallet string, typ t
 	return issuedTokens
 }
 
-func CheckBalance(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64, opts ...token.ServiceOption) {
+func CheckBalance(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expected uint64, opts ...token.ServiceOption) {
 	options, err := token.CompileServiceOptions(opts...)
 	Expect(err).NotTo(HaveOccurred())
 	res, err := network.Client(id.ReplicaName()).CallView("balance", common.JSONMarshall(&views2.Balance{
@@ -100,7 +100,7 @@ func CheckBalance(network *integration.Infrastructure, id *token3.NodeReference,
 	Expect(expectedQ.Cmp(q)).To(BeEquivalentTo(0), "[%s]!=[%s]", expected, q)
 }
 
-func CheckBalanceReturnError(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64, opts ...token.ServiceOption) (err error) {
+func CheckBalanceReturnError(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expected uint64, opts ...token.ServiceOption) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.Errorf("check balance panicked with err [%v]", r)
@@ -110,7 +110,7 @@ func CheckBalanceReturnError(network *integration.Infrastructure, id *token3.Nod
 	return nil
 }
 
-func CheckHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expected int64, opts ...token.ServiceOption) {
+func CheckHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expected int64, opts ...token.ServiceOption) {
 	opt, err := token.CompileServiceOptions(opts...)
 	Expect(err).NotTo(HaveOccurred(), "failed to compile options [%v]", opts)
 	tmsId := opt.TMSID()
@@ -131,7 +131,7 @@ func CheckHolding(network *integration.Infrastructure, id *token3.NodeReference,
 	Expect(holding).To(Equal(int(expected)))
 }
 
-func CheckBalanceWithLocked(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64, expectedLocked uint64, expectedExpired uint64, opts ...token.ServiceOption) {
+func CheckBalanceWithLocked(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expected uint64, expectedLocked uint64, expectedExpired uint64, opts ...token.ServiceOption) {
 	opt, err := token.CompileServiceOptions(opts...)
 	Expect(err).NotTo(HaveOccurred(), "failed to compile options [%v]", opts)
 	resBoxed, err := network.Client(id.ReplicaName()).CallView("balance", common.JSONMarshall(&views2.Balance{
@@ -156,12 +156,12 @@ func CheckBalanceWithLocked(network *integration.Infrastructure, id *token3.Node
 	Expect(expired).To(Equal(int(expectedExpired)), "expected expired [%d], got [%d]", expectedExpired, expired)
 }
 
-func CheckBalanceAndHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expected uint64, opts ...token.ServiceOption) {
+func CheckBalanceAndHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expected uint64, opts ...token.ServiceOption) {
 	CheckBalance(network, id, wallet, typ, expected, opts...)
 	CheckHolding(network, id, wallet, typ, int64(expected), opts...)
 }
 
-func CheckBalanceWithLockedAndHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.TokenType, expectedBalance uint64, expectedLocked uint64, expectedExpired uint64, expectedHolding int64, opts ...token.ServiceOption) {
+func CheckBalanceWithLockedAndHolding(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token2.Type, expectedBalance uint64, expectedLocked uint64, expectedExpired uint64, expectedHolding int64, opts ...token.ServiceOption) {
 	CheckBalanceWithLocked(network, id, wallet, typ, expectedBalance, expectedLocked, expectedExpired, opts...)
 	if expectedHolding == -1 {
 		expectedHolding = int64(expectedBalance + expectedLocked + expectedExpired)
@@ -265,7 +265,7 @@ func Restart(network *integration.Infrastructure, ids ...*token3.NodeReference) 
 	time.Sleep(10 * time.Second)
 }
 
-func HTLCLock(network *integration.Infrastructure, tmsID token.TMSID, id *token3.NodeReference, wallet string, typ token2.TokenType, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, deadline time.Duration, hash []byte, hashFunc crypto.Hash, errorMsgs ...string) (string, []byte, []byte) {
+func HTLCLock(network *integration.Infrastructure, tmsID token.TMSID, id *token3.NodeReference, wallet string, typ token2.Type, amount uint64, receiver *token3.NodeReference, auditor *token3.NodeReference, deadline time.Duration, hash []byte, hashFunc crypto.Hash, errorMsgs ...string) (string, []byte, []byte) {
 	result, err := network.Client(id.ReplicaName()).CallView("htlc.lock", common.JSONMarshall(&htlc.Lock{
 		TMSID:               tmsID,
 		ReclamationDeadline: deadline,
@@ -393,7 +393,7 @@ func htlcClaim(network *integration.Infrastructure, tmsID token.TMSID, id *token
 	}
 }
 
-func fastExchange(network *integration.Infrastructure, id *token3.NodeReference, recipient *token3.NodeReference, tmsID1 token.TMSID, typ1 token2.TokenType, amount1 uint64, tmsID2 token.TMSID, typ2 token2.TokenType, amount2 uint64, deadline time.Duration) {
+func fastExchange(network *integration.Infrastructure, id *token3.NodeReference, recipient *token3.NodeReference, tmsID1 token.TMSID, typ1 token2.Type, amount1 uint64, tmsID2 token.TMSID, typ2 token2.Type, amount2 uint64, deadline time.Duration) {
 	_, err := network.Client(id.ReplicaName()).CallView("htlc.fastExchange", common.JSONMarshall(&htlc.FastExchange{
 		Recipient:           network.Identity(recipient.Id()),
 		TMSID1:              tmsID1,

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	EUR = token3.TokenType("EUR")
-	USD = token3.TokenType("USD")
+	EUR = token3.Type("EUR")
+	USD = token3.Type("USD")
 )
 
 func TestHTLCSingleNetwork(network *integration.Infrastructure, sel *token2.ReplicaSelector) {

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -18,7 +18,13 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/interop/views"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	token3 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	. "github.com/onsi/gomega"
+)
+
+const (
+	EUR = token3.TokenType("EUR")
+	USD = token3.TokenType("USD")
 )
 
 func TestHTLCSingleNetwork(network *integration.Infrastructure, sel *token2.ReplicaSelector) {
@@ -33,86 +39,86 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure, sel *token2.Repl
 	defaultTMSID := token.TMSID{}
 	RegisterAuditor(network)
 
-	IssueCash(network, "", "USD", 110, alice, alice)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 110, 0, 0, -1)
-	IssueCash(network, "", "USD", 10, alice, alice)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 120, 0, 0, -1)
+	IssueCash(network, "", USD, 110, alice, alice)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 110, 0, 0, -1)
+	IssueCash(network, "", USD, 10, alice, alice)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 120, 0, 0, -1)
 
-	h := ListIssuerHistory(network, "", "USD")
+	h := ListIssuerHistory(network, "", USD)
 	Expect(h.Count() > 0).To(BeTrue())
 	Expect(h.Sum(64).ToBigInt().Cmp(big.NewInt(120))).To(BeEquivalentTo(0))
-	Expect(h.ByType("USD").Count()).To(BeEquivalentTo(h.Count()))
+	Expect(h.ByType(USD).Count()).To(BeEquivalentTo(h.Count()))
 
-	h = ListIssuerHistory(network, "", "EUR")
+	h = ListIssuerHistory(network, "", EUR)
 	Expect(h.Count()).To(BeEquivalentTo(0))
 
-	IssueCash(network, "", "EUR", 10, bob, bob)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 10, 0, 0, -1)
-	IssueCash(network, "", "EUR", 10, bob, bob)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 20, 0, 0, -1)
-	IssueCash(network, "", "EUR", 10, bob, bob)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
+	IssueCash(network, "", EUR, 10, bob, bob)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 10, 0, 0, -1)
+	IssueCash(network, "", EUR, 10, bob, bob)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 20, 0, 0, -1)
+	IssueCash(network, "", EUR, 10, bob, bob)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
 
-	h = ListIssuerHistory(network, "", "USD")
+	h = ListIssuerHistory(network, "", USD)
 	Expect(h.Count() > 0).To(BeTrue())
 	Expect(h.Sum(64).ToBigInt().Cmp(big.NewInt(120))).To(BeEquivalentTo(0))
-	Expect(h.ByType("USD").Count()).To(BeEquivalentTo(h.Count()))
+	Expect(h.ByType(USD).Count()).To(BeEquivalentTo(h.Count()))
 
-	h = ListIssuerHistory(network, "", "EUR")
+	h = ListIssuerHistory(network, "", EUR)
 	Expect(h.Count() > 0).To(BeTrue())
 	Expect(h.Sum(64).ToBigInt().Cmp(big.NewInt(30))).To(BeEquivalentTo(0))
-	Expect(h.ByType("EUR").Count()).To(BeEquivalentTo(h.Count()))
+	Expect(h.ByType(EUR).Count()).To(BeEquivalentTo(h.Count()))
 
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 120, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 120, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 0, 0, -1)
 
 	Restart(network, issuer, auditor, alice, bob)
 	RegisterAuditor(network)
 
 	// htlc (lock, failing claim, reclaim)
-	_, preImage, _ := HTLCLock(network, token.TMSID{}, alice, "", "USD", 10, bob, auditor, 10*time.Second, nil, crypto.SHA512)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 110, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 10, 0, -1)
+	_, preImage, _ := HTLCLock(network, token.TMSID{}, alice, "", USD, 10, bob, auditor, 10*time.Second, nil, crypto.SHA512)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 110, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 10, 0, -1)
 	time.Sleep(15 * time.Second)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 110, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 0, 10, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 110, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 0, 10, -1)
 	htlcClaim(network, defaultTMSID, bob, "", preImage, auditor, "deadline elapsed")
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 110, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 0, 10, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 110, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 0, 10, -1)
 
 	HTLCReclaimAll(network, alice, "")
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 120, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 120, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 0, 0, -1)
 
 	// htlc (lock, claim)
-	_, preImage, _ = HTLCLock(network, defaultTMSID, alice, "", "USD", 20, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 100, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 0, 20, 0, -1)
+	_, preImage, _ = HTLCLock(network, defaultTMSID, alice, "", USD, 20, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 100, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 0, 20, 0, -1)
 
 	htlcClaim(network, defaultTMSID, bob, "", preImage, auditor)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 100, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 20, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 100, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 20, 0, 0, -1)
 
 	// payment limit reached
-	_, _, _ = HTLCLock(network, defaultTMSID, alice, "", "USD", uint64(views.Limit+10), bob, auditor, 1*time.Hour, nil, crypto.SHA3_256, "payment limit reached")
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 100, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 0, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 30, 0, 0, -1)
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 20, 0, 0, -1)
+	_, _, _ = HTLCLock(network, defaultTMSID, alice, "", USD, uint64(views.Limit+10), bob, auditor, 1*time.Hour, nil, crypto.SHA3_256, "payment limit reached")
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 100, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 0, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 30, 0, 0, -1)
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 20, 0, 0, -1)
 
 	CheckPublicParams(network, defaultTMSID, issuer, auditor, alice, bob)
 	<-time.After(30 * time.Second)
@@ -120,14 +126,14 @@ func TestHTLCSingleNetwork(network *integration.Infrastructure, sel *token2.Repl
 	CheckAuditorDB(network, defaultTMSID, auditor, "", nil)
 
 	// lock two times with the same hash, the second lock should fail
-	_, _, hash := HTLCLock(network, defaultTMSID, alice, "", "USD", 1, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
-	_, _, _ = HTLCLock(network, defaultTMSID, alice, "", "USD", 1, bob, auditor, 1*time.Hour, hash, crypto.SHA3_256,
+	_, _, hash := HTLCLock(network, defaultTMSID, alice, "", USD, 1, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
+	_, _, _ = HTLCLock(network, defaultTMSID, alice, "", USD, 1, bob, auditor, 1*time.Hour, hash, crypto.SHA3_256,
 		fmt.Sprintf(
 			"entry with transfer metadata key [%s] is already occupied",
 			htlc.LockKey(hash),
 		),
 	)
-	HTLCLock(network, defaultTMSID, alice, "", "USD", 1, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
+	HTLCLock(network, defaultTMSID, alice, "", USD, 1, bob, auditor, 1*time.Hour, nil, crypto.SHA3_256)
 
 	CheckPublicParams(network, defaultTMSID, issuer, auditor, alice, bob)
 	CheckOwnerDB(network, defaultTMSID, nil, issuer, auditor, alice, bob)
@@ -154,41 +160,41 @@ func TestHTLCTwoNetworks(network *integration.Infrastructure, sel *token2.Replic
 	RegisterAuditor(network, token.WithTMSID(alpha))
 	RegisterAuditor(network, token.WithTMSID(beta))
 
-	IssueCashWithTMS(network, alpha, issuer, "", "EUR", 30, alice, auditor)
-	CheckBalanceAndHolding(network, alice, "", "EUR", 30, token.WithTMSID(alpha))
+	IssueCashWithTMS(network, alpha, issuer, "", EUR, 30, alice, auditor)
+	CheckBalanceAndHolding(network, alice, "", EUR, 30, token.WithTMSID(alpha))
 
-	IssueCashWithTMS(network, beta, issuer, "", "USD", 30, bob, auditor)
-	CheckBalanceAndHolding(network, bob, "", "USD", 30, token.WithTMSID(beta))
+	IssueCashWithTMS(network, beta, issuer, "", USD, 30, bob, auditor)
+	CheckBalanceAndHolding(network, bob, "", USD, 30, token.WithTMSID(beta))
 
-	_, preImage, hash := HTLCLock(network, alpha, alice, "", "EUR", 10, bob, auditor, 1*time.Hour, nil, 0)
-	HTLCLock(network, beta, bob, "", "USD", 10, alice, auditor, 1*time.Hour, hash, 0)
+	_, preImage, hash := HTLCLock(network, alpha, alice, "", EUR, 10, bob, auditor, 1*time.Hour, nil, 0)
+	HTLCLock(network, beta, bob, "", USD, 10, alice, auditor, 1*time.Hour, hash, 0)
 	htlcClaim(network, beta, alice, "", preImage, auditor)
 	htlcClaim(network, alpha, bob, "", preImage, auditor)
 
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 20, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 10, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 10, 0, 0, -1, token.WithTMSID(beta))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 20, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 20, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 10, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 10, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 20, 0, 0, -1, token.WithTMSID(beta))
 
 	// Try to claim again and get an error
 
 	htlcClaim(network, beta, alice, "", preImage, auditor, "expected only one htlc script to match")
 	htlcClaim(network, alpha, bob, "", preImage, auditor, "expected only one htlc script to match")
 
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 20, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 10, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 10, 0, 0, -1, token.WithTMSID(beta))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 20, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 20, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 10, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 10, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 20, 0, 0, -1, token.WithTMSID(beta))
 
 	// Try to claim without locking
 
 	htlcClaim(network, beta, alice, "", nil, auditor, "expected only one htlc script to match")
 	htlcClaim(network, alpha, bob, "", nil, auditor, "expected only one htlc script to match")
 
-	CheckBalanceWithLockedAndHolding(network, alice, "", "EUR", 20, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "EUR", 10, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, alice, "", "USD", 10, 0, 0, -1, token.WithTMSID(beta))
-	CheckBalanceWithLockedAndHolding(network, bob, "", "USD", 20, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, alice, "", EUR, 20, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, bob, "", EUR, 10, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, alice, "", USD, 10, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, bob, "", USD, 20, 0, 0, -1, token.WithTMSID(beta))
 
 	CheckPublicParams(network, alpha, issuer, auditor, alice, bob)
 	CheckPublicParams(network, beta, issuer, auditor, alice, bob)
@@ -206,7 +212,7 @@ func TestHTLCTwoNetworks(network *integration.Infrastructure, sel *token2.Replic
 	}
 
 	// "alice" locks to "alice.id1", the deadline expires, "alice" reclaims, "alice.id1" checks the existence of an expired received locked token
-	_, _, h := HTLCLock(network, alpha, alice, "", "EUR", 10, sel.Get("alice.id1"), auditor, 10*time.Second, nil, 0)
+	_, _, h := HTLCLock(network, alpha, alice, "", EUR, 10, sel.Get("alice.id1"), auditor, 10*time.Second, nil, 0)
 	time.Sleep(10 * time.Second)
 	HTLCReclaimByHash(network, alpha, alice, "", h)
 	HTLCCheckExistenceReceivedExpiredByHash(network, alpha, alice, "alice.id1", h, false)
@@ -227,14 +233,14 @@ func TestHTLCNoCrossClaimTwoNetworks(network *integration.Infrastructure, sel *t
 	RegisterAuditor(network, token.WithTMSID(alpha))
 	RegisterAuditor(network, token.WithTMSID(beta))
 
-	IssueCashWithTMS(network, alpha, issuer, "", "EUR", 30, sel.Get("alice.id1"), auditor)
-	CheckBalanceAndHolding(network, alice, "alice.id1", "EUR", 30, token.WithTMSID(alpha))
+	IssueCashWithTMS(network, alpha, issuer, "", EUR, 30, sel.Get("alice.id1"), auditor)
+	CheckBalanceAndHolding(network, alice, "alice.id1", EUR, 30, token.WithTMSID(alpha))
 
-	IssueCashWithTMS(network, beta, issuer, "", "USD", 30, sel.Get("bob.id1"), auditor)
-	CheckBalanceAndHolding(network, bob, "bob.id1", "USD", 30, token.WithTMSID(beta))
+	IssueCashWithTMS(network, beta, issuer, "", USD, 30, sel.Get("bob.id1"), auditor)
+	CheckBalanceAndHolding(network, bob, "bob.id1", USD, 30, token.WithTMSID(beta))
 
-	aliceLockTxID, preImage, hash := HTLCLock(network, alpha, alice, "alice.id1", "EUR", 10, sel.Get("alice.id2"), auditor, 30*time.Second, nil, 0)
-	bobLockTxID, _, _ := HTLCLock(network, beta, bob, "bob.id1", "USD", 10, sel.Get("bob.id2"), auditor, 30*time.Second, hash, 0)
+	aliceLockTxID, preImage, hash := HTLCLock(network, alpha, alice, "alice.id1", EUR, 10, sel.Get("alice.id2"), auditor, 30*time.Second, nil, 0)
+	bobLockTxID, _, _ := HTLCLock(network, beta, bob, "bob.id1", USD, 10, sel.Get("bob.id2"), auditor, 30*time.Second, hash, 0)
 
 	wg := sync.WaitGroup{}
 	wg.Add(2)
@@ -259,12 +265,12 @@ func TestHTLCNoCrossClaimTwoNetworks(network *integration.Infrastructure, sel *t
 	// wait the completion of the claims above
 	wg.Wait()
 
-	CheckBalanceWithLockedAndHolding(network, alice, "alice.id1", "EUR", 20, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, alice, "alice.id2", "EUR", 10, 0, 0, -1, token.WithTMSID(alpha))
-	CheckBalanceWithLockedAndHolding(network, bob, "bob.id1", "USD", 20, 0, 0, -1, token.WithTMSID(beta))
-	CheckBalanceWithLockedAndHolding(network, bob, "bob.id2", "USD", 10, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, alice, "alice.id1", EUR, 20, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, alice, "alice.id2", EUR, 10, 0, 0, -1, token.WithTMSID(alpha))
+	CheckBalanceWithLockedAndHolding(network, bob, "bob.id1", USD, 20, 0, 0, -1, token.WithTMSID(beta))
+	CheckBalanceWithLockedAndHolding(network, bob, "bob.id2", USD, 10, 0, 0, -1, token.WithTMSID(beta))
 
-	txID := IssueCashWithTMS(network, alpha, issuer, "", "EUR", 30, sel.Get("alice.id1"), auditor)
+	txID := IssueCashWithTMS(network, alpha, issuer, "", EUR, 30, sel.Get("alice.id1"), auditor)
 
 	scan(network, bob, hash, crypto.SHA256, bobLockTxID, true, token.WithTMSID(beta))
 	start := time.Now()
@@ -307,17 +313,18 @@ func TestFastExchange(network *integration.Infrastructure, sel *token2.ReplicaSe
 	RegisterAuditor(network, token.WithTMSID(alpha))
 	RegisterAuditor(network, token.WithTMSID(beta))
 
-	IssueCashWithTMS(network, alpha, issuer, "", "EUR", 30, alice, auditor)
-	CheckBalance(network, sel.Get("alice"), "", "EUR", 30, token.WithTMSID(alpha))
+	IssueCashWithTMS(network, alpha, issuer, "", EUR, 30, alice, auditor)
+	CheckBalance(network, sel.Get("alice"), "", EUR, 30, token.WithTMSID(alpha))
 
-	IssueCashWithTMS(network, beta, issuer, "", "USD", 30, bob, auditor)
-	CheckBalance(network, bob, "", "USD", 30, token.WithTMSID(beta))
+	IssueCashWithTMS(network, beta, issuer, "", USD, 30, bob, auditor)
+	CheckBalance(network, bob, "", USD, 30, token.WithTMSID(beta))
 
-	fastExchange(network, alice, bob, alpha, "EUR", 10, beta, "USD", 10, 1*time.Hour)
+	fastExchange(network, alice, bob, alpha, EUR, 10, beta, USD, 10, 1*time.Hour)
 
-	CheckBalance(network, sel.Get("alice"), "", "EUR", 20, token.WithTMSID(alpha))
-	Eventually(CheckBalanceReturnError).WithArguments(network, sel.Get("bob"), "", "EUR", uint64(10), token.WithTMSID(alpha)).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+	CheckBalance(network, sel.Get("alice"), "", EUR, 20, token.WithTMSID(alpha))
 
-	CheckBalance(network, sel.Get("alice"), "", "USD", 10, token.WithTMSID(beta))
-	Eventually(CheckBalanceReturnError).WithArguments(network, sel.Get("bob"), "", "USD", uint64(20), token.WithTMSID(beta)).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+	Eventually(CheckBalanceReturnError).WithArguments(network, sel.Get("bob"), "", EUR, uint64(10), token.WithTMSID(alpha)).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
+
+	CheckBalance(network, sel.Get("alice"), "", USD, 10, token.WithTMSID(beta))
+	Eventually(CheckBalanceReturnError).WithArguments(network, sel.Get("bob"), "", USD, uint64(20), token.WithTMSID(beta)).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Succeed())
 }

--- a/integration/token/interop/views/balance.go
+++ b/integration/token/interop/views/balance.go
@@ -20,11 +20,11 @@ import (
 type Balance struct {
 	TMSID  token.TMSID
 	Wallet string
-	Type   token2.TokenType
+	Type   token2.Type
 }
 
 type BalanceResult struct {
-	Type     token2.TokenType
+	Type     token2.Type
 	Quantity string
 	Locked   string
 	Expired  string

--- a/integration/token/interop/views/balance.go
+++ b/integration/token/interop/views/balance.go
@@ -14,16 +14,17 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Balance struct {
 	TMSID  token.TMSID
 	Wallet string
-	Type   string
+	Type   token2.TokenType
 }
 
 type BalanceResult struct {
-	Type     string
+	Type     token2.TokenType
 	Quantity string
 	Locked   string
 	Expired  string

--- a/integration/token/interop/views/htlc/exchange.go
+++ b/integration/token/interop/views/htlc/exchange.go
@@ -27,12 +27,12 @@ type FastExchange struct {
 	// TMSID identifies the TMS to use to perform the token operation
 	TMSID1 token.TMSID
 	// Type of tokens to transfer
-	Type1 token2.TokenType
+	Type1 token2.Type
 	// Amount to transfer
 	Amount1 uint64
 
 	TMSID2  token.TMSID
-	Type2   token2.TokenType
+	Type2   token2.Type
 	Amount2 uint64
 
 	// ReclamationDeadline is the time after which we can reclaim the funds in case they were not transferred

--- a/integration/token/interop/views/htlc/exchange.go
+++ b/integration/token/interop/views/htlc/exchange.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // FastExchange contains the input information to fast exchange tokens
@@ -26,12 +27,12 @@ type FastExchange struct {
 	// TMSID identifies the TMS to use to perform the token operation
 	TMSID1 token.TMSID
 	// Type of tokens to transfer
-	Type1 string
+	Type1 token2.TokenType
 	// Amount to transfer
 	Amount1 uint64
 
 	TMSID2  token.TMSID
-	Type2   string
+	Type2   token2.TokenType
 	Amount2 uint64
 
 	// ReclamationDeadline is the time after which we can reclaim the funds in case they were not transferred

--- a/integration/token/interop/views/htlc/lock.go
+++ b/integration/token/interop/views/htlc/lock.go
@@ -31,7 +31,7 @@ type Lock struct {
 	// Wallet is the identifier of the wallet that owns the tokens to transfer
 	Wallet string
 	// Type of tokens to transfer
-	Type token2.TokenType
+	Type token2.Type
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/interop/views/htlc/lock.go
+++ b/integration/token/interop/views/htlc/lock.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/encoding"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -30,7 +31,7 @@ type Lock struct {
 	// Wallet is the identifier of the wallet that owns the tokens to transfer
 	Wallet string
 	// Type of tokens to transfer
-	Type string
+	Type token2.TokenType
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/interop/views/issue.go
+++ b/integration/token/interop/views/issue.go
@@ -24,7 +24,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// Quantity represents the number of units of a certain token type to issue
 	Quantity uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/integration/token/interop/views/issue.go
+++ b/integration/token/interop/views/issue.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // IssueCash contains the input information to issue a token
@@ -23,7 +24,7 @@ type IssueCash struct {
 	// IssuerWallet is the issuer's wallet to use
 	IssuerWallet string
 	// TokenType is the type of token to issue
-	TokenType string
+	TokenType token2.TokenType
 	// Quantity represents the number of units of a certain token type to issue
 	Quantity uint64
 	// Recipient is the identity of the recipient's FSC node

--- a/token/core/common/loaders.go
+++ b/token/core/common/loaders.go
@@ -116,9 +116,9 @@ func (s *VaultLedgerTokenLoader[T]) isAnyPending(ids ...*token.ID) (anyPending b
 }
 
 type LoadedToken[T any, M any] struct {
-	TokenType token.Format
-	Token     T
-	Metadata  M
+	TokenFormat token.Format
+	Token       T
+	Metadata    M
 }
 
 type VaultLedgerTokenAndMetadataLoader[T any, M any] struct {
@@ -162,9 +162,9 @@ func (s *VaultLedgerTokenAndMetadataLoader[T, M]) LoadTokens(ctx context.Context
 			return nil, errors.Wrapf(err, "failed deserializeing token info for id [%v]", id)
 		}
 		result[i] = LoadedToken[T, M]{
-			TokenType: types[i],
-			Token:     tok,
-			Metadata:  meta,
+			TokenFormat: types[i],
+			Token:       tok,
+			Metadata:    meta,
 		}
 	}
 

--- a/token/core/common/loaders.go
+++ b/token/core/common/loaders.go
@@ -116,7 +116,7 @@ func (s *VaultLedgerTokenLoader[T]) isAnyPending(ids ...*token.ID) (anyPending b
 }
 
 type LoadedToken[T any, M any] struct {
-	TokenType string
+	TokenType token.TokenType
 	Token     T
 	Metadata  M
 }

--- a/token/core/common/loaders.go
+++ b/token/core/common/loaders.go
@@ -116,7 +116,7 @@ func (s *VaultLedgerTokenLoader[T]) isAnyPending(ids ...*token.ID) (anyPending b
 }
 
 type LoadedToken[T any, M any] struct {
-	TokenType token.TokenType
+	TokenType token.TokenFormat
 	Token     T
 	Metadata  M
 }

--- a/token/core/common/loaders.go
+++ b/token/core/common/loaders.go
@@ -116,7 +116,7 @@ func (s *VaultLedgerTokenLoader[T]) isAnyPending(ids ...*token.ID) (anyPending b
 }
 
 type LoadedToken[T any, M any] struct {
-	TokenType token.TokenFormat
+	TokenType token.Format
 	Token     T
 	Metadata  M
 }

--- a/token/core/common/observables/issue.go
+++ b/token/core/common/observables/issue.go
@@ -39,7 +39,7 @@ func NewObservableIssueService(issueService driver.IssueService, metrics *issueM
 	return &ObservableIssueService{IssueService: issueService, Metrics: metrics}
 }
 
-func (o *ObservableIssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (o *ObservableIssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.Type, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	newContext, span := o.Metrics.issueTracer.Start(ctx, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, string(tokenType))))
 	defer span.End()
 

--- a/token/core/common/observables/issue.go
+++ b/token/core/common/observables/issue.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/metrics"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -38,8 +39,8 @@ func NewObservableIssueService(issueService driver.IssueService, metrics *issueM
 	return &ObservableIssueService{IssueService: issueService, Metrics: metrics}
 }
 
-func (o *ObservableIssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
-	newContext, span := o.Metrics.issueTracer.Start(ctx, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, tokenType)))
+func (o *ObservableIssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+	newContext, span := o.Metrics.issueTracer.Start(ctx, "issue", trace.WithAttributes(attribute.String(TokenTypeLabel, string(tokenType))))
 	defer span.End()
 
 	action, meta, err := o.IssueService.Issue(newContext, issuerIdentity, tokenType, values, owners, opts)

--- a/token/core/common/tokens.go
+++ b/token/core/common/tokens.go
@@ -17,7 +17,7 @@ func NewTokensService() *TokensService {
 	return &TokensService{}
 }
 
-func (s *TokensService) GetTokenInfo(meta *driver.TokenRequestMetadata, target []byte) ([]byte, error) {
+func (s *TokensService) ExtractMetadata(meta *driver.TokenRequestMetadata, target []byte) ([]byte, error) {
 	tokenInfoRaw := meta.GetTokenInfo(target)
 	if len(tokenInfoRaw) == 0 {
 		return nil, errors.Errorf("metadata for [%s] not found", Hashable(target))

--- a/token/core/common/wallets.go
+++ b/token/core/common/wallets.go
@@ -16,8 +16,8 @@ import (
 )
 
 type OwnerTokenVault interface {
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
-	Balance(id string, tokenType token.TokenType) (uint64, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error)
+	Balance(id string, tokenType token.Type) (uint64, error)
 }
 
 type AuditorWallet struct {
@@ -91,7 +91,7 @@ func (w *IssuerWallet) ContainsToken(token *token.UnspentToken) bool {
 	return w.Contains(token.Owner)
 }
 
-func (w *IssuerWallet) GetIssuerIdentity(tokenType token.TokenType) (driver.Identity, error) {
+func (w *IssuerWallet) GetIssuerIdentity(tokenType token.Type) (driver.Identity, error) {
 	return w.IssuerIdentity, nil
 }
 

--- a/token/core/common/wallets.go
+++ b/token/core/common/wallets.go
@@ -16,8 +16,8 @@ import (
 )
 
 type OwnerTokenVault interface {
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
-	Balance(id, tokenType string) (uint64, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
+	Balance(id string, tokenType token.TokenType) (uint64, error)
 }
 
 type AuditorWallet struct {
@@ -91,7 +91,7 @@ func (w *IssuerWallet) ContainsToken(token *token.UnspentToken) bool {
 	return w.Contains(token.Owner)
 }
 
-func (w *IssuerWallet) GetIssuerIdentity(tokenType string) (driver.Identity, error) {
+func (w *IssuerWallet) GetIssuerIdentity(tokenType token.TokenType) (driver.Identity, error) {
 	return w.IssuerIdentity, nil
 }
 

--- a/token/core/common/ws.go
+++ b/token/core/common/ws.go
@@ -24,12 +24,12 @@ var (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []string, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
 	GetTokenOutputs(ids []*token.ID, callback driver.QueryCallbackFunc) error
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
 	PublicParams() ([]byte, error)
-	Balance(id, tokenType string) (uint64, error)
+	Balance(id string, tokenType token.TokenType) (uint64, error)
 }
 
 type WalletRegistry interface {

--- a/token/core/common/ws.go
+++ b/token/core/common/ws.go
@@ -24,7 +24,7 @@ var (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
 	GetTokenOutputs(ids []*token.ID, callback driver.QueryCallbackFunc) error
 	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)

--- a/token/core/common/ws.go
+++ b/token/core/common/ws.go
@@ -24,12 +24,12 @@ var (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.Format, error)
 	GetTokenOutputs(ids []*token.ID, callback driver.QueryCallbackFunc) error
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
 	PublicParams() ([]byte, error)
-	Balance(id string, tokenType token.TokenType) (uint64, error)
+	Balance(id string, tokenType token.Type) (uint64, error)
 }
 
 type WalletRegistry interface {

--- a/token/core/common/ws.go
+++ b/token/core/common/ws.go
@@ -24,7 +24,7 @@ var (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []string, error)
 	GetTokenOutputs(ids []*token.ID, callback driver.QueryCallbackFunc) error
 	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)

--- a/token/core/fabtoken/actions.go
+++ b/token/core/fabtoken/actions.go
@@ -55,9 +55,6 @@ func (t *Output) Deserialize(bytes []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed deserializing token")
 	}
-	if typed.Type != fabtoken.Type {
-		return errors.Errorf("invalid token type [%v]", typed.Type)
-	}
 	return json.Unmarshal(typed.Token, t)
 }
 

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -143,13 +143,13 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	return service, nil
 }
 
-func (d *Driver) NewValidator(tmsID driver.TMSID, params driver.PublicParameters) (driver.Validator, error) {
+func (d *Driver) NewDefaultValidator(params driver.PublicParameters) (driver.Validator, error) {
 	pp, ok := params.(*fabtoken.PublicParams)
 	if !ok {
 		return nil, errors.Errorf("invalid public parameters type [%T]", params)
 	}
 
-	metricsProvider := metrics.NewTMSProvider(tmsID, d.metricsProvider)
+	metricsProvider := metrics.NewTMSProvider(driver.TMSID{}, d.metricsProvider)
 	tracerProvider := tracing2.NewTracerProviderWithBackingProvider(d.tracerProvider, metricsProvider)
 	defaultValidator, err := d.DefaultValidator(pp)
 	if err != nil {

--- a/token/core/fabtoken/driver/driver.go
+++ b/token/core/fabtoken/driver/driver.go
@@ -110,6 +110,10 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 		common.NewTMSAuthorization(logger, publicParamsManager.PublicParams(), ws),
 		htlc.NewScriptAuth(ws),
 	)
+	tokensService, err := fabtoken.NewTokensService(publicParamsManager.PublicParams())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to initiliaze token service for [%s:%s]", networkID, namespace)
+	}
 	service, err := fabtoken.NewService(
 		logger,
 		ws,
@@ -130,7 +134,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 			fabtoken.NewAuditorService(),
 			observables.NewAudit(tracerProvider),
 		),
-		fabtoken.NewTokensService(),
+		tokensService,
 		authorization,
 	)
 	if err != nil {

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -27,7 +27,7 @@ func NewIssueService(publicParamsManager driver.PublicParamsManager, walletServi
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization OutputMetadata associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token2.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token2.Type, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -48,11 +48,9 @@ func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity
 			return nil, nil, errors.Wrapf(err, "failed to convert [%d] to quantity of precision [%d]", v, precision)
 		}
 		outs = append(outs, &Output{
-			Output: token2.Token{
-				Owner:    owners[i],
-				Type:     tokenType,
-				Quantity: q.Hex(),
-			},
+			Owner:    owners[i],
+			Type:     tokenType,
+			Quantity: q.Hex(),
 		})
 
 		meta := &OutputMetadata{

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -27,7 +27,7 @@ func NewIssueService(publicParamsManager driver.PublicParamsManager, walletServi
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization OutputMetadata associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token2.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/fabtoken/tokens.go
+++ b/token/core/fabtoken/tokens.go
@@ -19,19 +19,19 @@ import (
 
 type TokensService struct {
 	*common.TokensService
-	OutputTokenType token2.TokenType
+	OutputTokenFormat token2.TokenFormat
 }
 
 func NewTokensService(pp *PublicParams) (*TokensService, error) {
-	supportedTokens, err := supportedTokenTypes(pp.QuantityPrecision)
+	supportedTokens, err := supportedTokenFormat(pp.QuantityPrecision)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed getting supported token types")
 	}
-	return &TokensService{TokensService: common.NewTokensService(), OutputTokenType: supportedTokens}, nil
+	return &TokensService{TokensService: common.NewTokensService(), OutputTokenFormat: supportedTokens}, nil
 }
 
 // Deobfuscate returns a deserialized token and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, token2.TokenType, error) {
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, token2.TokenFormat, error) {
 	tok := &Output{}
 	if err := tok.Deserialize(output); err != nil {
 		return nil, nil, "", errors.Wrap(err, "failed unmarshalling token")
@@ -45,14 +45,14 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 		Owner:    tok.Owner,
 		Type:     tok.Type,
 		Quantity: tok.Quantity,
-	}, metadata.Issuer, s.OutputTokenType, nil
+	}, metadata.Issuer, s.OutputTokenFormat, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []token2.TokenType {
-	return []token2.TokenType{s.OutputTokenType}
+func (s *TokensService) SupportedTokenTypes() []token2.TokenFormat {
+	return []token2.TokenFormat{s.OutputTokenFormat}
 }
 
-func supportedTokenTypes(precision uint64) (token2.TokenType, error) {
+func supportedTokenFormat(precision uint64) (token2.TokenFormat, error) {
 	hasher := common.NewSHA256Hasher()
 	if err := errors2.Join(
 		hasher.AddInt32(fabtoken.Type),
@@ -61,5 +61,5 @@ func supportedTokenTypes(precision uint64) (token2.TokenType, error) {
 	); err != nil {
 		return "", errors.Wrapf(err, "failed to generator token type")
 	}
-	return token2.TokenType(hasher.HexDigest()), nil
+	return token2.TokenFormat(hasher.HexDigest()), nil
 }

--- a/token/core/fabtoken/tokens.go
+++ b/token/core/fabtoken/tokens.go
@@ -48,7 +48,7 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	}, metadata.Issuer, s.OutputTokenFormat, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []token2.Format {
+func (s *TokensService) SupportedTokenFormats() []token2.Format {
 	return []token2.Format{s.OutputTokenFormat}
 }
 

--- a/token/core/fabtoken/tokens.go
+++ b/token/core/fabtoken/tokens.go
@@ -19,7 +19,7 @@ import (
 
 type TokensService struct {
 	*common.TokensService
-	TokenTypes []string
+	TokenTypes []token2.TokenType
 }
 
 func NewTokensService(pp *PublicParams) (*TokensService, error) {
@@ -31,7 +31,7 @@ func NewTokensService(pp *PublicParams) (*TokensService, error) {
 }
 
 // Deobfuscate returns a deserialized token and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, string, error) {
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, token2.TokenType, error) {
 	tok := &Output{}
 	if err := tok.Deserialize(output); err != nil {
 		return nil, nil, "", errors.Wrap(err, "failed unmarshalling token")
@@ -48,12 +48,12 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	}, metadata.Issuer, s.TokenTypes[0], nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []string {
+func (s *TokensService) SupportedTokenTypes() []token2.TokenType {
 	return s.TokenTypes
 }
 
-func SupportedTokenTypes(precisions ...uint64) ([]string, error) {
-	result := make([]string, len(precisions))
+func SupportedTokenTypes(precisions ...uint64) ([]token2.TokenType, error) {
+	result := make([]token2.TokenType, len(precisions))
 	for i, precision := range precisions {
 		hasher := common.NewSHA256Hasher()
 		if err := errors2.Join(
@@ -63,7 +63,7 @@ func SupportedTokenTypes(precisions ...uint64) ([]string, error) {
 		); err != nil {
 			return nil, errors.Wrapf(err, "failed to generator token type")
 		}
-		result[i] = hasher.HexDigest()
+		result[i] = token2.TokenType(hasher.HexDigest())
 	}
 	return result, nil
 }

--- a/token/core/fabtoken/tokens.go
+++ b/token/core/fabtoken/tokens.go
@@ -19,7 +19,7 @@ import (
 
 type TokensService struct {
 	*common.TokensService
-	OutputTokenFormat token2.TokenFormat
+	OutputTokenFormat token2.Format
 }
 
 func NewTokensService(pp *PublicParams) (*TokensService, error) {
@@ -31,7 +31,7 @@ func NewTokensService(pp *PublicParams) (*TokensService, error) {
 }
 
 // Deobfuscate returns a deserialized token and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, token2.TokenFormat, error) {
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, token2.Format, error) {
 	tok := &Output{}
 	if err := tok.Deserialize(output); err != nil {
 		return nil, nil, "", errors.Wrap(err, "failed unmarshalling token")
@@ -48,11 +48,11 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	}, metadata.Issuer, s.OutputTokenFormat, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []token2.TokenFormat {
-	return []token2.TokenFormat{s.OutputTokenFormat}
+func (s *TokensService) SupportedTokenTypes() []token2.Format {
+	return []token2.Format{s.OutputTokenFormat}
 }
 
-func supportedTokenFormat(precision uint64) (token2.TokenFormat, error) {
+func supportedTokenFormat(precision uint64) (token2.Format, error) {
 	hasher := common.NewSHA256Hasher()
 	if err := errors2.Join(
 		hasher.AddInt32(fabtoken.Type),
@@ -61,5 +61,5 @@ func supportedTokenFormat(precision uint64) (token2.TokenFormat, error) {
 	); err != nil {
 		return "", errors.Wrapf(err, "failed to generator token type")
 	}
-	return token2.TokenFormat(hasher.HexDigest()), nil
+	return token2.Format(hasher.HexDigest()), nil
 }

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -43,7 +43,7 @@ func NewTransferService(
 
 // Transfer returns a TransferAction as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(ctx context.Context, _ string, _ driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	// select inputs
 	inputTokens, err := s.TokenLoader.GetTokens(tokenIDs)
 	if err != nil {

--- a/token/core/fabtoken/validator.go
+++ b/token/core/fabtoken/validator.go
@@ -10,12 +10,11 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
-type ValidateTransferFunc = common.ValidateTransferFunc[*PublicParams, *token.Token, *TransferAction, *IssueAction, driver.Deserializer]
+type ValidateTransferFunc = common.ValidateTransferFunc[*PublicParams, *Output, *TransferAction, *IssueAction, driver.Deserializer]
 
-type ValidateIssueFunc = common.ValidateIssueFunc[*PublicParams, *token.Token, *TransferAction, *IssueAction, driver.Deserializer]
+type ValidateIssueFunc = common.ValidateIssueFunc[*PublicParams, *Output, *TransferAction, *IssueAction, driver.Deserializer]
 
 type ActionDeserializer struct{}
 
@@ -41,9 +40,9 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*Iss
 	return issueActions, transferActions, nil
 }
 
-type Context = common.Context[*PublicParams, *token.Token, *TransferAction, *IssueAction, driver.Deserializer]
+type Context = common.Context[*PublicParams, *Output, *TransferAction, *IssueAction, driver.Deserializer]
 
-type Validator = common.Validator[*PublicParams, *token.Token, *TransferAction, *IssueAction, driver.Deserializer]
+type Validator = common.Validator[*PublicParams, *Output, *TransferAction, *IssueAction, driver.Deserializer]
 
 func NewValidator(logger logging.Logger, pp *PublicParams, deserializer driver.Deserializer, extraValidators ...ValidateTransferFunc) *Validator {
 	transferValidators := []ValidateTransferFunc{
@@ -57,7 +56,7 @@ func NewValidator(logger logging.Logger, pp *PublicParams, deserializer driver.D
 		IssueValidate,
 	}
 
-	return common.NewValidator[*PublicParams, *token.Token, *TransferAction, *IssueAction, driver.Deserializer](
+	return common.NewValidator[*PublicParams, *Output, *TransferAction, *IssueAction, driver.Deserializer](
 		logger,
 		pp,
 		deserializer,

--- a/token/core/fabtoken/validator_issue.go
+++ b/token/core/fabtoken/validator_issue.go
@@ -21,7 +21,7 @@ func IssueValidate(ctx *Context) error {
 		return errors.Errorf("there is no output")
 	}
 	for _, output := range action.GetOutputs() {
-		out := output.(*Output).Output
+		out := output.(*Output)
 		q, err := token.ToQuantity(out.Quantity, ctx.PP.QuantityPrecision)
 		if err != nil {
 			return errors.Wrapf(err, "failed parsing quantity [%s]", out.Quantity)

--- a/token/core/fabtoken/wallet.go
+++ b/token/core/fabtoken/wallet.go
@@ -18,9 +18,9 @@ import (
 
 type TokenVault interface {
 	PublicParams() ([]byte, error)
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
-	Balance(id string, tokenType token.TokenType) (uint64, error)
+	Balance(id string, tokenType token.Type) (uint64, error)
 }
 
 type WalletFactory struct {

--- a/token/core/fabtoken/wallet.go
+++ b/token/core/fabtoken/wallet.go
@@ -18,9 +18,9 @@ import (
 
 type TokenVault interface {
 	PublicParams() ([]byte, error)
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
-	Balance(id, tokenType string) (uint64, error)
+	Balance(id string, tokenType token.TokenType) (uint64, error)
 }
 
 type WalletFactory struct {

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -57,7 +57,7 @@ type AuditableToken struct {
 	Owner *OwnerOpening
 }
 
-func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType token2.TokenType, value *math.Zr, bf *math.Zr) (*AuditableToken, error) {
+func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType token2.Type, value *math.Zr, bf *math.Zr) (*AuditableToken, error) {
 	return &AuditableToken{
 		Token: token,
 		Owner: &OwnerOpening{
@@ -74,7 +74,7 @@ func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType token2.To
 // TokenDataOpening contains the opening of the TokenData.
 // TokenData is a Pedersen commitment to token type and Value.
 type TokenDataOpening struct {
-	TokenType token2.TokenType
+	TokenType token2.Type
 	Value     *math.Zr
 	BF        *math.Zr
 }

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/interop/htlc"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/msp"
 	htlc2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -56,7 +57,7 @@ type AuditableToken struct {
 	Owner *OwnerOpening
 }
 
-func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType string, value *math.Zr, bf *math.Zr) (*AuditableToken, error) {
+func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType token2.TokenType, value *math.Zr, bf *math.Zr) (*AuditableToken, error) {
 	return &AuditableToken{
 		Token: token,
 		Owner: &OwnerOpening{
@@ -73,7 +74,7 @@ func NewAuditableToken(token *token.Token, ownerInfo []byte, tokenType string, v
 // TokenDataOpening contains the opening of the TokenData.
 // TokenData is a Pedersen commitment to token type and Value.
 type TokenDataOpening struct {
-	TokenType string
+	TokenType token2.TokenType
 	Value     *math.Zr
 	BF        *math.Zr
 }

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -264,7 +264,7 @@ func InspectTokenOwner(des Deserializer, token *AuditableToken, index int) error
 	if len(token.Owner.OwnerInfo) == 0 {
 		return errors.Errorf("failed to inspect owner at index [%d]: owner info is nil", index)
 	}
-	ro, err := identity.UnmarshalTypedIdentity(token.Token.Owner)
+	ro, err := identity.UnmarshalTypedIdentity(token.Token.GetOwner())
 	if err != nil {
 		return errors.Errorf("owner at index [%d] cannot be unwrapped", index)
 	}
@@ -287,7 +287,7 @@ func InspectTokenOwner(des Deserializer, token *AuditableToken, index int) error
 }
 
 func inspectTokenOwnerOfScript(des Deserializer, token *AuditableToken, index int) error {
-	owner, err := identity.UnmarshalTypedIdentity(token.Token.Owner)
+	owner, err := identity.UnmarshalTypedIdentity(token.Token.GetOwner())
 	if err != nil {
 		return errors.Errorf("input owner at index [%d] cannot be unmarshalled", index)
 	}
@@ -347,7 +347,7 @@ func GetAuditInfoForIssues(issues [][]byte, metadata []driver.IssueMetadata) ([]
 		outputs[k] = make([]*AuditableToken, len(md.ReceiversAuditInfos))
 		for i := 0; i < len(md.ReceiversAuditInfos); i++ {
 			ti := &token.Metadata{}
-			err = json.Unmarshal(md.OutputsMetadata[i], ti)
+			err = ti.Deserialize(md.OutputsMetadata[i])
 			if err != nil {
 				return nil, err
 			}
@@ -406,7 +406,7 @@ func GetAuditInfoForTransfers(transfers [][]byte, metadata []driver.TransferMeta
 		outputs[k] = make([]*AuditableToken, len(tr.ReceiverAuditInfos))
 		for i := 0; i < len(tr.ReceiverAuditInfos); i++ {
 			ti := &token.Metadata{}
-			err = json.Unmarshal(tr.OutputsMetadata[i], ti)
+			err = ti.Deserialize(tr.OutputsMetadata[i])
 			if err != nil {
 				return nil, nil, err
 			}

--- a/token/core/zkatdlog/crypto/audit/auditor_test.go
+++ b/token/core/zkatdlog/crypto/audit/auditor_test.go
@@ -121,12 +121,12 @@ var _ = Describe("Auditor", func() {
 
 func createTransfer(pp *crypto.PublicParams) (*transfer2.Action, driver.TransferMetadata, [][]*token.Token) {
 	id, auditInfo := getIdemixInfo("./testdata/idemix")
-	transfer, inf, inputs := prepareTransfer(pp, id)
+	transfer, meta, inputs := prepareTransfer(pp, id)
 
-	marshalledInfo := make([][]byte, len(inf))
+	marshalledMeta := make([][]byte, len(meta))
 	var err error
-	for i := 0; i < len(inf); i++ {
-		marshalledInfo[i], err = json.Marshal(inf[i])
+	for i := 0; i < len(meta); i++ {
+		marshalledMeta[i], err = meta[i].Serialize()
 		Expect(err).NotTo(HaveOccurred())
 	}
 	metadata := driver.TransferMetadata{}
@@ -136,7 +136,7 @@ func createTransfer(pp *crypto.PublicParams) (*transfer2.Action, driver.Transfer
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	metadata.OutputsMetadata = marshalledInfo
+	metadata.OutputsMetadata = marshalledMeta
 	metadata.Outputs = make([][]byte, len(transfer.OutputTokens))
 	metadata.ReceiverAuditInfos = make([][]byte, len(transfer.OutputTokens))
 	metadata.OutputAuditInfos = make([][]byte, len(transfer.OutputTokens))

--- a/token/core/zkatdlog/crypto/issue/issuer.go
+++ b/token/core/zkatdlog/crypto/issue/issuer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -25,11 +26,11 @@ type SigningIdentity interface {
 type Issuer struct {
 	Signer       SigningIdentity
 	PublicParams *crypto.PublicParams
-	Type         string
+	Type         token2.TokenType
 }
 
 // New returns an Issuer as a function of the passed parameters
-func (i *Issuer) New(ttype string, signer common.SigningIdentity, pp *crypto.PublicParams) {
+func (i *Issuer) New(ttype token2.TokenType, signer common.SigningIdentity, pp *crypto.PublicParams) {
 	i.Signer = signer
 	i.Type = ttype
 	i.PublicParams = pp

--- a/token/core/zkatdlog/crypto/issue/issuer.go
+++ b/token/core/zkatdlog/crypto/issue/issuer.go
@@ -26,11 +26,11 @@ type SigningIdentity interface {
 type Issuer struct {
 	Signer       SigningIdentity
 	PublicParams *crypto.PublicParams
-	Type         token2.TokenType
+	Type         token2.Type
 }
 
 // New returns an Issuer as a function of the passed parameters
-func (i *Issuer) New(ttype token2.TokenType, signer common.SigningIdentity, pp *crypto.PublicParams) {
+func (i *Issuer) New(ttype token2.Type, signer common.SigningIdentity, pp *crypto.PublicParams) {
 	i.Signer = signer
 	i.Type = ttype
 	i.PublicParams = pp

--- a/token/core/zkatdlog/crypto/issue/sametype.go
+++ b/token/core/zkatdlog/crypto/issue/sametype.go
@@ -11,6 +11,7 @@ import (
 
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -53,7 +54,7 @@ type SameTypeProver struct {
 	PedParams []*math.G1
 	Curve     *math.Curve
 	// tokenType is the type of the tokens to be issued
-	tokenType string
+	tokenType token2.TokenType
 	// blindingFactor is the blinding factor in the CommitmentToType
 	blindingFactor *math.Zr
 	// CommitmentToType is a commitment to tokenType using blindingFactor
@@ -65,7 +66,7 @@ type SameTypeProver struct {
 }
 
 // NewSameTypeProver returns a SameTypeProver for the passed parameters
-func NewSameTypeProver(ttype string, bf *math.Zr, com *math.G1, pp []*math.G1, c *math.Curve) *SameTypeProver {
+func NewSameTypeProver(ttype token2.TokenType, bf *math.Zr, com *math.G1, pp []*math.G1, c *math.Curve) *SameTypeProver {
 
 	return &SameTypeProver{
 		tokenType:        ttype,

--- a/token/core/zkatdlog/crypto/issue/sametype.go
+++ b/token/core/zkatdlog/crypto/issue/sametype.go
@@ -54,7 +54,7 @@ type SameTypeProver struct {
 	PedParams []*math.G1
 	Curve     *math.Curve
 	// tokenType is the type of the tokens to be issued
-	tokenType token2.TokenType
+	tokenType token2.Type
 	// blindingFactor is the blinding factor in the CommitmentToType
 	blindingFactor *math.Zr
 	// CommitmentToType is a commitment to tokenType using blindingFactor
@@ -66,7 +66,7 @@ type SameTypeProver struct {
 }
 
 // NewSameTypeProver returns a SameTypeProver for the passed parameters
-func NewSameTypeProver(ttype token2.TokenType, bf *math.Zr, com *math.G1, pp []*math.G1, c *math.Curve) *SameTypeProver {
+func NewSameTypeProver(ttype token2.Type, bf *math.Zr, com *math.G1, pp []*math.G1, c *math.Curve) *SameTypeProver {
 
 	return &SameTypeProver{
 		tokenType:        ttype,

--- a/token/core/zkatdlog/crypto/math/math.go
+++ b/token/core/zkatdlog/crypto/math/math.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package math
+
+import (
+	"reflect"
+
+	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+type Element interface {
+	IsInfinity() bool
+	CurveID() math.CurveID
+}
+
+func CheckElements[E Element](elements []E, curveID math.CurveID, length int) error {
+	if len(elements) != length {
+		return errors.Errorf("length of elements does not match length of curveID")
+	}
+	for _, g1 := range elements {
+		if err := CheckElement[E](g1, curveID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CheckElement[E Element](element E, curveID math.CurveID) (err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = errors.Errorf("caught panic while checking element, err [%s]", e)
+		}
+	}()
+
+	if isNilInterface(element) {
+		return errors.Errorf("elememt is nil")
+	}
+	if element.CurveID() != curveID {
+		return errors.Errorf("element curve must equal curve ID")
+	}
+	if element.IsInfinity() {
+		return errors.New("element is infinity")
+	}
+	return nil
+}
+
+func isNilInterface(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	rv := reflect.ValueOf(i)
+	return rv.Kind() == reflect.Ptr && rv.IsNil()
+}

--- a/token/core/zkatdlog/crypto/math/math.go
+++ b/token/core/zkatdlog/crypto/math/math.go
@@ -18,8 +18,8 @@ type Element interface {
 	CurveID() math.CurveID
 }
 
-func CheckElements[E Element](elements []E, curveID math.CurveID, length int) error {
-	if len(elements) != length {
+func CheckElements[E Element](elements []E, curveID math.CurveID, length uint64) error {
+	if uint64(len(elements)) != length {
 		return errors.Errorf("length of elements does not match length of curveID")
 	}
 	for _, g1 := range elements {

--- a/token/core/zkatdlog/crypto/math/math_test.go
+++ b/token/core/zkatdlog/crypto/math/math_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package math
+
+import (
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckElement(t *testing.T) {
+	var g1 *math.G1
+	assert.Error(t, CheckElement(g1, 0))
+
+	g1 = &math.G1{}
+	assert.Error(t, CheckElement(g1, 0))
+}

--- a/token/core/zkatdlog/crypto/token/token.go
+++ b/token/core/zkatdlog/crypto/token/token.go
@@ -85,7 +85,7 @@ func computeTokens(tw []*TokenDataWitness, pp []*math.G1, c *math.Curve) ([]*mat
 	return tokens, nil
 }
 
-func GetTokensWithWitness(values []uint64, ttype token2.TokenType, pp []*math.G1, c *math.Curve) ([]*math.G1, []*TokenDataWitness, error) {
+func GetTokensWithWitness(values []uint64, ttype token2.Type, pp []*math.G1, c *math.Curve) ([]*math.G1, []*TokenDataWitness, error) {
 	if c == nil {
 		return nil, nil, errors.New("cannot get tokens with witness: please initialize curve")
 	}
@@ -131,7 +131,7 @@ func (m *Metadata) Serialize() ([]byte, error) {
 
 // TokenDataWitness contains the opening of Data in Token
 type TokenDataWitness struct {
-	Type           token2.TokenType
+	Type           token2.Type
 	Value          uint64
 	BlindingFactor *math.Zr
 }
@@ -146,7 +146,7 @@ func (tdw *TokenDataWitness) Clone() *TokenDataWitness {
 }
 
 // NewTokenDataWitness returns an array of TokenDataWitness that corresponds to the passed arguments
-func NewTokenDataWitness(ttype token2.TokenType, values []uint64, bfs []*math.Zr) []*TokenDataWitness {
+func NewTokenDataWitness(ttype token2.Type, values []uint64, bfs []*math.Zr) []*TokenDataWitness {
 	witness := make([]*TokenDataWitness, len(values))
 	for i, v := range values {
 		witness[i] = &TokenDataWitness{Value: v, BlindingFactor: bfs[i]}

--- a/token/core/zkatdlog/crypto/token/token.go
+++ b/token/core/zkatdlog/crypto/token/token.go
@@ -85,7 +85,7 @@ func computeTokens(tw []*TokenDataWitness, pp []*math.G1, c *math.Curve) ([]*mat
 	return tokens, nil
 }
 
-func GetTokensWithWitness(values []uint64, ttype string, pp []*math.G1, c *math.Curve) ([]*math.G1, []*TokenDataWitness, error) {
+func GetTokensWithWitness(values []uint64, ttype token2.TokenType, pp []*math.G1, c *math.Curve) ([]*math.G1, []*TokenDataWitness, error) {
 	if c == nil {
 		return nil, nil, errors.New("cannot get tokens with witness: please initialize curve")
 	}
@@ -131,7 +131,7 @@ func (m *Metadata) Serialize() ([]byte, error) {
 
 // TokenDataWitness contains the opening of Data in Token
 type TokenDataWitness struct {
-	Type           string
+	Type           token2.TokenType
 	Value          uint64
 	BlindingFactor *math.Zr
 }
@@ -146,7 +146,7 @@ func (tdw *TokenDataWitness) Clone() *TokenDataWitness {
 }
 
 // NewTokenDataWitness returns an array of TokenDataWitness that corresponds to the passed arguments
-func NewTokenDataWitness(ttype string, values []uint64, bfs []*math.Zr) []*TokenDataWitness {
+func NewTokenDataWitness(ttype token2.TokenType, values []uint64, bfs []*math.Zr) []*TokenDataWitness {
 	witness := make([]*TokenDataWitness, len(values))
 	for i, v := range values {
 		witness[i] = &TokenDataWitness{Value: v, BlindingFactor: bfs[i]}

--- a/token/core/zkatdlog/crypto/token/token_test.go
+++ b/token/core/zkatdlog/crypto/token/token_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Token", func() {
 	Describe("get token in the clear", func() {
 		When("token is computed correctly", func() {
 			It("succeeds", func() {
-				t, err := token.GetTokenInTheClear(inf, pp)
+				t, err := token.ToClear(inf, pp)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(t.Type).To(Equal("ABC"))
 				Expect(t.Quantity).To(Equal("0x" + inf.Value.String()))

--- a/token/core/zkatdlog/crypto/token/token_test.go
+++ b/token/core/zkatdlog/crypto/token/token_test.go
@@ -10,6 +10,7 @@ import (
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
+	token3 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -44,7 +45,7 @@ var _ = Describe("Token", func() {
 			It("succeeds", func() {
 				t, err := token.ToClear(inf, pp)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(t.Type).To(Equal("ABC"))
+				Expect(t.Type).To(Equal(token3.TokenType("ABC")))
 				Expect(t.Quantity).To(Equal("0x" + inf.Value.String()))
 			})
 		})

--- a/token/core/zkatdlog/crypto/token/token_test.go
+++ b/token/core/zkatdlog/crypto/token/token_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Token", func() {
 			It("succeeds", func() {
 				t, err := token.ToClear(inf, pp)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(t.Type).To(Equal(token3.TokenType("ABC")))
+				Expect(t.Type).To(Equal(token3.Type("ABC")))
 				Expect(t.Quantity).To(Equal("0x" + inf.Value.String()))
 			})
 		})

--- a/token/core/zkatdlog/crypto/transfer/transfer_test.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/transfer"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -137,7 +138,7 @@ func prepareInputsForZKTransfer(pp *crypto.PublicParams) ([]*token.TokenDataWitn
 	for i := 0; i < 2; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := "ABC"
+	ttype := token2.TokenType("ABC")
 	inValues[0] = 220
 	inValues[1] = 60
 	outValues[0] = 260
@@ -172,7 +173,7 @@ func prepareInvalidInputsForZKTransfer(pp *crypto.PublicParams) ([]*token.TokenD
 	for i := 0; i < 2; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := "ABC"
+	ttype := token2.TokenType("ABC")
 	inValues[0] = 90
 	inValues[1] = 60
 	outValues[0] = 110

--- a/token/core/zkatdlog/crypto/transfer/transfer_test.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer_test.go
@@ -138,7 +138,7 @@ func prepareInputsForZKTransfer(pp *crypto.PublicParams) ([]*token.TokenDataWitn
 	for i := 0; i < 2; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := token2.TokenType("ABC")
+	ttype := token2.Type("ABC")
 	inValues[0] = 220
 	inValues[1] = 60
 	outValues[0] = 260
@@ -173,7 +173,7 @@ func prepareInvalidInputsForZKTransfer(pp *crypto.PublicParams) ([]*token.TokenD
 	for i := 0; i < 2; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := token2.TokenType("ABC")
+	ttype := token2.Type("ABC")
 	inValues[0] = 90
 	inValues[1] = 60
 	outValues[0] = 110

--- a/token/core/zkatdlog/crypto/transfer/typeandsum_test.go
+++ b/token/core/zkatdlog/crypto/transfer/typeandsum_test.go
@@ -171,7 +171,7 @@ func prepareIOCProver(pp []*math.G1, c *math.Curve) (*transfer.TypeAndSumWitness
 	for i := 0; i < 3; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := token2.TokenType("ABC")
+	ttype := token2.Type("ABC")
 	inValues[0] = 100
 	inValues[1] = 50
 	outValues[0] = 75
@@ -196,7 +196,7 @@ func prepareIOCProver(pp []*math.G1, c *math.Curve) (*transfer.TypeAndSumWitness
 	return transfer.NewTypeAndSumWitness(typeBlindingFactor, intw, outtw, c), in, out, inBF, outBF, commitmentToType
 }
 
-func prepareInputsOutputs(inValues, outValues []uint64, inBF, outBF []*math.Zr, ttype token2.TokenType, pp []*math.G1, c *math.Curve) ([]*math.G1, []*math.G1) {
+func prepareInputsOutputs(inValues, outValues []uint64, inBF, outBF []*math.Zr, ttype token2.Type, pp []*math.G1, c *math.Curve) ([]*math.G1, []*math.G1) {
 	inputs := make([]*math.G1, len(inValues))
 	outputs := make([]*math.G1, len(outValues))
 

--- a/token/core/zkatdlog/crypto/transfer/typeandsum_test.go
+++ b/token/core/zkatdlog/crypto/transfer/typeandsum_test.go
@@ -9,6 +9,7 @@ import (
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/transfer"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -170,7 +171,7 @@ func prepareIOCProver(pp []*math.G1, c *math.Curve) (*transfer.TypeAndSumWitness
 	for i := 0; i < 3; i++ {
 		outBF[i] = c.NewRandomZr(rand)
 	}
-	ttype := "ABC"
+	ttype := token2.TokenType("ABC")
 	inValues[0] = 100
 	inValues[1] = 50
 	outValues[0] = 75
@@ -195,7 +196,7 @@ func prepareIOCProver(pp []*math.G1, c *math.Curve) (*transfer.TypeAndSumWitness
 	return transfer.NewTypeAndSumWitness(typeBlindingFactor, intw, outtw, c), in, out, inBF, outBF, commitmentToType
 }
 
-func prepareInputsOutputs(inValues, outValues []uint64, inBF, outBF []*math.Zr, ttype string, pp []*math.G1, c *math.Curve) ([]*math.G1, []*math.G1) {
+func prepareInputsOutputs(inValues, outValues []uint64, inBF, outBF []*math.Zr, ttype token2.TokenType, pp []*math.G1, c *math.Curve) ([]*math.G1, []*math.G1) {
 	inputs := make([]*math.G1, len(inValues))
 	outputs := make([]*math.G1, len(outValues))
 

--- a/token/core/zkatdlog/crypto/validator/validator_test.go
+++ b/token/core/zkatdlog/crypto/validator/validator_test.go
@@ -496,7 +496,7 @@ func prepareTransfer(pp *crypto.PublicParams, signer driver.SigningIdentity, aud
 	sender, err := transfer.NewSender(signers, tokens, ids, inputInf, pp)
 	Expect(err).NotTo(HaveOccurred())
 
-	transfer, inf, err := sender.GenerateZKTransfer(context.TODO(), outvalues, owners)
+	transfer, metas, err := sender.GenerateZKTransfer(context.TODO(), outvalues, owners)
 	Expect(err).NotTo(HaveOccurred())
 
 	raw, err := transfer.Serialize()
@@ -506,9 +506,9 @@ func prepareTransfer(pp *crypto.PublicParams, signer driver.SigningIdentity, aud
 	raw, err = asn1.Marshal(*tr)
 	Expect(err).NotTo(HaveOccurred())
 
-	marshalledInfo := make([][]byte, len(inf))
-	for i := 0; i < len(inf); i++ {
-		marshalledInfo[i], err = json.Marshal(inf[i])
+	marshalledInfo := make([][]byte, len(metas))
+	for i := 0; i < len(metas); i++ {
+		marshalledInfo[i], err = metas[i].Serialize()
 		Expect(err).NotTo(HaveOccurred())
 	}
 	metadata := driver.TransferMetadata{}

--- a/token/core/zkatdlog/nogh/auditor.go
+++ b/token/core/zkatdlog/nogh/auditor.go
@@ -22,6 +22,10 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+type TokenCommitmentLoader interface {
+	GetTokenOutputs(ctx context.Context, ids []*token2.ID) (map[string]*token.Token, error)
+}
+
 type AuditorService struct {
 	Logger                  logging.Logger
 	PublicParametersManager common.PublicParametersManager[*crypto.PublicParams]

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -163,7 +163,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	return service, err
 }
 
-func (d *Driver) NewValidator(tmsID driver.TMSID, params driver.PublicParameters) (driver.Validator, error) {
+func (d *Driver) NewDefaultValidator(params driver.PublicParameters) (driver.Validator, error) {
 	pp, ok := params.(*crypto.PublicParams)
 	if !ok {
 		return nil, errors.Errorf("invalid public parameters type [%T]", params)
@@ -173,7 +173,7 @@ func (d *Driver) NewValidator(tmsID driver.TMSID, params driver.PublicParameters
 	if err != nil {
 		return nil, err
 	}
-	metricsProvider := metrics.NewTMSProvider(tmsID, d.metricsProvider)
+	metricsProvider := metrics.NewTMSProvider(driver.TMSID{}, d.metricsProvider)
 	tracerProvider := tracing2.NewTracerProviderWithBackingProvider(d.tracerProvider, metricsProvider)
 	return observables.NewObservableValidator(defaultValidator, observables.NewValidator(tracerProvider)), nil
 }

--- a/token/core/zkatdlog/nogh/driver/driver.go
+++ b/token/core/zkatdlog/nogh/driver/driver.go
@@ -62,30 +62,30 @@ func NewDriver(
 	}
 }
 
-func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, channel string, namespace string, publicParams []byte) (driver.TokenManagerService, error) {
-	logger := logging.DriverLogger("token-sdk.driver.zkatdlog", networkID, channel, namespace)
+func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (driver.TokenManagerService, error) {
+	logger := logging.DriverLogger("token-sdk.driver.zkatdlog", tmsID.Network, tmsID.Channel, tmsID.Namespace)
 
 	logger.Debugf("creating new token service with public parameters [%s]", hash.Hashable(publicParams))
 
 	if len(publicParams) == 0 {
 		return nil, errors.Errorf("empty public parameters")
 	}
-	n, err := d.networkProvider.GetNetwork(networkID, channel)
+	n, err := d.networkProvider.GetNetwork(tmsID.Network, tmsID.Channel)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get network [%s]", networkID)
+		return nil, errors.Wrapf(err, "failed to get network [%s]", tmsID.Network)
 	}
 	if n == nil {
-		return nil, errors.Errorf("network [%s] does not exists", networkID)
+		return nil, errors.Errorf("network [%s] does not exists", tmsID.Network)
 	}
 	networkLocalMembership := n.LocalMembership()
-	v, err := n.TokenVault(namespace)
+	v, err := n.TokenVault(tmsID.Namespace)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "vault [%s:%s] does not exists", networkID, namespace)
+		return nil, errors.WithMessagef(err, "vault [%s:%s] does not exists", tmsID.Network, tmsID.Namespace)
 	}
 
-	tmsConfig, err := d.configService.ConfigurationFor(networkID, channel, namespace)
+	tmsConfig, err := d.configService.ConfigurationFor(tmsID.Network, tmsID.Channel, tmsID.Namespace)
 	if err != nil {
-		return nil, errors.WithMessagef(err, "failed to get config for token service for [%s:%s:%s]", networkID, channel, namespace)
+		return nil, errors.WithMessagef(err, "failed to get config for token service for [%s:%s:%s]", tmsID.Network, tmsID.Channel, tmsID.Namespace)
 	}
 
 	ppm, err := common.NewPublicParamsManager[*crypto.PublicParams](
@@ -100,7 +100,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 	qe := v.QueryEngine()
 	ws, err := d.newWalletService(tmsConfig, d.endpointService, d.storageProvider, qe, logger, d.identityProvider.DefaultIdentity(), networkLocalMembership.DefaultIdentity(), ppm.PublicParams(), false)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to initiliaze wallet service for [%s:%s]", networkID, namespace)
+		return nil, errors.Wrapf(err, "failed to initiliaze wallet service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}
 	deserializer := ws.Deserializer
 	ip := ws.IdentityProvider
@@ -115,7 +115,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 	driverMetrics := zkatdlog.NewMetrics(metricsProvider)
 	tokensService, err := zkatdlog.NewTokensService(ppm)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to initiliaze token service for [%s:%s]", networkID, namespace)
+		return nil, errors.Wrapf(err, "failed to initiliaze token service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}
 	service, err := zkatdlog.NewTokenService(
 		logger,
@@ -163,7 +163,7 @@ func (d *Driver) NewTokenService(_ driver.ServiceProvider, networkID string, cha
 	return service, err
 }
 
-func (d *Driver) NewValidator(_ driver.ServiceProvider, tmsID driver.TMSID, params driver.PublicParameters) (driver.Validator, error) {
+func (d *Driver) NewValidator(tmsID driver.TMSID, params driver.PublicParameters) (driver.Validator, error) {
 	pp, ok := params.(*crypto.PublicParams)
 	if !ok {
 		return nil, errors.Errorf("invalid public parameters type [%T]", params)

--- a/token/core/zkatdlog/nogh/issue.go
+++ b/token/core/zkatdlog/nogh/issue.go
@@ -43,7 +43,7 @@ func NewIssueService(
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization TokenInformation associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.Type, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/zkatdlog/nogh/issue.go
+++ b/token/core/zkatdlog/nogh/issue.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/issue"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -42,7 +43,7 @@ func NewIssueService(
 // Issue returns an IssueAction as a function of the passed arguments
 // Issue also returns a serialization TokenInformation associated with issued tokens
 // and the identity of the issuer
-func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType string, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
+func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *driver.IssueOptions) (driver.IssueAction, *driver.IssueMetadata, error) {
 	for _, owner := range owners {
 		// a recipient cannot be empty
 		if len(owner) == 0 {

--- a/token/core/zkatdlog/nogh/service.go
+++ b/token/core/zkatdlog/nogh/service.go
@@ -7,26 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package nogh
 
 import (
-	"context"
-
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/validator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
-	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
-	"github.com/pkg/errors"
 )
-
-type TokenCommitmentLoader interface {
-	GetTokenOutputs(ctx context.Context, ids []*token2.ID) (map[string]*token.Token, error)
-}
-
-type TokenLoader interface {
-	LoadTokens(ctx context.Context, ids []*token2.ID) ([]*token.Token, []*token.Metadata, []driver.Identity, error)
-}
 
 type Service struct {
 	*common.Service[*crypto.PublicParams]
@@ -69,40 +55,6 @@ func NewTokenService(
 		Service: root,
 	}
 	return s, nil
-}
-
-// DeserializeToken un-marshals a token and token info from raw bytes
-// It checks if the un-marshalled token matches the token info. If not, it returns
-// an error. Else it returns the token in cleartext and the identity of its issuer
-func (s *Service) DeserializeToken(tok []byte, infoRaw []byte) (*token2.Token, driver.Identity, error) {
-	// get zkatdlog token
-	output := &token.Token{}
-	if err := output.Deserialize(tok); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize zkatdlog token")
-	}
-
-	// get token info
-	ti := &token.Metadata{}
-	err := ti.Deserialize(infoRaw)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize token information")
-	}
-	pp := s.PublicParametersManager.PublicParams()
-	to, err := output.GetTokenInTheClear(ti, pp)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize token")
-	}
-
-	return to, ti.Issuer, nil
-}
-
-func (s *Service) GetTokenInfo(meta *driver.TokenRequestMetadata, target []byte) ([]byte, error) {
-	tokenInfoRaw := meta.GetTokenInfo(target)
-	if len(tokenInfoRaw) == 0 {
-		s.Logger.Debugf("metadata for [%s] not found", hash.Hashable(target).String())
-		return nil, errors.Errorf("metadata for [%s] not found", hash.Hashable(target).String())
-	}
-	return tokenInfoRaw, nil
 }
 
 func (s *Service) Validator() (driver.Validator, error) {

--- a/token/core/zkatdlog/nogh/tokens.go
+++ b/token/core/zkatdlog/nogh/tokens.go
@@ -7,10 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package nogh
 
 import (
+	errors2 "errors"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/math"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/core/comm"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -18,33 +22,111 @@ import (
 type TokensService struct {
 	*common.TokensService
 	PublicParametersManager common.PublicParametersManager[*crypto.PublicParams]
+	TokenTypes              []string
+	OutputTokenType         string
 }
 
-func NewTokensService(publicParametersManager common.PublicParametersManager[*crypto.PublicParams]) *TokensService {
-	return &TokensService{TokensService: common.NewTokensService(), PublicParametersManager: publicParametersManager}
+func NewTokensService(publicParametersManager common.PublicParametersManager[*crypto.PublicParams]) (*TokensService, error) {
+	// compute supported tokens
+	// dlog without graph hiding
+	commTokenTypes, err := SupportedTokenTypes(publicParametersManager.PublicParams())
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed computing comm token types")
+	}
+
+	return &TokensService{
+		TokensService:           common.NewTokensService(),
+		PublicParametersManager: publicParametersManager,
+		TokenTypes:              commTokenTypes,
+		OutputTokenType:         commTokenTypes[0],
+	}, nil
 }
 
-// DeserializeToken un-marshals a token and token info from raw bytes
+// Deobfuscate unmarshals a token and token info from raw bytes
 // It checks if the un-marshalled token matches the token info. If not, it returns
 // an error. Else it returns the token in cleartext and the identity of its issuer
-func (s *TokensService) DeserializeToken(tok []byte, infoRaw []byte) (*token.Token, driver.Identity, error) {
-	// get zkatdlog token
-	output := &token2.Token{}
-	if err := output.Deserialize(tok); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize zkatdlog token")
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, driver.Identity, string, error) {
+	_, metadata, tok, err := s.deserializeToken(output, outputMetadata, false)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return tok, metadata.Issuer, s.OutputTokenType, nil
+}
+
+func (s *TokensService) SupportedTokenTypes() []string {
+	return s.TokenTypes
+}
+
+func (s *TokensService) DeserializeToken(outputType string, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
+	// Here we have to check if what we get in input is already as expected.
+	// If not, we need to check if a conversion is possible.
+	// If not, a failure is to be returned
+	if outputType != s.OutputTokenType {
+		return nil, nil, nil, errors.Errorf("invalid token type [%s], expected [%s]", outputType, s.OutputTokenType)
 	}
 
-	// get token info
-	ti := &token2.Metadata{}
-	err := ti.Deserialize(infoRaw)
+	// get zkatdlog token
+	output, err := s.getOutput(outputRaw, false)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize token information")
+		return nil, nil, nil, errors.Wrapf(err, "failed getting token output")
+	}
+
+	// get metadata
+	metadata := &token2.Metadata{}
+	err = metadata.Deserialize(metadataRaw)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to deserialize token metadata")
+	}
+
+	return output, metadata, nil, nil
+}
+
+func (s *TokensService) deserializeToken(outputRaw []byte, metadataRaw []byte, checkOwner bool) (*token2.Token, *token2.Metadata, *token.Token, error) {
+	// get zkatdlog token
+	output, err := s.getOutput(outputRaw, checkOwner)
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "failed getting token output")
+	}
+
+	// get metadata
+	metadata := &token2.Metadata{}
+	err = metadata.Deserialize(metadataRaw)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to deserialize token metadata")
 	}
 	pp := s.PublicParametersManager.PublicParams()
-	to, err := output.GetTokenInTheClear(ti, pp)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to deserialize token")
-	}
 
-	return to, ti.Issuer, nil
+	tok, err := output.ToClear(metadata, pp)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "failed to deserialize token")
+	}
+	return output, metadata, tok, nil
+}
+
+func (s *TokensService) getOutput(outputRaw []byte, checkOwner bool) (*token2.Token, error) {
+	output := &token2.Token{}
+	if err := output.Deserialize(outputRaw); err != nil {
+		return nil, errors.Wrap(err, "failed to deserialize token")
+	}
+	if checkOwner && len(output.Owner) == 0 {
+		return nil, errors.Errorf("token owner not found in output")
+	}
+	if err := math.CheckElement(output.Data, s.PublicParametersManager.PublicParams().Curve); err != nil {
+		return nil, errors.Wrap(err, "data in invalid in output")
+	}
+	return output, nil
+}
+
+func SupportedTokenTypes(pp *crypto.PublicParams) ([]string, error) {
+	hasher := common.NewSHA256Hasher()
+	if err := errors2.Join(
+		hasher.AddInt32(comm.Type),
+		hasher.AddInt(int(pp.Curve)),
+		hasher.AddG1s(pp.PedersenGenerators),
+		hasher.AddInt(int(pp.IdemixCurveID)),
+		hasher.AddBytes(pp.IdemixIssuerPK),
+	); err != nil {
+		return nil, errors.Wrapf(err, "failed to generator token type")
+	}
+	return []string{hasher.HexDigest()}, nil
 }

--- a/token/core/zkatdlog/nogh/tokens.go
+++ b/token/core/zkatdlog/nogh/tokens.go
@@ -22,8 +22,8 @@ import (
 type TokensService struct {
 	*common.TokensService
 	PublicParametersManager common.PublicParametersManager[*crypto.PublicParams]
-	TokenTypes              []string
-	OutputTokenType         string
+	TokenTypes              []token.TokenType
+	OutputTokenType         token.TokenType
 }
 
 func NewTokensService(publicParametersManager common.PublicParametersManager[*crypto.PublicParams]) (*TokensService, error) {
@@ -45,7 +45,7 @@ func NewTokensService(publicParametersManager common.PublicParametersManager[*cr
 // Deobfuscate unmarshals a token and token info from raw bytes
 // It checks if the un-marshalled token matches the token info. If not, it returns
 // an error. Else it returns the token in cleartext and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, driver.Identity, string, error) {
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, driver.Identity, token.TokenType, error) {
 	_, metadata, tok, err := s.deserializeToken(output, outputMetadata, false)
 	if err != nil {
 		return nil, nil, "", err
@@ -53,11 +53,11 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	return tok, metadata.Issuer, s.OutputTokenType, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []string {
+func (s *TokensService) SupportedTokenTypes() []token.TokenType {
 	return s.TokenTypes
 }
 
-func (s *TokensService) DeserializeToken(outputType string, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
+func (s *TokensService) DeserializeToken(outputType token.TokenType, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
 	// Here we have to check if what we get in input is already as expected.
 	// If not, we need to check if a conversion is possible.
 	// If not, a failure is to be returned
@@ -117,7 +117,7 @@ func (s *TokensService) getOutput(outputRaw []byte, checkOwner bool) (*token2.To
 	return output, nil
 }
 
-func SupportedTokenTypes(pp *crypto.PublicParams) ([]string, error) {
+func SupportedTokenTypes(pp *crypto.PublicParams) ([]token.TokenType, error) {
 	hasher := common.NewSHA256Hasher()
 	if err := errors2.Join(
 		hasher.AddInt32(comm.Type),
@@ -128,5 +128,5 @@ func SupportedTokenTypes(pp *crypto.PublicParams) ([]string, error) {
 	); err != nil {
 		return nil, errors.Wrapf(err, "failed to generator token type")
 	}
-	return []string{hasher.HexDigest()}, nil
+	return []token.TokenType{token.TokenType(hasher.HexDigest())}, nil
 }

--- a/token/core/zkatdlog/nogh/tokens.go
+++ b/token/core/zkatdlog/nogh/tokens.go
@@ -51,16 +51,16 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	return tok, metadata.Issuer, s.OutputTokenFormat, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []token.Format {
+func (s *TokensService) SupportedTokenFormats() []token.Format {
 	return []token.Format{s.OutputTokenFormat}
 }
 
-func (s *TokensService) DeserializeToken(outputType token.Format, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
+func (s *TokensService) DeserializeToken(outputFormat token.Format, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
 	// Here we have to check if what we get in input is already as expected.
 	// If not, we need to check if a conversion is possible.
 	// If not, a failure is to be returned
-	if outputType != s.OutputTokenFormat {
-		return nil, nil, nil, errors.Errorf("invalid token type [%s], expected [%s]", outputType, s.OutputTokenFormat)
+	if outputFormat != s.OutputTokenFormat {
+		return nil, nil, nil, errors.Errorf("invalid token type [%s], expected [%s]", outputFormat, s.OutputTokenFormat)
 	}
 
 	// get zkatdlog token

--- a/token/core/zkatdlog/nogh/tokens.go
+++ b/token/core/zkatdlog/nogh/tokens.go
@@ -22,7 +22,7 @@ import (
 type TokensService struct {
 	*common.TokensService
 	PublicParametersManager common.PublicParametersManager[*crypto.PublicParams]
-	OutputTokenFormat       token.TokenFormat
+	OutputTokenFormat       token.Format
 }
 
 func NewTokensService(publicParametersManager common.PublicParametersManager[*crypto.PublicParams]) (*TokensService, error) {
@@ -43,7 +43,7 @@ func NewTokensService(publicParametersManager common.PublicParametersManager[*cr
 // Deobfuscate unmarshals a token and token info from raw bytes
 // It checks if the un-marshalled token matches the token info. If not, it returns
 // an error. Else it returns the token in cleartext and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, driver.Identity, token.TokenFormat, error) {
+func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, driver.Identity, token.Format, error) {
 	_, metadata, tok, err := s.deserializeToken(output, outputMetadata, false)
 	if err != nil {
 		return nil, nil, "", err
@@ -51,11 +51,11 @@ func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*toke
 	return tok, metadata.Issuer, s.OutputTokenFormat, nil
 }
 
-func (s *TokensService) SupportedTokenTypes() []token.TokenFormat {
-	return []token.TokenFormat{s.OutputTokenFormat}
+func (s *TokensService) SupportedTokenTypes() []token.Format {
+	return []token.Format{s.OutputTokenFormat}
 }
 
-func (s *TokensService) DeserializeToken(outputType token.TokenFormat, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
+func (s *TokensService) DeserializeToken(outputType token.Format, outputRaw []byte, metadataRaw []byte) (*token2.Token, *token2.Metadata, *token2.ConversionWitness, error) {
 	// Here we have to check if what we get in input is already as expected.
 	// If not, we need to check if a conversion is possible.
 	// If not, a failure is to be returned
@@ -115,7 +115,7 @@ func (s *TokensService) getOutput(outputRaw []byte, checkOwner bool) (*token2.To
 	return output, nil
 }
 
-func supportedTokenFormat(pp *crypto.PublicParams) (token.TokenFormat, error) {
+func supportedTokenFormat(pp *crypto.PublicParams) (token.Format, error) {
 	hasher := common.NewSHA256Hasher()
 	if err := errors2.Join(
 		hasher.AddInt32(comm.Type),
@@ -126,5 +126,5 @@ func supportedTokenFormat(pp *crypto.PublicParams) (token.TokenFormat, error) {
 	); err != nil {
 		return "", errors.Wrapf(err, "failed to generator token type")
 	}
-	return token.TokenFormat(hasher.HexDigest()), nil
+	return token.Format(hasher.HexDigest()), nil
 }

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -31,7 +31,7 @@ type TokenLoader interface {
 }
 
 type TokenDeserializer interface {
-	DeserializeToken(outputType token2.Format, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
+	DeserializeToken(outputFormat token2.Format, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
 }
 
 type TransferService struct {
@@ -257,7 +257,7 @@ func (s *TransferService) prepareInputs(loadedTokens []LoadedToken) ([]*token.To
 	metadata := make([]*token.Metadata, len(loadedTokens))
 	signers := make([]driver.Identity, len(loadedTokens))
 	for i, loadedToken := range loadedTokens {
-		tok, meta, _, err := s.TokenDeserializer.DeserializeToken(loadedToken.TokenType, loadedToken.Token, loadedToken.Metadata)
+		tok, meta, _, err := s.TokenDeserializer.DeserializeToken(loadedToken.TokenFormat, loadedToken.Token, loadedToken.Metadata)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "failed deserializing token [%s]", string(loadedToken.Token))
 		}

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -31,7 +31,7 @@ type TokenLoader interface {
 }
 
 type TokenDeserializer interface {
-	DeserializeToken(outputType token2.TokenType, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
+	DeserializeToken(outputType token2.TokenFormat, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
 }
 
 type TransferService struct {

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -31,7 +31,7 @@ type TokenLoader interface {
 }
 
 type TokenDeserializer interface {
-	DeserializeToken(outputType token2.TokenFormat, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
+	DeserializeToken(outputType token2.Format, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
 }
 
 type TransferService struct {

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -72,7 +72,7 @@ func NewTransferService(
 
 // Transfer returns a TransferActionMetadata as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driver.OwnerWallet, tokenIDs []*token2.ID, outputTokens []*token2.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(ctx context.Context, txID string, _ driver.OwnerWallet, tokenIDs []*token2.ID, outputTokens []*token2.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	newCtx, span := s.tracer.Start(ctx, "transfer")
 	defer span.End()
 	s.Logger.Debugf("Prepare Transfer Action [%s,%v]", txID, tokenIDs)

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -31,7 +31,7 @@ type TokenLoader interface {
 }
 
 type TokenDeserializer interface {
-	DeserializeToken(outputType string, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
+	DeserializeToken(outputType token2.TokenType, outputRaw []byte, metadataRaw []byte) (*token.Token, *token.Metadata, *token.ConversionWitness, error)
 }
 
 type TransferService struct {

--- a/token/core/zkatdlog/nogh/wallet.go
+++ b/token/core/zkatdlog/nogh/wallet.go
@@ -18,9 +18,9 @@ import (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
-	Balance(id string, tokenType token.TokenType) (uint64, error)
+	Balance(id string, tokenType token.Type) (uint64, error)
 }
 
 type WalletsConfiguration interface {

--- a/token/core/zkatdlog/nogh/wallet.go
+++ b/token/core/zkatdlog/nogh/wallet.go
@@ -18,9 +18,9 @@ import (
 
 type TokenVault interface {
 	IsPending(id *token.ID) (bool, error)
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
-	Balance(id, tokenType string) (uint64, error)
+	Balance(id string, tokenType token.TokenType) (uint64, error)
 }
 
 type WalletsConfiguration interface {

--- a/token/driver/action.go
+++ b/token/driver/action.go
@@ -41,6 +41,8 @@ type Output interface {
 	Serialize() ([]byte, error)
 	// IsRedeem returns true if the output is a redeem output
 	IsRedeem() bool
+	// GetOwner returns the owner of this token
+	GetOwner() []byte
 }
 
 //go:generate counterfeiter -o mock/ta.go -fake-name TransferAction . TransferAction

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -45,6 +45,6 @@ type Driver interface {
 	PPReader
 	// NewTokenService returns a new TokenManagerService instance.
 	NewTokenService(tmsID TMSID, publicParams []byte) (TokenManagerService, error)
-	// NewValidator returns a new Validator instance from the passed public parameters
-	NewValidator(tmsID TMSID, pp PublicParameters) (Validator, error)
+	// NewDefaultValidator returns a new Validator instance from the passed public parameters
+	NewDefaultValidator(pp PublicParameters) (Validator, error)
 }

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -44,7 +44,7 @@ type WalletServiceFactory interface {
 type Driver interface {
 	PPReader
 	// NewTokenService returns a new TokenManagerService instance.
-	NewTokenService(sp ServiceProvider, networkID string, channel string, namespace string, publicParams []byte) (TokenManagerService, error)
+	NewTokenService(tmsID TMSID, publicParams []byte) (TokenManagerService, error)
 	// NewValidator returns a new Validator instance from the passed public parameters
-	NewValidator(sp ServiceProvider, tmsID TMSID, pp PublicParameters) (Validator, error)
+	NewValidator(tmsID TMSID, pp PublicParameters) (Validator, error)
 }

--- a/token/driver/issue.go
+++ b/token/driver/issue.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import "context"
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
 
 // IssueOptions models the options that can be passed to the issue command
 type IssueOptions struct {
@@ -22,7 +26,7 @@ type IssueService interface {
 	// The function returns an IssuerAction, the associated metadata, and the identity of the issuer (depending on the implementation, it can be different from
 	// the one passed in input).
 	// The metadata is an array with an entry for each output created by the action.
-	Issue(ctx context.Context, issuerIdentity Identity, tokenType string, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
+	Issue(ctx context.Context, issuerIdentity Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
 
 	// VerifyIssue checks the well-formedness of the passed IssuerAction with the respect to the passed metadata
 	VerifyIssue(tr IssueAction, metadata [][]byte) error

--- a/token/driver/issue.go
+++ b/token/driver/issue.go
@@ -26,7 +26,7 @@ type IssueService interface {
 	// The function returns an IssuerAction, the associated metadata, and the identity of the issuer (depending on the implementation, it can be different from
 	// the one passed in input).
 	// The metadata is an array with an entry for each output created by the action.
-	Issue(ctx context.Context, issuerIdentity Identity, tokenType token.TokenType, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
+	Issue(ctx context.Context, issuerIdentity Identity, tokenType token.Type, values []uint64, owners [][]byte, opts *IssueOptions) (IssueAction, *IssueMetadata, error)
 
 	// VerifyIssue checks the well-formedness of the passed IssuerAction with the respect to the passed metadata
 	VerifyIssue(tr IssueAction, metadata [][]byte) error

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -64,7 +64,7 @@ type QueryEngine struct {
 	getTokenOutputsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
+	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
 	getTokenOutputsAndMetaMutex       sync.RWMutex
 	getTokenOutputsAndMetaArgsForCall []struct {
 		arg1 context.Context
@@ -73,13 +73,13 @@ type QueryEngine struct {
 	getTokenOutputsAndMetaReturns struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenType
+		result3 []token.TokenFormat
 		result4 error
 	}
 	getTokenOutputsAndMetaReturnsOnCall map[int]struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenType
+		result3 []token.TokenFormat
 		result4 error
 	}
 	GetTokensStub        func(...*token.ID) ([]*token.Token, error)
@@ -484,7 +484,7 @@ func (fake *QueryEngine) GetTokenOutputsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []token.TokenType, error) {
+func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error) {
 	var arg2Copy []*token.ID
 	if arg2 != nil {
 		arg2Copy = make([]*token.ID, len(arg2))
@@ -515,7 +515,7 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaCallCount() int {
 	return len(fake.getTokenOutputsAndMetaArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = stub
@@ -528,19 +528,19 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaArgsForCall(i int) (context.Conte
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []token.TokenType, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []token.TokenFormat, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
 	fake.getTokenOutputsAndMetaReturns = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenType
+		result3 []token.TokenFormat
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []token.TokenType, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []token.TokenFormat, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
@@ -548,14 +548,14 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]
 		fake.getTokenOutputsAndMetaReturnsOnCall = make(map[int]struct {
 			result1 [][]byte
 			result2 [][]byte
-			result3 []token.TokenType
+			result3 []token.TokenFormat
 			result4 error
 		})
 	}
 	fake.getTokenOutputsAndMetaReturnsOnCall[i] = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenType
+		result3 []token.TokenFormat
 		result4 error
 	}{result1, result2, result3, result4}
 }

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -10,11 +10,11 @@ import (
 )
 
 type QueryEngine struct {
-	BalanceStub        func(string, token.TokenType) (uint64, error)
+	BalanceStub        func(string, token.Type) (uint64, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 string
-		arg2 token.TokenType
+		arg2 token.Type
 	}
 	balanceReturns struct {
 		result1 uint64
@@ -64,7 +64,7 @@ type QueryEngine struct {
 	getTokenOutputsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
+	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.Format, error)
 	getTokenOutputsAndMetaMutex       sync.RWMutex
 	getTokenOutputsAndMetaArgsForCall []struct {
 		arg1 context.Context
@@ -73,13 +73,13 @@ type QueryEngine struct {
 	getTokenOutputsAndMetaReturns struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenFormat
+		result3 []token.Format
 		result4 error
 	}
 	getTokenOutputsAndMetaReturnsOnCall map[int]struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenFormat
+		result3 []token.Format
 		result4 error
 	}
 	GetTokensStub        func(...*token.ID) ([]*token.Token, error)
@@ -182,12 +182,12 @@ type QueryEngine struct {
 		result1 driver.UnspentTokensIterator
 		result2 error
 	}
-	UnspentTokensIteratorByStub        func(context.Context, string, token.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorByStub        func(context.Context, string, token.Type) (driver.UnspentTokensIterator, error)
 	unspentTokensIteratorByMutex       sync.RWMutex
 	unspentTokensIteratorByArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
-		arg3 token.TokenType
+		arg3 token.Type
 	}
 	unspentTokensIteratorByReturns struct {
 		result1 driver.UnspentTokensIterator
@@ -216,12 +216,12 @@ type QueryEngine struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *QueryEngine) Balance(arg1 string, arg2 token.TokenType) (uint64, error) {
+func (fake *QueryEngine) Balance(arg1 string, arg2 token.Type) (uint64, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
 		arg1 string
-		arg2 token.TokenType
+		arg2 token.Type
 	}{arg1, arg2})
 	stub := fake.BalanceStub
 	fakeReturns := fake.balanceReturns
@@ -242,13 +242,13 @@ func (fake *QueryEngine) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *QueryEngine) BalanceCalls(stub func(string, token.TokenType) (uint64, error)) {
+func (fake *QueryEngine) BalanceCalls(stub func(string, token.Type) (uint64, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
 }
 
-func (fake *QueryEngine) BalanceArgsForCall(i int) (string, token.TokenType) {
+func (fake *QueryEngine) BalanceArgsForCall(i int) (string, token.Type) {
 	fake.balanceMutex.RLock()
 	defer fake.balanceMutex.RUnlock()
 	argsForCall := fake.balanceArgsForCall[i]
@@ -484,7 +484,7 @@ func (fake *QueryEngine) GetTokenOutputsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error) {
+func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []token.Format, error) {
 	var arg2Copy []*token.ID
 	if arg2 != nil {
 		arg2Copy = make([]*token.ID, len(arg2))
@@ -515,7 +515,7 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaCallCount() int {
 	return len(fake.getTokenOutputsAndMetaArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.Format, error)) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = stub
@@ -528,19 +528,19 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaArgsForCall(i int) (context.Conte
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []token.TokenFormat, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []token.Format, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
 	fake.getTokenOutputsAndMetaReturns = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenFormat
+		result3 []token.Format
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []token.TokenFormat, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []token.Format, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
@@ -548,14 +548,14 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]
 		fake.getTokenOutputsAndMetaReturnsOnCall = make(map[int]struct {
 			result1 [][]byte
 			result2 [][]byte
-			result3 []token.TokenFormat
+			result3 []token.Format
 			result4 error
 		})
 	}
 	fake.getTokenOutputsAndMetaReturnsOnCall[i] = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []token.TokenFormat
+		result3 []token.Format
 		result4 error
 	}{result1, result2, result3, result4}
 }
@@ -1040,13 +1040,13 @@ func (fake *QueryEngine) UnspentTokensIteratorReturnsOnCall(i int, result1 drive
 	}{result1, result2}
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorBy(arg1 context.Context, arg2 string, arg3 token.TokenType) (driver.UnspentTokensIterator, error) {
+func (fake *QueryEngine) UnspentTokensIteratorBy(arg1 context.Context, arg2 string, arg3 token.Type) (driver.UnspentTokensIterator, error) {
 	fake.unspentTokensIteratorByMutex.Lock()
 	ret, specificReturn := fake.unspentTokensIteratorByReturnsOnCall[len(fake.unspentTokensIteratorByArgsForCall)]
 	fake.unspentTokensIteratorByArgsForCall = append(fake.unspentTokensIteratorByArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-		arg3 token.TokenType
+		arg3 token.Type
 	}{arg1, arg2, arg3})
 	stub := fake.UnspentTokensIteratorByStub
 	fakeReturns := fake.unspentTokensIteratorByReturns
@@ -1067,13 +1067,13 @@ func (fake *QueryEngine) UnspentTokensIteratorByCallCount() int {
 	return len(fake.unspentTokensIteratorByArgsForCall)
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorByCalls(stub func(context.Context, string, token.TokenType) (driver.UnspentTokensIterator, error)) {
+func (fake *QueryEngine) UnspentTokensIteratorByCalls(stub func(context.Context, string, token.Type) (driver.UnspentTokensIterator, error)) {
 	fake.unspentTokensIteratorByMutex.Lock()
 	defer fake.unspentTokensIteratorByMutex.Unlock()
 	fake.UnspentTokensIteratorByStub = stub
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorByArgsForCall(i int) (context.Context, string, token.TokenType) {
+func (fake *QueryEngine) UnspentTokensIteratorByArgsForCall(i int) (context.Context, string, token.Type) {
 	fake.unspentTokensIteratorByMutex.RLock()
 	defer fake.unspentTokensIteratorByMutex.RUnlock()
 	argsForCall := fake.unspentTokensIteratorByArgsForCall[i]

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -39,32 +39,16 @@ type QueryEngine struct {
 		result2 string
 		result3 error
 	}
-	GetTokenInfoAndOutputsStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, error)
-	getTokenInfoAndOutputsMutex       sync.RWMutex
-	getTokenInfoAndOutputsArgsForCall []struct {
-		arg1 context.Context
-		arg2 []*token.ID
-	}
-	getTokenInfoAndOutputsReturns struct {
-		result1 [][]byte
-		result2 [][]byte
-		result3 error
-	}
-	getTokenInfoAndOutputsReturnsOnCall map[int]struct {
-		result1 [][]byte
-		result2 [][]byte
-		result3 error
-	}
-	GetTokenInfosStub        func([]*token.ID) ([][]byte, error)
-	getTokenInfosMutex       sync.RWMutex
-	getTokenInfosArgsForCall []struct {
+	GetTokenMetadataStub        func([]*token.ID) ([][]byte, error)
+	getTokenMetadataMutex       sync.RWMutex
+	getTokenMetadataArgsForCall []struct {
 		arg1 []*token.ID
 	}
-	getTokenInfosReturns struct {
+	getTokenMetadataReturns struct {
 		result1 [][]byte
 		result2 error
 	}
-	getTokenInfosReturnsOnCall map[int]struct {
+	getTokenMetadataReturnsOnCall map[int]struct {
 		result1 [][]byte
 		result2 error
 	}
@@ -79,6 +63,24 @@ type QueryEngine struct {
 	}
 	getTokenOutputsReturnsOnCall map[int]struct {
 		result1 error
+	}
+	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []string, error)
+	getTokenOutputsAndMetaMutex       sync.RWMutex
+	getTokenOutputsAndMetaArgsForCall []struct {
+		arg1 context.Context
+		arg2 []*token.ID
+	}
+	getTokenOutputsAndMetaReturns struct {
+		result1 [][]byte
+		result2 [][]byte
+		result3 []string
+		result4 error
+	}
+	getTokenOutputsAndMetaReturnsOnCall map[int]struct {
+		result1 [][]byte
+		result2 [][]byte
+		result3 []string
+		result4 error
 	}
 	GetTokensStub        func(...*token.ID) ([]*token.Token, error)
 	getTokensMutex       sync.RWMutex
@@ -346,94 +348,21 @@ func (fake *QueryEngine) GetStatusReturnsOnCall(i int, result1 int, result2 stri
 	}{result1, result2, result3}
 }
 
-func (fake *QueryEngine) GetTokenInfoAndOutputs(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, error) {
-	var arg2Copy []*token.ID
-	if arg2 != nil {
-		arg2Copy = make([]*token.ID, len(arg2))
-		copy(arg2Copy, arg2)
-	}
-	fake.getTokenInfoAndOutputsMutex.Lock()
-	ret, specificReturn := fake.getTokenInfoAndOutputsReturnsOnCall[len(fake.getTokenInfoAndOutputsArgsForCall)]
-	fake.getTokenInfoAndOutputsArgsForCall = append(fake.getTokenInfoAndOutputsArgsForCall, struct {
-		arg1 context.Context
-		arg2 []*token.ID
-	}{arg1, arg2Copy})
-	stub := fake.GetTokenInfoAndOutputsStub
-	fakeReturns := fake.getTokenInfoAndOutputsReturns
-	fake.recordInvocation("GetTokenInfoAndOutputs", []interface{}{arg1, arg2Copy})
-	fake.getTokenInfoAndOutputsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
-	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
-}
-
-func (fake *QueryEngine) GetTokenInfoAndOutputsCallCount() int {
-	fake.getTokenInfoAndOutputsMutex.RLock()
-	defer fake.getTokenInfoAndOutputsMutex.RUnlock()
-	return len(fake.getTokenInfoAndOutputsArgsForCall)
-}
-
-func (fake *QueryEngine) GetTokenInfoAndOutputsCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, error)) {
-	fake.getTokenInfoAndOutputsMutex.Lock()
-	defer fake.getTokenInfoAndOutputsMutex.Unlock()
-	fake.GetTokenInfoAndOutputsStub = stub
-}
-
-func (fake *QueryEngine) GetTokenInfoAndOutputsArgsForCall(i int) (context.Context, []*token.ID) {
-	fake.getTokenInfoAndOutputsMutex.RLock()
-	defer fake.getTokenInfoAndOutputsMutex.RUnlock()
-	argsForCall := fake.getTokenInfoAndOutputsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *QueryEngine) GetTokenInfoAndOutputsReturns(result1 [][]byte, result2 [][]byte, result3 error) {
-	fake.getTokenInfoAndOutputsMutex.Lock()
-	defer fake.getTokenInfoAndOutputsMutex.Unlock()
-	fake.GetTokenInfoAndOutputsStub = nil
-	fake.getTokenInfoAndOutputsReturns = struct {
-		result1 [][]byte
-		result2 [][]byte
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *QueryEngine) GetTokenInfoAndOutputsReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 error) {
-	fake.getTokenInfoAndOutputsMutex.Lock()
-	defer fake.getTokenInfoAndOutputsMutex.Unlock()
-	fake.GetTokenInfoAndOutputsStub = nil
-	if fake.getTokenInfoAndOutputsReturnsOnCall == nil {
-		fake.getTokenInfoAndOutputsReturnsOnCall = make(map[int]struct {
-			result1 [][]byte
-			result2 [][]byte
-			result3 error
-		})
-	}
-	fake.getTokenInfoAndOutputsReturnsOnCall[i] = struct {
-		result1 [][]byte
-		result2 [][]byte
-		result3 error
-	}{result1, result2, result3}
-}
-
-func (fake *QueryEngine) GetTokenInfos(arg1 []*token.ID) ([][]byte, error) {
+func (fake *QueryEngine) GetTokenMetadata(arg1 []*token.ID) ([][]byte, error) {
 	var arg1Copy []*token.ID
 	if arg1 != nil {
 		arg1Copy = make([]*token.ID, len(arg1))
 		copy(arg1Copy, arg1)
 	}
-	fake.getTokenInfosMutex.Lock()
-	ret, specificReturn := fake.getTokenInfosReturnsOnCall[len(fake.getTokenInfosArgsForCall)]
-	fake.getTokenInfosArgsForCall = append(fake.getTokenInfosArgsForCall, struct {
+	fake.getTokenMetadataMutex.Lock()
+	ret, specificReturn := fake.getTokenMetadataReturnsOnCall[len(fake.getTokenMetadataArgsForCall)]
+	fake.getTokenMetadataArgsForCall = append(fake.getTokenMetadataArgsForCall, struct {
 		arg1 []*token.ID
 	}{arg1Copy})
-	stub := fake.GetTokenInfosStub
-	fakeReturns := fake.getTokenInfosReturns
-	fake.recordInvocation("GetTokenInfos", []interface{}{arg1Copy})
-	fake.getTokenInfosMutex.Unlock()
+	stub := fake.GetTokenMetadataStub
+	fakeReturns := fake.getTokenMetadataReturns
+	fake.recordInvocation("GetTokenMetadata", []interface{}{arg1Copy})
+	fake.getTokenMetadataMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
 	}
@@ -443,46 +372,46 @@ func (fake *QueryEngine) GetTokenInfos(arg1 []*token.ID) ([][]byte, error) {
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *QueryEngine) GetTokenInfosCallCount() int {
-	fake.getTokenInfosMutex.RLock()
-	defer fake.getTokenInfosMutex.RUnlock()
-	return len(fake.getTokenInfosArgsForCall)
+func (fake *QueryEngine) GetTokenMetadataCallCount() int {
+	fake.getTokenMetadataMutex.RLock()
+	defer fake.getTokenMetadataMutex.RUnlock()
+	return len(fake.getTokenMetadataArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokenInfosCalls(stub func([]*token.ID) ([][]byte, error)) {
-	fake.getTokenInfosMutex.Lock()
-	defer fake.getTokenInfosMutex.Unlock()
-	fake.GetTokenInfosStub = stub
+func (fake *QueryEngine) GetTokenMetadataCalls(stub func([]*token.ID) ([][]byte, error)) {
+	fake.getTokenMetadataMutex.Lock()
+	defer fake.getTokenMetadataMutex.Unlock()
+	fake.GetTokenMetadataStub = stub
 }
 
-func (fake *QueryEngine) GetTokenInfosArgsForCall(i int) []*token.ID {
-	fake.getTokenInfosMutex.RLock()
-	defer fake.getTokenInfosMutex.RUnlock()
-	argsForCall := fake.getTokenInfosArgsForCall[i]
+func (fake *QueryEngine) GetTokenMetadataArgsForCall(i int) []*token.ID {
+	fake.getTokenMetadataMutex.RLock()
+	defer fake.getTokenMetadataMutex.RUnlock()
+	argsForCall := fake.getTokenMetadataArgsForCall[i]
 	return argsForCall.arg1
 }
 
-func (fake *QueryEngine) GetTokenInfosReturns(result1 [][]byte, result2 error) {
-	fake.getTokenInfosMutex.Lock()
-	defer fake.getTokenInfosMutex.Unlock()
-	fake.GetTokenInfosStub = nil
-	fake.getTokenInfosReturns = struct {
+func (fake *QueryEngine) GetTokenMetadataReturns(result1 [][]byte, result2 error) {
+	fake.getTokenMetadataMutex.Lock()
+	defer fake.getTokenMetadataMutex.Unlock()
+	fake.GetTokenMetadataStub = nil
+	fake.getTokenMetadataReturns = struct {
 		result1 [][]byte
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryEngine) GetTokenInfosReturnsOnCall(i int, result1 [][]byte, result2 error) {
-	fake.getTokenInfosMutex.Lock()
-	defer fake.getTokenInfosMutex.Unlock()
-	fake.GetTokenInfosStub = nil
-	if fake.getTokenInfosReturnsOnCall == nil {
-		fake.getTokenInfosReturnsOnCall = make(map[int]struct {
+func (fake *QueryEngine) GetTokenMetadataReturnsOnCall(i int, result1 [][]byte, result2 error) {
+	fake.getTokenMetadataMutex.Lock()
+	defer fake.getTokenMetadataMutex.Unlock()
+	fake.GetTokenMetadataStub = nil
+	if fake.getTokenMetadataReturnsOnCall == nil {
+		fake.getTokenMetadataReturnsOnCall = make(map[int]struct {
 			result1 [][]byte
 			result2 error
 		})
 	}
-	fake.getTokenInfosReturnsOnCall[i] = struct {
+	fake.getTokenMetadataReturnsOnCall[i] = struct {
 		result1 [][]byte
 		result2 error
 	}{result1, result2}
@@ -553,6 +482,82 @@ func (fake *QueryEngine) GetTokenOutputsReturnsOnCall(i int, result1 error) {
 	fake.getTokenOutputsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []string, error) {
+	var arg2Copy []*token.ID
+	if arg2 != nil {
+		arg2Copy = make([]*token.ID, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.getTokenOutputsAndMetaMutex.Lock()
+	ret, specificReturn := fake.getTokenOutputsAndMetaReturnsOnCall[len(fake.getTokenOutputsAndMetaArgsForCall)]
+	fake.getTokenOutputsAndMetaArgsForCall = append(fake.getTokenOutputsAndMetaArgsForCall, struct {
+		arg1 context.Context
+		arg2 []*token.ID
+	}{arg1, arg2Copy})
+	stub := fake.GetTokenOutputsAndMetaStub
+	fakeReturns := fake.getTokenOutputsAndMetaReturns
+	fake.recordInvocation("GetTokenOutputsAndMeta", []interface{}{arg1, arg2Copy})
+	fake.getTokenOutputsAndMetaMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3, ret.result4
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMetaCallCount() int {
+	fake.getTokenOutputsAndMetaMutex.RLock()
+	defer fake.getTokenOutputsAndMetaMutex.RUnlock()
+	return len(fake.getTokenOutputsAndMetaArgsForCall)
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []string, error)) {
+	fake.getTokenOutputsAndMetaMutex.Lock()
+	defer fake.getTokenOutputsAndMetaMutex.Unlock()
+	fake.GetTokenOutputsAndMetaStub = stub
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMetaArgsForCall(i int) (context.Context, []*token.ID) {
+	fake.getTokenOutputsAndMetaMutex.RLock()
+	defer fake.getTokenOutputsAndMetaMutex.RUnlock()
+	argsForCall := fake.getTokenOutputsAndMetaArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []string, result4 error) {
+	fake.getTokenOutputsAndMetaMutex.Lock()
+	defer fake.getTokenOutputsAndMetaMutex.Unlock()
+	fake.GetTokenOutputsAndMetaStub = nil
+	fake.getTokenOutputsAndMetaReturns = struct {
+		result1 [][]byte
+		result2 [][]byte
+		result3 []string
+		result4 error
+	}{result1, result2, result3, result4}
+}
+
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []string, result4 error) {
+	fake.getTokenOutputsAndMetaMutex.Lock()
+	defer fake.getTokenOutputsAndMetaMutex.Unlock()
+	fake.GetTokenOutputsAndMetaStub = nil
+	if fake.getTokenOutputsAndMetaReturnsOnCall == nil {
+		fake.getTokenOutputsAndMetaReturnsOnCall = make(map[int]struct {
+			result1 [][]byte
+			result2 [][]byte
+			result3 []string
+			result4 error
+		})
+	}
+	fake.getTokenOutputsAndMetaReturnsOnCall[i] = struct {
+		result1 [][]byte
+		result2 [][]byte
+		result3 []string
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
 func (fake *QueryEngine) GetTokens(arg1 ...*token.ID) ([]*token.Token, error) {
@@ -1175,12 +1180,12 @@ func (fake *QueryEngine) Invocations() map[string][][]interface{} {
 	defer fake.balanceMutex.RUnlock()
 	fake.getStatusMutex.RLock()
 	defer fake.getStatusMutex.RUnlock()
-	fake.getTokenInfoAndOutputsMutex.RLock()
-	defer fake.getTokenInfoAndOutputsMutex.RUnlock()
-	fake.getTokenInfosMutex.RLock()
-	defer fake.getTokenInfosMutex.RUnlock()
+	fake.getTokenMetadataMutex.RLock()
+	defer fake.getTokenMetadataMutex.RUnlock()
 	fake.getTokenOutputsMutex.RLock()
 	defer fake.getTokenOutputsMutex.RUnlock()
+	fake.getTokenOutputsAndMetaMutex.RLock()
+	defer fake.getTokenOutputsAndMetaMutex.RUnlock()
 	fake.getTokensMutex.RLock()
 	defer fake.getTokensMutex.RUnlock()
 	fake.isMineMutex.RLock()

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -10,11 +10,11 @@ import (
 )
 
 type QueryEngine struct {
-	BalanceStub        func(string, string) (uint64, error)
+	BalanceStub        func(string, token.TokenType) (uint64, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 string
-		arg2 string
+		arg2 token.TokenType
 	}
 	balanceReturns struct {
 		result1 uint64
@@ -64,7 +64,7 @@ type QueryEngine struct {
 	getTokenOutputsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []string, error)
+	GetTokenOutputsAndMetaStub        func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
 	getTokenOutputsAndMetaMutex       sync.RWMutex
 	getTokenOutputsAndMetaArgsForCall []struct {
 		arg1 context.Context
@@ -73,13 +73,13 @@ type QueryEngine struct {
 	getTokenOutputsAndMetaReturns struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []string
+		result3 []token.TokenType
 		result4 error
 	}
 	getTokenOutputsAndMetaReturnsOnCall map[int]struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []string
+		result3 []token.TokenType
 		result4 error
 	}
 	GetTokensStub        func(...*token.ID) ([]*token.Token, error)
@@ -182,12 +182,12 @@ type QueryEngine struct {
 		result1 driver.UnspentTokensIterator
 		result2 error
 	}
-	UnspentTokensIteratorByStub        func(context.Context, string, string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorByStub        func(context.Context, string, token.TokenType) (driver.UnspentTokensIterator, error)
 	unspentTokensIteratorByMutex       sync.RWMutex
 	unspentTokensIteratorByArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
-		arg3 string
+		arg3 token.TokenType
 	}
 	unspentTokensIteratorByReturns struct {
 		result1 driver.UnspentTokensIterator
@@ -216,12 +216,12 @@ type QueryEngine struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *QueryEngine) Balance(arg1 string, arg2 string) (uint64, error) {
+func (fake *QueryEngine) Balance(arg1 string, arg2 token.TokenType) (uint64, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
 		arg1 string
-		arg2 string
+		arg2 token.TokenType
 	}{arg1, arg2})
 	stub := fake.BalanceStub
 	fakeReturns := fake.balanceReturns
@@ -242,13 +242,13 @@ func (fake *QueryEngine) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *QueryEngine) BalanceCalls(stub func(string, string) (uint64, error)) {
+func (fake *QueryEngine) BalanceCalls(stub func(string, token.TokenType) (uint64, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
 }
 
-func (fake *QueryEngine) BalanceArgsForCall(i int) (string, string) {
+func (fake *QueryEngine) BalanceArgsForCall(i int) (string, token.TokenType) {
 	fake.balanceMutex.RLock()
 	defer fake.balanceMutex.RUnlock()
 	argsForCall := fake.balanceArgsForCall[i]
@@ -484,7 +484,7 @@ func (fake *QueryEngine) GetTokenOutputsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []string, error) {
+func (fake *QueryEngine) GetTokenOutputsAndMeta(arg1 context.Context, arg2 []*token.ID) ([][]byte, [][]byte, []token.TokenType, error) {
 	var arg2Copy []*token.ID
 	if arg2 != nil {
 		arg2Copy = make([]*token.ID, len(arg2))
@@ -515,7 +515,7 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaCallCount() int {
 	return len(fake.getTokenOutputsAndMetaArgsForCall)
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []string, error)) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaCalls(stub func(context.Context, []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = stub
@@ -528,19 +528,19 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaArgsForCall(i int) (context.Conte
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []string, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturns(result1 [][]byte, result2 [][]byte, result3 []token.TokenType, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
 	fake.getTokenOutputsAndMetaReturns = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []string
+		result3 []token.TokenType
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []string, result4 error) {
+func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]byte, result2 [][]byte, result3 []token.TokenType, result4 error) {
 	fake.getTokenOutputsAndMetaMutex.Lock()
 	defer fake.getTokenOutputsAndMetaMutex.Unlock()
 	fake.GetTokenOutputsAndMetaStub = nil
@@ -548,14 +548,14 @@ func (fake *QueryEngine) GetTokenOutputsAndMetaReturnsOnCall(i int, result1 [][]
 		fake.getTokenOutputsAndMetaReturnsOnCall = make(map[int]struct {
 			result1 [][]byte
 			result2 [][]byte
-			result3 []string
+			result3 []token.TokenType
 			result4 error
 		})
 	}
 	fake.getTokenOutputsAndMetaReturnsOnCall[i] = struct {
 		result1 [][]byte
 		result2 [][]byte
-		result3 []string
+		result3 []token.TokenType
 		result4 error
 	}{result1, result2, result3, result4}
 }
@@ -1040,13 +1040,13 @@ func (fake *QueryEngine) UnspentTokensIteratorReturnsOnCall(i int, result1 drive
 	}{result1, result2}
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorBy(arg1 context.Context, arg2 string, arg3 string) (driver.UnspentTokensIterator, error) {
+func (fake *QueryEngine) UnspentTokensIteratorBy(arg1 context.Context, arg2 string, arg3 token.TokenType) (driver.UnspentTokensIterator, error) {
 	fake.unspentTokensIteratorByMutex.Lock()
 	ret, specificReturn := fake.unspentTokensIteratorByReturnsOnCall[len(fake.unspentTokensIteratorByArgsForCall)]
 	fake.unspentTokensIteratorByArgsForCall = append(fake.unspentTokensIteratorByArgsForCall, struct {
 		arg1 context.Context
 		arg2 string
-		arg3 string
+		arg3 token.TokenType
 	}{arg1, arg2, arg3})
 	stub := fake.UnspentTokensIteratorByStub
 	fakeReturns := fake.unspentTokensIteratorByReturns
@@ -1067,13 +1067,13 @@ func (fake *QueryEngine) UnspentTokensIteratorByCallCount() int {
 	return len(fake.unspentTokensIteratorByArgsForCall)
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorByCalls(stub func(context.Context, string, string) (driver.UnspentTokensIterator, error)) {
+func (fake *QueryEngine) UnspentTokensIteratorByCalls(stub func(context.Context, string, token.TokenType) (driver.UnspentTokensIterator, error)) {
 	fake.unspentTokensIteratorByMutex.Lock()
 	defer fake.unspentTokensIteratorByMutex.Unlock()
 	fake.UnspentTokensIteratorByStub = stub
 }
 
-func (fake *QueryEngine) UnspentTokensIteratorByArgsForCall(i int) (context.Context, string, string) {
+func (fake *QueryEngine) UnspentTokensIteratorByArgsForCall(i int) (context.Context, string, token.TokenType) {
 	fake.unspentTokensIteratorByMutex.RLock()
 	defer fake.unspentTokensIteratorByMutex.RUnlock()
 	argsForCall := fake.unspentTokensIteratorByArgsForCall[i]

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TokensService struct {
-	DeobfuscateStub        func([]byte, []byte) (*token.Token, view.Identity, string, error)
+	DeobfuscateStub        func([]byte, []byte) (*token.Token, view.Identity, token.TokenType, error)
 	deobfuscateMutex       sync.RWMutex
 	deobfuscateArgsForCall []struct {
 		arg1 []byte
@@ -19,13 +19,13 @@ type TokensService struct {
 	deobfuscateReturns struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 string
+		result3 token.TokenType
 		result4 error
 	}
 	deobfuscateReturnsOnCall map[int]struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 string
+		result3 token.TokenType
 		result4 error
 	}
 	ExtractMetadataStub        func(*driver.TokenRequestMetadata, []byte) ([]byte, error)
@@ -42,21 +42,21 @@ type TokensService struct {
 		result1 []byte
 		result2 error
 	}
-	SupportedTokenTypesStub        func() []string
+	SupportedTokenTypesStub        func() []token.TokenType
 	supportedTokenTypesMutex       sync.RWMutex
 	supportedTokenTypesArgsForCall []struct {
 	}
 	supportedTokenTypesReturns struct {
-		result1 []string
+		result1 []token.TokenType
 	}
 	supportedTokenTypesReturnsOnCall map[int]struct {
-		result1 []string
+		result1 []token.TokenType
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, view.Identity, string, error) {
+func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, view.Identity, token.TokenType, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -92,7 +92,7 @@ func (fake *TokensService) DeobfuscateCallCount() int {
 	return len(fake.deobfuscateArgsForCall)
 }
 
-func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, view.Identity, string, error)) {
+func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, view.Identity, token.TokenType, error)) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = stub
@@ -105,19 +105,19 @@ func (fake *TokensService) DeobfuscateArgsForCall(i int) ([]byte, []byte) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 view.Identity, result3 string, result4 error) {
+func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 view.Identity, result3 token.TokenType, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
 	fake.deobfuscateReturns = struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 string
+		result3 token.TokenType
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 view.Identity, result3 string, result4 error) {
+func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 view.Identity, result3 token.TokenType, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
@@ -125,14 +125,14 @@ func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token,
 		fake.deobfuscateReturnsOnCall = make(map[int]struct {
 			result1 *token.Token
 			result2 view.Identity
-			result3 string
+			result3 token.TokenType
 			result4 error
 		})
 	}
 	fake.deobfuscateReturnsOnCall[i] = struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 string
+		result3 token.TokenType
 		result4 error
 	}{result1, result2, result3, result4}
 }
@@ -207,7 +207,7 @@ func (fake *TokensService) ExtractMetadataReturnsOnCall(i int, result1 []byte, r
 	}{result1, result2}
 }
 
-func (fake *TokensService) SupportedTokenTypes() []string {
+func (fake *TokensService) SupportedTokenTypes() []token.TokenType {
 	fake.supportedTokenTypesMutex.Lock()
 	ret, specificReturn := fake.supportedTokenTypesReturnsOnCall[len(fake.supportedTokenTypesArgsForCall)]
 	fake.supportedTokenTypesArgsForCall = append(fake.supportedTokenTypesArgsForCall, struct {
@@ -231,32 +231,32 @@ func (fake *TokensService) SupportedTokenTypesCallCount() int {
 	return len(fake.supportedTokenTypesArgsForCall)
 }
 
-func (fake *TokensService) SupportedTokenTypesCalls(stub func() []string) {
+func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.TokenType) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = stub
 }
 
-func (fake *TokensService) SupportedTokenTypesReturns(result1 []string) {
+func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.TokenType) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	fake.supportedTokenTypesReturns = struct {
-		result1 []string
+		result1 []token.TokenType
 	}{result1}
 }
 
-func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []string) {
+func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.TokenType) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	if fake.supportedTokenTypesReturnsOnCall == nil {
 		fake.supportedTokenTypesReturnsOnCall = make(map[int]struct {
-			result1 []string
+			result1 []token.TokenType
 		})
 	}
 	fake.supportedTokenTypesReturnsOnCall[i] = struct {
-		result1 []string
+		result1 []token.TokenType
 	}{result1}
 }
 

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -42,14 +42,14 @@ type TokensService struct {
 		result1 []byte
 		result2 error
 	}
-	SupportedTokenTypesStub        func() []token.Format
-	supportedTokenTypesMutex       sync.RWMutex
-	supportedTokenTypesArgsForCall []struct {
+	SupportedTokenFormatsStub        func() []token.Format
+	supportedTokenFormatsMutex       sync.RWMutex
+	supportedTokenFormatsArgsForCall []struct {
 	}
-	supportedTokenTypesReturns struct {
+	supportedTokenFormatsReturns struct {
 		result1 []token.Format
 	}
-	supportedTokenTypesReturnsOnCall map[int]struct {
+	supportedTokenFormatsReturnsOnCall map[int]struct {
 		result1 []token.Format
 	}
 	invocations      map[string][][]interface{}
@@ -207,15 +207,15 @@ func (fake *TokensService) ExtractMetadataReturnsOnCall(i int, result1 []byte, r
 	}{result1, result2}
 }
 
-func (fake *TokensService) SupportedTokenTypes() []token.Format {
-	fake.supportedTokenTypesMutex.Lock()
-	ret, specificReturn := fake.supportedTokenTypesReturnsOnCall[len(fake.supportedTokenTypesArgsForCall)]
-	fake.supportedTokenTypesArgsForCall = append(fake.supportedTokenTypesArgsForCall, struct {
+func (fake *TokensService) SupportedTokenFormats() []token.Format {
+	fake.supportedTokenFormatsMutex.Lock()
+	ret, specificReturn := fake.supportedTokenFormatsReturnsOnCall[len(fake.supportedTokenFormatsArgsForCall)]
+	fake.supportedTokenFormatsArgsForCall = append(fake.supportedTokenFormatsArgsForCall, struct {
 	}{})
-	stub := fake.SupportedTokenTypesStub
-	fakeReturns := fake.supportedTokenTypesReturns
-	fake.recordInvocation("SupportedTokenTypes", []interface{}{})
-	fake.supportedTokenTypesMutex.Unlock()
+	stub := fake.SupportedTokenFormatsStub
+	fakeReturns := fake.supportedTokenFormatsReturns
+	fake.recordInvocation("SupportedTokenFormats", []interface{}{})
+	fake.supportedTokenFormatsMutex.Unlock()
 	if stub != nil {
 		return stub()
 	}
@@ -225,37 +225,37 @@ func (fake *TokensService) SupportedTokenTypes() []token.Format {
 	return fakeReturns.result1
 }
 
-func (fake *TokensService) SupportedTokenTypesCallCount() int {
-	fake.supportedTokenTypesMutex.RLock()
-	defer fake.supportedTokenTypesMutex.RUnlock()
-	return len(fake.supportedTokenTypesArgsForCall)
+func (fake *TokensService) SupportedTokenFormatsCallCount() int {
+	fake.supportedTokenFormatsMutex.RLock()
+	defer fake.supportedTokenFormatsMutex.RUnlock()
+	return len(fake.supportedTokenFormatsArgsForCall)
 }
 
-func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.Format) {
-	fake.supportedTokenTypesMutex.Lock()
-	defer fake.supportedTokenTypesMutex.Unlock()
-	fake.SupportedTokenTypesStub = stub
+func (fake *TokensService) SupportedTokenFormatsCalls(stub func() []token.Format) {
+	fake.supportedTokenFormatsMutex.Lock()
+	defer fake.supportedTokenFormatsMutex.Unlock()
+	fake.SupportedTokenFormatsStub = stub
 }
 
-func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.Format) {
-	fake.supportedTokenTypesMutex.Lock()
-	defer fake.supportedTokenTypesMutex.Unlock()
-	fake.SupportedTokenTypesStub = nil
-	fake.supportedTokenTypesReturns = struct {
+func (fake *TokensService) SupportedTokenFormatsReturns(result1 []token.Format) {
+	fake.supportedTokenFormatsMutex.Lock()
+	defer fake.supportedTokenFormatsMutex.Unlock()
+	fake.SupportedTokenFormatsStub = nil
+	fake.supportedTokenFormatsReturns = struct {
 		result1 []token.Format
 	}{result1}
 }
 
-func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.Format) {
-	fake.supportedTokenTypesMutex.Lock()
-	defer fake.supportedTokenTypesMutex.Unlock()
-	fake.SupportedTokenTypesStub = nil
-	if fake.supportedTokenTypesReturnsOnCall == nil {
-		fake.supportedTokenTypesReturnsOnCall = make(map[int]struct {
+func (fake *TokensService) SupportedTokenFormatsReturnsOnCall(i int, result1 []token.Format) {
+	fake.supportedTokenFormatsMutex.Lock()
+	defer fake.supportedTokenFormatsMutex.Unlock()
+	fake.SupportedTokenFormatsStub = nil
+	if fake.supportedTokenFormatsReturnsOnCall == nil {
+		fake.supportedTokenFormatsReturnsOnCall = make(map[int]struct {
 			result1 []token.Format
 		})
 	}
-	fake.supportedTokenTypesReturnsOnCall[i] = struct {
+	fake.supportedTokenFormatsReturnsOnCall[i] = struct {
 		result1 []token.Format
 	}{result1}
 }
@@ -267,8 +267,8 @@ func (fake *TokensService) Invocations() map[string][][]interface{} {
 	defer fake.deobfuscateMutex.RUnlock()
 	fake.extractMetadataMutex.RLock()
 	defer fake.extractMetadataMutex.RUnlock()
-	fake.supportedTokenTypesMutex.RLock()
-	defer fake.supportedTokenTypesMutex.RUnlock()
+	fake.supportedTokenFormatsMutex.RLock()
+	defer fake.supportedTokenFormatsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -10,41 +10,53 @@ import (
 )
 
 type TokensService struct {
-	DeserializeTokenStub        func([]byte, []byte) (*token.Token, view.Identity, error)
-	deserializeTokenMutex       sync.RWMutex
-	deserializeTokenArgsForCall []struct {
+	DeobfuscateStub        func([]byte, []byte) (*token.Token, view.Identity, string, error)
+	deobfuscateMutex       sync.RWMutex
+	deobfuscateArgsForCall []struct {
 		arg1 []byte
 		arg2 []byte
 	}
-	deserializeTokenReturns struct {
+	deobfuscateReturns struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 error
+		result3 string
+		result4 error
 	}
-	deserializeTokenReturnsOnCall map[int]struct {
+	deobfuscateReturnsOnCall map[int]struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 error
+		result3 string
+		result4 error
 	}
-	GetTokenInfoStub        func(*driver.TokenRequestMetadata, []byte) ([]byte, error)
-	getTokenInfoMutex       sync.RWMutex
-	getTokenInfoArgsForCall []struct {
+	ExtractMetadataStub        func(*driver.TokenRequestMetadata, []byte) ([]byte, error)
+	extractMetadataMutex       sync.RWMutex
+	extractMetadataArgsForCall []struct {
 		arg1 *driver.TokenRequestMetadata
 		arg2 []byte
 	}
-	getTokenInfoReturns struct {
+	extractMetadataReturns struct {
 		result1 []byte
 		result2 error
 	}
-	getTokenInfoReturnsOnCall map[int]struct {
+	extractMetadataReturnsOnCall map[int]struct {
 		result1 []byte
 		result2 error
+	}
+	SupportedTokenTypesStub        func() []string
+	supportedTokenTypesMutex       sync.RWMutex
+	supportedTokenTypesArgsForCall []struct {
+	}
+	supportedTokenTypesReturns struct {
+		result1 []string
+	}
+	supportedTokenTypesReturnsOnCall map[int]struct {
+		result1 []string
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokensService) DeserializeToken(arg1 []byte, arg2 []byte) (*token.Token, view.Identity, error) {
+func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, view.Identity, string, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -55,89 +67,92 @@ func (fake *TokensService) DeserializeToken(arg1 []byte, arg2 []byte) (*token.To
 		arg2Copy = make([]byte, len(arg2))
 		copy(arg2Copy, arg2)
 	}
-	fake.deserializeTokenMutex.Lock()
-	ret, specificReturn := fake.deserializeTokenReturnsOnCall[len(fake.deserializeTokenArgsForCall)]
-	fake.deserializeTokenArgsForCall = append(fake.deserializeTokenArgsForCall, struct {
+	fake.deobfuscateMutex.Lock()
+	ret, specificReturn := fake.deobfuscateReturnsOnCall[len(fake.deobfuscateArgsForCall)]
+	fake.deobfuscateArgsForCall = append(fake.deobfuscateArgsForCall, struct {
 		arg1 []byte
 		arg2 []byte
 	}{arg1Copy, arg2Copy})
-	stub := fake.DeserializeTokenStub
-	fakeReturns := fake.deserializeTokenReturns
-	fake.recordInvocation("DeserializeToken", []interface{}{arg1Copy, arg2Copy})
-	fake.deserializeTokenMutex.Unlock()
+	stub := fake.DeobfuscateStub
+	fakeReturns := fake.deobfuscateReturns
+	fake.recordInvocation("Deobfuscate", []interface{}{arg1Copy, arg2Copy})
+	fake.deobfuscateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2, ret.result3, ret.result4
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3, fakeReturns.result4
 }
 
-func (fake *TokensService) DeserializeTokenCallCount() int {
-	fake.deserializeTokenMutex.RLock()
-	defer fake.deserializeTokenMutex.RUnlock()
-	return len(fake.deserializeTokenArgsForCall)
+func (fake *TokensService) DeobfuscateCallCount() int {
+	fake.deobfuscateMutex.RLock()
+	defer fake.deobfuscateMutex.RUnlock()
+	return len(fake.deobfuscateArgsForCall)
 }
 
-func (fake *TokensService) DeserializeTokenCalls(stub func([]byte, []byte) (*token.Token, view.Identity, error)) {
-	fake.deserializeTokenMutex.Lock()
-	defer fake.deserializeTokenMutex.Unlock()
-	fake.DeserializeTokenStub = stub
+func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, view.Identity, string, error)) {
+	fake.deobfuscateMutex.Lock()
+	defer fake.deobfuscateMutex.Unlock()
+	fake.DeobfuscateStub = stub
 }
 
-func (fake *TokensService) DeserializeTokenArgsForCall(i int) ([]byte, []byte) {
-	fake.deserializeTokenMutex.RLock()
-	defer fake.deserializeTokenMutex.RUnlock()
-	argsForCall := fake.deserializeTokenArgsForCall[i]
+func (fake *TokensService) DeobfuscateArgsForCall(i int) ([]byte, []byte) {
+	fake.deobfuscateMutex.RLock()
+	defer fake.deobfuscateMutex.RUnlock()
+	argsForCall := fake.deobfuscateArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TokensService) DeserializeTokenReturns(result1 *token.Token, result2 view.Identity, result3 error) {
-	fake.deserializeTokenMutex.Lock()
-	defer fake.deserializeTokenMutex.Unlock()
-	fake.DeserializeTokenStub = nil
-	fake.deserializeTokenReturns = struct {
+func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 view.Identity, result3 string, result4 error) {
+	fake.deobfuscateMutex.Lock()
+	defer fake.deobfuscateMutex.Unlock()
+	fake.DeobfuscateStub = nil
+	fake.deobfuscateReturns = struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 error
-	}{result1, result2, result3}
+		result3 string
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
-func (fake *TokensService) DeserializeTokenReturnsOnCall(i int, result1 *token.Token, result2 view.Identity, result3 error) {
-	fake.deserializeTokenMutex.Lock()
-	defer fake.deserializeTokenMutex.Unlock()
-	fake.DeserializeTokenStub = nil
-	if fake.deserializeTokenReturnsOnCall == nil {
-		fake.deserializeTokenReturnsOnCall = make(map[int]struct {
+func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 view.Identity, result3 string, result4 error) {
+	fake.deobfuscateMutex.Lock()
+	defer fake.deobfuscateMutex.Unlock()
+	fake.DeobfuscateStub = nil
+	if fake.deobfuscateReturnsOnCall == nil {
+		fake.deobfuscateReturnsOnCall = make(map[int]struct {
 			result1 *token.Token
 			result2 view.Identity
-			result3 error
+			result3 string
+			result4 error
 		})
 	}
-	fake.deserializeTokenReturnsOnCall[i] = struct {
+	fake.deobfuscateReturnsOnCall[i] = struct {
 		result1 *token.Token
 		result2 view.Identity
-		result3 error
-	}{result1, result2, result3}
+		result3 string
+		result4 error
+	}{result1, result2, result3, result4}
 }
 
-func (fake *TokensService) GetTokenInfo(arg1 *driver.TokenRequestMetadata, arg2 []byte) ([]byte, error) {
+func (fake *TokensService) ExtractMetadata(arg1 *driver.TokenRequestMetadata, arg2 []byte) ([]byte, error) {
 	var arg2Copy []byte
 	if arg2 != nil {
 		arg2Copy = make([]byte, len(arg2))
 		copy(arg2Copy, arg2)
 	}
-	fake.getTokenInfoMutex.Lock()
-	ret, specificReturn := fake.getTokenInfoReturnsOnCall[len(fake.getTokenInfoArgsForCall)]
-	fake.getTokenInfoArgsForCall = append(fake.getTokenInfoArgsForCall, struct {
+	fake.extractMetadataMutex.Lock()
+	ret, specificReturn := fake.extractMetadataReturnsOnCall[len(fake.extractMetadataArgsForCall)]
+	fake.extractMetadataArgsForCall = append(fake.extractMetadataArgsForCall, struct {
 		arg1 *driver.TokenRequestMetadata
 		arg2 []byte
 	}{arg1, arg2Copy})
-	stub := fake.GetTokenInfoStub
-	fakeReturns := fake.getTokenInfoReturns
-	fake.recordInvocation("GetTokenInfo", []interface{}{arg1, arg2Copy})
-	fake.getTokenInfoMutex.Unlock()
+	stub := fake.ExtractMetadataStub
+	fakeReturns := fake.extractMetadataReturns
+	fake.recordInvocation("ExtractMetadata", []interface{}{arg1, arg2Copy})
+	fake.extractMetadataMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -147,58 +162,113 @@ func (fake *TokensService) GetTokenInfo(arg1 *driver.TokenRequestMetadata, arg2 
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *TokensService) GetTokenInfoCallCount() int {
-	fake.getTokenInfoMutex.RLock()
-	defer fake.getTokenInfoMutex.RUnlock()
-	return len(fake.getTokenInfoArgsForCall)
+func (fake *TokensService) ExtractMetadataCallCount() int {
+	fake.extractMetadataMutex.RLock()
+	defer fake.extractMetadataMutex.RUnlock()
+	return len(fake.extractMetadataArgsForCall)
 }
 
-func (fake *TokensService) GetTokenInfoCalls(stub func(*driver.TokenRequestMetadata, []byte) ([]byte, error)) {
-	fake.getTokenInfoMutex.Lock()
-	defer fake.getTokenInfoMutex.Unlock()
-	fake.GetTokenInfoStub = stub
+func (fake *TokensService) ExtractMetadataCalls(stub func(*driver.TokenRequestMetadata, []byte) ([]byte, error)) {
+	fake.extractMetadataMutex.Lock()
+	defer fake.extractMetadataMutex.Unlock()
+	fake.ExtractMetadataStub = stub
 }
 
-func (fake *TokensService) GetTokenInfoArgsForCall(i int) (*driver.TokenRequestMetadata, []byte) {
-	fake.getTokenInfoMutex.RLock()
-	defer fake.getTokenInfoMutex.RUnlock()
-	argsForCall := fake.getTokenInfoArgsForCall[i]
+func (fake *TokensService) ExtractMetadataArgsForCall(i int) (*driver.TokenRequestMetadata, []byte) {
+	fake.extractMetadataMutex.RLock()
+	defer fake.extractMetadataMutex.RUnlock()
+	argsForCall := fake.extractMetadataArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TokensService) GetTokenInfoReturns(result1 []byte, result2 error) {
-	fake.getTokenInfoMutex.Lock()
-	defer fake.getTokenInfoMutex.Unlock()
-	fake.GetTokenInfoStub = nil
-	fake.getTokenInfoReturns = struct {
+func (fake *TokensService) ExtractMetadataReturns(result1 []byte, result2 error) {
+	fake.extractMetadataMutex.Lock()
+	defer fake.extractMetadataMutex.Unlock()
+	fake.ExtractMetadataStub = nil
+	fake.extractMetadataReturns = struct {
 		result1 []byte
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *TokensService) GetTokenInfoReturnsOnCall(i int, result1 []byte, result2 error) {
-	fake.getTokenInfoMutex.Lock()
-	defer fake.getTokenInfoMutex.Unlock()
-	fake.GetTokenInfoStub = nil
-	if fake.getTokenInfoReturnsOnCall == nil {
-		fake.getTokenInfoReturnsOnCall = make(map[int]struct {
+func (fake *TokensService) ExtractMetadataReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.extractMetadataMutex.Lock()
+	defer fake.extractMetadataMutex.Unlock()
+	fake.ExtractMetadataStub = nil
+	if fake.extractMetadataReturnsOnCall == nil {
+		fake.extractMetadataReturnsOnCall = make(map[int]struct {
 			result1 []byte
 			result2 error
 		})
 	}
-	fake.getTokenInfoReturnsOnCall[i] = struct {
+	fake.extractMetadataReturnsOnCall[i] = struct {
 		result1 []byte
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *TokensService) SupportedTokenTypes() []string {
+	fake.supportedTokenTypesMutex.Lock()
+	ret, specificReturn := fake.supportedTokenTypesReturnsOnCall[len(fake.supportedTokenTypesArgsForCall)]
+	fake.supportedTokenTypesArgsForCall = append(fake.supportedTokenTypesArgsForCall, struct {
+	}{})
+	stub := fake.SupportedTokenTypesStub
+	fakeReturns := fake.supportedTokenTypesReturns
+	fake.recordInvocation("SupportedTokenTypes", []interface{}{})
+	fake.supportedTokenTypesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *TokensService) SupportedTokenTypesCallCount() int {
+	fake.supportedTokenTypesMutex.RLock()
+	defer fake.supportedTokenTypesMutex.RUnlock()
+	return len(fake.supportedTokenTypesArgsForCall)
+}
+
+func (fake *TokensService) SupportedTokenTypesCalls(stub func() []string) {
+	fake.supportedTokenTypesMutex.Lock()
+	defer fake.supportedTokenTypesMutex.Unlock()
+	fake.SupportedTokenTypesStub = stub
+}
+
+func (fake *TokensService) SupportedTokenTypesReturns(result1 []string) {
+	fake.supportedTokenTypesMutex.Lock()
+	defer fake.supportedTokenTypesMutex.Unlock()
+	fake.SupportedTokenTypesStub = nil
+	fake.supportedTokenTypesReturns = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []string) {
+	fake.supportedTokenTypesMutex.Lock()
+	defer fake.supportedTokenTypesMutex.Unlock()
+	fake.SupportedTokenTypesStub = nil
+	if fake.supportedTokenTypesReturnsOnCall == nil {
+		fake.supportedTokenTypesReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.supportedTokenTypesReturnsOnCall[i] = struct {
+		result1 []string
+	}{result1}
 }
 
 func (fake *TokensService) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.deserializeTokenMutex.RLock()
-	defer fake.deserializeTokenMutex.RUnlock()
-	fake.getTokenInfoMutex.RLock()
-	defer fake.getTokenInfoMutex.RUnlock()
+	fake.deobfuscateMutex.RLock()
+	defer fake.deobfuscateMutex.RUnlock()
+	fake.extractMetadataMutex.RLock()
+	defer fake.extractMetadataMutex.RUnlock()
+	fake.supportedTokenTypesMutex.RLock()
+	defer fake.supportedTokenTypesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -4,13 +4,13 @@ package mock
 import (
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/services/identity"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type TokensService struct {
-	DeobfuscateStub        func([]byte, []byte) (*token.Token, view.Identity, token.TokenType, error)
+	DeobfuscateStub        func([]byte, []byte) (*token.Token, identity.Identity, token.TokenFormat, error)
 	deobfuscateMutex       sync.RWMutex
 	deobfuscateArgsForCall []struct {
 		arg1 []byte
@@ -18,14 +18,14 @@ type TokensService struct {
 	}
 	deobfuscateReturns struct {
 		result1 *token.Token
-		result2 view.Identity
-		result3 token.TokenType
+		result2 identity.Identity
+		result3 token.TokenFormat
 		result4 error
 	}
 	deobfuscateReturnsOnCall map[int]struct {
 		result1 *token.Token
-		result2 view.Identity
-		result3 token.TokenType
+		result2 identity.Identity
+		result3 token.TokenFormat
 		result4 error
 	}
 	ExtractMetadataStub        func(*driver.TokenRequestMetadata, []byte) ([]byte, error)
@@ -42,21 +42,21 @@ type TokensService struct {
 		result1 []byte
 		result2 error
 	}
-	SupportedTokenTypesStub        func() []token.TokenType
+	SupportedTokenTypesStub        func() []token.TokenFormat
 	supportedTokenTypesMutex       sync.RWMutex
 	supportedTokenTypesArgsForCall []struct {
 	}
 	supportedTokenTypesReturns struct {
-		result1 []token.TokenType
+		result1 []token.TokenFormat
 	}
 	supportedTokenTypesReturnsOnCall map[int]struct {
-		result1 []token.TokenType
+		result1 []token.TokenFormat
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, view.Identity, token.TokenType, error) {
+func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, identity.Identity, token.TokenFormat, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -92,7 +92,7 @@ func (fake *TokensService) DeobfuscateCallCount() int {
 	return len(fake.deobfuscateArgsForCall)
 }
 
-func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, view.Identity, token.TokenType, error)) {
+func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, identity.Identity, token.TokenFormat, error)) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = stub
@@ -105,34 +105,34 @@ func (fake *TokensService) DeobfuscateArgsForCall(i int) ([]byte, []byte) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 view.Identity, result3 token.TokenType, result4 error) {
+func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 identity.Identity, result3 token.TokenFormat, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
 	fake.deobfuscateReturns = struct {
 		result1 *token.Token
-		result2 view.Identity
-		result3 token.TokenType
+		result2 identity.Identity
+		result3 token.TokenFormat
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 view.Identity, result3 token.TokenType, result4 error) {
+func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 identity.Identity, result3 token.TokenFormat, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
 	if fake.deobfuscateReturnsOnCall == nil {
 		fake.deobfuscateReturnsOnCall = make(map[int]struct {
 			result1 *token.Token
-			result2 view.Identity
-			result3 token.TokenType
+			result2 identity.Identity
+			result3 token.TokenFormat
 			result4 error
 		})
 	}
 	fake.deobfuscateReturnsOnCall[i] = struct {
 		result1 *token.Token
-		result2 view.Identity
-		result3 token.TokenType
+		result2 identity.Identity
+		result3 token.TokenFormat
 		result4 error
 	}{result1, result2, result3, result4}
 }
@@ -207,7 +207,7 @@ func (fake *TokensService) ExtractMetadataReturnsOnCall(i int, result1 []byte, r
 	}{result1, result2}
 }
 
-func (fake *TokensService) SupportedTokenTypes() []token.TokenType {
+func (fake *TokensService) SupportedTokenTypes() []token.TokenFormat {
 	fake.supportedTokenTypesMutex.Lock()
 	ret, specificReturn := fake.supportedTokenTypesReturnsOnCall[len(fake.supportedTokenTypesArgsForCall)]
 	fake.supportedTokenTypesArgsForCall = append(fake.supportedTokenTypesArgsForCall, struct {
@@ -231,32 +231,32 @@ func (fake *TokensService) SupportedTokenTypesCallCount() int {
 	return len(fake.supportedTokenTypesArgsForCall)
 }
 
-func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.TokenType) {
+func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.TokenFormat) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = stub
 }
 
-func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.TokenType) {
+func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.TokenFormat) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	fake.supportedTokenTypesReturns = struct {
-		result1 []token.TokenType
+		result1 []token.TokenFormat
 	}{result1}
 }
 
-func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.TokenType) {
+func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.TokenFormat) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	if fake.supportedTokenTypesReturnsOnCall == nil {
 		fake.supportedTokenTypesReturnsOnCall = make(map[int]struct {
-			result1 []token.TokenType
+			result1 []token.TokenFormat
 		})
 	}
 	fake.supportedTokenTypesReturnsOnCall[i] = struct {
-		result1 []token.TokenType
+		result1 []token.TokenFormat
 	}{result1}
 }
 

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -10,7 +10,7 @@ import (
 )
 
 type TokensService struct {
-	DeobfuscateStub        func([]byte, []byte) (*token.Token, identity.Identity, token.TokenFormat, error)
+	DeobfuscateStub        func([]byte, []byte) (*token.Token, identity.Identity, token.Format, error)
 	deobfuscateMutex       sync.RWMutex
 	deobfuscateArgsForCall []struct {
 		arg1 []byte
@@ -19,13 +19,13 @@ type TokensService struct {
 	deobfuscateReturns struct {
 		result1 *token.Token
 		result2 identity.Identity
-		result3 token.TokenFormat
+		result3 token.Format
 		result4 error
 	}
 	deobfuscateReturnsOnCall map[int]struct {
 		result1 *token.Token
 		result2 identity.Identity
-		result3 token.TokenFormat
+		result3 token.Format
 		result4 error
 	}
 	ExtractMetadataStub        func(*driver.TokenRequestMetadata, []byte) ([]byte, error)
@@ -42,21 +42,21 @@ type TokensService struct {
 		result1 []byte
 		result2 error
 	}
-	SupportedTokenTypesStub        func() []token.TokenFormat
+	SupportedTokenTypesStub        func() []token.Format
 	supportedTokenTypesMutex       sync.RWMutex
 	supportedTokenTypesArgsForCall []struct {
 	}
 	supportedTokenTypesReturns struct {
-		result1 []token.TokenFormat
+		result1 []token.Format
 	}
 	supportedTokenTypesReturnsOnCall map[int]struct {
-		result1 []token.TokenFormat
+		result1 []token.Format
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, identity.Identity, token.TokenFormat, error) {
+func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, identity.Identity, token.Format, error) {
 	var arg1Copy []byte
 	if arg1 != nil {
 		arg1Copy = make([]byte, len(arg1))
@@ -92,7 +92,7 @@ func (fake *TokensService) DeobfuscateCallCount() int {
 	return len(fake.deobfuscateArgsForCall)
 }
 
-func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, identity.Identity, token.TokenFormat, error)) {
+func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, identity.Identity, token.Format, error)) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = stub
@@ -105,19 +105,19 @@ func (fake *TokensService) DeobfuscateArgsForCall(i int) ([]byte, []byte) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 identity.Identity, result3 token.TokenFormat, result4 error) {
+func (fake *TokensService) DeobfuscateReturns(result1 *token.Token, result2 identity.Identity, result3 token.Format, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
 	fake.deobfuscateReturns = struct {
 		result1 *token.Token
 		result2 identity.Identity
-		result3 token.TokenFormat
+		result3 token.Format
 		result4 error
 	}{result1, result2, result3, result4}
 }
 
-func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 identity.Identity, result3 token.TokenFormat, result4 error) {
+func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token, result2 identity.Identity, result3 token.Format, result4 error) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = nil
@@ -125,14 +125,14 @@ func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token,
 		fake.deobfuscateReturnsOnCall = make(map[int]struct {
 			result1 *token.Token
 			result2 identity.Identity
-			result3 token.TokenFormat
+			result3 token.Format
 			result4 error
 		})
 	}
 	fake.deobfuscateReturnsOnCall[i] = struct {
 		result1 *token.Token
 		result2 identity.Identity
-		result3 token.TokenFormat
+		result3 token.Format
 		result4 error
 	}{result1, result2, result3, result4}
 }
@@ -207,7 +207,7 @@ func (fake *TokensService) ExtractMetadataReturnsOnCall(i int, result1 []byte, r
 	}{result1, result2}
 }
 
-func (fake *TokensService) SupportedTokenTypes() []token.TokenFormat {
+func (fake *TokensService) SupportedTokenTypes() []token.Format {
 	fake.supportedTokenTypesMutex.Lock()
 	ret, specificReturn := fake.supportedTokenTypesReturnsOnCall[len(fake.supportedTokenTypesArgsForCall)]
 	fake.supportedTokenTypesArgsForCall = append(fake.supportedTokenTypesArgsForCall, struct {
@@ -231,32 +231,32 @@ func (fake *TokensService) SupportedTokenTypesCallCount() int {
 	return len(fake.supportedTokenTypesArgsForCall)
 }
 
-func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.TokenFormat) {
+func (fake *TokensService) SupportedTokenTypesCalls(stub func() []token.Format) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = stub
 }
 
-func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.TokenFormat) {
+func (fake *TokensService) SupportedTokenTypesReturns(result1 []token.Format) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	fake.supportedTokenTypesReturns = struct {
-		result1 []token.TokenFormat
+		result1 []token.Format
 	}{result1}
 }
 
-func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.TokenFormat) {
+func (fake *TokensService) SupportedTokenTypesReturnsOnCall(i int, result1 []token.Format) {
 	fake.supportedTokenTypesMutex.Lock()
 	defer fake.supportedTokenTypesMutex.Unlock()
 	fake.SupportedTokenTypesStub = nil
 	if fake.supportedTokenTypesReturnsOnCall == nil {
 		fake.supportedTokenTypesReturnsOnCall = make(map[int]struct {
-			result1 []token.TokenFormat
+			result1 []token.Format
 		})
 	}
 	fake.supportedTokenTypesReturnsOnCall[i] = struct {
-		result1 []token.TokenFormat
+		result1 []token.Format
 	}{result1}
 }
 

--- a/token/driver/service.go
+++ b/token/driver/service.go
@@ -113,9 +113,9 @@ func (s *TokenDriverService) NewTokenService(tmsID TMSID, publicParams []byte) (
 	return nil, errors.Errorf("no token driver named '%s' found", TokenDriverName(pp.Identifier()))
 }
 
-func (s *TokenDriverService) NewValidator(tmsID TMSID, pp PublicParameters) (Validator, error) {
+func (s *TokenDriverService) NewDefaultValidator(pp PublicParameters) (Validator, error) {
 	if driver, ok := s.factories[TokenDriverName(pp.Identifier())]; ok {
-		return driver.NewValidator(tmsID, pp)
+		return driver.NewDefaultValidator(pp)
 	}
 	return nil, errors.Errorf("no validator found for token driver [%s]", pp.Identifier())
 }

--- a/token/driver/service.go
+++ b/token/driver/service.go
@@ -108,14 +108,14 @@ func (s *TokenDriverService) NewTokenService(tmsID TMSID, publicParams []byte) (
 		return nil, err
 	}
 	if driver, ok := s.factories[TokenDriverName(pp.Identifier())]; ok {
-		return driver.NewTokenService(nil, tmsID.Network, tmsID.Channel, tmsID.Namespace, publicParams)
+		return driver.NewTokenService(tmsID, publicParams)
 	}
 	return nil, errors.Errorf("no token driver named '%s' found", TokenDriverName(pp.Identifier()))
 }
 
 func (s *TokenDriverService) NewValidator(tmsID TMSID, pp PublicParameters) (Validator, error) {
 	if driver, ok := s.factories[TokenDriverName(pp.Identifier())]; ok {
-		return driver.NewValidator(nil, tmsID, pp)
+		return driver.NewValidator(tmsID, pp)
 	}
 	return nil, errors.Errorf("no validator found for token driver [%s]", pp.Identifier())
 }

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -12,10 +12,10 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 type TokensService interface {
 	// SupportedTokenTypes returns the supported token types
-	SupportedTokenTypes() []token.TokenType
+	SupportedTokenTypes() []token.TokenFormat
 
 	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token type tag
-	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.TokenType, error)
+	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.TokenFormat, error)
 
 	// ExtractMetadata extracts from the given token request metadata the metadata to the given target
 	ExtractMetadata(meta *TokenRequestMetadata, target []byte) ([]byte, error)

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -11,10 +11,10 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 //go:generate counterfeiter -o mock/tss.go -fake-name TokensService . TokensService
 
 type TokensService interface {
-	// SupportedTokenTypes returns the supported token types
-	SupportedTokenTypes() []token.Format
+	// SupportedTokenFormats returns the supported token formats
+	SupportedTokenFormats() []token.Format
 
-	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token type tag
+	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token format
 	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.Format, error)
 
 	// ExtractMetadata extracts from the given token request metadata the metadata to the given target

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -12,10 +12,10 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 type TokensService interface {
 	// SupportedTokenTypes returns the supported token types
-	SupportedTokenTypes() []string
+	SupportedTokenTypes() []token.TokenType
 
 	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token type tag
-	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, string, error)
+	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.TokenType, error)
 
 	// ExtractMetadata extracts from the given token request metadata the metadata to the given target
 	ExtractMetadata(meta *TokenRequestMetadata, target []byte) ([]byte, error)

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -11,9 +11,12 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 //go:generate counterfeiter -o mock/tss.go -fake-name TokensService . TokensService
 
 type TokensService interface {
-	// DeserializeToken unmarshals the passed output and uses the passed metadata to derive a token and its issuer (if any).
-	DeserializeToken(output []byte, outputMetadata []byte) (*token.Token, Identity, error)
+	// SupportedTokenTypes returns the supported token types
+	SupportedTokenTypes() []string
 
-	// GetTokenInfo extracts from the given metadata the token info entry corresponding to the given target
-	GetTokenInfo(meta *TokenRequestMetadata, target []byte) ([]byte, error)
+	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token type tag
+	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, string, error)
+
+	// ExtractMetadata extracts from the given token request metadata the metadata to the given target
+	ExtractMetadata(meta *TokenRequestMetadata, target []byte) ([]byte, error)
 }

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -12,10 +12,10 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 type TokensService interface {
 	// SupportedTokenTypes returns the supported token types
-	SupportedTokenTypes() []token.TokenFormat
+	SupportedTokenTypes() []token.Format
 
 	// Deobfuscate processes the passed output and metadata to derive a token.Token, its issuer (if any), and its token type tag
-	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.TokenFormat, error)
+	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, token.Format, error)
 
 	// ExtractMetadata extracts from the given token request metadata the metadata to the given target
 	ExtractMetadata(meta *TokenRequestMetadata, target []byte) ([]byte, error)

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -67,7 +67,7 @@ type QueryEngine interface {
 	UnspentTokensIterator() (UnspentTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.
 	// The token type can be empty. In that case, tokens of any type are returned.
-	UnspentTokensIteratorBy(ctx context.Context, walletID, tokenType string) (UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.TokenType) (UnspentTokensIterator, error)
 	// ListUnspentTokens returns the list of unspent tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens associated to the passed ids
@@ -83,12 +83,12 @@ type QueryEngine interface {
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
 	// GetTokenOutputsAndMeta retrieves both the token output and information for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []string, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.
 	// The bool array is an indicator used to tell if the token at a given position has been deleted or not
 	WhoDeletedTokens(inputs ...*token.ID) ([]string, []bool, error)
 	// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
-	Balance(id, tokenType string) (uint64, error)
+	Balance(id string, tokenType token.TokenType) (uint64, error)
 }

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -76,14 +76,14 @@ type QueryEngine interface {
 	ListHistoryIssuedTokens() (*token.IssuedTokens, error)
 	// PublicParams returns the public parameters
 	PublicParams() ([]byte, error)
-	// GetTokenInfos retrieves the token information for the passed ids.
+	// GetTokenMetadata retrieves the token information for the passed ids.
 	// For each id, the callback is invoked to unmarshal the token information
-	GetTokenInfos(ids []*token.ID) ([][]byte, error)
+	GetTokenMetadata(ids []*token.ID) ([][]byte, error)
 	// GetTokenOutputs retrieves the token output as stored on the ledger for the passed ids.
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
-	// GetTokenInfoAndOutputs retrieves both the token output and information for the passed ids.
-	GetTokenInfoAndOutputs(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, error)
+	// GetTokenOutputsAndMeta retrieves both the token output and information for the passed ids.
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []string, error)
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -83,7 +83,7 @@ type QueryEngine interface {
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
 	// GetTokenOutputsAndMeta retrieves both the token output and information for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -67,7 +67,7 @@ type QueryEngine interface {
 	UnspentTokensIterator() (UnspentTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.
 	// The token type can be empty. In that case, tokens of any type are returned.
-	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.TokenType) (UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.Type) (UnspentTokensIterator, error)
 	// ListUnspentTokens returns the list of unspent tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens associated to the passed ids
@@ -83,12 +83,12 @@ type QueryEngine interface {
 	// For each id, the callback is invoked to unmarshal the output
 	GetTokenOutputs(ids []*token.ID, callback QueryCallbackFunc) error
 	// GetTokenOutputsAndMeta retrieves both the token output and information for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.Format, error)
 	// GetTokens returns the list of tokens with their respective vault keys
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens returns info about who deleted the passed tokens.
 	// The bool array is an indicator used to tell if the token at a given position has been deleted or not
 	WhoDeletedTokens(inputs ...*token.ID) ([]string, []bool, error)
 	// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
-	Balance(id string, tokenType token.TokenType) (uint64, error)
+	Balance(id string, tokenType token.Type) (uint64, error)
 }

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -27,7 +27,7 @@ type RecipientData struct {
 // ListTokensOptions contains options that can be used to list tokens from a wallet
 type ListTokensOptions struct {
 	// TokenType is the type of token to list
-	TokenType string
+	TokenType token.TokenType
 	// Context is used to track the operation
 	Context context.Context
 }
@@ -93,7 +93,7 @@ type IssuerWallet interface {
 
 	// GetIssuerIdentity returns an issuer identity for the passed token type.
 	// Depending on the underlying wallet implementation, this can be a long-term or ephemeral identity.
-	GetIssuerIdentity(tokenType string) (Identity, error)
+	GetIssuerIdentity(tokenType token.TokenType) (Identity, error)
 
 	// HistoryTokens returns the list of tokens issued by this wallet filtered using the passed options.
 	HistoryTokens(opts *ListTokensOptions) (*token.IssuedTokens, error)

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -27,7 +27,7 @@ type RecipientData struct {
 // ListTokensOptions contains options that can be used to list tokens from a wallet
 type ListTokensOptions struct {
 	// TokenType is the type of token to list
-	TokenType token.TokenType
+	TokenType token.Type
 	// Context is used to track the operation
 	Context context.Context
 }
@@ -93,7 +93,7 @@ type IssuerWallet interface {
 
 	// GetIssuerIdentity returns an issuer identity for the passed token type.
 	// Depending on the underlying wallet implementation, this can be a long-term or ephemeral identity.
-	GetIssuerIdentity(tokenType token.TokenType) (Identity, error)
+	GetIssuerIdentity(tokenType token.Type) (Identity, error)
 
 	// HistoryTokens returns the list of tokens issued by this wallet filtered using the passed options.
 	HistoryTokens(opts *ListTokensOptions) (*token.IssuedTokens, error)

--- a/token/metadata.go
+++ b/token/metadata.go
@@ -23,15 +23,15 @@ type Metadata struct {
 
 // GetToken unmarshals the given bytes to extract the token and its issuer (if any).
 func (m *Metadata) GetToken(raw []byte) (*token.Token, Identity, []byte, error) {
-	tokenInfoRaw, err := m.TokenService.GetTokenInfo(m.TokenRequestMetadata, raw)
+	metadata, err := m.TokenService.ExtractMetadata(m.TokenRequestMetadata, raw)
 	if err != nil {
 		return nil, nil, nil, errors.WithMessagef(err, "metadata for [%s] not found", Hashable(raw).String())
 	}
-	tok, id, err := m.TokenService.DeserializeToken(raw, tokenInfoRaw)
+	tok, id, _, err := m.TokenService.Deobfuscate(raw, metadata)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "failed getting token in the clear")
 	}
-	return tok, id, tokenInfoRaw, nil
+	return tok, id, metadata, nil
 }
 
 // SpentTokenID returns the token IDs of the tokens that were spent by the Token Request this metadata is associated with.

--- a/token/metadata_test.go
+++ b/token/metadata_test.go
@@ -343,7 +343,7 @@ func TestMetadata_GetToken(t *testing.T) {
 	mockTokenService.ExtractMetadataStub = func(metadata *driver.TokenRequestMetadata, raw []byte) ([]byte, error) {
 		return expectedTokenInfoRaw, nil
 	}
-	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, token2.TokenFormat, error) {
+	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, token2.Format, error) {
 		return expectedToken, expectedIdentity, "", nil
 	}
 

--- a/token/metadata_test.go
+++ b/token/metadata_test.go
@@ -340,11 +340,11 @@ func TestMetadata_GetToken(t *testing.T) {
 	expectedToken := &token2.Token{}
 	expectedIdentity := token.Identity("identity1")
 	expectedTokenInfoRaw := []byte("token info raw")
-	mockTokenService.GetTokenInfoStub = func(metadata *driver.TokenRequestMetadata, raw []byte) ([]byte, error) {
+	mockTokenService.ExtractMetadataStub = func(metadata *driver.TokenRequestMetadata, raw []byte) ([]byte, error) {
 		return expectedTokenInfoRaw, nil
 	}
-	mockTokenService.DeserializeTokenStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, error) {
-		return expectedToken, expectedIdentity, nil
+	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, string, error) {
+		return expectedToken, expectedIdentity, "", nil
 	}
 
 	// Test

--- a/token/metadata_test.go
+++ b/token/metadata_test.go
@@ -343,7 +343,7 @@ func TestMetadata_GetToken(t *testing.T) {
 	mockTokenService.ExtractMetadataStub = func(metadata *driver.TokenRequestMetadata, raw []byte) ([]byte, error) {
 		return expectedTokenInfoRaw, nil
 	}
-	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, string, error) {
+	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, token2.TokenType, error) {
 		return expectedToken, expectedIdentity, "", nil
 	}
 

--- a/token/metadata_test.go
+++ b/token/metadata_test.go
@@ -343,7 +343,7 @@ func TestMetadata_GetToken(t *testing.T) {
 	mockTokenService.ExtractMetadataStub = func(metadata *driver.TokenRequestMetadata, raw []byte) ([]byte, error) {
 		return expectedTokenInfoRaw, nil
 	}
-	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, token2.TokenType, error) {
+	mockTokenService.DeobfuscateStub = func(raw []byte, tokenInfoRaw []byte) (*token2.Token, token.Identity, token2.TokenFormat, error) {
 		return expectedToken, expectedIdentity, "", nil
 	}
 

--- a/token/request.go
+++ b/token/request.go
@@ -219,7 +219,7 @@ func (r *Request) ID() string {
 // Issue appends an issue action to the request. The action will be prepared using the provided issuer wallet.
 // The action issues to the receiver a token of the passed type and quantity.
 // Additional options can be passed to customize the action.
-func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Identity, typ token.TokenType, q uint64, opts ...IssueOption) (*IssueAction, error) {
+func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Identity, typ token.Type, q uint64, opts ...IssueOption) (*IssueAction, error) {
 	if wallet == nil {
 		return nil, errors.Errorf("wallet is nil")
 	}
@@ -278,7 +278,7 @@ func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Iden
 // The action transfers tokens of the passed types to the receivers for the passed quantities.
 // In other words, owners[0] will receives values[0], and so on.
 // Additional options can be passed to customize the action.
-func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ token.TokenType, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
+func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ token.Type, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
 	for _, v := range values {
 		if v == 0 {
 			return nil, errors.Errorf("value is zero")
@@ -332,7 +332,7 @@ func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ token.T
 // Redeem appends a redeem action to the request. The action will be prepared using the provided owner wallet.
 // The action redeems tokens of the passed type for a total amount matching the passed value.
 // Additional options can be passed to customize the action.
-func (r *Request) Redeem(ctx context.Context, wallet *OwnerWallet, typ token.TokenType, value uint64, opts ...TransferOption) error {
+func (r *Request) Redeem(ctx context.Context, wallet *OwnerWallet, typ token.Type, value uint64, opts ...TransferOption) error {
 	opt, err := compileTransferOptions(opts...)
 	if err != nil {
 		return errors.WithMessagef(err, "failed compiling options [%v]", opts)
@@ -1078,12 +1078,12 @@ func (r *Request) GetMetadata() (*Metadata, error) {
 	}, nil
 }
 
-func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity, token.TokenType, error) {
+func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity, token.Type, error) {
 	inputTokens, err := r.TokenService.Vault().NewQueryEngine().GetTokens(inputs...)
 	if err != nil {
 		return nil, nil, "", errors.WithMessagef(err, "failed querying tokens ids")
 	}
-	var typ token.TokenType
+	var typ token.Type
 	pp := r.TokenService.tms.PublicParamsManager().PublicParameters()
 	if pp == nil {
 		return nil, nil, "", errors.Errorf("public paramenters not set")
@@ -1107,7 +1107,7 @@ func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity
 	return inputs, sum, typ, nil
 }
 
-func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType token.TokenType, values []uint64, owners []Identity, transferOpts *TransferOptions) ([]*token.ID, []*token.Token, error) {
+func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType token.Type, values []uint64, owners []Identity, transferOpts *TransferOptions) ([]*token.ID, []*token.Token, error) {
 	for _, owner := range owners {
 		if redeem {
 			if !owner.IsNone() {
@@ -1209,7 +1209,7 @@ func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType to
 	return tokenIDs, outputTokens, nil
 }
 
-func (r *Request) genOutputs(values []uint64, owners []Identity, tokenType token.TokenType) ([]*token.Token, token.Quantity, error) {
+func (r *Request) genOutputs(values []uint64, owners []Identity, tokenType token.Type) ([]*token.Token, token.Quantity, error) {
 	pp := r.TokenService.PublicParametersManager().PublicParameters()
 	precision := pp.Precision()
 	maxTokenValue := pp.MaxTokenValue()

--- a/token/request.go
+++ b/token/request.go
@@ -482,7 +482,7 @@ func (r *Request) extractIssueOutputs(i int, counter uint64, issueAction driver.
 		if len(issueAction.GetOutputs()) != len(issueMeta.OutputsMetadata) || len(issueMeta.ReceiversAuditInfos) != len(issueAction.GetOutputs()) {
 			return nil, 0, errors.Wrapf(err, "failed matching issue action with its metadata [%d]: invalid metadata", i)
 		}
-		tok, _, err := tms.TokensService().DeserializeToken(raw, issueMeta.OutputsMetadata[j])
+		tok, _, tokType, err := tms.TokensService().Deobfuscate(raw, issueMeta.OutputsMetadata[j])
 		if err != nil {
 			return nil, 0, errors.Wrapf(err, "failed getting issue action output in the clear [%d,%d]", i, j)
 		}
@@ -505,6 +505,7 @@ func (r *Request) extractIssueOutputs(i int, counter uint64, issueAction driver.
 			Type:              tok.Type,
 			Quantity:          q,
 			LedgerOutput:      raw,
+			LedgerOutputType:  tokType,
 		})
 		counter++
 
@@ -538,7 +539,7 @@ func (r *Request) extractTransferOutputs(i int, counter uint64, transferAction d
 			continue
 		}
 
-		tok, _, err := tms.TokensService().DeserializeToken(raw, transferMeta.OutputsMetadata[j])
+		tok, _, tokType, err := tms.TokensService().Deobfuscate(raw, transferMeta.OutputsMetadata[j])
 		if err != nil {
 			return nil, 0, errors.Wrapf(err, "failed getting transfer action output in the clear [%d,%d]", i, j)
 		}
@@ -572,6 +573,7 @@ func (r *Request) extractTransferOutputs(i int, counter uint64, transferAction d
 			Type:              tok.Type,
 			Quantity:          q,
 			LedgerOutput:      ledgerOutput,
+			LedgerOutputType:  tokType,
 		})
 		counter++
 	}

--- a/token/request.go
+++ b/token/request.go
@@ -219,7 +219,7 @@ func (r *Request) ID() string {
 // Issue appends an issue action to the request. The action will be prepared using the provided issuer wallet.
 // The action issues to the receiver a token of the passed type and quantity.
 // Additional options can be passed to customize the action.
-func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Identity, typ string, q uint64, opts ...IssueOption) (*IssueAction, error) {
+func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Identity, typ token.TokenType, q uint64, opts ...IssueOption) (*IssueAction, error) {
 	if wallet == nil {
 		return nil, errors.Errorf("wallet is nil")
 	}
@@ -278,7 +278,7 @@ func (r *Request) Issue(ctx context.Context, wallet *IssuerWallet, receiver Iden
 // The action transfers tokens of the passed types to the receivers for the passed quantities.
 // In other words, owners[0] will receives values[0], and so on.
 // Additional options can be passed to customize the action.
-func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ string, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
+func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ token.TokenType, values []uint64, owners []Identity, opts ...TransferOption) (*TransferAction, error) {
 	for _, v := range values {
 		if v == 0 {
 			return nil, errors.Errorf("value is zero")
@@ -332,7 +332,7 @@ func (r *Request) Transfer(ctx context.Context, wallet *OwnerWallet, typ string,
 // Redeem appends a redeem action to the request. The action will be prepared using the provided owner wallet.
 // The action redeems tokens of the passed type for a total amount matching the passed value.
 // Additional options can be passed to customize the action.
-func (r *Request) Redeem(ctx context.Context, wallet *OwnerWallet, typ string, value uint64, opts ...TransferOption) error {
+func (r *Request) Redeem(ctx context.Context, wallet *OwnerWallet, typ token.TokenType, value uint64, opts ...TransferOption) error {
 	opt, err := compileTransferOptions(opts...)
 	if err != nil {
 		return errors.WithMessagef(err, "failed compiling options [%v]", opts)
@@ -1078,12 +1078,12 @@ func (r *Request) GetMetadata() (*Metadata, error) {
 	}, nil
 }
 
-func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity, string, error) {
+func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity, token.TokenType, error) {
 	inputTokens, err := r.TokenService.Vault().NewQueryEngine().GetTokens(inputs...)
 	if err != nil {
 		return nil, nil, "", errors.WithMessagef(err, "failed querying tokens ids")
 	}
-	var typ string
+	var typ token.TokenType
 	pp := r.TokenService.tms.PublicParamsManager().PublicParameters()
 	if pp == nil {
 		return nil, nil, "", errors.Errorf("public paramenters not set")
@@ -1107,7 +1107,7 @@ func (r *Request) parseInputIDs(inputs []*token.ID) ([]*token.ID, token.Quantity
 	return inputs, sum, typ, nil
 }
 
-func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType string, values []uint64, owners []Identity, transferOpts *TransferOptions) ([]*token.ID, []*token.Token, error) {
+func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType token.TokenType, values []uint64, owners []Identity, transferOpts *TransferOptions) ([]*token.ID, []*token.Token, error) {
 	for _, owner := range owners {
 		if redeem {
 			if !owner.IsNone() {
@@ -1209,7 +1209,7 @@ func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType st
 	return tokenIDs, outputTokens, nil
 }
 
-func (r *Request) genOutputs(values []uint64, owners []Identity, tokenType string) ([]*token.Token, token.Quantity, error) {
+func (r *Request) genOutputs(values []uint64, owners []Identity, tokenType token.TokenType) ([]*token.Token, token.Quantity, error) {
 	pp := r.TokenService.PublicParametersManager().PublicParameters()
 	precision := pp.Precision()
 	maxTokenValue := pp.MaxTokenValue()

--- a/token/request.go
+++ b/token/request.go
@@ -482,7 +482,7 @@ func (r *Request) extractIssueOutputs(i int, counter uint64, issueAction driver.
 		if len(issueAction.GetOutputs()) != len(issueMeta.OutputsMetadata) || len(issueMeta.ReceiversAuditInfos) != len(issueAction.GetOutputs()) {
 			return nil, 0, errors.Wrapf(err, "failed matching issue action with its metadata [%d]: invalid metadata", i)
 		}
-		tok, _, tokType, err := tms.TokensService().Deobfuscate(raw, issueMeta.OutputsMetadata[j])
+		tok, _, format, err := tms.TokensService().Deobfuscate(raw, issueMeta.OutputsMetadata[j])
 		if err != nil {
 			return nil, 0, errors.Wrapf(err, "failed getting issue action output in the clear [%d,%d]", i, j)
 		}
@@ -496,16 +496,16 @@ func (r *Request) extractIssueOutputs(i int, counter uint64, issueAction driver.
 		}
 
 		outputs = append(outputs, &Output{
-			ActionIndex:       i,
-			Index:             counter,
-			Owner:             tok.Owner,
-			OwnerAuditInfo:    issueMeta.ReceiversAuditInfos[j],
-			EnrollmentID:      eID,
-			RevocationHandler: rID,
-			Type:              tok.Type,
-			Quantity:          q,
-			LedgerOutput:      raw,
-			LedgerOutputType:  tokType,
+			ActionIndex:        i,
+			Index:              counter,
+			Owner:              tok.Owner,
+			OwnerAuditInfo:     issueMeta.ReceiversAuditInfos[j],
+			EnrollmentID:       eID,
+			RevocationHandler:  rID,
+			Type:               tok.Type,
+			Quantity:           q,
+			LedgerOutput:       raw,
+			LedgerOutputFormat: format,
 		})
 		counter++
 
@@ -564,16 +564,16 @@ func (r *Request) extractTransferOutputs(i int, counter uint64, transferAction d
 		}
 		r.TokenService.logger.Debugf("Transfer Action Output [%d,%d][%s:%d] is present, extract [%s]", i, j, r.Anchor, counter, Hashable(ledgerOutput))
 		outputs = append(outputs, &Output{
-			ActionIndex:       i,
-			Index:             counter,
-			Owner:             tok.Owner,
-			OwnerAuditInfo:    receiverAuditInfo,
-			EnrollmentID:      eID,
-			RevocationHandler: rID,
-			Type:              tok.Type,
-			Quantity:          q,
-			LedgerOutput:      ledgerOutput,
-			LedgerOutputType:  tokType,
+			ActionIndex:        i,
+			Index:              counter,
+			Owner:              tok.Owner,
+			OwnerAuditInfo:     receiverAuditInfo,
+			EnrollmentID:       eID,
+			RevocationHandler:  rID,
+			Type:               tok.Type,
+			Quantity:           q,
+			LedgerOutput:       ledgerOutput,
+			LedgerOutputFormat: tokType,
 		})
 		counter++
 	}

--- a/token/sdk/tms/tms.go
+++ b/token/sdk/tms/tms.go
@@ -55,7 +55,7 @@ func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, ch
 	if err != nil {
 		return errors.WithMessagef(err, "failed to get tokens for [%s]", tmsID)
 	}
-	supportedTokens := tms.TokensService().SupportedTokenTypes()
+	supportedTokens := tms.TokensService().SupportedTokenFormats()
 	if err := tokens.SetSupportedTokenTypes(supportedTokens); err != nil {
 		return errors.WithMessagef(err, "failed to set supported tokens for [%s] to [%s]", tmsID, supportedTokens)
 	}

--- a/token/sdk/tms/tms.go
+++ b/token/sdk/tms/tms.go
@@ -56,7 +56,7 @@ func (p *PostInitializer) PostInit(tms driver.TokenManagerService, networkID, ch
 		return errors.WithMessagef(err, "failed to get tokens for [%s]", tmsID)
 	}
 	supportedTokens := tms.TokensService().SupportedTokenTypes()
-	if err := tokens.SetSupportedTokens(supportedTokens); err != nil {
+	if err := tokens.SetSupportedTokenTypes(supportedTokens); err != nil {
 		return errors.WithMessagef(err, "failed to set supported tokens for [%s] to [%s]", tmsID, supportedTokens)
 	}
 

--- a/token/selector.go
+++ b/token/selector.go
@@ -40,7 +40,7 @@ type Selector interface {
 	// Quantity is a string in decimal format
 	// Notice that, the quantity selected might exceed the quantity requested due to the amounts
 	// stored in each token.
-	Select(ownerFilter OwnerFilter, q, tokenType string) ([]*token2.ID, token2.Quantity, error)
+	Select(ownerFilter OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error)
 	// Close closes the selector and releases its memory/cpu resources
 	Close() error
 }

--- a/token/selector.go
+++ b/token/selector.go
@@ -40,7 +40,7 @@ type Selector interface {
 	// Quantity is a string in decimal format
 	// Notice that, the quantity selected might exceed the quantity requested due to the amounts
 	// stored in each token.
-	Select(ownerFilter OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error)
+	Select(ownerFilter OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error)
 	// Close closes the selector and releases its memory/cpu resources
 	Close() error
 }

--- a/token/services/auditdb/filter.go
+++ b/token/services/auditdb/filter.go
@@ -26,7 +26,7 @@ func (f *PaymentsFilter) ByEnrollmentId(id string) *PaymentsFilter {
 	return f
 }
 
-func (f *PaymentsFilter) ByType(tokenType token.TokenType) *PaymentsFilter {
+func (f *PaymentsFilter) ByType(tokenType token.Type) *PaymentsFilter {
 	f.params.TokenTypes = append(f.params.TokenTypes, tokenType)
 	return f
 }
@@ -68,7 +68,7 @@ func (f *HoldingsFilter) ByEnrollmentId(id string) *HoldingsFilter {
 	return f
 }
 
-func (f *HoldingsFilter) ByType(tokenType token.TokenType) *HoldingsFilter {
+func (f *HoldingsFilter) ByType(tokenType token.Type) *HoldingsFilter {
 	f.params.TokenTypes = append(f.params.TokenTypes, tokenType)
 	return f
 }

--- a/token/services/auditdb/filter.go
+++ b/token/services/auditdb/filter.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // PaymentsFilter is a filter for payments.
@@ -25,7 +26,7 @@ func (f *PaymentsFilter) ByEnrollmentId(id string) *PaymentsFilter {
 	return f
 }
 
-func (f *PaymentsFilter) ByType(tokenType string) *PaymentsFilter {
+func (f *PaymentsFilter) ByType(tokenType token.TokenType) *PaymentsFilter {
 	f.params.TokenTypes = append(f.params.TokenTypes, tokenType)
 	return f
 }
@@ -67,7 +68,7 @@ func (f *HoldingsFilter) ByEnrollmentId(id string) *HoldingsFilter {
 	return f
 }
 
-func (f *HoldingsFilter) ByType(tokenType string) *HoldingsFilter {
+func (f *HoldingsFilter) ByType(tokenType token.TokenType) *HoldingsFilter {
 	f.params.TokenTypes = append(f.params.TokenTypes, tokenType)
 	return f
 }

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	driver2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // ActionType is the type of transaction
@@ -85,7 +86,7 @@ type MovementRecord struct {
 	// EnrollmentID is the enrollment ID of the account that is receiving or sending
 	EnrollmentID string
 	// TokenType is the type of token
-	TokenType string
+	TokenType token2.TokenType
 	// Amount is positive if tokens are received. Negative otherwise
 	Amount *big.Int
 	// Timestamp is the time the transaction was submitted to the db
@@ -109,7 +110,7 @@ type TransactionRecord struct {
 	// RecipientEID is the enrollment ID of the account that is receiving tokens
 	RecipientEID string
 	// TokenType is the type of token
-	TokenType string
+	TokenType token2.TokenType
 	// Amount is positive if tokens are received. Negative otherwise
 	Amount *big.Int
 	// Timestamp is the time the transaction was submitted to the db
@@ -132,7 +133,7 @@ func (t *TransactionRecord) String() string {
 	s.WriteString(" ")
 	s.WriteString(t.RecipientEID)
 	s.WriteString(" ")
-	s.WriteString(t.TokenType)
+	s.WriteString(string(t.TokenType))
 	s.WriteString(" ")
 	s.WriteString(t.Amount.String())
 	s.WriteString(" ")
@@ -184,7 +185,7 @@ type QueryMovementsParams struct {
 	// EnrollmentIDs is the enrollment IDs of the accounts to query
 	EnrollmentIDs []string
 	// TokenTypes is the token types to query
-	TokenTypes []string
+	TokenTypes []token2.TokenType
 	// TxStatuses is the statuses of the transactions to query
 	TxStatuses []TxStatus
 	// SearchDirection is the direction of the search

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -177,7 +177,7 @@ type ValidationRecordsIterator = collections.Iterator[*ValidationRecord]
 type TokenRequestIterator = collections.Iterator[*TokenRequestRecord]
 
 // QueryMovementsParams defines the parameters for querying movements.
-// Movement records will be filtered by EnrollmentID, TokenType, and Status.
+// Movement records will be filtered by EnrollmentID, TokenFormat, and Status.
 // SearchDirection tells if the search should start from the oldest to the newest records or vice versa.
 // MovementDirection which amounts to consider. Sent correspond to a negative amount,
 // Received to a positive amount, and All to both.

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -86,7 +86,7 @@ type MovementRecord struct {
 	// EnrollmentID is the enrollment ID of the account that is receiving or sending
 	EnrollmentID string
 	// TokenType is the type of token
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// Amount is positive if tokens are received. Negative otherwise
 	Amount *big.Int
 	// Timestamp is the time the transaction was submitted to the db
@@ -110,7 +110,7 @@ type TransactionRecord struct {
 	// RecipientEID is the enrollment ID of the account that is receiving tokens
 	RecipientEID string
 	// TokenType is the type of token
-	TokenType token2.TokenType
+	TokenType token2.Type
 	// Amount is positive if tokens are received. Negative otherwise
 	Amount *big.Int
 	// Timestamp is the time the transaction was submitted to the db
@@ -185,7 +185,7 @@ type QueryMovementsParams struct {
 	// EnrollmentIDs is the enrollment IDs of the accounts to query
 	EnrollmentIDs []string
 	// TokenTypes is the token types to query
-	TokenTypes []token2.TokenType
+	TokenTypes []token2.Type
 	// TxStatuses is the statuses of the transactions to query
 	TxStatuses []TxStatus
 	// SearchDirection is the direction of the search

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -124,13 +124,13 @@ type CertificationDB interface {
 
 type TokenDBTransaction interface {
 	// GetToken returns the owned tokens and their identifier keys for the passed ids.
-	GetToken(txID string, index uint64, includeDeleted bool) (*token.Token, []string, error)
+	GetToken(tokenID token.ID, includeDeleted bool) (*token.Token, []string, error)
 	// Delete marks the passed token as deleted by a given identifier (idempotent)
-	Delete(txID string, index uint64, deletedBy string) error
+	Delete(tokenID token.ID, deletedBy string) error
 	// StoreToken stores the passed token record in relation to the passed owner identifiers, if any
 	StoreToken(tr TokenRecord, owners []string) error
 	// SetSpendable updates the spendable flag of the passed token
-	SetSpendable(txID string, index uint64, spendable bool) error
+	SetSpendable(tokenID token.ID, spendable bool) error
 	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
 	SetSpendableBySupportedTokenTypes(supportedTokenTypes []token.TokenType) error

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -37,14 +37,14 @@ type TokenRecord struct {
 	// Ledger is the raw token as stored on the ledger
 	Ledger []byte
 	// LedgerType is the type of the raw token as stored on the ledger
-	LedgerType token.TokenFormat
+	LedgerType token.Format
 	// LedgerMetadata is the metadata associated to the content of Ledger
 	LedgerMetadata []byte
 	// Quantity is the number of units of Type carried in the token.
 	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
 	Quantity string
 	// Type is the type of token
-	Type token.TokenType
+	Type token.Type
 	// Amount is the Quantity converted to decimal
 	Amount uint64
 	// Owner is used to mark the token as owned by this node
@@ -86,7 +86,7 @@ type QueryTokenDetailsParams struct {
 	// OwnerType is the type of owner, for instance 'idemix' or 'htlc'
 	OwnerType string
 	// TokenType (optional) is the type of token
-	TokenType token.TokenType
+	TokenType token.Type
 	// IDs is an optional list of specific token ids to return
 	IDs []*token.ID
 	// TransactionIDs selects tokens that are the output of the provided transaction ids.
@@ -96,7 +96,7 @@ type QueryTokenDetailsParams struct {
 	// Spendable determines whether to include only spendable/non-spendable or any tokens. It defaults to nil (any tokens)
 	Spendable SpendableFilter
 
-	LedgerTokenTypes []token.TokenFormat
+	LedgerTokenTypes []token.Format
 }
 
 type SpendableFilter int
@@ -133,7 +133,7 @@ type TokenDBTransaction interface {
 	SetSpendable(ctx context.Context, tokenID token.ID, spendable bool) error
 	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.TokenFormat) error
+	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.Format) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction
@@ -150,11 +150,11 @@ type TokenDB interface {
 	// UnspentTokensIterator returns an iterator over all owned tokens
 	UnspentTokensIterator() (driver.UnspentTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator over all tokens owned by the passed wallet identifier and of a given type
-	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	// SpendableTokensIteratorBy returns an iterator over all tokens owned solely by the passed wallet identifier and of a given type
-	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token.TokenType) (driver.SpendableTokensIterator, error)
+	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token.Type) (driver.SpendableTokensIterator, error)
 	// ListUnspentTokensBy returns the list of all tokens owned by the passed identifier of a given type
-	ListUnspentTokensBy(walletID string, typ token.TokenType) (*token.UnspentTokens, error)
+	ListUnspentTokensBy(walletID string, typ token.Type) (*token.UnspentTokens, error)
 	// ListUnspentTokens returns the list of all owned tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens for the passed ids
@@ -167,7 +167,7 @@ type TokenDB interface {
 	// GetTokenMetadata returns the metadata of the tokens for the passed ids.
 	GetTokenMetadata(ids []*token.ID) ([][]byte, error)
 	// GetTokenOutputsAndMeta retrieves both the token output, metadata, and type for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.Format, error)
 	// GetTokens returns the owned tokens and their identifier keys for the passed ids.
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens for each id, the function return if it was deleted and by who as per the Delete function
@@ -188,9 +188,9 @@ type TokenDB interface {
 	// QueryTokenDetails provides detailed information about tokens
 	QueryTokenDetails(params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
-	Balance(ownerEID string, typ token.TokenType) (uint64, error)
+	Balance(ownerEID string, typ token.Type) (uint64, error)
 	// SetSupportedTokenTypes sets the supported token types
-	SetSupportedTokenTypes(supportedTokenTypes []token.TokenFormat) error
+	SetSupportedTokenTypes(supportedTokenTypes []token.Format) error
 }
 
 // TokenDBDriver is the interface for a token database driver

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -37,7 +37,7 @@ type TokenRecord struct {
 	// Ledger is the raw token as stored on the ledger
 	Ledger []byte
 	// LedgerType is the type of the raw token as stored on the ledger
-	LedgerType token.TokenType
+	LedgerType token.TokenFormat
 	// LedgerMetadata is the metadata associated to the content of Ledger
 	LedgerMetadata []byte
 	// Quantity is the number of units of Type carried in the token.
@@ -96,7 +96,7 @@ type QueryTokenDetailsParams struct {
 	// Spendable determines whether to include only spendable/non-spendable or any tokens. It defaults to nil (any tokens)
 	Spendable SpendableFilter
 
-	LedgerTokenTypes []token.TokenType
+	LedgerTokenTypes []token.TokenFormat
 }
 
 type SpendableFilter int
@@ -133,7 +133,7 @@ type TokenDBTransaction interface {
 	SetSpendable(ctx context.Context, tokenID token.ID, spendable bool) error
 	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.TokenType) error
+	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.TokenFormat) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction
@@ -167,7 +167,7 @@ type TokenDB interface {
 	// GetTokenMetadata returns the metadata of the tokens for the passed ids.
 	GetTokenMetadata(ids []*token.ID) ([][]byte, error)
 	// GetTokenOutputsAndMeta retrieves both the token output, metadata, and type for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenFormat, error)
 	// GetTokens returns the owned tokens and their identifier keys for the passed ids.
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens for each id, the function return if it was deleted and by who as per the Delete function
@@ -190,7 +190,7 @@ type TokenDB interface {
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
 	Balance(ownerEID string, typ token.TokenType) (uint64, error)
 	// SetSupportedTokenTypes sets the supported token types
-	SetSupportedTokenTypes(supportedTokenTypes []token.TokenType) error
+	SetSupportedTokenTypes(supportedTokenTypes []token.TokenFormat) error
 }
 
 // TokenDBDriver is the interface for a token database driver

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -124,16 +124,16 @@ type CertificationDB interface {
 
 type TokenDBTransaction interface {
 	// GetToken returns the owned tokens and their identifier keys for the passed ids.
-	GetToken(tokenID token.ID, includeDeleted bool) (*token.Token, []string, error)
+	GetToken(ctx context.Context, tokenID token.ID, includeDeleted bool) (*token.Token, []string, error)
 	// Delete marks the passed token as deleted by a given identifier (idempotent)
-	Delete(tokenID token.ID, deletedBy string) error
+	Delete(ctx context.Context, tokenID token.ID, deletedBy string) error
 	// StoreToken stores the passed token record in relation to the passed owner identifiers, if any
-	StoreToken(tr TokenRecord, owners []string) error
+	StoreToken(ctx context.Context, tr TokenRecord, owners []string) error
 	// SetSpendable updates the spendable flag of the passed token
-	SetSpendable(tokenID token.ID, spendable bool) error
+	SetSpendable(ctx context.Context, tokenID token.ID, spendable bool) error
 	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSpendableBySupportedTokenTypes(supportedTokenTypes []token.TokenType) error
+	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.TokenType) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction
@@ -184,7 +184,7 @@ type TokenDB interface {
 	// If not public parameters are available for that hash, it returns an error
 	PublicParamsByHash(rawHash driver.PPHash) ([]byte, error)
 	// NewTokenDBTransaction returns a new Transaction to commit atomically multiple operations
-	NewTokenDBTransaction(ctx context.Context) (TokenDBTransaction, error)
+	NewTokenDBTransaction() (TokenDBTransaction, error)
 	// QueryTokenDetails provides detailed information about tokens
 	QueryTokenDetails(params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -37,14 +37,14 @@ type TokenRecord struct {
 	// Ledger is the raw token as stored on the ledger
 	Ledger []byte
 	// LedgerType is the type of the raw token as stored on the ledger
-	LedgerType string
+	LedgerType token.TokenType
 	// LedgerMetadata is the metadata associated to the content of Ledger
 	LedgerMetadata []byte
 	// Quantity is the number of units of Type carried in the token.
 	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
 	Quantity string
 	// Type is the type of token
-	Type string
+	Type token.TokenType
 	// Amount is the Quantity converted to decimal
 	Amount uint64
 	// Owner is used to mark the token as owned by this node
@@ -86,7 +86,7 @@ type QueryTokenDetailsParams struct {
 	// OwnerType is the type of owner, for instance 'idemix' or 'htlc'
 	OwnerType string
 	// TokenType (optional) is the type of token
-	TokenType string
+	TokenType token.TokenType
 	// IDs is an optional list of specific token ids to return
 	IDs []*token.ID
 	// TransactionIDs selects tokens that are the output of the provided transaction ids.
@@ -98,7 +98,7 @@ type QueryTokenDetailsParams struct {
 	// OnlySpendable determines whether to include only spendable tokens. It defaults to false
 	OnlySpendable bool
 
-	LedgerTokenTypes []string
+	LedgerTokenTypes []token.TokenType
 }
 
 // CertificationDB defines a database to manager token certifications
@@ -144,11 +144,11 @@ type TokenDB interface {
 	// UnspentTokensIterator returns an iterator over all owned tokens
 	UnspentTokensIterator() (driver.UnspentTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator over all tokens owned by the passed wallet identifier and of a given type
-	UnspentTokensIteratorBy(ctx context.Context, walletID, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.TokenType) (driver.UnspentTokensIterator, error)
 	// SpendableTokensIteratorBy returns an iterator over all tokens owned solely by the passed wallet identifier and of a given type
-	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ string) (driver.SpendableTokensIterator, error)
+	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token.TokenType) (driver.SpendableTokensIterator, error)
 	// ListUnspentTokensBy returns the list of all tokens owned by the passed identifier of a given type
-	ListUnspentTokensBy(walletID, typ string) (*token.UnspentTokens, error)
+	ListUnspentTokensBy(walletID string, typ token.TokenType) (*token.UnspentTokens, error)
 	// ListUnspentTokens returns the list of all owned tokens
 	ListUnspentTokens() (*token.UnspentTokens, error)
 	// ListAuditTokens returns the audited tokens for the passed ids
@@ -161,7 +161,7 @@ type TokenDB interface {
 	// GetTokenMetadata returns the metadata of the tokens for the passed ids.
 	GetTokenMetadata(ids []*token.ID) ([][]byte, error)
 	// GetTokenOutputsAndMeta retrieves both the token output, metadata, and type for the passed ids.
-	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []string, error)
+	GetTokenOutputsAndMeta(ctx context.Context, ids []*token.ID) ([][]byte, [][]byte, []token.TokenType, error)
 	// GetTokens returns the owned tokens and their identifier keys for the passed ids.
 	GetTokens(inputs ...*token.ID) ([]*token.Token, error)
 	// WhoDeletedTokens for each id, the function return if it was deleted and by who as per the Delete function
@@ -182,9 +182,9 @@ type TokenDB interface {
 	// QueryTokenDetails provides detailed information about tokens
 	QueryTokenDetails(params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
-	Balance(ownerEID, typ string) (uint64, error)
+	Balance(ownerEID string, typ token.TokenType) (uint64, error)
 	// SetSupportedTokenTypes sets the supported token types
-	SetSupportedTokenTypes(supportedTokenTypes []string) error
+	SetSupportedTokenTypes(supportedTokenTypes []token.TokenType) error
 }
 
 // TokenDBDriver is the interface for a token database driver

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -36,8 +36,8 @@ type TokenRecord struct {
 	OwnerWalletID string
 	// Ledger is the raw token as stored on the ledger
 	Ledger []byte
-	// LedgerType is the type of the raw token as stored on the ledger
-	LedgerType token.Format
+	// LedgerFormat is the type of the raw token as stored on the ledger
+	LedgerFormat token.Format
 	// LedgerMetadata is the metadata associated to the content of Ledger
 	LedgerMetadata []byte
 	// Quantity is the number of units of Type carried in the token.
@@ -95,8 +95,8 @@ type QueryTokenDetailsParams struct {
 	IncludeDeleted bool
 	// Spendable determines whether to include only spendable/non-spendable or any tokens. It defaults to nil (any tokens)
 	Spendable SpendableFilter
-
-	LedgerTokenTypes []token.Format
+	// LedgerTokenFormats selects tokens whose output on the ledger has a format in the list
+	LedgerTokenFormats []token.Format
 }
 
 type SpendableFilter int
@@ -131,9 +131,9 @@ type TokenDBTransaction interface {
 	StoreToken(ctx context.Context, tr TokenRecord, owners []string) error
 	// SetSpendable updates the spendable flag of the passed token
 	SetSpendable(ctx context.Context, tokenID token.ID, spendable bool) error
-	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
+	// SetSpendableBySupportedTokenFormats sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokenTypes []token.Format) error
+	SetSpendableBySupportedTokenFormats(ctx context.Context, formats []token.Format) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction
@@ -189,8 +189,8 @@ type TokenDB interface {
 	QueryTokenDetails(params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
 	Balance(ownerEID string, typ token.Type) (uint64, error)
-	// SetSupportedTokenTypes sets the supported token types
-	SetSupportedTokenTypes(supportedTokenTypes []token.Format) error
+	// SetSupportedTokenFormats sets the supported token formats
+	SetSupportedTokenFormats(formats []token.Format) error
 }
 
 // TokenDBDriver is the interface for a token database driver

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -127,7 +127,7 @@ type TokenDBTransaction interface {
 	SetSpendable(txID string, index uint64, spendable bool) error
 	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSpendableBySupportedTokenTypes(supportedTokenTypes []string) error
+	SetSpendableBySupportedTokenTypes(supportedTokenTypes []token.TokenType) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -97,6 +97,8 @@ type QueryTokenDetailsParams struct {
 	OnlyNonSpendable bool
 	// OnlySpendable determines whether to include only spendable tokens. It defaults to false
 	OnlySpendable bool
+
+	LedgerTokenTypes []string
 }
 
 // CertificationDB defines a database to manager token certifications
@@ -123,9 +125,9 @@ type TokenDBTransaction interface {
 	StoreToken(tr TokenRecord, owners []string) error
 	// SetSpendable updates the spendable flag of the passed token
 	SetSpendable(txID string, index uint64, spendable bool) error
-	// SetSupportedTokens sets the spendable flag to true for all the tokens having one of the passed token type.
+	// SetSpendableBySupportedTokenTypes sets the spendable flag to true for all the tokens having one of the passed token type.
 	// The spendable flag is set to false for the other tokens
-	SetSupportedTokens(supportedTokenTypes []string) error
+	SetSpendableBySupportedTokenTypes(supportedTokenTypes []string) error
 	// Commit commits this transaction
 	Commit() error
 	// Rollback rollbacks this transaction
@@ -181,6 +183,8 @@ type TokenDB interface {
 	QueryTokenDetails(params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
 	Balance(ownerEID, typ string) (uint64, error)
+	// SetSupportedTokenTypes sets the supported token types
+	SetSupportedTokenTypes(supportedTokenTypes []string) error
 }
 
 // TokenDBDriver is the interface for a token database driver

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -93,13 +93,19 @@ type QueryTokenDetailsParams struct {
 	TransactionIDs []string
 	// IncludeDeleted determines whether to include spent tokens. It defaults to false.
 	IncludeDeleted bool
-	// OnlyNonSpendable determines whether to include only non-spendable tokens. It defaults to false
-	OnlyNonSpendable bool
-	// OnlySpendable determines whether to include only spendable tokens. It defaults to false
-	OnlySpendable bool
+	// Spendable determines whether to include only spendable/non-spendable or any tokens. It defaults to nil (any tokens)
+	Spendable SpendableFilter
 
 	LedgerTokenTypes []token.TokenType
 }
+
+type SpendableFilter int
+
+const (
+	Any SpendableFilter = iota
+	SpendableOnly
+	NonSpendableOnly
+)
 
 // CertificationDB defines a database to manager token certifications
 type CertificationDB interface {

--- a/token/services/db/sql/common/querybuilder_test.go
+++ b/token/services/db/sql/common/querybuilder_test.go
@@ -184,7 +184,7 @@ func TestMovementConditions(t *testing.T) {
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
-				TokenTypes:        []string{"ABC", "XYZ"},
+				TokenTypes:        []token.TokenType{"ABC", "XYZ"},
 				MovementDirection: driver.All,
 			},
 			expectedSql:  "WHERE (enrollment_id = $1 AND (token_type) IN (($2), ($3)) AND status = $4) ORDER BY stored_at DESC",
@@ -195,7 +195,7 @@ func TestMovementConditions(t *testing.T) {
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
-				TokenTypes:        []string{"ABC", "XYZ"},
+				TokenTypes:        []token.TokenType{"ABC", "XYZ"},
 				NumRecords:        5,
 				MovementDirection: driver.All,
 			},
@@ -206,7 +206,7 @@ func TestMovementConditions(t *testing.T) {
 			name: "Sent XYZ from alice",
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
-				TokenTypes:        []string{"XYZ"},
+				TokenTypes:        []token.TokenType{"XYZ"},
 				MovementDirection: driver.Sent,
 			},
 			expectedSql:  "WHERE (enrollment_id = $1 AND token_type = $2 AND status != 3 AND amount < 0) ORDER BY stored_at DESC",
@@ -290,7 +290,7 @@ func TestTokenSql(t *testing.T) {
 		{
 			name: "owner and type and id",
 			params: driver.QueryTokenDetailsParams{
-				TokenType: "tok",
+				TokenType: token.TokenType("tok"),
 				WalletID:  "me",
 				IDs:       []*token.ID{{TxId: "a", Index: 1}},
 			},
@@ -300,7 +300,7 @@ func TestTokenSql(t *testing.T) {
 		{
 			name: "type and ids",
 			params: driver.QueryTokenDetailsParams{
-				TokenType:      "tok",
+				TokenType:      token.TokenType("tok"),
 				IDs:            []*token.ID{{TxId: "a", Index: 1}, {TxId: "b", Index: 2}},
 				IncludeDeleted: true,
 			},

--- a/token/services/db/sql/common/querybuilder_test.go
+++ b/token/services/db/sql/common/querybuilder_test.go
@@ -184,7 +184,7 @@ func TestMovementConditions(t *testing.T) {
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
-				TokenTypes:        []token.TokenType{"ABC", "XYZ"},
+				TokenTypes:        []token.Type{"ABC", "XYZ"},
 				MovementDirection: driver.All,
 			},
 			expectedSql:  "WHERE (enrollment_id = $1 AND (token_type) IN (($2), ($3)) AND status = $4) ORDER BY stored_at DESC",
@@ -195,7 +195,7 @@ func TestMovementConditions(t *testing.T) {
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
 				TxStatuses:        []driver.TxStatus{driver.Confirmed},
-				TokenTypes:        []token.TokenType{"ABC", "XYZ"},
+				TokenTypes:        []token.Type{"ABC", "XYZ"},
 				NumRecords:        5,
 				MovementDirection: driver.All,
 			},
@@ -206,7 +206,7 @@ func TestMovementConditions(t *testing.T) {
 			name: "Sent XYZ from alice",
 			params: driver.QueryMovementsParams{
 				EnrollmentIDs:     []string{"alice"},
-				TokenTypes:        []token.TokenType{"XYZ"},
+				TokenTypes:        []token.Type{"XYZ"},
 				MovementDirection: driver.Sent,
 			},
 			expectedSql:  "WHERE (enrollment_id = $1 AND token_type = $2 AND status != 3 AND amount < 0) ORDER BY stored_at DESC",
@@ -290,7 +290,7 @@ func TestTokenSql(t *testing.T) {
 		{
 			name: "owner and type and id",
 			params: driver.QueryTokenDetailsParams{
-				TokenType: token.TokenType("tok"),
+				TokenType: token.Type("tok"),
 				WalletID:  "me",
 				IDs:       []*token.ID{{TxId: "a", Index: 1}},
 			},
@@ -300,7 +300,7 @@ func TestTokenSql(t *testing.T) {
 		{
 			name: "type and ids",
 			params: driver.QueryTokenDetailsParams{
-				TokenType:      token.TokenType("tok"),
+				TokenType:      token.Type("tok"),
 				IDs:            []*token.ID{{TxId: "a", Index: 1}, {TxId: "b", Index: 2}},
 				IncludeDeleted: true,
 			},

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -17,8 +17,8 @@ import (
 type TokenInterpreter interface {
 	common.Interpreter
 	HasTokens(colTxID, colIdx common.FieldName, ids ...*token.ID) common.Condition
-	HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.TokenType) common.Condition
-	HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.TokenFormat) common.Condition
+	HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.Type) common.Condition
+	HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.Format) common.Condition
 	HasTokenDetails(params driver.QueryTokenDetailsParams, tokenTable string) common.Condition
 	HasMovementsParams(params driver.QueryMovementsParams) common.Condition
 	HasValidationParams(params driver.QueryValidationRecordsParams) common.Condition
@@ -45,7 +45,7 @@ func (c *tokenInterpreter) HasTokens(colTxID, colIdx common.FieldName, ids ...*t
 	return c.InTuple([]common.FieldName{colTxID, colIdx}, vals)
 }
 
-func (c *tokenInterpreter) HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.TokenType) common.Condition {
+func (c *tokenInterpreter) HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.Type) common.Condition {
 	if len(tokenTypes) == 0 {
 		return common.EmptyCondition
 	}
@@ -56,7 +56,7 @@ func (c *tokenInterpreter) HasTokenTypes(colTokenType common.FieldName, tokenTyp
 	return c.InStrings(colTokenType, types)
 }
 
-func (c *tokenInterpreter) HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.TokenFormat) common.Condition {
+func (c *tokenInterpreter) HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.Format) common.Condition {
 	if len(tokenTypes) == 0 {
 		return common.EmptyCondition
 	}

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -74,15 +74,23 @@ func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams
 		conds = append(conds, common.ConstCondition("spendable = true"))
 	}
 	if len(params.LedgerTokenTypes) > 0 {
-		conds = append(conds, c.InStrings("ledger_type", params.LedgerTokenTypes))
+		types := make([]string, len(params.LedgerTokenTypes))
+		for i, typ := range params.LedgerTokenTypes {
+			types[i] = string(typ)
+		}
+		conds = append(conds, c.InStrings("ledger_type", types))
 	}
 	return c.And(conds...)
 }
 
 func (c *tokenInterpreter) HasMovementsParams(params driver.QueryMovementsParams) common.Condition {
+	tokenTypes := make([]string, len(params.TokenTypes))
+	for i, typ := range params.TokenTypes {
+		tokenTypes[i] = string(typ)
+	}
 	conds := []common.Condition{
 		c.InStrings("enrollment_id", params.EnrollmentIDs),
-		c.InStrings("token_type", params.TokenTypes),
+		c.InStrings("token_type", tokenTypes),
 		c.InInts("status", params.TxStatuses),
 	}
 

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -18,7 +18,7 @@ type TokenInterpreter interface {
 	common.Interpreter
 	HasTokens(colTxID, colIdx common.FieldName, ids ...*token.ID) common.Condition
 	HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.Type) common.Condition
-	HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.Format) common.Condition
+	HasTokenFormats(colTokenType common.FieldName, formats ...token.Format) common.Condition
 	HasTokenDetails(params driver.QueryTokenDetailsParams, tokenTable string) common.Condition
 	HasMovementsParams(params driver.QueryMovementsParams) common.Condition
 	HasValidationParams(params driver.QueryValidationRecordsParams) common.Condition
@@ -56,12 +56,12 @@ func (c *tokenInterpreter) HasTokenTypes(colTokenType common.FieldName, tokenTyp
 	return c.InStrings(colTokenType, types)
 }
 
-func (c *tokenInterpreter) HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.Format) common.Condition {
-	if len(tokenTypes) == 0 {
+func (c *tokenInterpreter) HasTokenFormats(colTokenType common.FieldName, formats ...token.Format) common.Condition {
+	if len(formats) == 0 {
 		return common.EmptyCondition
 	}
-	types := make([]string, len(tokenTypes))
-	for i, typ := range tokenTypes {
+	types := make([]string, len(formats))
+	for i, typ := range formats {
 		types[i] = string(typ)
 	}
 	return c.InStrings(colTokenType, types)
@@ -88,8 +88,8 @@ func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams
 	} else if params.Spendable == driver.SpendableOnly {
 		conds = append(conds, common.ConstCondition("spendable = true"))
 	}
-	if len(params.LedgerTokenTypes) > 0 {
-		conds = append(conds, c.HasTokenFormats("ledger_type", params.LedgerTokenTypes...))
+	if len(params.LedgerTokenFormats) > 0 {
+		conds = append(conds, c.HasTokenFormats("ledger_type", params.LedgerTokenFormats...))
 	}
 	return c.And(conds...)
 }

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -71,10 +71,9 @@ func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams
 	if !params.IncludeDeleted {
 		conds = append(conds, common.ConstCondition("is_deleted = false"))
 	}
-	if params.OnlyNonSpendable {
+	if params.Spendable == driver.NonSpendableOnly {
 		conds = append(conds, common.ConstCondition("spendable = false"))
-	}
-	if params.OnlySpendable {
+	} else if params.Spendable == driver.SpendableOnly {
 		conds = append(conds, common.ConstCondition("spendable = true"))
 	}
 	if len(params.LedgerTokenTypes) > 0 {

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -18,6 +18,7 @@ type TokenInterpreter interface {
 	common.Interpreter
 	HasTokens(colTxID, colIdx common.FieldName, ids ...*token.ID) common.Condition
 	HasTokenTypes(colTokenType common.FieldName, tokenTypes ...token.TokenType) common.Condition
+	HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.TokenFormat) common.Condition
 	HasTokenDetails(params driver.QueryTokenDetailsParams, tokenTable string) common.Condition
 	HasMovementsParams(params driver.QueryMovementsParams) common.Condition
 	HasValidationParams(params driver.QueryValidationRecordsParams) common.Condition
@@ -55,6 +56,17 @@ func (c *tokenInterpreter) HasTokenTypes(colTokenType common.FieldName, tokenTyp
 	return c.InStrings(colTokenType, types)
 }
 
+func (c *tokenInterpreter) HasTokenFormats(colTokenType common.FieldName, tokenTypes ...token.TokenFormat) common.Condition {
+	if len(tokenTypes) == 0 {
+		return common.EmptyCondition
+	}
+	types := make([]string, len(tokenTypes))
+	for i, typ := range tokenTypes {
+		types[i] = string(typ)
+	}
+	return c.InStrings(colTokenType, types)
+}
+
 func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams, tokenTable string) common.Condition {
 	conds := []common.Condition{
 		common.ConstCondition("owner = true"),
@@ -77,7 +89,7 @@ func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams
 		conds = append(conds, common.ConstCondition("spendable = true"))
 	}
 	if len(params.LedgerTokenTypes) > 0 {
-		conds = append(conds, c.HasTokenTypes("ledger_type", params.LedgerTokenTypes...))
+		conds = append(conds, c.HasTokenFormats("ledger_type", params.LedgerTokenTypes...))
 	}
 	return c.And(conds...)
 }

--- a/token/services/db/sql/common/tcondition.go
+++ b/token/services/db/sql/common/tcondition.go
@@ -73,7 +73,9 @@ func (c *tokenInterpreter) HasTokenDetails(params driver.QueryTokenDetailsParams
 	if params.OnlySpendable {
 		conds = append(conds, common.ConstCondition("spendable = true"))
 	}
-
+	if len(params.LedgerTokenTypes) > 0 {
+		conds = append(conds, c.InStrings("ledger_type", params.LedgerTokenTypes))
+	}
 	return c.And(conds...)
 }
 

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -1028,7 +1028,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make all non-spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSupportedTokens([]string{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1041,7 +1041,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSupportedTokens([]string{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1054,7 +1054,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST1 spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSupportedTokens([]string{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1067,7 +1067,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make both spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSupportedTokens([]string{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -993,7 +993,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 		OwnerType:      "idemix",
 		OwnerIdentity:  []byte{},
 		Ledger:         []byte("ledger"),
-		LedgerType:     "CLEAR",
+		LedgerFormat:   "CLEAR",
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
 		Type:           TST,
@@ -1010,7 +1010,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 		OwnerType:      "htlc",
 		OwnerIdentity:  []byte("{}"),
 		Ledger:         []byte("ledger"),
-		LedgerType:     "CLEAR1",
+		LedgerFormat:   "CLEAR1",
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
 		Type:           "TST1",
@@ -1033,7 +1033,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make all non-spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenFormats(context.TODO(), []token.Format{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1046,7 +1046,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenFormats(context.TODO(), []token.Format{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1059,7 +1059,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST1 spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenFormats(context.TODO(), []token.Format{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1072,7 +1072,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make both spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenFormats(context.TODO(), []token.Format{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -1033,7 +1033,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make all non-spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1046,7 +1046,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1059,7 +1059,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST1 spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1072,7 +1072,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make both spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -1028,7 +1028,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make all non-spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1041,7 +1041,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1054,7 +1054,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST1 spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
@@ -1067,7 +1067,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make both spendable
 	tx, err = db.NewTokenDBTransaction(context.TODO())
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]string{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -22,6 +22,8 @@ import (
 	"github.com/test-go/testify/assert"
 )
 
+const TST = token.TokenType("TST")
+
 var TokenNotifierCases = []struct {
 	Name string
 	Fn   func(*testing.T, driver.TokenDB, driver.TokenNotifier)
@@ -136,7 +138,7 @@ func TTransaction(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -200,7 +202,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 			Ledger:         []byte("ledger"),
 			LedgerMetadata: []byte{},
 			Quantity:       "0x02",
-			Type:           "TST",
+			Type:           TST,
 			Amount:         2,
 			Owner:          true,
 			Auditor:        false,
@@ -218,7 +220,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -236,7 +238,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -266,7 +268,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.NoError(t, err)
 	assert.Len(t, tok.Tokens, 24, "unspentTokensIterator: expected all tokens to be returned (2 for the one owned by alice and bob)")
 	assert.Equal(t, "48", tok.Sum(64).Decimal(), "expect sum to be 2*22")
-	assert.Len(t, tok.ByType("TST").Tokens, 23, "expect filter on type to work")
+	assert.Len(t, tok.ByType(TST).Tokens, 23, "expect filter on type to work")
 	for _, token := range tok.Tokens {
 		assert.NotNil(t, token.Owner, "expected owner to not be nil")
 		assert.NotEmpty(t, token.Owner, "expected owner raw to not be empty")
@@ -868,7 +870,7 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -884,7 +886,7 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -936,20 +938,20 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 	assert.Equal(t, res[0].Amount, balance)
 
 	// alice TST
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "alice", TokenType: "TST"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "alice", TokenType: TST})
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 	assertEqual(t, tx2, res[0])
-	balance, err = db.Balance("alice", "TST")
+	balance, err = db.Balance("alice", TST)
 	assert.NoError(t, err)
 	assert.Equal(t, res[0].Amount, balance)
 
 	// bob TST
-	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "bob", TokenType: "TST"})
+	res, err = db.QueryTokenDetails(driver.QueryTokenDetailsParams{WalletID: "bob", TokenType: TST})
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
 	assertEqual(t, tx21, res[0])
-	balance, err = db.Balance("bob", "TST")
+	balance, err = db.Balance("bob", TST)
 	assert.NoError(t, err)
 	assert.Equal(t, res[0].Amount, balance)
 
@@ -991,7 +993,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 		LedgerType:     "CLEAR",
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "TST",
+		Type:           TST,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -1018,9 +1020,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.StoreToken(tx2, []string{"alice"}))
 	assert.NoError(t, tx.Commit())
 
-	it, err := db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
+	it, err := db.SpendableTokensIteratorBy(context.TODO(), "", TST)
 	assert.NoError(t, err)
-	consumeSpendableTokensIterator(t, it, "TST", 1)
+	consumeSpendableTokensIterator(t, it, TST, 1)
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST1")
 	assert.NoError(t, err)
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
@@ -1031,9 +1033,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
-	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
+	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
 	assert.NoError(t, err)
-	consumeSpendableTokensIterator(t, it, "TST", 0)
+	consumeSpendableTokensIterator(t, it, TST, 0)
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST1")
 	assert.NoError(t, err)
 	consumeSpendableTokensIterator(t, it, "TST1", 0)
@@ -1044,9 +1046,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
-	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
+	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
 	assert.NoError(t, err)
-	consumeSpendableTokensIterator(t, it, "TST", 1)
+	consumeSpendableTokensIterator(t, it, TST, 1)
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST1")
 	assert.NoError(t, err)
 	consumeSpendableTokensIterator(t, it, "TST1", 0)
@@ -1057,9 +1059,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
-	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
+	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
 	assert.NoError(t, err)
-	consumeSpendableTokensIterator(t, it, "TST", 0)
+	consumeSpendableTokensIterator(t, it, TST, 0)
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST1")
 	assert.NoError(t, err)
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
@@ -1070,15 +1072,15 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
-	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST")
+	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
 	assert.NoError(t, err)
-	consumeSpendableTokensIterator(t, it, "TST", 1)
+	consumeSpendableTokensIterator(t, it, TST, 1)
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", "TST1")
 	assert.NoError(t, err)
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
 }
 
-func consumeSpendableTokensIterator(t *testing.T, it driver3.SpendableTokensIterator, tokenType string, count int) {
+func consumeSpendableTokensIterator(t *testing.T, it driver3.SpendableTokensIterator, tokenType token.TokenType, count int) {
 	defer it.Close()
 	for i := 0; i < count; i++ {
 		tok, err := it.Next()

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	TST = token.TokenType("TST")
-	ABC = token.TokenType("ABC")
+	TST = token.Type("TST")
+	ABC = token.Type("ABC")
 )
 
 var TokenNotifierCases = []struct {
@@ -322,7 +322,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.Rollback())
 }
 
-func getTokensBy(t *testing.T, db *TokenDB, ownerEID string, typ token.TokenType) []*token.UnspentToken {
+func getTokensBy(t *testing.T, db *TokenDB, ownerEID string, typ token.Type) []*token.UnspentToken {
 	it, err := db.UnspentTokensIteratorBy(context.TODO(), ownerEID, typ)
 	assert.NoError(t, err)
 	defer it.Close()
@@ -1033,7 +1033,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make all non-spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1046,7 +1046,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1059,7 +1059,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make TST1 spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1072,7 +1072,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	// make both spendable
 	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenFormat{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.Format{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1083,7 +1083,7 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
 }
 
-func consumeSpendableTokensIterator(t *testing.T, it driver3.SpendableTokensIterator, tokenType token.TokenType, count int) {
+func consumeSpendableTokensIterator(t *testing.T, it driver3.SpendableTokensIterator, tokenType token.Type, count int) {
 	defer it.Close()
 	for i := 0; i < count; i++ {
 		tok, err := it.Next()

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -317,7 +317,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.NoError(t, tx.Rollback())
 }
 
-func getTokensBy(t *testing.T, db *TokenDB, ownerEID, typ string) []*token.UnspentToken {
+func getTokensBy(t *testing.T, db *TokenDB, ownerEID string, typ token.TokenType) []*token.UnspentToken {
 	it, err := db.UnspentTokensIteratorBy(context.TODO(), ownerEID, typ)
 	assert.NoError(t, err)
 	defer it.Close()

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -22,7 +22,10 @@ import (
 	"github.com/test-go/testify/assert"
 )
 
-const TST = token.TokenType("TST")
+const (
+	TST = token.TokenType("TST")
+	ABC = token.TokenType("ABC")
+)
 
 var TokenNotifierCases = []struct {
 	Name string
@@ -256,7 +259,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -278,17 +281,17 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.NoError(t, err)
 	assert.Len(t, tokens, 22, "unspentTokensIteratorBy: expected only Alice tokens to be returned")
 
-	tokens = getTokensBy(t, db, "", "ABC")
+	tokens = getTokensBy(t, db, "", ABC)
 	assert.Len(t, tokens, 1, "unspentTokensIteratorBy: expected only ABC tokens to be returned")
 
-	tokens = getTokensBy(t, db, "alice", "ABC")
+	tokens = getTokensBy(t, db, "alice", ABC)
 	assert.Len(t, tokens, 1, "unspentTokensIteratorBy: expected only Alice ABC tokens to be returned")
 
 	unsp, err := db.GetTokens(&token.ID{TxId: "tx101", Index: 0})
 	assert.NoError(t, err)
 	assert.Len(t, unsp, 1)
 	assert.Equal(t, "0x02", unsp[0].Quantity)
-	assert.Equal(t, "ABC", unsp[0].Type)
+	assert.Equal(t, ABC, unsp[0].Type)
 
 	tr = driver.TokenRecord{
 		TxID:           fmt.Sprintf("tx%d", 2000),
@@ -301,7 +304,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         2,
 		Owner:          true,
 		Auditor:        false,
@@ -349,7 +352,7 @@ func TDeleteAndMine(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -366,7 +369,7 @@ func TDeleteAndMine(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -383,7 +386,7 @@ func TDeleteAndMine(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -428,7 +431,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          false,
 		Auditor:        true,
@@ -445,7 +448,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          false,
 		Auditor:        true,
@@ -462,7 +465,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x03",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          false,
 		Auditor:        true,
@@ -501,7 +504,7 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          false,
 		Auditor:        false,
@@ -519,7 +522,7 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x02",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          false,
 		Auditor:        false,
@@ -585,7 +588,7 @@ func TGetTokenInfos(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("tx101l"),
 		LedgerMetadata: []byte("tx101"),
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -602,7 +605,7 @@ func TGetTokenInfos(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("tx102l"),
 		LedgerMetadata: []byte("tx102"),
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -619,7 +622,7 @@ func TGetTokenInfos(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("tx102l"),
 		LedgerMetadata: []byte("tx102"),
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Amount:         0,
 		Owner:          true,
 		Auditor:        false,
@@ -686,7 +689,7 @@ func TDeleteMultiple(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Owner:          true,
 	}
 	assert.NoError(t, db.StoreToken(tr, []string{"alice"}))
@@ -699,7 +702,7 @@ func TDeleteMultiple(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Owner:          true,
 	}
 	assert.NoError(t, db.StoreToken(tr, []string{"bob"}))
@@ -712,7 +715,7 @@ func TDeleteMultiple(t *testing.T, db *TokenDB) {
 		Ledger:         []byte("ledger"),
 		LedgerMetadata: []byte{},
 		Quantity:       "0x01",
-		Type:           "ABC",
+		Type:           ABC,
 		Owner:          true,
 	}
 	assert.NoError(t, db.StoreToken(tr, []string{"alice"}))
@@ -784,7 +787,7 @@ func TCertification(t *testing.T, db *TokenDB) {
 				Quantity:       "0x01",
 				Ledger:         []byte("ledger"),
 				LedgerMetadata: []byte{},
-				Type:           "ABC",
+				Type:           ABC,
 				Owner:          true,
 			}, []string{"alice"})
 			if err != nil {

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -63,10 +63,10 @@ func collectDBEvents(db driver.TokenNotifier) (*[]dbEvent, error) {
 func TSubscribeStore(t *testing.T, db driver.TokenDB, notifier driver.TokenNotifier) {
 	result, err := collectDBEvents(notifier)
 	assert.Nil(t, err)
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
 	assert.NoError(t, tx.Commit())
 
 	assert2.Eventually(t, func() bool { return len(*result) == 2 }, time.Second, 20*time.Millisecond)
@@ -75,11 +75,11 @@ func TSubscribeStore(t *testing.T, db driver.TokenDB, notifier driver.TokenNotif
 func TSubscribeStoreDelete(t *testing.T, db driver.TokenDB, notifier driver.TokenNotifier) {
 	result, err := collectDBEvents(notifier)
 	assert.Nil(t, err)
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
-	assert.NoError(t, tx.Delete(token.ID{TxId: "tx1", Index: 1}, "alice"))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
+	assert.NoError(t, tx.Delete(context.TODO(), token.ID{TxId: "tx1", Index: 1}, "alice"))
 	assert.NoError(t, tx.Commit())
 
 	assert2.Eventually(t, func() bool { return len(*result) == 3 }, time.Second, 20*time.Millisecond)
@@ -88,10 +88,10 @@ func TSubscribeStoreDelete(t *testing.T, db driver.TokenDB, notifier driver.Toke
 func TSubscribeStoreNoCommit(t *testing.T, db driver.TokenDB, notifier driver.TokenNotifier) {
 	result, err := collectDBEvents(notifier)
 	assert.Nil(t, err)
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
-	assert.NoError(t, tx.StoreToken(driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 1}, []string{"alice"}))
 
 	assert2.Eventually(t, func() bool { return len(*result) == 0 }, time.Second, 20*time.Millisecond)
 }
@@ -99,10 +99,10 @@ func TSubscribeStoreNoCommit(t *testing.T, db driver.TokenDB, notifier driver.To
 func TSubscribeRead(t *testing.T, db driver.TokenDB, notifier driver.TokenNotifier) {
 	result, err := collectDBEvents(notifier)
 	assert.Nil(t, err)
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
 	// assert.NoError(t, tx.StoreToken(context.TODO(), driver.TokenRecord{TxID: "tx1", Index: 0}, []string{"alice"}))
-	_, _, err = tx.GetToken(token.ID{TxId: "tx1"}, true)
+	_, _, err = tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, true)
 	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 
@@ -127,11 +127,11 @@ var TokensCases = []struct {
 }
 
 func TTransaction(t *testing.T, db *TokenDB) {
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tx.StoreToken(driver.TokenRecord{
+	err = tx.StoreToken(context.TODO(), driver.TokenRecord{
 		TxID:           "tx1",
 		Index:          0,
 		IssuerRaw:      []byte{},
@@ -150,43 +150,43 @@ func TTransaction(t *testing.T, db *TokenDB) {
 	assert.NoError(t, err)
 	assert.NoError(t, tx.Commit())
 
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tok, owners, err := tx.GetToken(token.ID{TxId: "tx1"}, false)
+	tok, owners, err := tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, false)
 	assert.NoError(t, err, "get token")
 	assert.Equal(t, "0x02", tok.Quantity)
 	assert.Equal(t, []string{"alice"}, owners)
 
-	assert.NoError(t, tx.Delete(token.ID{TxId: "tx1"}, "me"))
-	tok, owners, err = tx.GetToken(token.ID{TxId: "tx1"}, false)
+	assert.NoError(t, tx.Delete(context.TODO(), token.ID{TxId: "tx1"}, "me"))
+	tok, owners, err = tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, false)
 	assert.NoError(t, err)
 	assert.Nil(t, tok)
 	assert.Len(t, owners, 0)
 
-	tok, _, err = tx.GetToken(token.ID{TxId: "tx1"}, true) // include deleted
+	tok, _, err = tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, true) // include deleted
 	assert.NoError(t, err)
 	assert.Equal(t, "0x02", tok.Quantity)
 	assert.NoError(t, tx.Rollback())
 
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tok, owners, err = tx.GetToken(token.ID{TxId: "tx1"}, false)
+	tok, owners, err = tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, false)
 	assert.NoError(t, err)
 	assert.NotNil(t, tok)
 	assert.Equal(t, "0x02", tok.Quantity)
 	assert.Equal(t, []string{"alice"}, owners)
-	assert.NoError(t, tx.Delete(token.ID{TxId: "tx1"}, "me"))
+	assert.NoError(t, tx.Delete(context.TODO(), token.ID{TxId: "tx1"}, "me"))
 	assert.NoError(t, tx.Commit())
 
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	if err != nil {
 		t.Fatal(err)
 	}
-	tok, owners, err = tx.GetToken(token.ID{TxId: "tx1"}, false)
+	tok, owners, err = tx.GetToken(context.TODO(), token.ID{TxId: "tx1"}, false)
 	assert.NoError(t, err)
 	assert.Nil(t, tok)
 	assert.Equal(t, []string(nil), owners)
@@ -314,9 +314,9 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	_, err = db.GetTokens(&token.ID{TxId: fmt.Sprintf("tx%d", 2000)})
 	assert.NoError(t, err)
 
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	_, owners, err := tx.GetToken(token.ID{TxId: fmt.Sprintf("tx%d", 2000)}, true)
+	_, owners, err := tx.GetToken(context.TODO(), token.ID{TxId: fmt.Sprintf("tx%d", 2000)}, true)
 	assert.NoError(t, err)
 	assert.Len(t, owners, 1)
 	assert.NoError(t, tx.Rollback())
@@ -843,7 +843,7 @@ func TCertification(t *testing.T, db *TokenDB) {
 }
 
 func TQueryTokenDetails(t *testing.T, db *TokenDB) {
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -896,15 +896,15 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 		Issuer:         false,
 	}
 
-	err = tx.StoreToken(tx1, []string{"alice"})
+	err = tx.StoreToken(context.TODO(), tx1, []string{"alice"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tx.StoreToken(tx2, []string{"alice"})
+	err = tx.StoreToken(context.TODO(), tx2, []string{"alice"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tx.StoreToken(tx21, []string{"bob"})
+	err = tx.StoreToken(context.TODO(), tx21, []string{"bob"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -983,7 +983,7 @@ func TQueryTokenDetails(t *testing.T, db *TokenDB) {
 }
 
 func TTokenTypes(t *testing.T, db *TokenDB) {
-	tx, err := db.NewTokenDBTransaction(context.TODO())
+	tx, err := db.NewTokenDBTransaction()
 	assert.NoError(t, err)
 	tx1 := driver.TokenRecord{
 		TxID:           "tx1",
@@ -1019,8 +1019,8 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 		Auditor:        false,
 		Issuer:         false,
 	}
-	assert.NoError(t, tx.StoreToken(tx1, []string{"alice"}))
-	assert.NoError(t, tx.StoreToken(tx2, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), tx1, []string{"alice"}))
+	assert.NoError(t, tx.StoreToken(context.TODO(), tx2, []string{"alice"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err := db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1031,9 +1031,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
 
 	// make all non-spendable
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"htlc"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"htlc"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1044,9 +1044,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	consumeSpendableTokensIterator(t, it, "TST1", 0)
 
 	// make TST spendable
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1057,9 +1057,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	consumeSpendableTokensIterator(t, it, "TST1", 0)
 
 	// make TST1 spendable
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)
@@ -1070,9 +1070,9 @@ func TTokenTypes(t *testing.T, db *TokenDB) {
 	consumeSpendableTokensIterator(t, it, "TST1", 1)
 
 	// make both spendable
-	tx, err = db.NewTokenDBTransaction(context.TODO())
+	tx, err = db.NewTokenDBTransaction()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes([]token.TokenType{"CLEAR", "CLEAR1"}))
+	assert.NoError(t, tx.SetSpendableBySupportedTokenTypes(context.TODO(), []token.TokenType{"CLEAR", "CLEAR1"}))
 	assert.NoError(t, tx.Commit())
 
 	it, err = db.SpendableTokensIteratorBy(context.TODO(), "", TST)

--- a/token/services/db/sql/common/tokens.go
+++ b/token/services/db/sql/common/tokens.go
@@ -168,7 +168,7 @@ func (db *TokenDB) SpendableTokensIteratorBy(ctx context.Context, walletID strin
 	where, args := common.Where(db.ci.HasTokenDetails(driver.QueryTokenDetailsParams{
 		WalletID:         walletID,
 		TokenType:        typ,
-		OnlySpendable:    true,
+		Spendable:        driver.SpendableOnly,
 		LedgerTokenTypes: db.getSupportedTokenTypes(),
 	}, ""))
 

--- a/token/services/db/sql/common/tokens.go
+++ b/token/services/db/sql/common/tokens.go
@@ -455,7 +455,7 @@ func (db *TokenDB) getLedgerTokenAndMeta(ctx context.Context, ids []*token.ID) (
 
 	query, err := NewSelect("tx_id, idx, ledger, ledger_type, ledger_metadata  ").From(db.table.Tokens).Where(where).Compile()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to compile query")
+		return nil, nil, nil, errors.Wrapf(err, "failed to compile query")
 	}
 	span.AddEvent("query", tracing.WithAttributes(tracing.String(QueryLabel, query)))
 	logger.Debug(query, args)

--- a/token/services/db/sql/common/tokens.go
+++ b/token/services/db/sql/common/tokens.go
@@ -176,7 +176,7 @@ func (db *TokenDB) SpendableTokensIteratorBy(ctx context.Context, walletID strin
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to compile query")
 	}
-	logger.Debug(query, args)
+	logger.Warn(query, args)
 	span.AddEvent("start_query", tracing.WithAttributes(tracing.String(QueryLabel, query)))
 	rows, err := db.db.Query(query, args...)
 	span.AddEvent("end_query")
@@ -1132,7 +1132,7 @@ func (t *TokenTransaction) SetSpendable(txID string, index uint64, spendable boo
 
 }
 
-func (t *TokenTransaction) SetSpendableBySupportedTokenTypes(supportedTokenTypes []string) error {
+func (t *TokenTransaction) SetSpendableBySupportedTokenTypes(supportedTokenTypes []token.TokenType) error {
 	span := trace.SpanFromContext(t.ctx)
 
 	// first set all spendable flags to false

--- a/token/services/db/sql/common/tokens.go
+++ b/token/services/db/sql/common/tokens.go
@@ -1054,7 +1054,8 @@ func (t *TokenTransaction) StoreToken(tr driver.TokenRecord, owners []string) er
 
 	// Store token
 	now := time.Now().UTC()
-	query, err := NewInsertInto(t.db.table.Tokens).Rows("tx_id, idx, issuer_raw, owner_raw, owner_type, owner_identity, owner_wallet_id, ledger, ledger_metadata, token_type, quantity, amount, stored_at, owner, auditor, issuer").Compile()
+	query, err := NewInsertInto(t.db.table.Tokens).Rows(
+		"tx_id, idx, issuer_raw, owner_raw, owner_type, owner_identity, owner_wallet_id, ledger, ledger_type, ledger_metadata, token_type, quantity, amount, stored_at, owner, auditor, issuer").Compile()
 	if err != nil {
 		return errors.Wrapf(err, "failed building insert")
 	}

--- a/token/services/interop/htlc/distribute.go
+++ b/token/services/interop/htlc/distribute.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -20,10 +21,10 @@ import (
 type Terms struct {
 	ReclamationDeadline time.Duration
 	TMSID1              token.TMSID
-	Type1               string
+	Type1               token2.TokenType
 	Amount1             uint64
 	TMSID2              token.TMSID
-	Type2               string
+	Type2               token2.TokenType
 	Amount2             uint64
 }
 

--- a/token/services/interop/htlc/distribute.go
+++ b/token/services/interop/htlc/distribute.go
@@ -21,10 +21,10 @@ import (
 type Terms struct {
 	ReclamationDeadline time.Duration
 	TMSID1              token.TMSID
-	Type1               token2.TokenType
+	Type1               token2.Type
 	Amount1             uint64
 	TMSID2              token.TMSID
-	Type2               token2.TokenType
+	Type2               token2.Type
 	Amount2             uint64
 }
 

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -127,7 +127,7 @@ func (t *Transaction) Outputs() (*OutputStream, error) {
 }
 
 // Lock appends a lock action to the token request of the transaction
-func (t *Transaction) Lock(wallet *token.OwnerWallet, sender view.Identity, typ token2.TokenType, value uint64, recipient view.Identity, deadline time.Duration, opts ...token.TransferOption) ([]byte, error) {
+func (t *Transaction) Lock(wallet *token.OwnerWallet, sender view.Identity, typ token2.Type, value uint64, recipient view.Identity, deadline time.Duration, opts ...token.TransferOption) ([]byte, error) {
 	options, err := compileTransferOptions(opts...)
 	if err != nil {
 		return nil, err

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -127,7 +127,7 @@ func (t *Transaction) Outputs() (*OutputStream, error) {
 }
 
 // Lock appends a lock action to the token request of the transaction
-func (t *Transaction) Lock(wallet *token.OwnerWallet, sender view.Identity, typ string, value uint64, recipient view.Identity, deadline time.Duration, opts ...token.TransferOption) ([]byte, error) {
+func (t *Transaction) Lock(wallet *token.OwnerWallet, sender view.Identity, typ token2.TokenType, value uint64, recipient view.Identity, deadline time.Duration, opts ...token.TransferOption) ([]byte, error) {
 	options, err := compileTransferOptions(opts...)
 	if err != nil {
 		return nil, err

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -26,7 +26,7 @@ type Vault interface {
 
 type QueryEngine interface {
 	// UnspentTokensIteratorBy returns an iterator over all unspent tokens by type and id. Type can be empty
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.Type) (driver.UnspentTokensIterator, error)
 }
 
 type TokenVault interface {
@@ -269,7 +269,7 @@ func (w *OwnerWallet) deleteTokens(context view.Context, tokens []*token2.Unspen
 	return nil
 }
 
-func (w *OwnerWallet) filter(tokenType token2.TokenType, sender bool, selector SelectFunction) (*token2.UnspentTokens, error) {
+func (w *OwnerWallet) filter(tokenType token2.Type, sender bool, selector SelectFunction) (*token2.UnspentTokens, error) {
 	it, err := w.filterIterator(tokenType, sender, selector)
 	if err != nil {
 		return nil, errors.Wrap(err, "token selection failed")
@@ -291,7 +291,7 @@ func (w *OwnerWallet) filter(tokenType token2.TokenType, sender bool, selector S
 	return &token2.UnspentTokens{Tokens: tokens}, nil
 }
 
-func (w *OwnerWallet) filterIterator(tokenType token2.TokenType, sender bool, selector SelectFunction) (*FilteredIterator, error) {
+func (w *OwnerWallet) filterIterator(tokenType token2.Type, sender bool, selector SelectFunction) (*FilteredIterator, error) {
 	var walletID string
 	if sender {
 		walletID = senderWallet(w.wallet)

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -26,7 +26,7 @@ type Vault interface {
 
 type QueryEngine interface {
 	// UnspentTokensIteratorBy returns an iterator over all unspent tokens by type and id. Type can be empty
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
 }
 
 type TokenVault interface {
@@ -269,7 +269,7 @@ func (w *OwnerWallet) deleteTokens(context view.Context, tokens []*token2.Unspen
 	return nil
 }
 
-func (w *OwnerWallet) filter(tokenType string, sender bool, selector SelectFunction) (*token2.UnspentTokens, error) {
+func (w *OwnerWallet) filter(tokenType token2.TokenType, sender bool, selector SelectFunction) (*token2.UnspentTokens, error) {
 	it, err := w.filterIterator(tokenType, sender, selector)
 	if err != nil {
 		return nil, errors.Wrap(err, "token selection failed")
@@ -291,7 +291,7 @@ func (w *OwnerWallet) filter(tokenType string, sender bool, selector SelectFunct
 	return &token2.UnspentTokens{Tokens: tokens}, nil
 }
 
-func (w *OwnerWallet) filterIterator(tokenType string, sender bool, selector SelectFunction) (*FilteredIterator, error) {
+func (w *OwnerWallet) filterIterator(tokenType token2.TokenType, sender bool, selector SelectFunction) (*FilteredIterator, error) {
 	var walletID string
 	if sender {
 		walletID = senderWallet(w.wallet)

--- a/token/services/network/orion/approval.go
+++ b/token/services/network/orion/approval.go
@@ -151,7 +151,7 @@ func (r *RequestApprovalResponderView) process(context view.Context, request *Ap
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get public parameters for network [%s]", request.Network)
 	}
-	validator, err := ds.NewValidator(token.TMSID{Network: request.Network, Namespace: request.Namespace}, pp)
+	validator, err := ds.NewDefaultValidator(pp)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create validator")
 	}

--- a/token/services/nfttx/filter.go
+++ b/token/services/nfttx/filter.go
@@ -26,7 +26,7 @@ type Filter interface {
 
 type QueryService interface {
 	UnspentTokensIterator() (*token.UnspentTokensIterator, error)
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.Type) (driver.UnspentTokensIterator, error)
 	GetTokens(inputs ...*token2.ID) ([]*token2.Token, error)
 }
 

--- a/token/services/nfttx/filter.go
+++ b/token/services/nfttx/filter.go
@@ -26,7 +26,7 @@ type Filter interface {
 
 type QueryService interface {
 	UnspentTokensIterator() (*token.UnspentTokensIterator, error)
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
 	GetTokens(inputs ...*token2.ID) ([]*token2.Token, error)
 }
 

--- a/token/services/nfttx/qe.go
+++ b/token/services/nfttx/qe.go
@@ -72,7 +72,7 @@ func (s *QueryExecutor) QueryByKey(state interface{}, key string, value string) 
 		}
 		if q.Cmp(token2.NewOneQuantity(s.precision)) == 0 {
 			// this is the token
-			decoded, err := base64.StdEncoding.DecodeString(t.Type)
+			decoded, err := base64.StdEncoding.DecodeString(string(t.Type))
 			if err != nil {
 				return errors.Wrap(err, "failed to decode type")
 			}
@@ -90,7 +90,7 @@ type jsonFilter struct {
 }
 
 func (j *jsonFilter) ContainsToken(token *token2.UnspentToken) bool {
-	decoded, err := base64.StdEncoding.DecodeString(token.Type)
+	decoded, err := base64.StdEncoding.DecodeString(string(token.Type))
 	if err != nil {
 		logger.Debugf("failed to decode token type [%s]", token.Type)
 		return false

--- a/token/services/nfttx/qe_test.go
+++ b/token/services/nfttx/qe_test.go
@@ -31,7 +31,7 @@ func TestJsonFilter(t *testing.T) {
 	raw, err := json.Marshal(h)
 	assert.NoError(t, err, "json marshal failed")
 	tok := &token2.UnspentToken{
-		Type: base64.StdEncoding.EncodeToString(raw),
+		Type: token2.TokenType(base64.StdEncoding.EncodeToString(raw)),
 	}
 
 	// hit

--- a/token/services/nfttx/qe_test.go
+++ b/token/services/nfttx/qe_test.go
@@ -31,7 +31,7 @@ func TestJsonFilter(t *testing.T) {
 	raw, err := json.Marshal(h)
 	assert.NoError(t, err, "json marshal failed")
 	tok := &token2.UnspentToken{
-		Type: token2.TokenType(base64.StdEncoding.EncodeToString(raw)),
+		Type: token2.Type(base64.StdEncoding.EncodeToString(raw)),
 	}
 
 	// hit

--- a/token/services/nfttx/streams.go
+++ b/token/services/nfttx/streams.go
@@ -29,7 +29,7 @@ func (o *OutputStream) ByRecipient(id view.Identity) *OutputStream {
 	return &OutputStream{OutputStream: o.OutputStream.ByRecipient(id)}
 }
 
-func (o *OutputStream) ByType(typ string) *OutputStream {
+func (o *OutputStream) ByType(typ token2.TokenType) *OutputStream {
 	return &OutputStream{OutputStream: o.OutputStream.ByType(typ)}
 }
 
@@ -39,7 +39,7 @@ func (o *OutputStream) ByEnrollmentID(id string) *OutputStream {
 
 func (o *OutputStream) StateAt(index int, state interface{}) error {
 	output := o.OutputStream.At(index)
-	decoded, err := base64.StdEncoding.DecodeString(output.Type)
+	decoded, err := base64.StdEncoding.DecodeString(string(output.Type))
 	if err != nil {
 		return errors.Wrap(err, "failed to decode type")
 	}

--- a/token/services/nfttx/streams.go
+++ b/token/services/nfttx/streams.go
@@ -29,7 +29,7 @@ func (o *OutputStream) ByRecipient(id view.Identity) *OutputStream {
 	return &OutputStream{OutputStream: o.OutputStream.ByRecipient(id)}
 }
 
-func (o *OutputStream) ByType(typ token2.TokenType) *OutputStream {
+func (o *OutputStream) ByType(typ token2.Type) *OutputStream {
 	return &OutputStream{OutputStream: o.OutputStream.ByType(typ)}
 }
 

--- a/token/services/nfttx/transaction.go
+++ b/token/services/nfttx/transaction.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/marshaller"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
@@ -87,7 +88,7 @@ func (t *Transaction) Issue(wallet *token.IssuerWallet, state interface{}, recip
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal state")
 	}
-	stateJSONStr := base64.StdEncoding.EncodeToString(stateJSON)
+	stateJSONStr := token2.TokenType(base64.StdEncoding.EncodeToString(stateJSON))
 
 	// Issue
 	return t.Transaction.Issue(wallet, recipient, stateJSONStr, 1, opts...)
@@ -99,7 +100,7 @@ func (t *Transaction) Transfer(wallet *OwnerWallet, state interface{}, recipient
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal state")
 	}
-	stateJSONStr := base64.StdEncoding.EncodeToString(stateJSON)
+	stateJSONStr := token2.TokenType(base64.StdEncoding.EncodeToString(stateJSON))
 
 	return t.Transaction.Transfer(wallet.OwnerWallet, stateJSONStr, []uint64{1}, []view.Identity{recipient}, opts...)
 }

--- a/token/services/nfttx/transaction.go
+++ b/token/services/nfttx/transaction.go
@@ -88,7 +88,7 @@ func (t *Transaction) Issue(wallet *token.IssuerWallet, state interface{}, recip
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal state")
 	}
-	stateJSONStr := token2.TokenType(base64.StdEncoding.EncodeToString(stateJSON))
+	stateJSONStr := token2.Type(base64.StdEncoding.EncodeToString(stateJSON))
 
 	// Issue
 	return t.Transaction.Issue(wallet, recipient, stateJSONStr, 1, opts...)
@@ -100,7 +100,7 @@ func (t *Transaction) Transfer(wallet *OwnerWallet, state interface{}, recipient
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal state")
 	}
-	stateJSONStr := token2.TokenType(base64.StdEncoding.EncodeToString(stateJSON))
+	stateJSONStr := token2.Type(base64.StdEncoding.EncodeToString(stateJSON))
 
 	return t.Transaction.Transfer(wallet.OwnerWallet, stateJSONStr, []uint64{1}, []view.Identity{recipient}, opts...)
 }

--- a/token/services/nfttx/wallet.go
+++ b/token/services/nfttx/wallet.go
@@ -9,6 +9,7 @@ package nfttx
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +29,7 @@ func (o *OwnerWallet) QueryByKey(state interface{}, key string, value string) er
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType string) token.ListTokensOption {
+func WithType(tokenType token2.TokenType) token.ListTokensOption {
 	return func(o *token.ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil

--- a/token/services/nfttx/wallet.go
+++ b/token/services/nfttx/wallet.go
@@ -29,7 +29,7 @@ func (o *OwnerWallet) QueryByKey(state interface{}, key string, value string) er
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType token2.TokenType) token.ListTokensOption {
+func WithType(tokenType token2.Type) token.ListTokensOption {
 	return func(o *token.ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil

--- a/token/services/selector/benchmark_test.go
+++ b/token/services/selector/benchmark_test.go
@@ -36,7 +36,7 @@ type extendedSelector struct {
 	Lock     Locker
 }
 
-func (s *extendedSelector) Select(ownerFilter token.OwnerFilter, q, tokenType string) ([]*token2.ID, token2.Quantity, error) {
+func (s *extendedSelector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
 	return s.Selector.Select(ownerFilter, q, tokenType)
 }
 func (s *extendedSelector) Close() error { return s.Selector.Close() }

--- a/token/services/selector/benchmark_test.go
+++ b/token/services/selector/benchmark_test.go
@@ -36,7 +36,7 @@ type extendedSelector struct {
 	Lock     Locker
 }
 
-func (s *extendedSelector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
+func (s *extendedSelector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	return s.Selector.Select(ownerFilter, q, tokenType)
 }
 func (s *extendedSelector) Close() error { return s.Selector.Close() }

--- a/token/services/selector/sherdlock/fetcher.go
+++ b/token/services/selector/sherdlock/fetcher.go
@@ -26,11 +26,11 @@ const (
 )
 
 type tokenFetcher interface {
-	UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error)
+	UnspentTokensIteratorBy(walletID string, currency token2.Type) (iterator[*token2.UnspentTokenInWallet], error)
 }
 
 type TokenDB interface {
-	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.TokenType) (driver.SpendableTokensIterator, error)
+	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.Type) (driver.SpendableTokensIterator, error)
 }
 
 type enhancedIterator[T any] interface {
@@ -115,7 +115,7 @@ func newMixedFetcher(tokenDB TokenDB, m *Metrics) *mixedFetcher {
 	}
 }
 
-func (f *mixedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *mixedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.Type) (iterator[*token2.UnspentTokenInWallet], error) {
 	logger.Debugf("call unspent tokens iterator")
 	it, err := f.eagerFetcher.UnspentTokensIteratorBy(walletID, currency)
 	logger.Debugf("fetched eager iterator")
@@ -139,7 +139,7 @@ func NewLazyFetcher(tokenDB TokenDB) *lazyFetcher {
 	return &lazyFetcher{tokenDB: tokenDB}
 }
 
-func (f *lazyFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *lazyFetcher) UnspentTokensIteratorBy(walletID string, currency token2.Type) (iterator[*token2.UnspentTokenInWallet], error) {
 	logger.Debugf("Query the DB for new tokens")
 	it, err := f.tokenDB.SpendableTokensIteratorBy(context.TODO(), walletID, currency)
 	if err != nil {
@@ -203,7 +203,7 @@ func (f *cachedFetcher) update() {
 	atomic.StoreUint32(&f.queriesResponded, 0)
 }
 
-func (f *cachedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *cachedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.Type) (iterator[*token2.UnspentTokenInWallet], error) {
 	defer atomic.AddUint32(&f.queriesResponded, 1)
 	if f.isCacheOverused() {
 		logger.Debugf("Overused data. Soft refresh (in the background)...")

--- a/token/services/selector/sherdlock/fetcher.go
+++ b/token/services/selector/sherdlock/fetcher.go
@@ -26,11 +26,11 @@ const (
 )
 
 type tokenFetcher interface {
-	UnspentTokensIteratorBy(walletID, currency string) (iterator[*token2.UnspentTokenInWallet], error)
+	UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error)
 }
 
 type TokenDB interface {
-	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ string) (driver.SpendableTokensIterator, error)
+	SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.TokenType) (driver.SpendableTokensIterator, error)
 }
 
 type enhancedIterator[T any] interface {
@@ -115,7 +115,7 @@ func newMixedFetcher(tokenDB TokenDB, m *Metrics) *mixedFetcher {
 	}
 }
 
-func (f *mixedFetcher) UnspentTokensIteratorBy(walletID, currency string) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *mixedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
 	logger.Debugf("call unspent tokens iterator")
 	it, err := f.eagerFetcher.UnspentTokensIteratorBy(walletID, currency)
 	logger.Debugf("fetched eager iterator")
@@ -139,7 +139,7 @@ func NewLazyFetcher(tokenDB TokenDB) *lazyFetcher {
 	return &lazyFetcher{tokenDB: tokenDB}
 }
 
-func (f *lazyFetcher) UnspentTokensIteratorBy(walletID, currency string) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *lazyFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
 	logger.Debugf("Query the DB for new tokens")
 	it, err := f.tokenDB.SpendableTokensIteratorBy(context.TODO(), walletID, currency)
 	if err != nil {
@@ -203,7 +203,7 @@ func (f *cachedFetcher) update() {
 	atomic.StoreUint32(&f.queriesResponded, 0)
 }
 
-func (f *cachedFetcher) UnspentTokensIteratorBy(walletID, currency string) (iterator[*token2.UnspentTokenInWallet], error) {
+func (f *cachedFetcher) UnspentTokensIteratorBy(walletID string, currency token2.TokenType) (iterator[*token2.UnspentTokenInWallet], error) {
 	defer atomic.AddUint32(&f.queriesResponded, 1)
 	if f.isCacheOverused() {
 		logger.Debugf("Overused data. Soft refresh (in the background)...")

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -58,7 +58,7 @@ type stubbornSelector struct {
 	maxRetriesAfterBackoff int
 }
 
-func (m *stubbornSelector) Select(owner token.OwnerFilter, q string, currency token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
+func (m *stubbornSelector) Select(owner token.OwnerFilter, q string, currency token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	for retriesAfterBackoff := 0; retriesAfterBackoff <= m.maxRetriesAfterBackoff; retriesAfterBackoff++ {
 		if tokens, quantity, err := m.selector.Select(owner, q, currency); err == nil || !errors.Is(err, token.SelectorSufficientButLockedFunds) {
 			return tokens, quantity, err
@@ -89,7 +89,7 @@ func NewSelector(logger logging.Logger, tokenDB tokenFetcher, lockDB tokenLocker
 	}
 }
 
-func (s *selector) Select(owner token.OwnerFilter, q string, currency token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) Select(owner token.OwnerFilter, q string, currency token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	if s.isClosed() {
 		return nil, nil, errors.Errorf("selector is already closed")
 	}
@@ -172,7 +172,7 @@ func (s *selector) UnlockAll() error {
 	return s.locker.UnlockAll()
 }
 
-func tokenKey(walletID string, typ token2.TokenType) string {
+func tokenKey(walletID string, typ token2.Type) string {
 	return fmt.Sprintf("%s.%s", walletID, typ)
 }
 

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -58,7 +58,7 @@ type stubbornSelector struct {
 	maxRetriesAfterBackoff int
 }
 
-func (m *stubbornSelector) Select(owner token.OwnerFilter, q, currency string) ([]*token2.ID, token2.Quantity, error) {
+func (m *stubbornSelector) Select(owner token.OwnerFilter, q string, currency token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
 	for retriesAfterBackoff := 0; retriesAfterBackoff <= m.maxRetriesAfterBackoff; retriesAfterBackoff++ {
 		if tokens, quantity, err := m.selector.Select(owner, q, currency); err == nil || !errors.Is(err, token.SelectorSufficientButLockedFunds) {
 			return tokens, quantity, err
@@ -89,7 +89,7 @@ func NewSelector(logger logging.Logger, tokenDB tokenFetcher, lockDB tokenLocker
 	}
 }
 
-func (s *selector) Select(owner token.OwnerFilter, q, currency string) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) Select(owner token.OwnerFilter, q string, currency token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
 	if s.isClosed() {
 		return nil, nil, errors.Errorf("selector is already closed")
 	}
@@ -172,7 +172,7 @@ func (s *selector) UnlockAll() error {
 	return s.locker.UnlockAll()
 }
 
-func tokenKey(walletID, typ string) string {
+func tokenKey(walletID string, typ token2.TokenType) string {
 	return fmt.Sprintf("%s.%s", walletID, typ)
 }
 

--- a/token/services/selector/simple/selector.go
+++ b/token/services/selector/simple/selector.go
@@ -19,7 +19,7 @@ import (
 
 type QueryService interface {
 	UnspentTokensIterator() (*token.UnspentTokensIterator, error)
-	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.Type) (driver.UnspentTokensIterator, error)
 	GetTokens(inputs ...*token2.ID) ([]*token2.Token, error)
 }
 
@@ -44,7 +44,7 @@ type selector struct {
 }
 
 // Select selects tokens to be spent based on ownership, quantity, and type
-func (s *selector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	if ownerFilter == nil || len(ownerFilter.ID()) == 0 {
 		return nil, nil, errors.Errorf("no owner filter specified")
 	}
@@ -58,7 +58,7 @@ func (s *selector) concurrencyCheck(ids []*token2.ID) error {
 	return err
 }
 
-func (s *selector) selectByID(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) selectByID(ownerFilter token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	var toBeSpent []*token2.ID
 	var sum token2.Quantity
 	var potentialSumWithLocked token2.Quantity

--- a/token/services/selector/simple/selector.go
+++ b/token/services/selector/simple/selector.go
@@ -19,7 +19,7 @@ import (
 
 type QueryService interface {
 	UnspentTokensIterator() (*token.UnspentTokensIterator, error)
-	UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error)
+	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error)
 	GetTokens(inputs ...*token2.ID) ([]*token2.Token, error)
 }
 
@@ -44,7 +44,7 @@ type selector struct {
 }
 
 // Select selects tokens to be spent based on ownership, quantity, and type
-func (s *selector) Select(ownerFilter token.OwnerFilter, q, tokenType string) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) Select(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
 	if ownerFilter == nil || len(ownerFilter.ID()) == 0 {
 		return nil, nil, errors.Errorf("no owner filter specified")
 	}
@@ -58,7 +58,7 @@ func (s *selector) concurrencyCheck(ids []*token2.ID) error {
 	return err
 }
 
-func (s *selector) selectByID(ownerFilter token.OwnerFilter, q string, tokenType string) ([]*token2.ID, token2.Quantity, error) {
+func (s *selector) selectByID(ownerFilter token.OwnerFilter, q string, tokenType token2.TokenType) ([]*token2.ID, token2.Quantity, error) {
 	var toBeSpent []*token2.ID
 	var sum token2.Quantity
 	var potentialSumWithLocked token2.Quantity

--- a/token/services/selector/simple/service.go
+++ b/token/services/selector/simple/service.go
@@ -68,7 +68,7 @@ func (q *queryService) UnspentTokensIterator() (*token.UnspentTokensIterator, er
 	return q.qe.UnspentTokensIterator()
 }
 
-func (q *queryService) UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error) {
+func (q *queryService) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error) {
 	return q.qe.UnspentTokensIteratorBy(ctx, id, tokenType)
 }
 

--- a/token/services/selector/simple/service.go
+++ b/token/services/selector/simple/service.go
@@ -68,7 +68,7 @@ func (q *queryService) UnspentTokensIterator() (*token.UnspentTokensIterator, er
 	return q.qe.UnspentTokensIterator()
 }
 
-func (q *queryService) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.TokenType) (driver.UnspentTokensIterator, error) {
+func (q *queryService) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token2.Type) (driver.UnspentTokensIterator, error) {
 	return q.qe.UnspentTokensIteratorBy(ctx, id, tokenType)
 }
 

--- a/token/services/selector/testutils/test_cases.go
+++ b/token/services/selector/testutils/test_cases.go
@@ -146,7 +146,7 @@ func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.Unspen
 	}
 	if len(deleted) > 0 {
 		for _, t := range deleted {
-			if err := tx.Delete(t.TxId, t.Index, "me"); err != nil {
+			if err := tx.Delete(*t, "me"); err != nil {
 				err2 := tx.Rollback()
 				return errors.Wrapf(err, "failed to delete - while rolling back: %v", err2)
 			}

--- a/token/services/selector/testutils/test_cases.go
+++ b/token/services/selector/testutils/test_cases.go
@@ -146,7 +146,7 @@ func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.Unspen
 	}
 	if len(deleted) > 0 {
 		for _, t := range deleted {
-			if err := tx.Delete(context.TODO(), t.TxId, t.Index, "me"); err != nil {
+			if err := tx.Delete(t.TxId, t.Index, "me"); err != nil {
 				err2 := tx.Rollback()
 				return errors.Wrapf(err, "failed to delete - while rolling back: %v", err2)
 			}
@@ -154,7 +154,7 @@ func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.Unspen
 	}
 	if len(added) > 0 {
 		for _, t := range added {
-			if err := tx.StoreToken(context.TODO(), driver.TokenRecord{
+			if err := tx.StoreToken(driver.TokenRecord{
 				TxID:           t.Id.TxId,
 				Index:          t.Id.Index,
 				IssuerRaw:      []byte{},

--- a/token/services/selector/testutils/test_cases.go
+++ b/token/services/selector/testutils/test_cases.go
@@ -140,13 +140,13 @@ func (m *enhancedManager) TokenSum() (token.Quantity, error) {
 }
 
 func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.UnspentToken) error {
-	tx, err := m.tokenDB.NewTokenDBTransaction(context.TODO())
+	tx, err := m.tokenDB.NewTokenDBTransaction()
 	if err != nil {
 		return err
 	}
 	if len(deleted) > 0 {
 		for _, t := range deleted {
-			if err := tx.Delete(*t, "me"); err != nil {
+			if err := tx.Delete(context.TODO(), *t, "me"); err != nil {
 				err2 := tx.Rollback()
 				return errors.Wrapf(err, "failed to delete - while rolling back: %v", err2)
 			}
@@ -154,7 +154,7 @@ func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.Unspen
 	}
 	if len(added) > 0 {
 		for _, t := range added {
-			if err := tx.StoreToken(driver.TokenRecord{
+			if err := tx.StoreToken(context.TODO(), driver.TokenRecord{
 				TxID:           t.Id.TxId,
 				Index:          t.Id.Index,
 				IssuerRaw:      []byte{},

--- a/token/services/selector/testutils/testutils.go
+++ b/token/services/selector/testutils/testutils.go
@@ -126,7 +126,7 @@ func (q *MockQueryService) UnspentTokensIterator() (*token.UnspentTokensIterator
 	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.allKeys, 0}}, nil
 }
 
-func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.TokenType) (driver.SpendableTokensIterator, error) {
+func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.Type) (driver.SpendableTokensIterator, error) {
 	it, err := q.UnspentTokensIteratorBy(ctx, walletID, typ)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, wallet
 	}), nil
 }
 
-func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, walletID string, _ token2.TokenType) (driver.UnspentTokensIterator, error) {
+func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, walletID string, _ token2.Type) (driver.UnspentTokensIterator, error) {
 	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.cache[walletID], 0}}, nil
 }
 

--- a/token/services/selector/testutils/testutils.go
+++ b/token/services/selector/testutils/testutils.go
@@ -126,12 +126,12 @@ func (q *MockQueryService) UnspentTokensIterator() (*token.UnspentTokensIterator
 	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.allKeys, 0}}, nil
 }
 
-func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, walletID string, typ string) (driver.SpendableTokensIterator, error) {
+func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, walletID string, typ token2.TokenType) (driver.SpendableTokensIterator, error) {
 	it, err := q.UnspentTokensIteratorBy(ctx, walletID, typ)
 	if err != nil {
 		return nil, err
 	}
-	return collections.Map(it, func(ut *token2.UnspentToken) (*token2.UnspentTokenInWallet, error) {
+	return collections.Map[*token2.UnspentToken, *token2.UnspentTokenInWallet](it, func(ut *token2.UnspentToken) (*token2.UnspentTokenInWallet, error) {
 		return &token2.UnspentTokenInWallet{
 			Id:       ut.Id,
 			WalletID: string(ut.Owner),
@@ -141,7 +141,7 @@ func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, wallet
 	}), nil
 }
 
-func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, walletID, _ string) (driver.UnspentTokensIterator, error) {
+func (q *MockQueryService) UnspentTokensIteratorBy(_ context.Context, walletID string, _ token2.TokenType) (driver.UnspentTokensIterator, error) {
 	return &token.UnspentTokensIterator{UnspentTokensIterator: &MockIterator{q, q.cache[walletID], 0}}, nil
 }
 

--- a/token/services/tokendb/db.go
+++ b/token/services/tokendb/db.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package tokendb
 
 import (
-	"context"
 	"reflect"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -61,8 +60,8 @@ type DB struct {
 	driver.TokenDB
 }
 
-func (d *DB) NewTransaction(ctx context.Context) (*Transaction, error) {
-	tx, err := d.TokenDB.NewTokenDBTransaction(ctx)
+func (d *DB) NewTransaction() (*Transaction, error) {
+	tx, err := d.TokenDB.NewTokenDBTransaction()
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/tokens/core/comm/token.go
+++ b/token/services/tokens/core/comm/token.go
@@ -1,0 +1,70 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package comm
+
+import (
+	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/driver"
+)
+
+const (
+	Type driver.Type = 2
+)
+
+// Token encodes Type, Value, Owner
+type Token struct {
+	// Owner is the owner of the token
+	Owner []byte
+	// Data is the Pedersen commitment to type and value
+	Data *math.G1
+}
+
+// Metadata contains the metadata of a token
+type Metadata struct {
+	// Type is the type of the token
+	Type string
+	// Value is the quantity of the token
+	Value *math.Zr
+	// BlindingFactor is the blinding factor used to commit type and value
+	BlindingFactor *math.Zr
+	// Owner is the owner of the token
+	Owner []byte
+	// Issuer is the issuer of the token, if defined
+	Issuer []byte
+}
+
+func WrapTokenWithType(token driver.Token) (driver.Token, error) {
+	return tokens.WrapWithType(Type, token)
+}
+
+func UnmarshalTypedToken(token driver.Token) (*tokens.TypedToken, error) {
+	ttoken, err := tokens.UnmarshalTypedToken(token)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshalling token")
+	}
+	if ttoken.Type != Type {
+		return nil, errors.Errorf("invalid token type [%v]", ttoken.Type)
+	}
+	return ttoken, nil
+}
+
+func WrapMetadataWithType(metadata driver.Metadata) (driver.Metadata, error) {
+	return tokens.WrapMetadataWithType(Type, metadata)
+}
+
+func UnmarshalTypedMetadata(metadata driver.Metadata) (*tokens.TypedMetadata, error) {
+	tmetadata, err := tokens.UnmarshalTypedMetadata(metadata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshalling metadata")
+	}
+	if tmetadata.Type != Type {
+		return nil, errors.Errorf("invalid metadata type [%v]", tmetadata.Type)
+	}
+	return tmetadata, nil
+}

--- a/token/services/tokens/core/comm/token.go
+++ b/token/services/tokens/core/comm/token.go
@@ -29,7 +29,7 @@ type Token struct {
 // Metadata contains the metadata of a token
 type Metadata struct {
 	// Type is the type of the token
-	Type token2.TokenType
+	Type token2.Type
 	// Value is the quantity of the token
 	Value *math.Zr
 	// BlindingFactor is the blinding factor used to commit type and value

--- a/token/services/tokens/core/comm/token.go
+++ b/token/services/tokens/core/comm/token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/driver"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 const (
@@ -28,7 +29,7 @@ type Token struct {
 // Metadata contains the metadata of a token
 type Metadata struct {
 	// Type is the type of the token
-	Type string
+	Type token2.TokenType
 	// Value is the quantity of the token
 	Value *math.Zr
 	// BlindingFactor is the blinding factor used to commit type and value

--- a/token/services/tokens/core/fabtoken/token.go
+++ b/token/services/tokens/core/fabtoken/token.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fabtoken
+
+import (
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/driver"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/pkg/errors"
+)
+
+const (
+	Type driver.Type = 1
+)
+
+// Token carries the output of an action
+type Token = token2.Token
+
+// Metadata contains a serialization of the issuer of the token..
+// Type, value and owner of token can be derived from the token itself.
+type Metadata struct {
+	Issuer []byte
+}
+
+func WrapTokenWithType(token driver.Token) (driver.Token, error) {
+	return tokens.WrapWithType(Type, token)
+}
+
+func UnmarshalTypedToken(token driver.Token) (*tokens.TypedToken, error) {
+	ttoken, err := tokens.UnmarshalTypedToken(token)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshalling token")
+	}
+	if ttoken.Type != Type {
+		return nil, errors.Errorf("invalid token type [%v]", ttoken.Type)
+	}
+	return ttoken, nil
+}
+
+func WrapMetadataWithType(metadata driver.Metadata) (driver.Metadata, error) {
+	return tokens.WrapMetadataWithType(Type, metadata)
+}
+
+func UnmarshalTypedMetadata(metadata driver.Metadata) (*tokens.TypedMetadata, error) {
+	tmetadata, err := tokens.UnmarshalTypedMetadata(metadata)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshalling metadata")
+	}
+	if tmetadata.Type != Type {
+		return nil, errors.Errorf("invalid metadata type [%v]", tmetadata.Type)
+	}
+	return tmetadata, nil
+}

--- a/token/services/tokens/driver/token.go
+++ b/token/services/tokens/driver/token.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"bytes"
+	"encoding/base64"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
+)
+
+type (
+	Type = int32
+)
+
+// Token wraps the byte representation of a lower level token.
+type Token []byte
+
+// Equal return true if the identities are the same
+func (id Token) Equal(id2 Token) bool {
+	return bytes.Equal(id, id2)
+}
+
+// UniqueID returns a unique identifier of this token
+func (id Token) UniqueID() string {
+	if len(id) == 0 {
+		return "<empty>"
+	}
+	return base64.StdEncoding.EncodeToString(utils.MustGet(utils.SHA256(id)))
+}
+
+// Hash returns the hash of this token
+func (id Token) Hash() string {
+	if len(id) == 0 {
+		return "<empty>"
+	}
+	return string(utils.MustGet(utils.SHA256(id)))
+}
+
+// String returns a string representation of this token
+func (id Token) String() string {
+	return id.UniqueID()
+}
+
+// Bytes returns the byte representation of this token
+func (id Token) Bytes() []byte {
+	return id
+}
+
+// IsNone returns true if this token is empty
+func (id Token) IsNone() bool {
+	return len(id) == 0
+}
+
+// Metadata wraps the byte representation of a lower level metadata.
+type Metadata []byte
+
+// Equal return true if the identities are the same
+func (id Metadata) Equal(id2 Metadata) bool {
+	return bytes.Equal(id, id2)
+}
+
+// UniqueID returns a unique identifier of this metadata
+func (id Metadata) UniqueID() string {
+	if len(id) == 0 {
+		return "<empty>"
+	}
+	return base64.StdEncoding.EncodeToString(utils.MustGet(utils.SHA256(id)))
+}
+
+// Hash returns the hash of this metadata
+func (id Metadata) Hash() string {
+	if len(id) == 0 {
+		return "<empty>"
+	}
+	return string(utils.MustGet(utils.SHA256(id)))
+}
+
+// String returns a string representation of this metadata
+func (id Metadata) String() string {
+	return id.UniqueID()
+}
+
+// Bytes returns the byte representation of this metadata
+func (id Metadata) Bytes() []byte {
+	return id
+}
+
+// IsNone returns true if this metadata is empty
+func (id Metadata) IsNone() bool {
+	return len(id) == 0
+}

--- a/token/services/tokens/manager.go
+++ b/token/services/tokens/manager.go
@@ -79,8 +79,9 @@ func (cm *Manager) newTokens(tmsID token.TMSID) (*Tokens, error) {
 		return nil, errors.WithMessagef(err, "failed to get token store for [%s]", tmsID)
 	}
 	tokens := &Tokens{
-		TMSProvider: cm.tmsProvider,
-		Storage:     storage, RequestsCache: secondcache.NewTyped[*CacheEntry](1000),
+		TMSProvider:   cm.tmsProvider,
+		Storage:       storage,
+		RequestsCache: secondcache.NewTyped[*CacheEntry](1000),
 	}
 	return tokens, nil
 }

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -64,7 +64,7 @@ type TokenToAppend struct {
 	txID                  string
 	index                 uint64
 	tok                   *token2.Token
-	tokenOnLedgerType     token2.TokenFormat
+	tokenOnLedgerType     token2.Format
 	tokenOnLedger         []byte
 	tokenOnLedgerMetadata []byte
 	ownerType             string
@@ -168,7 +168,7 @@ func (t *transaction) AppendToken(ctx context.Context, tta TokenToAppend) error 
 	return nil
 }
 
-func (t *transaction) Notify(topic string, tmsID token.TMSID, walletID string, tokenType token2.TokenType, txID string, index uint64) {
+func (t *transaction) Notify(topic string, tmsID token.TMSID, walletID string, tokenType token2.Type, txID string, index uint64) {
 	if t.notifier == nil {
 		logger.Warnf("cannot notify others!")
 		return
@@ -205,7 +205,7 @@ func (t *transaction) SetSpendableFlag(ctx context.Context, value bool, ids []*t
 	return nil
 }
 
-func (t *transaction) SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokens []token2.TokenFormat) error {
+func (t *transaction) SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokens []token2.Format) error {
 	return t.tx.SetSpendableBySupportedTokenTypes(ctx, supportedTokens)
 }
 
@@ -224,7 +224,7 @@ func NewTokenProcessorEvent(topic string, message *TokenMessage) *TokenProcessor
 type TokenMessage struct {
 	TMSID     token.TMSID
 	WalletID  string
-	TokenType token2.TokenType
+	TokenType token2.Type
 	TxID      string
 	Index     uint64
 }

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -207,8 +207,8 @@ func (t *transaction) SetSpendableFlag(value bool, ids []*token2.ID) error {
 	return nil
 }
 
-func (t *transaction) SetSupportedTokens(supportedTokens []string) error {
-	return t.tx.SetSupportedTokens(supportedTokens)
+func (t *transaction) SetSpendableBySupportedTokenTypes(supportedTokens []string) error {
+	return t.tx.SetSpendableBySupportedTokenTypes(supportedTokens)
 }
 
 type TokenProcessorEvent struct {

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -64,7 +64,7 @@ type TokenToAppend struct {
 	txID                  string
 	index                 uint64
 	tok                   *token2.Token
-	tokenOnLedgerType     string
+	tokenOnLedgerType     token2.TokenType
 	tokenOnLedger         []byte
 	tokenOnLedgerMetadata []byte
 	ownerType             string
@@ -170,7 +170,7 @@ func (t *transaction) AppendToken(tta TokenToAppend) error {
 	return nil
 }
 
-func (t *transaction) Notify(topic string, tmsID token.TMSID, walletID, tokenType, txID string, index uint64) {
+func (t *transaction) Notify(topic string, tmsID token.TMSID, walletID string, tokenType token2.TokenType, txID string, index uint64) {
 	if t.notifier == nil {
 		logger.Warnf("cannot notify others!")
 		return
@@ -226,7 +226,7 @@ func NewTokenProcessorEvent(topic string, message *TokenMessage) *TokenProcessor
 type TokenMessage struct {
 	TMSID     token.TMSID
 	WalletID  string
-	TokenType string
+	TokenType token2.TokenType
 	TxID      string
 	Index     uint64
 }

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -207,7 +207,7 @@ func (t *transaction) SetSpendableFlag(value bool, ids []*token2.ID) error {
 	return nil
 }
 
-func (t *transaction) SetSpendableBySupportedTokenTypes(supportedTokens []string) error {
+func (t *transaction) SetSpendableBySupportedTokenTypes(supportedTokens []token2.TokenType) error {
 	return t.tx.SetSpendableBySupportedTokenTypes(supportedTokens)
 }
 

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -64,7 +64,7 @@ type TokenToAppend struct {
 	txID                  string
 	index                 uint64
 	tok                   *token2.Token
-	tokenOnLedgerType     token2.Format
+	tokenOnLedgerFormat   token2.Format
 	tokenOnLedger         []byte
 	tokenOnLedgerMetadata []byte
 	ownerType             string
@@ -144,7 +144,7 @@ func (t *transaction) AppendToken(ctx context.Context, tta TokenToAppend) error 
 		OwnerIdentity:  tta.ownerIdentity,
 		OwnerWalletID:  tta.ownerWalletID,
 		Ledger:         tta.tokenOnLedger,
-		LedgerType:     tta.tokenOnLedgerType,
+		LedgerFormat:   tta.tokenOnLedgerFormat,
 		LedgerMetadata: tta.tokenOnLedgerMetadata,
 		Quantity:       tta.tok.Quantity,
 		Type:           tta.tok.Type,
@@ -206,7 +206,7 @@ func (t *transaction) SetSpendableFlag(ctx context.Context, value bool, ids []*t
 }
 
 func (t *transaction) SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokens []token2.Format) error {
-	return t.tx.SetSpendableBySupportedTokenTypes(ctx, supportedTokens)
+	return t.tx.SetSpendableBySupportedTokenFormats(ctx, supportedTokens)
 }
 
 type TokenProcessorEvent struct {

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -64,7 +64,7 @@ type TokenToAppend struct {
 	txID                  string
 	index                 uint64
 	tok                   *token2.Token
-	tokenOnLedgerType     token2.TokenType
+	tokenOnLedgerType     token2.TokenFormat
 	tokenOnLedger         []byte
 	tokenOnLedgerMetadata []byte
 	ownerType             string
@@ -205,7 +205,7 @@ func (t *transaction) SetSpendableFlag(ctx context.Context, value bool, ids []*t
 	return nil
 }
 
-func (t *transaction) SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokens []token2.TokenType) error {
+func (t *transaction) SetSpendableBySupportedTokenTypes(ctx context.Context, supportedTokens []token2.TokenFormat) error {
 	return t.tx.SetSpendableBySupportedTokenTypes(ctx, supportedTokens)
 }
 

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -198,7 +198,7 @@ func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
 	return tx.Commit()
 }
 
-func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenType) error {
+func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenFormat) error {
 	tx, err := t.Storage.NewTransaction()
 	if err != nil {
 		return errors.WithMessagef(err, "error creating new transaction")
@@ -215,7 +215,7 @@ func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenType) err
 	return nil
 }
 
-func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.TokenType) error {
+func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.TokenFormat) error {
 	return t.Storage.tokenDB.SetSupportedTokenTypes(tokenTypes)
 }
 

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -198,12 +198,12 @@ func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
 	return tx.Commit()
 }
 
-func (t *Tokens) SetSupportedTokens(types []string) error {
+func (t *Tokens) SetSpendableBySupportedTokenTypes(types []string) error {
 	tx, err := t.Storage.NewTransaction(context.TODO())
 	if err != nil {
 		return errors.WithMessagef(err, "error creating new transaction")
 	}
-	if err := tx.SetSupportedTokens(types); err != nil {
+	if err := tx.SetSpendableBySupportedTokenTypes(types); err != nil {
 		if err2 := tx.Rollback(); err2 != nil {
 			logger.Errorf("error rolling back transaction: %v", err2)
 		}
@@ -213,6 +213,10 @@ func (t *Tokens) SetSupportedTokens(types []string) error {
 		return errors.WithMessagef(err, "error committing transaction")
 	}
 	return nil
+}
+
+func (t *Tokens) SetSupportedTokenTypes(tokenTypes []string) error {
+	return t.Storage.tokenDB.SetSupportedTokenTypes(tokenTypes)
 }
 
 func (t *Tokens) getActions(tmsID token.TMSID, txID string, request *token.Request) ([]*token2.ID, []TokenToAppend, error) {

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -198,7 +198,7 @@ func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
 	return tx.Commit()
 }
 
-func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenFormat) error {
+func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.Format) error {
 	tx, err := t.Storage.NewTransaction()
 	if err != nil {
 		return errors.WithMessagef(err, "error creating new transaction")
@@ -215,7 +215,7 @@ func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenFormat) e
 	return nil
 }
 
-func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.TokenFormat) error {
+func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.Format) error {
 	return t.Storage.tokenDB.SetSupportedTokenTypes(tokenTypes)
 }
 

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -88,7 +88,7 @@ func (t *Tokens) Append(ctx context.Context, tmsID token.TMSID, txID string, req
 
 	logger.Debugf("transaction [%s] start db transaction", txID)
 	span.AddEvent("create_new_tx")
-	ts, err := t.Storage.NewTransaction(ctx)
+	ts, err := t.Storage.NewTransaction()
 	if err != nil {
 		return errors.WithMessagef(err, "transaction [%s], failed to start db transaction", txID)
 	}
@@ -105,13 +105,13 @@ func (t *Tokens) Append(ctx context.Context, tmsID token.TMSID, txID string, req
 	}()
 	span.AddEvent("append_tokens")
 	for _, tta := range toAppend {
-		err = ts.AppendToken(tta)
+		err = ts.AppendToken(context.TODO(), tta)
 		if err != nil {
 			return errors.WithMessagef(err, "transaction [%s], failed to append token", txID)
 		}
 	}
 	span.AddEvent("delete_tokens")
-	err = ts.DeleteTokens(txID, toSpend)
+	err = ts.DeleteTokens(context.TODO(), txID, toSpend)
 	if err != nil {
 		return errors.WithMessagef(err, "transaction [%s], failed to delete tokens", txID)
 	}
@@ -185,11 +185,11 @@ func (t *Tokens) DeleteToken(deletedBy string, ids ...*token2.ID) (err error) {
 }
 
 func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
-	tx, err := t.Storage.NewTransaction(context.TODO())
+	tx, err := t.Storage.NewTransaction()
 	if err != nil {
 		return errors.Wrapf(err, "failed initiating transaction")
 	}
-	if err := tx.SetSpendableFlag(value, ids); err != nil {
+	if err := tx.SetSpendableFlag(context.TODO(), value, ids); err != nil {
 		if err2 := tx.Rollback(); err2 != nil {
 			logger.Errorf("failed rolling back transaction that set spendable flag [%s]", err2)
 		}
@@ -199,11 +199,11 @@ func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
 }
 
 func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenType) error {
-	tx, err := t.Storage.NewTransaction(context.TODO())
+	tx, err := t.Storage.NewTransaction()
 	if err != nil {
 		return errors.WithMessagef(err, "error creating new transaction")
 	}
-	if err := tx.SetSpendableBySupportedTokenTypes(types); err != nil {
+	if err := tx.SetSpendableBySupportedTokenTypes(context.TODO(), types); err != nil {
 		if err2 := tx.Rollback(); err2 != nil {
 			logger.Errorf("error rolling back transaction: %v", err2)
 		}

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -215,7 +215,7 @@ func (t *Tokens) SetSpendableBySupportedTokenTypes(types []string) error {
 	return nil
 }
 
-func (t *Tokens) SetSupportedTokenTypes(tokenTypes []string) error {
+func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.TokenType) error {
 	return t.Storage.tokenDB.SetSupportedTokenTypes(tokenTypes)
 }
 

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -198,7 +198,7 @@ func (t *Tokens) SetSpendableFlag(value bool, ids ...*token2.ID) error {
 	return tx.Commit()
 }
 
-func (t *Tokens) SetSpendableBySupportedTokenTypes(types []string) error {
+func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.TokenType) error {
 	tx, err := t.Storage.NewTransaction(context.TODO())
 	if err != nil {
 		return errors.WithMessagef(err, "error creating new transaction")

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -216,7 +216,7 @@ func (t *Tokens) SetSpendableBySupportedTokenTypes(types []token2.Format) error 
 }
 
 func (t *Tokens) SetSupportedTokenTypes(tokenTypes []token2.Format) error {
-	return t.Storage.tokenDB.SetSupportedTokenTypes(tokenTypes)
+	return t.Storage.tokenDB.SetSupportedTokenFormats(tokenTypes)
 }
 
 func (t *Tokens) getActions(tmsID token.TMSID, txID string, request *token.Request) ([]*token2.ID, []TokenToAppend, error) {
@@ -335,7 +335,7 @@ func (t *Tokens) parse(
 			index:                 output.Index,
 			tok:                   tok,
 			tokenOnLedger:         output.LedgerOutput,
-			tokenOnLedgerType:     output.LedgerOutputType,
+			tokenOnLedgerFormat:   output.LedgerOutputFormat,
 			tokenOnLedgerMetadata: tokenOnLedgerMetadata,
 			ownerType:             ownerType,
 			ownerIdentity:         ownerIdentity,

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -54,7 +54,7 @@ func (md mdMock) GetToken(raw []byte) (*token2.Token, token.Identity, []byte, er
 	}
 	return &token2.Token{
 		Owner:    []byte(parsed[0]),
-		Type:     parsed[1],
+		Type:     token2.TokenType(parsed[1]),
 		Quantity: parsed[2],
 	}, []byte{}, []byte{}, nil
 }

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -54,7 +54,7 @@ func (md mdMock) GetToken(raw []byte) (*token2.Token, token.Identity, []byte, er
 	}
 	return &token2.Token{
 		Owner:    []byte(parsed[0]),
-		Type:     token2.TokenType(parsed[1]),
+		Type:     token2.Type(parsed[1]),
 		Quantity: parsed[2],
 	}, []byte{}, []byte{}, nil
 }

--- a/token/services/tokens/typed.go
+++ b/token/services/tokens/typed.go
@@ -1,0 +1,72 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tokens
+
+import (
+	"encoding/asn1"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/driver"
+	"github.com/pkg/errors"
+)
+
+// TypedToken encodes a token with a type.
+type TypedToken struct {
+	// Type encodes the token's type
+	Type driver.Type
+	// Token encodes the token itself
+	Token driver.Token
+}
+
+func (i TypedToken) Bytes() ([]byte, error) {
+	return asn1.Marshal(i)
+}
+
+func UnmarshalTypedToken(token driver.Token) (*TypedToken, error) {
+	si := &TypedToken{}
+	_, err := asn1.Unmarshal(token, si)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal to TypedToken")
+	}
+	return si, nil
+}
+
+func WrapWithType(typ driver.Type, id driver.Token) (driver.Token, error) {
+	raw, err := (&TypedToken{Type: typ, Token: id}).Bytes()
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// TypedMetadata encodes metadata with a type.
+type TypedMetadata struct {
+	// Type encodes the metadata type
+	Type driver.Type
+	// Metadata encodes the metadata itself
+	Metadata driver.Metadata
+}
+
+func (i TypedMetadata) Bytes() ([]byte, error) {
+	return asn1.Marshal(i)
+}
+
+func UnmarshalTypedMetadata(metadata driver.Metadata) (*TypedMetadata, error) {
+	si := &TypedMetadata{}
+	_, err := asn1.Unmarshal(metadata, si)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal to TypedMetadata")
+	}
+	return si, nil
+}
+
+func WrapMetadataWithType(typ driver.Type, id driver.Metadata) (driver.Metadata, error) {
+	raw, err := (&TypedMetadata{Type: typ, Metadata: id}).Bytes()
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/token/services/tokens/typed_test.go
+++ b/token/services/tokens/typed_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tokens
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSerialization(t *testing.T) {
+	raw := []byte("pineapple")
+	wrappedToken, err := WrapWithType(0, raw)
+	assert.NoError(t, err)
+	tok, err := UnmarshalTypedToken(wrappedToken)
+	assert.NoError(t, err)
+	assert.Equal(t, driver.Type(0), tok.Type)
+	assert.Equal(t, driver.Token(raw), tok.Token)
+}

--- a/token/services/ttx/collect.go
+++ b/token/services/ttx/collect.go
@@ -32,7 +32,7 @@ type ActionTransfer struct {
 	// From is the sender
 	From view.Identity
 	// Type of tokens to transfer
-	Type token2.TokenType
+	Type token2.Type
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the recipient of the transfer

--- a/token/services/ttx/collect.go
+++ b/token/services/ttx/collect.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	view2 "github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 	"go.uber.org/zap/zapcore"
 
@@ -31,7 +32,7 @@ type ActionTransfer struct {
 	// From is the sender
 	From view.Identity
 	// Type of tokens to transfer
-	Type string
+	Type token2.TokenType
 	// Amount to transfer
 	Amount uint64
 	// Recipient is the recipient of the transfer

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -210,18 +210,18 @@ func (t *Transaction) Bytes(eIDs ...string) ([]byte, error) {
 }
 
 // Issue appends a new Issue operation to the TokenRequest inside this transaction
-func (t *Transaction) Issue(wallet *token.IssuerWallet, receiver view.Identity, typ token2.TokenType, q uint64, opts ...token.IssueOption) error {
+func (t *Transaction) Issue(wallet *token.IssuerWallet, receiver view.Identity, typ token2.Type, q uint64, opts ...token.IssueOption) error {
 	_, err := t.TokenRequest.Issue(t.Context, wallet, receiver, typ, q, opts...)
 	return err
 }
 
 // Transfer appends a new Transfer operation to the TokenRequest inside this transaction
-func (t *Transaction) Transfer(wallet *token.OwnerWallet, typ token2.TokenType, values []uint64, owners []view.Identity, opts ...token.TransferOption) error {
+func (t *Transaction) Transfer(wallet *token.OwnerWallet, typ token2.Type, values []uint64, owners []view.Identity, opts ...token.TransferOption) error {
 	_, err := t.TokenRequest.Transfer(t.Context, wallet, typ, values, owners, opts...)
 	return err
 }
 
-func (t *Transaction) Redeem(wallet *token.OwnerWallet, typ token2.TokenType, value uint64, opts ...token.TransferOption) error {
+func (t *Transaction) Redeem(wallet *token.OwnerWallet, typ token2.Type, value uint64, opts ...token.TransferOption) error {
 	return t.TokenRequest.Redeem(t.Context, wallet, typ, value, opts...)
 }
 

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
@@ -209,18 +210,18 @@ func (t *Transaction) Bytes(eIDs ...string) ([]byte, error) {
 }
 
 // Issue appends a new Issue operation to the TokenRequest inside this transaction
-func (t *Transaction) Issue(wallet *token.IssuerWallet, receiver view.Identity, typ string, q uint64, opts ...token.IssueOption) error {
+func (t *Transaction) Issue(wallet *token.IssuerWallet, receiver view.Identity, typ token2.TokenType, q uint64, opts ...token.IssueOption) error {
 	_, err := t.TokenRequest.Issue(t.Context, wallet, receiver, typ, q, opts...)
 	return err
 }
 
 // Transfer appends a new Transfer operation to the TokenRequest inside this transaction
-func (t *Transaction) Transfer(wallet *token.OwnerWallet, typ string, values []uint64, owners []view.Identity, opts ...token.TransferOption) error {
+func (t *Transaction) Transfer(wallet *token.OwnerWallet, typ token2.TokenType, values []uint64, owners []view.Identity, opts ...token.TransferOption) error {
 	_, err := t.TokenRequest.Transfer(t.Context, wallet, typ, values, owners, opts...)
 	return err
 }
 
-func (t *Transaction) Redeem(wallet *token.OwnerWallet, typ string, value uint64, opts ...token.TransferOption) error {
+func (t *Transaction) Redeem(wallet *token.OwnerWallet, typ token2.TokenType, value uint64, opts ...token.TransferOption) error {
 	return t.TokenRequest.Redeem(t.Context, wallet, typ, value, opts...)
 }
 

--- a/token/services/ttx/wallet.go
+++ b/token/services/ttx/wallet.go
@@ -14,7 +14,7 @@ import (
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType token2.TokenType) token.ListTokensOption {
+func WithType(tokenType token2.Type) token.ListTokensOption {
 	return func(o *token.ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil

--- a/token/services/ttx/wallet.go
+++ b/token/services/ttx/wallet.go
@@ -9,11 +9,12 @@ package ttx
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType string) token.ListTokensOption {
+func WithType(tokenType token2.TokenType) token.ListTokensOption {
 	return func(o *token.ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil

--- a/token/services/ttx/withdrawal.go
+++ b/token/services/ttx/withdrawal.go
@@ -22,7 +22,7 @@ import (
 type WithdrawalRequest struct {
 	TMSID         token.TMSID
 	RecipientData RecipientData
-	TokenType     token2.TokenType
+	TokenType     token2.Type
 	Amount        uint64
 	NotAnonymous  bool
 }
@@ -31,7 +31,7 @@ type WithdrawalRequest struct {
 // The view prepares an instance of WithdrawalRequest and send it to the issuer.
 type RequestWithdrawalView struct {
 	Issuer       view.Identity
-	TokenType    token2.TokenType
+	TokenType    token2.Type
 	Amount       uint64
 	TMSID        token.TMSID
 	Wallet       string
@@ -40,19 +40,19 @@ type RequestWithdrawalView struct {
 	RecipientData *RecipientData
 }
 
-func NewRequestWithdrawalView(issuer view.Identity, tokenType token2.TokenType, amount uint64, notAnonymous bool) *RequestWithdrawalView {
+func NewRequestWithdrawalView(issuer view.Identity, tokenType token2.Type, amount uint64, notAnonymous bool) *RequestWithdrawalView {
 	return &RequestWithdrawalView{Issuer: issuer, TokenType: tokenType, Amount: amount, NotAnonymous: notAnonymous}
 }
 
 // RequestWithdrawal runs RequestWithdrawalView with the passed arguments.
 // The view will generate a recipient identity and pass it to the issuer.
-func RequestWithdrawal(context view.Context, issuer view.Identity, wallet string, tokenType token2.TokenType, amount uint64, notAnonymous bool, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
+func RequestWithdrawal(context view.Context, issuer view.Identity, wallet string, tokenType token2.Type, amount uint64, notAnonymous bool, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
 	return RequestWithdrawalForRecipient(context, issuer, wallet, tokenType, amount, notAnonymous, nil, opts...)
 }
 
 // RequestWithdrawalForRecipient runs RequestWithdrawalView with the passed arguments.
 // The view will send the passed recipient data to the issuer.
-func RequestWithdrawalForRecipient(context view.Context, issuer view.Identity, wallet string, tokenType token2.TokenType, amount uint64, notAnonymous bool, recipientData *RecipientData, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
+func RequestWithdrawalForRecipient(context view.Context, issuer view.Identity, wallet string, tokenType token2.Type, amount uint64, notAnonymous bool, recipientData *RecipientData, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
 	options, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "failed to compile options")

--- a/token/services/ttx/withdrawal.go
+++ b/token/services/ttx/withdrawal.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/session"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 )
@@ -21,7 +22,7 @@ import (
 type WithdrawalRequest struct {
 	TMSID         token.TMSID
 	RecipientData RecipientData
-	TokenType     string
+	TokenType     token2.TokenType
 	Amount        uint64
 	NotAnonymous  bool
 }
@@ -30,7 +31,7 @@ type WithdrawalRequest struct {
 // The view prepares an instance of WithdrawalRequest and send it to the issuer.
 type RequestWithdrawalView struct {
 	Issuer       view.Identity
-	TokenType    string
+	TokenType    token2.TokenType
 	Amount       uint64
 	TMSID        token.TMSID
 	Wallet       string
@@ -39,19 +40,19 @@ type RequestWithdrawalView struct {
 	RecipientData *RecipientData
 }
 
-func NewRequestWithdrawalView(issuer view.Identity, tokenType string, amount uint64, notAnonymous bool) *RequestWithdrawalView {
+func NewRequestWithdrawalView(issuer view.Identity, tokenType token2.TokenType, amount uint64, notAnonymous bool) *RequestWithdrawalView {
 	return &RequestWithdrawalView{Issuer: issuer, TokenType: tokenType, Amount: amount, NotAnonymous: notAnonymous}
 }
 
 // RequestWithdrawal runs RequestWithdrawalView with the passed arguments.
 // The view will generate a recipient identity and pass it to the issuer.
-func RequestWithdrawal(context view.Context, issuer view.Identity, wallet string, tokenType string, amount uint64, notAnonymous bool, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
+func RequestWithdrawal(context view.Context, issuer view.Identity, wallet string, tokenType token2.TokenType, amount uint64, notAnonymous bool, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
 	return RequestWithdrawalForRecipient(context, issuer, wallet, tokenType, amount, notAnonymous, nil, opts...)
 }
 
 // RequestWithdrawalForRecipient runs RequestWithdrawalView with the passed arguments.
 // The view will send the passed recipient data to the issuer.
-func RequestWithdrawalForRecipient(context view.Context, issuer view.Identity, wallet string, tokenType string, amount uint64, notAnonymous bool, recipientData *RecipientData, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
+func RequestWithdrawalForRecipient(context view.Context, issuer view.Identity, wallet string, tokenType token2.TokenType, amount uint64, notAnonymous bool, recipientData *RecipientData, opts ...token.ServiceOption) (view.Identity, view.Session, error) {
 	options, err := CompileServiceOptions(opts...)
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "failed to compile options")

--- a/token/stream.go
+++ b/token/stream.go
@@ -39,7 +39,7 @@ type Output struct {
 	// LedgerOutput contains the output as it appears on the ledger
 	LedgerOutput []byte
 	// LedgerOutputType is the output type
-	LedgerOutputType token.TokenType
+	LedgerOutputType token.TokenFormat
 }
 
 func (o Output) ID(txID string) *token.ID {

--- a/token/stream.go
+++ b/token/stream.go
@@ -36,8 +36,10 @@ type Output struct {
 	Type string
 	// Quantity is the quantity of tokens
 	Quantity token.Quantity
-
+	// LedgerOutput contains the output as it appears on the ledger
 	LedgerOutput []byte
+	// LedgerOutputType is the output type
+	LedgerOutputType string
 }
 
 func (o Output) ID(txID string) *token.ID {

--- a/token/stream.go
+++ b/token/stream.go
@@ -38,8 +38,8 @@ type Output struct {
 	Quantity token.Quantity
 	// LedgerOutput contains the output as it appears on the ledger
 	LedgerOutput []byte
-	// LedgerOutputType is the output type
-	LedgerOutputType token.Format
+	// LedgerOutputFormat is the output type
+	LedgerOutputFormat token.Format
 }
 
 func (o Output) ID(txID string) *token.ID {

--- a/token/stream.go
+++ b/token/stream.go
@@ -33,13 +33,13 @@ type Output struct {
 	// RevocationHandler is the revocation handler of the owner of this output
 	RevocationHandler string
 	// Type is the type of token
-	Type string
+	Type token.TokenType
 	// Quantity is the quantity of tokens
 	Quantity token.Quantity
 	// LedgerOutput contains the output as it appears on the ledger
 	LedgerOutput []byte
 	// LedgerOutputType is the output type
-	LedgerOutputType string
+	LedgerOutputType token.TokenType
 }
 
 func (o Output) ID(txID string) *token.ID {
@@ -76,7 +76,7 @@ func (o *OutputStream) ByRecipient(id Identity) *OutputStream {
 }
 
 // ByType filters the OutputStream to only include outputs that match the passed type.
-func (o *OutputStream) ByType(typ string) *OutputStream {
+func (o *OutputStream) ByType(typ token.TokenType) *OutputStream {
 	return o.Filter(func(t *Output) bool {
 		return t.Type == typ
 	})
@@ -130,9 +130,9 @@ func (o *OutputStream) EnrollmentIDs() []string {
 }
 
 // TokenTypes returns the token types of the outputs in the OutputStream.
-func (o *OutputStream) TokenTypes() []string {
-	duplicates := map[string]interface{}{}
-	var types []string
+func (o *OutputStream) TokenTypes() []token.TokenType {
+	duplicates := map[token.TokenType]interface{}{}
+	var types []token.TokenType
 	for _, output := range o.outputs {
 		if _, ok := duplicates[output.Type]; !ok {
 			types = append(types, output.Type)
@@ -174,7 +174,7 @@ type Input struct {
 	OwnerAuditInfo    []byte
 	EnrollmentID      string
 	RevocationHandler string
-	Type              string
+	Type              token.TokenType
 	Quantity          token.Quantity
 }
 
@@ -294,9 +294,9 @@ func (is *InputStream) RevocationHandles() []string {
 }
 
 // TokenTypes returns the token types of the inputs.
-func (is *InputStream) TokenTypes() []string {
-	duplicates := map[string]interface{}{}
-	var types []string
+func (is *InputStream) TokenTypes() []token.TokenType {
+	duplicates := map[token.TokenType]interface{}{}
+	var types []token.TokenType
 	for _, input := range is.inputs {
 		_, ok := duplicates[input.Type]
 		if !ok {
@@ -315,7 +315,7 @@ func (is *InputStream) ByEnrollmentID(id string) *InputStream {
 }
 
 // ByType filters by token type.
-func (is *InputStream) ByType(tokenType string) *InputStream {
+func (is *InputStream) ByType(tokenType token.TokenType) *InputStream {
 	return is.Filter(func(t *Input) bool {
 		return t.Type == tokenType
 	})

--- a/token/stream.go
+++ b/token/stream.go
@@ -33,13 +33,13 @@ type Output struct {
 	// RevocationHandler is the revocation handler of the owner of this output
 	RevocationHandler string
 	// Type is the type of token
-	Type token.TokenType
+	Type token.Type
 	// Quantity is the quantity of tokens
 	Quantity token.Quantity
 	// LedgerOutput contains the output as it appears on the ledger
 	LedgerOutput []byte
 	// LedgerOutputType is the output type
-	LedgerOutputType token.TokenFormat
+	LedgerOutputType token.Format
 }
 
 func (o Output) ID(txID string) *token.ID {
@@ -76,7 +76,7 @@ func (o *OutputStream) ByRecipient(id Identity) *OutputStream {
 }
 
 // ByType filters the OutputStream to only include outputs that match the passed type.
-func (o *OutputStream) ByType(typ token.TokenType) *OutputStream {
+func (o *OutputStream) ByType(typ token.Type) *OutputStream {
 	return o.Filter(func(t *Output) bool {
 		return t.Type == typ
 	})
@@ -130,9 +130,9 @@ func (o *OutputStream) EnrollmentIDs() []string {
 }
 
 // TokenTypes returns the token types of the outputs in the OutputStream.
-func (o *OutputStream) TokenTypes() []token.TokenType {
-	duplicates := map[token.TokenType]interface{}{}
-	var types []token.TokenType
+func (o *OutputStream) TokenTypes() []token.Type {
+	duplicates := map[token.Type]interface{}{}
+	var types []token.Type
 	for _, output := range o.outputs {
 		if _, ok := duplicates[output.Type]; !ok {
 			types = append(types, output.Type)
@@ -174,7 +174,7 @@ type Input struct {
 	OwnerAuditInfo    []byte
 	EnrollmentID      string
 	RevocationHandler string
-	Type              token.TokenType
+	Type              token.Type
 	Quantity          token.Quantity
 }
 
@@ -294,9 +294,9 @@ func (is *InputStream) RevocationHandles() []string {
 }
 
 // TokenTypes returns the token types of the inputs.
-func (is *InputStream) TokenTypes() []token.TokenType {
-	duplicates := map[token.TokenType]interface{}{}
-	var types []token.TokenType
+func (is *InputStream) TokenTypes() []token.Type {
+	duplicates := map[token.Type]interface{}{}
+	var types []token.Type
 	for _, input := range is.inputs {
 		_, ok := duplicates[input.Type]
 		if !ok {
@@ -315,7 +315,7 @@ func (is *InputStream) ByEnrollmentID(id string) *InputStream {
 }
 
 // ByType filters by token type.
-func (is *InputStream) ByType(tokenType token.TokenType) *InputStream {
+func (is *InputStream) ByType(tokenType token.Type) *InputStream {
 	return is.Filter(func(t *Input) bool {
 		return t.Type == tokenType
 	})

--- a/token/stream_test.go
+++ b/token/stream_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	type1 = token.TokenType("type1")
-	type2 = token.TokenType("type2")
+	type1 = token.Type("type1")
+	type2 = token.Type("type2")
 )
 
 type MockQueryService struct {
@@ -231,7 +231,7 @@ func TestOutputStream_TokenTypes(t *testing.T) {
 
 	tokenTypes := stream.TokenTypes()
 
-	assert.ElementsMatch(t, []token.TokenType{type1, type2}, tokenTypes)
+	assert.ElementsMatch(t, []token.Type{type1, type2}, tokenTypes)
 }
 
 func TestInputStream_Owners(t *testing.T) {
@@ -279,7 +279,7 @@ func TestInputStream_TokenTypes(t *testing.T) {
 
 	tokenTypes := stream.TokenTypes()
 
-	assert.ElementsMatch(t, []token.TokenType{type1, type2}, tokenTypes)
+	assert.ElementsMatch(t, []token.Type{type1, type2}, tokenTypes)
 }
 
 func TestInputStream_Count(t *testing.T) {

--- a/token/stream_test.go
+++ b/token/stream_test.go
@@ -17,6 +17,11 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const (
+	type1 = token.TokenType("type1")
+	type2 = token.TokenType("type2")
+)
+
 type MockQueryService struct {
 	mock.Mock
 }
@@ -120,12 +125,12 @@ func TestOutputStream_ByRecipient(t *testing.T) {
 }
 
 func TestOutputStream_ByType(t *testing.T) {
-	output1 := &Output{Type: "type1"}
-	output2 := &Output{Type: "type2"}
-	output3 := &Output{Type: "type1"}
+	output1 := &Output{Type: type1}
+	output2 := &Output{Type: type2}
+	output3 := &Output{Type: type1}
 	stream := NewOutputStream([]*Output{output1, output2, output3}, 0)
 
-	filtered := stream.ByType("type1")
+	filtered := stream.ByType(type1)
 
 	assert.Equal(t, 2, filtered.Count())
 	assert.Equal(t, []*Output{output1, output3}, filtered.Outputs())
@@ -219,14 +224,14 @@ func TestOwnerStream_Count(t *testing.T) {
 }
 
 func TestOutputStream_TokenTypes(t *testing.T) {
-	output1 := &Output{Type: "type1"}
-	output2 := &Output{Type: "type2"}
-	output3 := &Output{Type: "type1"}
+	output1 := &Output{Type: type1}
+	output2 := &Output{Type: type2}
+	output3 := &Output{Type: type1}
 	stream := NewOutputStream([]*Output{output1, output2, output3}, 0)
 
 	tokenTypes := stream.TokenTypes()
 
-	assert.ElementsMatch(t, []string{"type1", "type2"}, tokenTypes)
+	assert.ElementsMatch(t, []token.TokenType{type1, type2}, tokenTypes)
 }
 
 func TestInputStream_Owners(t *testing.T) {
@@ -267,14 +272,14 @@ func TestInputStream_RevocationHandles(t *testing.T) {
 }
 
 func TestInputStream_TokenTypes(t *testing.T) {
-	input1 := &Input{Type: "type1"}
-	input2 := &Input{Type: "type2"}
-	input3 := &Input{Type: "type1"}
+	input1 := &Input{Type: type1}
+	input2 := &Input{Type: type2}
+	input3 := &Input{Type: type1}
 	stream := NewInputStream(nil, []*Input{input1, input2, input3}, 0)
 
 	tokenTypes := stream.TokenTypes()
 
-	assert.ElementsMatch(t, []string{"type1", "type2"}, tokenTypes)
+	assert.ElementsMatch(t, []token.TokenType{type1, type2}, tokenTypes)
 }
 
 func TestInputStream_Count(t *testing.T) {
@@ -343,9 +348,9 @@ func TestInputStream_ByEnrollmentID(t *testing.T) {
 }
 
 func TestInputStream_ByType(t *testing.T) {
-	tokenType := token.TokenType("type1")
+	tokenType := type1
 	input1 := &Input{Type: tokenType}
-	input2 := &Input{Type: "type2"}
+	input2 := &Input{Type: type2}
 	input3 := &Input{Type: tokenType}
 	stream := NewInputStream(nil, []*Input{input1, input2, input3}, 0)
 

--- a/token/stream_test.go
+++ b/token/stream_test.go
@@ -343,7 +343,7 @@ func TestInputStream_ByEnrollmentID(t *testing.T) {
 }
 
 func TestInputStream_ByType(t *testing.T) {
-	tokenType := "type1"
+	tokenType := token.TokenType("type1")
 	input1 := &Input{Type: tokenType}
 	input2 := &Input{Type: "type2"}
 	input3 := &Input{Type: tokenType}

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -25,7 +25,7 @@ func (id ID) String() string {
 	return fmt.Sprintf("[%s:%d]", id.TxId, id.Index)
 }
 
-type TokenType = string
+type TokenType string
 
 // Token is the result of issue and transfer transactions
 type Token struct {

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -26,13 +26,13 @@ func (id ID) String() string {
 }
 
 type (
-	// TokenType is the currency, e.g. USD
-	TokenType string
-	// TokenFormat is the encoding of a token, e.g. fabtoken, comm.
+	// Type is the currency, e.g. USD
+	Type string
+	// Format is the encoding of a token, e.g. fabtoken, comm.
 	// It is a many-to-many relationship with the token driver,
 	// i.e. a token driver can support multiple formats (e.g. fabtoken1, fabtoken2),
 	// but a format can also be supported by multiple drivers (e.g. zkat, zkatlog).
-	TokenFormat string
+	Format string
 )
 
 // Token is the result of issue and transfer transactions
@@ -40,7 +40,7 @@ type Token struct {
 	// Owner is the token owner
 	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
-	Type TokenType `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type Type `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity is the number of units of Type carried in the token.
 	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
 	Quantity string `protobuf:"bytes,3,opt,name=quantity,proto3" json:"quantity,omitempty"`
@@ -52,7 +52,7 @@ type IssuedToken struct {
 	// Owner is the token owner
 	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
-	Type TokenType `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type Type `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity represents the number of units of Type that this unspent token holds.
 	// It is formatted in decimal representation
 	Quantity string `protobuf:"bytes,3,opt,name=quantity,proto3" json:"quantity,omitempty"`
@@ -77,7 +77,7 @@ func (it *IssuedTokens) Sum(precision uint64) Quantity {
 	return sum
 }
 
-func (it *IssuedTokens) ByType(typ TokenType) *IssuedTokens {
+func (it *IssuedTokens) ByType(typ Type) *IssuedTokens {
 	res := &IssuedTokens{Tokens: []*IssuedToken{}}
 	for _, token := range it.Tokens {
 		if token.Type == typ {
@@ -98,7 +98,7 @@ type UnspentTokenInWallet struct {
 	// WalletID is the ID of the wallet owning this token
 	WalletID string
 	// Type is the type of the token
-	Type TokenType
+	Type Type
 	// Quantity represents the number of units of Type that this unspent token holds.
 	Quantity string
 }
@@ -110,7 +110,7 @@ type UnspentToken struct {
 	// Owner is the token owner
 	Owner []byte
 	// Type is the type of the token
-	Type TokenType
+	Type Type
 	// Quantity represents the number of units of Type that this unspent token holds.
 	Quantity string
 }
@@ -137,7 +137,7 @@ func (it *UnspentTokens) Sum(precision uint64) Quantity {
 	return sum
 }
 
-func (it *UnspentTokens) ByType(typ TokenType) *UnspentTokens {
+func (it *UnspentTokens) ByType(typ Type) *UnspentTokens {
 	res := &UnspentTokens{Tokens: []*UnspentToken{}}
 	for _, token := range it.Tokens {
 		if token.Type == typ {

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -25,7 +25,15 @@ func (id ID) String() string {
 	return fmt.Sprintf("[%s:%d]", id.TxId, id.Index)
 }
 
-type TokenType string
+type (
+	// TokenType is the currency, e.g. USD
+	TokenType string
+	// TokenFormat is the encoding of a token, e.g. fabtoken, comm.
+	// It is a many-to-many relationship with the token driver,
+	// i.e. a token driver can support multiple formats (e.g. fabtoken1, fabtoken2),
+	// but a format can also be supported by multiple drivers (e.g. zkat, zkatlog).
+	TokenFormat string
+)
 
 // Token is the result of issue and transfer transactions
 type Token struct {

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -25,7 +25,7 @@ func (id ID) String() string {
 	return fmt.Sprintf("[%s:%d]", id.TxId, id.Index)
 }
 
-type TokenType string
+type TokenType = string
 
 // Token is the result of issue and transfer transactions
 type Token struct {

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -25,12 +25,14 @@ func (id ID) String() string {
 	return fmt.Sprintf("[%s:%d]", id.TxId, id.Index)
 }
 
+type TokenType string
+
 // Token is the result of issue and transfer transactions
 type Token struct {
 	// Owner is the token owner
 	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
-	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type TokenType `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity is the number of units of Type carried in the token.
 	// It is encoded as a string containing a number in base 16. The string has prefix ``0x''.
 	Quantity string `protobuf:"bytes,3,opt,name=quantity,proto3" json:"quantity,omitempty"`
@@ -42,7 +44,7 @@ type IssuedToken struct {
 	// Owner is the token owner
 	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
-	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
+	Type TokenType `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity represents the number of units of Type that this unspent token holds.
 	// It is formatted in decimal representation
 	Quantity string `protobuf:"bytes,3,opt,name=quantity,proto3" json:"quantity,omitempty"`
@@ -67,7 +69,7 @@ func (it *IssuedTokens) Sum(precision uint64) Quantity {
 	return sum
 }
 
-func (it *IssuedTokens) ByType(typ string) *IssuedTokens {
+func (it *IssuedTokens) ByType(typ TokenType) *IssuedTokens {
 	res := &IssuedTokens{Tokens: []*IssuedToken{}}
 	for _, token := range it.Tokens {
 		if token.Type == typ {
@@ -88,7 +90,7 @@ type UnspentTokenInWallet struct {
 	// WalletID is the ID of the wallet owning this token
 	WalletID string
 	// Type is the type of the token
-	Type string
+	Type TokenType
 	// Quantity represents the number of units of Type that this unspent token holds.
 	Quantity string
 }
@@ -100,7 +102,7 @@ type UnspentToken struct {
 	// Owner is the token owner
 	Owner []byte
 	// Type is the type of the token
-	Type string
+	Type TokenType
 	// Quantity represents the number of units of Type that this unspent token holds.
 	Quantity string
 }
@@ -127,7 +129,7 @@ func (it *UnspentTokens) Sum(precision uint64) Quantity {
 	return sum
 }
 
-func (it *UnspentTokens) ByType(typ string) *UnspentTokens {
+func (it *UnspentTokens) ByType(typ TokenType) *UnspentTokens {
 	res := &UnspentTokens{Tokens: []*UnspentToken{}}
 	for _, token := range it.Tokens {
 		if token.Type == typ {

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -28,7 +28,7 @@ func (id ID) String() string {
 type (
 	// Type is the currency, e.g. USD
 	Type string
-	// Format is the encoding of a token, e.g. fabtoken, comm.
+	// Format is the encoding of a token on the ledger, e.g. fabtoken, comm.
 	// It is a many-to-many relationship with the token driver,
 	// i.e. a token driver can support multiple formats (e.g. fabtoken1, fabtoken2),
 	// but a format can also be supported by multiple drivers (e.g. zkat, zkatlog).

--- a/token/vault.go
+++ b/token/vault.go
@@ -60,7 +60,7 @@ func (q *QueryEngine) UnspentTokensIterator() (*UnspentTokensIterator, error) {
 }
 
 // UnspentTokensIteratorBy is an iterator over all unspent tokens in this vault owned by passed wallet id and whose token type matches the passed token type
-func (q *QueryEngine) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error) {
+func (q *QueryEngine) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error) {
 	it, err := q.qe.UnspentTokensIteratorBy(ctx, id, tokenType)
 	if err != nil {
 		return nil, err

--- a/token/vault.go
+++ b/token/vault.go
@@ -60,7 +60,7 @@ func (q *QueryEngine) UnspentTokensIterator() (*UnspentTokensIterator, error) {
 }
 
 // UnspentTokensIteratorBy is an iterator over all unspent tokens in this vault owned by passed wallet id and whose token type matches the passed token type
-func (q *QueryEngine) UnspentTokensIteratorBy(ctx context.Context, id, tokenType string) (driver.UnspentTokensIterator, error) {
+func (q *QueryEngine) UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.TokenType) (driver.UnspentTokensIterator, error) {
 	it, err := q.qe.UnspentTokensIteratorBy(ctx, id, tokenType)
 	if err != nil {
 		return nil, err

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -28,7 +28,7 @@ type ListTokensOption func(*ListTokensOptions) error
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType token.TokenType) ListTokensOption {
+func WithType(tokenType token.Type) ListTokensOption {
 	return func(o *ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil
@@ -331,7 +331,7 @@ type IssuerWallet struct {
 
 // GetIssuerIdentity returns the issuer identity. This can be a long term identity or a pseudonym depending
 // on the underlying token driver.
-func (i *IssuerWallet) GetIssuerIdentity(tokenType token.TokenType) (Identity, error) {
+func (i *IssuerWallet) GetIssuerIdentity(tokenType token.Type) (Identity, error) {
 	return i.w.GetIssuerIdentity(tokenType)
 }
 

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -28,7 +28,7 @@ type ListTokensOption func(*ListTokensOptions) error
 
 // WithType returns a list token option that filter by the passed token type.
 // If the passed token type is the empty string, all token types are selected.
-func WithType(tokenType string) ListTokensOption {
+func WithType(tokenType token.TokenType) ListTokensOption {
 	return func(o *ListTokensOptions) error {
 		o.TokenType = tokenType
 		return nil
@@ -331,7 +331,7 @@ type IssuerWallet struct {
 
 // GetIssuerIdentity returns the issuer identity. This can be a long term identity or a pseudonym depending
 // on the underlying token driver.
-func (i *IssuerWallet) GetIssuerIdentity(tokenType string) (Identity, error) {
+func (i *IssuerWallet) GetIssuerIdentity(tokenType token.TokenType) (Identity, error) {
 	return i.w.GetIssuerIdentity(tokenType)
 }
 


### PR DESCRIPTION
In the context of #785 , this PR tackles the following:
- [x] Extend the tokens service to provide the supported token types
- [x] Introduce a `spendable` flag in the tokensdb to mark the tokens that cannot be spent with the current driver.
- [x] Introduce a `token type` field in the tokensdb to track the type of a token.