### PR TITLE
selector: support for additional configuration

### DIFF
--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -22,8 +22,12 @@ token:
     retryInterval: 5s
     # retry to gain a lock on tokens this amount of times before failing the transaction
     numRetries: 3
-    evictionInterval: 1m
-    cleanupPeriod: 1m
+    # evictionInterval is the period a token can be locked, after which it is forcefully unlocked
+    # if evictionInterval is zero, the eviction algorithm is never executed
+    evictionInterval: 3m
+    # cleanupTickPeriod defines how often the eviction algorithm must be executed
+    # if cleanupTickPeriod is zero, the eviction algorithm is never executed
+    cleanupTickPeriod: 1m
 
   tms:
     mytms: # unique name of this token management system

--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -22,6 +22,8 @@ token:
     retryInterval: 5s
     # retry to gain a lock on tokens this amount of times before failing the transaction
     numRetries: 3
+    evictionInterval: 1m
+    cleanupPeriod: 1m
 
   tms:
     mytms: # unique name of this token management system

--- a/token/services/selector/config/driver.go
+++ b/token/services/selector/config/driver.go
@@ -1,0 +1,79 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/driver"
+	"github.com/pkg/errors"
+)
+
+const (
+	defaultDriver            = driver.Sherdlock
+	defaultEvictionInterval  = 3 * time.Minute
+	defaultCleanupTickPeriod = 1 * time.Minute
+	defaultNumRetries        = 3
+	defaultRetryInterval     = 5 * time.Second
+)
+
+type configService interface {
+	UnmarshalKey(key string, rawVal interface{}) error
+}
+
+type Config struct {
+	Driver            driver.Driver `yaml:"driver,omitempty"`
+	RetryInterval     time.Duration `yaml:"retryInterval,omitempty"`
+	NumRetries        int           `yaml:"numRetries,omitempty"`
+	EvictionInterval  time.Duration `yaml:"evictionInterval,omitempty"`
+	CleanupTickPeriod time.Duration `yaml:"cleanupTickPeriod,omitempty"`
+}
+
+// New returns a SelectorConfig with the values from the token.selector key
+func New(config configService) (*Config, error) {
+	c := &Config{}
+	err := config.UnmarshalKey("token.selector", c)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid config for key [token.selector]: expected retryInterval (duration) and numRetries (integer))")
+	}
+	return c, nil
+}
+
+func (c *Config) GetDriver() driver.Driver {
+	if c.Driver == "" {
+		return defaultDriver
+	}
+	return c.Driver
+}
+
+func (c *Config) GetNumRetries() int {
+	if c.NumRetries > 0 {
+		return c.NumRetries
+	}
+	return defaultNumRetries
+}
+
+func (c *Config) GetRetryInterval() time.Duration {
+	if c.RetryInterval != 0 {
+		return c.RetryInterval
+	}
+	return defaultRetryInterval
+}
+
+func (c *Config) GetEvictionInterval() time.Duration {
+	if c.EvictionInterval != 0 {
+		return c.EvictionInterval
+	}
+	return defaultEvictionInterval
+}
+
+func (c *Config) GetCleanupTickPeriod() time.Duration {
+	if c.CleanupTickPeriod != 0 {
+		return c.CleanupTickPeriod
+	}
+	return defaultCleanupTickPeriod
+}

--- a/token/services/selector/driver/driver.go
+++ b/token/services/selector/driver/driver.go
@@ -8,15 +8,11 @@ package driver
 
 import (
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
-	Sherdlock         Driver = "sherdlock"
-	Simple            Driver = "simple"
-	evictionPeriod           = 1 * time.Minute
-	cleanupTickPeriod        = 1 * time.Minute
+	Sherdlock Driver = "sherdlock"
+	Simple    Driver = "simple"
 )
 
 type SelectorConfig interface {
@@ -28,60 +24,3 @@ type SelectorConfig interface {
 }
 
 type Driver string
-
-type Config struct {
-	Driver            Driver        `yaml:"driver,omitempty"`
-	RetryInterval     time.Duration `yaml:"retryInterval,omitempty"`
-	NumRetries        int           `yaml:"numRetries,omitempty"`
-	EvictionInterval  time.Duration `yaml:"evictionInterval,omitempty"`
-	CleanupTickPeriod time.Duration `yaml:"cleanupPeriod,omitempty"`
-}
-
-func (c Config) GetDriver() Driver {
-	if c.Driver == "" {
-		return Sherdlock
-	}
-	return c.Driver
-}
-
-func (c Config) GetNumRetries() int {
-	if c.NumRetries > 0 {
-		return c.NumRetries
-	}
-	return 3
-}
-
-func (c Config) GetRetryInterval() time.Duration {
-	if c.RetryInterval != 0 {
-		return c.RetryInterval
-	}
-	return 5 * time.Second
-}
-
-func (c Config) GetEvictionInterval() time.Duration {
-	if c.EvictionInterval != 0 {
-		return c.EvictionInterval
-	}
-	return evictionPeriod
-}
-
-func (c Config) GetCleanupTickPeriod() time.Duration {
-	if c.CleanupTickPeriod != 0 {
-		return c.CleanupTickPeriod
-	}
-	return cleanupTickPeriod
-}
-
-type configService interface {
-	UnmarshalKey(key string, rawVal interface{}) error
-}
-
-// New returns a SelectorConfig with the values from the token.selector key
-func New(config configService) (SelectorConfig, error) {
-	c := Config{}
-	err := config.UnmarshalKey("token.selector", &c)
-	if err != nil {
-		return c, errors.Wrap(err, "invalid config for key [token.selector]: expected retryInterval (duration) and numRetries (integer))")
-	}
-	return c, nil
-}

--- a/token/services/selector/driver/driver.go
+++ b/token/services/selector/driver/driver.go
@@ -13,22 +13,28 @@ import (
 )
 
 const (
-	Sherdlock Driver = "sherdlock"
-	Simple    Driver = "simple"
+	Sherdlock         Driver = "sherdlock"
+	Simple            Driver = "simple"
+	evictionPeriod           = 1 * time.Minute
+	cleanupTickPeriod        = 1 * time.Minute
 )
 
 type SelectorConfig interface {
 	GetDriver() Driver
 	GetNumRetries() int
 	GetRetryInterval() time.Duration
+	GetEvictionInterval() time.Duration
+	GetCleanupTickPeriod() time.Duration
 }
 
 type Driver string
 
 type Config struct {
-	Driver        Driver        `yaml:"driver,omitempty"`
-	RetryInterval time.Duration `yaml:"retryInterval,omitempty"`
-	NumRetries    int           `yaml:"numRetries,omitempty"`
+	Driver            Driver        `yaml:"driver,omitempty"`
+	RetryInterval     time.Duration `yaml:"retryInterval,omitempty"`
+	NumRetries        int           `yaml:"numRetries,omitempty"`
+	EvictionInterval  time.Duration `yaml:"evictionInterval,omitempty"`
+	CleanupTickPeriod time.Duration `yaml:"cleanupPeriod,omitempty"`
 }
 
 func (c Config) GetDriver() Driver {
@@ -44,11 +50,26 @@ func (c Config) GetNumRetries() int {
 	}
 	return 3
 }
+
 func (c Config) GetRetryInterval() time.Duration {
 	if c.RetryInterval != 0 {
 		return c.RetryInterval
 	}
 	return 5 * time.Second
+}
+
+func (c Config) GetEvictionInterval() time.Duration {
+	if c.EvictionInterval != 0 {
+		return c.EvictionInterval
+	}
+	return evictionPeriod
+}
+
+func (c Config) GetCleanupTickPeriod() time.Duration {
+	if c.CleanupTickPeriod != 0 {
+		return c.CleanupTickPeriod
+	}
+	return cleanupTickPeriod
 }
 
 type configService interface {

--- a/token/services/selector/sherdlock/manager.go
+++ b/token/services/selector/sherdlock/manager.go
@@ -54,14 +54,14 @@ func NewManager(
 	cleanupTickPeriod time.Duration,
 ) *manager {
 	m := &manager{
-		locker:           locker,
-		evictionInterval: evictionInterval,
+		locker:            locker,
+		evictionInterval:  evictionInterval,
+		cleanupTickPeriod: cleanupTickPeriod,
 		selectorCache: lazy2.NewProvider(func(txID transaction.ID) (tokenSelectorUnlocker, error) {
 			return NewSherdSelector(txID, fetcher, locker, precision, backoff, maxRetriesAfterBackOff), nil
 		}),
-		cleanupTickPeriod: cleanupTickPeriod,
 	}
-	if cleanupTickPeriod > 0 {
+	if cleanupTickPeriod > 0 && evictionInterval > 0 {
 		go m.cleaner()
 	}
 	return m

--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -95,7 +95,7 @@ func createManager(pgConnStr string, backoff time.Duration, maxRetries int) (tes
 		return nil, err
 	}
 	fetcher := newMixedFetcher(tokenDB, newMetrics(&disabled.Provider{}))
-	manager := NewManager(fetcher, lockDB, testutils.TokenQuantityPrecision, backoff, maxRetries, 0)
+	manager := NewManager(fetcher, lockDB, testutils.TokenQuantityPrecision, backoff, maxRetries, 0, 0)
 
 	return testutils.NewEnhancedManager(manager, tokenDB), nil
 }

--- a/token/services/selector/sherdlock/service.go
+++ b/token/services/selector/sherdlock/service.go
@@ -12,7 +12,7 @@ import (
 	lazy2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/lazy"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokenlockdb"
 	"github.com/pkg/errors"
 )
@@ -22,7 +22,7 @@ type SelectorService struct {
 }
 
 func NewService(fetcherProvider FetcherProvider, tokenLockDBManager *tokenlockdb.Manager, c core.ConfigProvider) *SelectorService {
-	cfg, err := driver.New(c)
+	cfg, err := config.New(c)
 	if err != nil {
 		logger.Errorf("error getting selector config, using defaults. %s", err.Error())
 	}

--- a/token/services/selector/sherdlock/service.go
+++ b/token/services/selector/sherdlock/service.go
@@ -17,11 +17,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	cleanupTickPeriod = 1 * time.Minute
-	cleanupPeriod     = 30 * time.Second
-)
-
 type SelectorService struct {
 	managerLazyCache lazy2.Provider[*token.ManagementService, token.SelectorManager]
 }
@@ -37,6 +32,8 @@ func NewService(fetcherProvider FetcherProvider, tokenLockDBManager *tokenlockdb
 		fetcherProvider:    fetcherProvider,
 		retryInterval:      cfg.GetRetryInterval(),
 		numRetries:         cfg.GetNumRetries(),
+		evictionInterval:   cfg.GetEvictionInterval(),
+		cleanupTickPeriod:  cfg.GetCleanupTickPeriod(),
 	}
 	return &SelectorService{
 		managerLazyCache: lazy2.NewProviderWithKeyMapper(key, loader.load),
@@ -56,6 +53,8 @@ type loader struct {
 	fetcherProvider    FetcherProvider
 	numRetries         int
 	retryInterval      time.Duration
+	evictionInterval   time.Duration
+	cleanupTickPeriod  time.Duration
 }
 
 func (s *loader) load(tms *token.ManagementService) (token.SelectorManager, error) {
@@ -77,7 +76,8 @@ func (s *loader) load(tms *token.ManagementService) (token.SelectorManager, erro
 		pp.Precision(),
 		s.retryInterval,
 		s.numRetries,
-		cleanupTickPeriod,
+		s.evictionInterval,
+		s.cleanupTickPeriod,
 	), nil
 }
 

--- a/token/services/selector/simple/service.go
+++ b/token/services/selector/simple/service.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
-	sdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/config"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -31,7 +31,7 @@ type SelectorService struct {
 }
 
 func NewService(lockerProvider LockerProvider, c core.ConfigProvider) *SelectorService {
-	cfg, err := sdriver.New(c)
+	cfg, err := config.New(c)
 	if err != nil {
 		logger.Errorf("error getting selector config, using defaults. %s", err.Error())
 	}


### PR DESCRIPTION
This PR adds support for the following configuration properties (`evictionInterval`, and `cleanupTickPeriod`) :

```yaml
# token selector configuration allows to use different implementations of the token selector
  # the "sherdlock" driver is the default implementation, other possible configurations are: "simple"
  # if empty, the default selector is used
  selector:
    driver: sherdlock
    # tokens might be locked because of an ongoing transaction from the same wallet. Instead of failing immediately, the selector can retry.
    # The interval is the exact amount of seconds (for simple selector) or the max amount of seconds (sherdlock) the selector waits before retrying.
    # default: 5s
    retryInterval: 5s
    # retry to gain a lock on tokens this amount of times before failing the transaction
    numRetries: 3
    # evictionInterval is the period a token can be locked, after which it is forcefully unlocked
    # if evictionInterval is zero, the eviction algorithm is never executed
    evictionInterval: 3m
    # cleanupTickPeriod defines how often the eviction algorithm must be executed
    # if cleanupTickPeriod is zero, the eviction algorithm is never executed
    cleanupTickPeriod: 1m
```