### PR TITLE
simplified token owner

### DIFF
--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		LibP2PNoReplication,
-		WebSocketWithReplication,
+		// LibP2PNoReplication,
+		// WebSocketWithReplication,
 	}
 )
 

--- a/token/core/common/authrorization.go
+++ b/token/core/common/authrorization.go
@@ -53,7 +53,7 @@ func NewTMSAuthorization(logger logging.Logger, publicParameters driver.PublicPa
 // IsMine returns true if the passed token is owned by an owner wallet.
 // It returns the ID of the owner wallet and no additional owner identifiers.
 func (w *WalletBasedAuthorization) IsMine(tok *token2.Token) (string, []string, bool) {
-	wallet, err := w.WalletService.OwnerWallet(tok.Owner.Raw)
+	wallet, err := w.WalletService.OwnerWallet(tok.Owner)
 	if err != nil {
 		return "", nil, false
 	}

--- a/token/core/common/wallets.go
+++ b/token/core/common/wallets.go
@@ -43,7 +43,7 @@ func (w *AuditorWallet) Contains(identity driver.Identity) bool {
 }
 
 func (w *AuditorWallet) ContainsToken(token *token.UnspentToken) bool {
-	return w.Contains(token.Owner.Raw)
+	return w.Contains(token.Owner)
 }
 
 func (w *AuditorWallet) GetAuditorIdentity() (driver.Identity, error) {
@@ -88,7 +88,7 @@ func (w *IssuerWallet) Contains(identity driver.Identity) bool {
 }
 
 func (w *IssuerWallet) ContainsToken(token *token.UnspentToken) bool {
-	return w.Contains(token.Owner.Raw)
+	return w.Contains(token.Owner)
 }
 
 func (w *IssuerWallet) GetIssuerIdentity(tokenType string) (driver.Identity, error) {
@@ -116,7 +116,7 @@ func (w *IssuerWallet) HistoryTokens(opts *driver.ListTokensOptions) (*token.Iss
 			continue
 		}
 
-		if !w.Contains(t.Issuer.Raw) {
+		if !w.Contains(t.Issuer) {
 			w.Logger.Debugf("issuer wallet [%s]: discarding token, issuer does not belong to wallet", w.ID())
 			continue
 		}
@@ -152,7 +152,7 @@ func (w *CertifierWallet) Contains(identity driver.Identity) bool {
 }
 
 func (w *CertifierWallet) ContainsToken(token *token.UnspentToken) bool {
-	return w.Contains(token.Owner.Raw)
+	return w.Contains(token.Owner)
 }
 
 func (w *CertifierWallet) GetCertifierIdentity() (driver.Identity, error) {
@@ -193,7 +193,7 @@ func (w *LongTermOwnerWallet) Contains(identity driver.Identity) bool {
 }
 
 func (w *LongTermOwnerWallet) ContainsToken(token *token.UnspentToken) bool {
-	return w.Contains(token.Owner.Raw)
+	return w.Contains(token.Owner)
 }
 
 func (w *LongTermOwnerWallet) GetRecipientIdentity() (driver.Identity, error) {
@@ -309,7 +309,7 @@ func (w *AnonymousOwnerWallet) Contains(identity driver.Identity) bool {
 
 // ContainsToken returns true if the passed token is owned by this wallet
 func (w *AnonymousOwnerWallet) ContainsToken(token *token.UnspentToken) bool {
-	return w.Contains(token.Owner.Raw)
+	return w.Contains(token.Owner)
 }
 
 func (w *AnonymousOwnerWallet) GetRecipientIdentity() (driver.Identity, error) {

--- a/token/core/fabtoken/actions.go
+++ b/token/core/fabtoken/actions.go
@@ -43,7 +43,7 @@ func (t *Output) Serialize() ([]byte, error) {
 // IsRedeem returns true if the owner of a Output is empty
 // todo update interface to account for nil t.Output.Owner and nil t.Output
 func (t *Output) IsRedeem() bool {
-	return len(t.Output.Owner.Raw) == 0
+	return len(t.Output.Owner) == 0
 }
 
 // IssueAction encodes a fabtoken Issue

--- a/token/core/fabtoken/actions.go
+++ b/token/core/fabtoken/actions.go
@@ -32,7 +32,7 @@ func (m *OutputMetadata) Serialize() ([]byte, error) {
 
 // Output carries the output of an action
 type Output struct {
-	Output *token.Token
+	Output token.Token
 }
 
 // Serialize marshals a Output

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -49,9 +49,7 @@ func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity
 		}
 		outs = append(outs, &Output{
 			Output: &token2.Token{
-				Owner: &token2.Owner{
-					Raw: owners[i],
-				},
+				Owner:    owners[i],
 				Type:     tokenType,
 				Quantity: q.Hex(),
 			},

--- a/token/core/fabtoken/issue.go
+++ b/token/core/fabtoken/issue.go
@@ -48,7 +48,7 @@ func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity
 			return nil, nil, errors.Wrapf(err, "failed to convert [%d] to quantity of precision [%d]", v, precision)
 		}
 		outs = append(outs, &Output{
-			Output: &token2.Token{
+			Output: token2.Token{
 				Owner:    owners[i],
 				Type:     tokenType,
 				Quantity: q.Hex(),

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -52,8 +52,8 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 
 	var senders []driver.Identity
 	for _, tok := range inputTokens {
-		s.Logger.Debugf("Selected output [%s,%s,%s]", tok.Type, tok.Quantity, driver.Identity(tok.Owner.Raw))
-		senders = append(senders, tok.Owner.Raw)
+		s.Logger.Debugf("Selected output [%s,%s,%s]", tok.Type, tok.Quantity, driver.Identity(tok.Owner))
+		senders = append(senders, tok.Owner)
 	}
 
 	// prepare outputs
@@ -88,28 +88,28 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 		if output.Output == nil || output.Output.Owner == nil {
 			return nil, nil, errors.Errorf("failed to transfer: invalid output at index %d", i)
 		}
-		if len(output.Output.Owner.Raw) == 0 { // redeem
-			receivers = append(receivers, output.Output.Owner.Raw)
+		if len(output.Output.Owner) == 0 { // redeem
+			receivers = append(receivers, output.Output.Owner)
 			outputAuditInfos = append(outputAuditInfos, []byte{})
 			continue
 		}
-		recipients, err := s.Deserializer.Recipients(output.Output.Owner.Raw)
+		recipients, err := s.Deserializer.Recipients(output.Output.Owner)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed getting recipients")
 		}
 		receivers = append(receivers, recipients...)
-		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(output.Output.Owner.Raw, ws)
+		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(output.Output.Owner, ws)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(output.Output.Owner.Raw).String())
+			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(output.Output.Owner).String())
 		}
 		outputAuditInfos = append(outputAuditInfos, auditInfo...)
 	}
 
 	var senderAuditInfos [][]byte
 	for _, t := range inputTokens {
-		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(t.Owner.Raw, ws)
+		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(t.Owner, ws)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(t.Owner.Raw).String())
+			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(t.Owner).String())
 		}
 		senderAuditInfos = append(senderAuditInfos, auditInfo...)
 	}

--- a/token/core/fabtoken/transfer.go
+++ b/token/core/fabtoken/transfer.go
@@ -61,7 +61,7 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 	var outputsMetadata [][]byte
 	for _, output := range Outputs {
 		outs = append(outs, &Output{
-			Output: output,
+			Output: *output,
 		})
 		meta := &OutputMetadata{}
 		metaRaw, err := meta.Serialize()
@@ -84,10 +84,7 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 	// assemble transfer metadata
 	var receivers []driver.Identity
 	var outputAuditInfos [][]byte
-	for i, output := range outs {
-		if output.Output == nil || output.Output.Owner == nil {
-			return nil, nil, errors.Errorf("failed to transfer: invalid output at index %d", i)
-		}
+	for _, output := range outs {
 		if len(output.Output.Owner) == 0 { // redeem
 			receivers = append(receivers, output.Output.Owner)
 			outputAuditInfos = append(outputAuditInfos, []byte{})

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -22,15 +22,15 @@ import (
 func TransferSignatureValidate(ctx *Context) error {
 	ctx.InputTokens = ctx.TransferAction.InputTokens
 	for _, tok := range ctx.InputTokens {
-		ctx.Logger.Debugf("check sender [%s]", driver.Identity(tok.Owner.Raw).UniqueID())
-		verifier, err := ctx.Deserializer.GetOwnerVerifier(tok.Owner.Raw)
+		ctx.Logger.Debugf("check sender [%s]", driver.Identity(tok.Owner).UniqueID())
+		verifier, err := ctx.Deserializer.GetOwnerVerifier(tok.Owner)
 		if err != nil {
-			return errors.Wrapf(err, "failed deserializing owner [%v][%s]", tok, driver.Identity(tok.Owner.Raw).UniqueID())
+			return errors.Wrapf(err, "failed deserializing owner [%v][%s]", tok, driver.Identity(tok.Owner).UniqueID())
 		}
-		ctx.Logger.Debugf("signature verification [%v][%s]", tok, driver.Identity(tok.Owner.Raw).UniqueID())
-		sigma, err := ctx.SignatureProvider.HasBeenSignedBy(tok.Owner.Raw, verifier)
+		ctx.Logger.Debugf("signature verification [%v][%s]", tok, driver.Identity(tok.Owner).UniqueID())
+		sigma, err := ctx.SignatureProvider.HasBeenSignedBy(tok.Owner, verifier)
 		if err != nil {
-			return errors.Wrapf(err, "failed signature verification [%v][%s]", tok, driver.Identity(tok.Owner.Raw).UniqueID())
+			return errors.Wrapf(err, "failed signature verification [%v][%s]", tok, driver.Identity(tok.Owner).UniqueID())
 		}
 		ctx.Signatures = append(ctx.Signatures, sigma)
 	}
@@ -90,7 +90,7 @@ func TransferHTLCValidate(ctx *Context) error {
 	now := time.Now()
 
 	for i, in := range ctx.InputTokens {
-		owner, err := identity.UnmarshalTypedIdentity(in.Owner.Raw)
+		owner, err := identity.UnmarshalTypedIdentity(in.Owner)
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshal owner of input token")
 		}
@@ -115,7 +115,7 @@ func TransferHTLCValidate(ctx *Context) error {
 			}
 
 			// check owner field
-			script, op, err := htlc2.VerifyOwner(ctx.InputTokens[0].Owner.Raw, tok.Owner.Raw, now)
+			script, op, err := htlc2.VerifyOwner(ctx.InputTokens[0].Owner, tok.Owner, now)
 			if err != nil {
 				return errors.Wrap(err, "failed to verify transfer from htlc script")
 			}
@@ -142,7 +142,7 @@ func TransferHTLCValidate(ctx *Context) error {
 		}
 
 		// if it is an htlc script then the deadline must still be valid
-		owner, err := identity.UnmarshalTypedIdentity(out.Output.Owner.Raw)
+		owner, err := identity.UnmarshalTypedIdentity(out.Output.Owner)
 		if err != nil {
 			return err
 		}

--- a/token/core/zkatdlog/crypto/token/token.go
+++ b/token/core/zkatdlog/crypto/token/token.go
@@ -60,7 +60,7 @@ func (t *Token) GetTokenInTheClear(meta *Metadata, pp *crypto.PublicParams) (*to
 	return &token2.Token{
 		Type:     meta.Type,
 		Quantity: "0x" + meta.Value.String(),
-		Owner:    &token2.Owner{Raw: t.Owner},
+		Owner:    t.Owner,
 	}, nil
 }
 

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -89,9 +89,6 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 			return nil, nil, errors.Wrapf(err, "failed to get value for %dth output", i)
 		}
 		values = append(values, q.ToBigInt().Uint64())
-		if output.Owner == nil {
-			return nil, nil, errors.Errorf("failed to get owner for %dth output: nil owner", i)
-		}
 		owners = append(owners, output.Owner)
 		if len(output.Owner) == 0 { // redeem
 			receivers = append(receivers, output.Owner)

--- a/token/core/zkatdlog/nogh/transfer.go
+++ b/token/core/zkatdlog/nogh/transfer.go
@@ -92,20 +92,20 @@ func (s *TransferService) Transfer(ctx context.Context, txID string, wallet driv
 		if output.Owner == nil {
 			return nil, nil, errors.Errorf("failed to get owner for %dth output: nil owner", i)
 		}
-		owners = append(owners, output.Owner.Raw)
-		if len(output.Owner.Raw) == 0 { // redeem
-			receivers = append(receivers, output.Owner.Raw)
+		owners = append(owners, output.Owner)
+		if len(output.Owner) == 0 { // redeem
+			receivers = append(receivers, output.Owner)
 			outputAuditInfos = append(outputAuditInfos, []byte{})
 			continue
 		}
-		recipients, err := s.Deserializer.Recipients(output.Owner.Raw)
+		recipients, err := s.Deserializer.Recipients(output.Owner)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "failed getting recipients")
 		}
 		receivers = append(receivers, recipients...)
-		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(output.Owner.Raw, s.WalletService)
+		auditInfo, err := s.Deserializer.GetOwnerAuditInfo(output.Owner, s.WalletService)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(output.Owner.Raw).String())
+			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(output.Owner).String())
 		}
 		outputAuditInfos = append(outputAuditInfos, auditInfo...)
 	}
@@ -221,7 +221,7 @@ func (s *TransferService) VerifyTransfer(action driver.TransferAction, outputsMe
 		if err != nil {
 			return errors.Wrap(err, "failed getting token in the clear")
 		}
-		s.Logger.Debugf("transfer output [%s,%s,%s]", tok.Type, tok.Quantity, driver.Identity(tok.Owner.Raw))
+		s.Logger.Debugf("transfer output [%s,%s,%s]", tok.Type, tok.Quantity, driver.Identity(tok.Owner))
 	}
 
 	return transfer.NewVerifier(getTokenData(tr.InputTokens), com, pp).Verify(tr.Proof)

--- a/token/request.go
+++ b/token/request.go
@@ -498,7 +498,7 @@ func (r *Request) extractIssueOutputs(i int, counter uint64, issueAction driver.
 		outputs = append(outputs, &Output{
 			ActionIndex:       i,
 			Index:             counter,
-			Owner:             tok.Owner.Raw,
+			Owner:             tok.Owner,
 			OwnerAuditInfo:    issueMeta.ReceiversAuditInfos[j],
 			EnrollmentID:      eID,
 			RevocationHandler: rID,
@@ -545,7 +545,7 @@ func (r *Request) extractTransferOutputs(i int, counter uint64, transferAction d
 		var eID string
 		var rID string
 		var receiverAuditInfo []byte
-		if len(tok.Owner.Raw) != 0 {
+		if len(tok.Owner) != 0 {
 			receiverAuditInfo = transferMeta.ReceiverAuditInfos[j]
 			eID, rID, err = tms.WalletService().GetEIDAndRH(transferMeta.Receivers[j], receiverAuditInfo)
 			if err != nil {
@@ -565,7 +565,7 @@ func (r *Request) extractTransferOutputs(i int, counter uint64, transferAction d
 		outputs = append(outputs, &Output{
 			ActionIndex:       i,
 			Index:             counter,
-			Owner:             tok.Owner.Raw,
+			Owner:             tok.Owner,
 			OwnerAuditInfo:    receiverAuditInfo,
 			EnrollmentID:      eID,
 			RevocationHandler: rID,
@@ -1012,7 +1012,7 @@ func (r *Request) AuditRecord() (*AuditRecord, error) {
 		in.Quantity = q
 
 		// retrieve the owner's audit info
-		ownerAuditInfo, err := r.TokenService.tms.WalletService().GetAuditInfo(toks[i].Owner.Raw)
+		ownerAuditInfo, err := r.TokenService.tms.WalletService().GetAuditInfo(toks[i].Owner)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed getting audit info for owner [%s]", toks[i].Owner)
 		}
@@ -1184,7 +1184,7 @@ func (r *Request) prepareTransfer(redeem bool, wallet *OwnerWallet, tokenType st
 		}
 
 		outputTokens = append(outputTokens, &token.Token{
-			Owner:    &token.Owner{Raw: restIdentity},
+			Owner:    restIdentity,
 			Type:     tokenType,
 			Quantity: diff.Hex(),
 		})
@@ -1229,7 +1229,7 @@ func (r *Request) genOutputs(values []uint64, owners []Identity, tokenType strin
 
 		// single output is fine
 		outputTokens = append(outputTokens, &token.Token{
-			Owner:    &token.Owner{Raw: owners[i]},
+			Owner:    owners[i],
 			Type:     tokenType,
 			Quantity: q.Hex(),
 		})

--- a/token/services/db/sql/common/test_cases.go
+++ b/token/services/db/sql/common/test_cases.go
@@ -267,7 +267,7 @@ func TSaveAndGetToken(t *testing.T, db *TokenDB) {
 	assert.Len(t, tok.ByType("TST").Tokens, 23, "expect filter on type to work")
 	for _, token := range tok.Tokens {
 		assert.NotNil(t, token.Owner, "expected owner to not be nil")
-		assert.NotEmpty(t, token.Owner.Raw, "expected owner raw to not be empty")
+		assert.NotEmpty(t, token.Owner, "expected owner raw to not be empty")
 	}
 
 	tokens := getTokensBy(t, db, "alice", "")
@@ -477,7 +477,7 @@ func TListAuditTokens(t *testing.T, db *TokenDB) {
 	assert.Equal(t, "0x02", tok[1].Quantity, "expected tx101-1 to be returned")
 	for _, token := range tok {
 		assert.NotNil(t, token.Owner, "expected owner to not be nil")
-		assert.NotEmpty(t, token.Owner.Raw, "expected owner raw to not be empty")
+		assert.NotEmpty(t, token.Owner, "expected owner raw to not be empty")
 	}
 
 	tok, err = db.ListAuditTokens()
@@ -552,9 +552,9 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 	assert.Equal(t, "0x03", tok.Tokens[2].Quantity, "expected tx102-0 to be returned")
 	for _, token := range tok.Tokens {
 		assert.NotNil(t, token.Issuer, "expected issuer to not be nil")
-		assert.NotEmpty(t, token.Issuer.Raw, "expected issuer raw to not be empty")
+		assert.NotEmpty(t, token.Issuer, "expected issuer raw to not be empty")
 		assert.NotNil(t, token.Owner, "expected owner to not be nil")
-		assert.NotEmpty(t, token.Owner.Raw, "expected owner raw to not be empty")
+		assert.NotEmpty(t, token.Owner, "expected owner raw to not be empty")
 	}
 
 	tok, err = db.ListHistoryIssuedTokens()
@@ -562,9 +562,9 @@ func TListIssuedTokens(t *testing.T, db *TokenDB) {
 	assert.Len(t, tok.ByType("DEF").Tokens, 1, "expected tx102-0 to be filtered")
 	for _, token := range tok.Tokens {
 		assert.NotNil(t, token.Issuer, "expected issuer to not be nil")
-		assert.NotEmpty(t, token.Issuer.Raw, "expected issuer raw to not be empty")
+		assert.NotEmpty(t, token.Issuer, "expected issuer raw to not be empty")
 		assert.NotNil(t, token.Owner, "expected owner to not be nil")
-		assert.NotEmpty(t, token.Owner.Raw, "expected owner raw to not be empty")
+		assert.NotEmpty(t, token.Owner, "expected owner raw to not be empty")
 	}
 }
 

--- a/token/services/db/sql/common/tokens.go
+++ b/token/services/db/sql/common/tokens.go
@@ -259,13 +259,11 @@ func (db *TokenDB) ListAuditTokens(ids ...*token.ID) ([]*token.Token, error) {
 	for rows.Next() {
 		id := token.ID{}
 		tok := token.Token{
-			Owner: &token.Owner{
-				Raw: []byte{},
-			},
+			Owner:    []byte{},
 			Type:     "",
 			Quantity: "",
 		}
-		if err := rows.Scan(&id.TxId, &id.Index, &tok.Owner.Raw, &tok.Type, &tok.Quantity); err != nil {
+		if err := rows.Scan(&id.TxId, &id.Index, &tok.Owner, &tok.Type, &tok.Quantity); err != nil {
 			return tokens, err
 		}
 
@@ -317,16 +315,12 @@ func (db *TokenDB) ListHistoryIssuedTokens() (*token.IssuedTokens, error) {
 				TxId:  "",
 				Index: 0,
 			},
-			Owner: &token.Owner{
-				Raw: []byte{},
-			},
+			Owner:    []byte{},
 			Type:     "",
 			Quantity: "",
-			Issuer: &token.Owner{
-				Raw: []byte{},
-			},
+			Issuer:   []byte{},
 		}
-		if err := rows.Scan(&tok.Id.TxId, &tok.Id.Index, &tok.Owner.Raw, &tok.Type, &tok.Quantity, &tok.Issuer.Raw); err != nil {
+		if err := rows.Scan(&tok.Id.TxId, &tok.Id.Index, &tok.Owner, &tok.Type, &tok.Quantity, &tok.Issuer); err != nil {
 			return nil, err
 		}
 		tokens = append(tokens, &tok)
@@ -498,7 +492,7 @@ func (db *TokenDB) GetTokens(inputs ...*token.ID) ([]*token.Token, error) {
 			return tokens, err
 		}
 		tok := &token.Token{
-			Owner:    &token.Owner{Raw: ownerRaw},
+			Owner:    ownerRaw,
 			Type:     typ,
 			Quantity: quantity,
 		}
@@ -927,9 +921,7 @@ func (t *TokenTransaction) GetToken(ctx context.Context, txID string, index uint
 		return nil, owners, nil
 	}
 	return &token.Token{
-		Owner: &token.Owner{
-			Raw: raw,
-		},
+		Owner:    raw,
 		Type:     tokenType,
 		Quantity: quantity,
 	}, owners, nil
@@ -1076,10 +1068,8 @@ func (u *UnspentTokensIterator) Next() (*token.UnspentToken, error) {
 		return nil, err
 	}
 	return &token.UnspentToken{
-		Id: &id,
-		Owner: &token.Owner{
-			Raw: owner,
-		},
+		Id:       &id,
+		Owner:    owner,
 		Type:     typ,
 		Quantity: quantity,
 	}, err

--- a/token/services/interop/htlc/script.go
+++ b/token/services/interop/htlc/script.go
@@ -106,41 +106,41 @@ func (s *ScriptAuth) AmIAnAuditor() bool {
 // IsMine returns true if either the sender or the recipient is in one of the owner wallets.
 // It returns an empty wallet id.
 func (s *ScriptAuth) IsMine(tok *token3.Token) (string, []string, bool) {
-	owner, err := identity.UnmarshalTypedIdentity(tok.Owner.Raw)
+	owner, err := identity.UnmarshalTypedIdentity(tok.Owner)
 	if err != nil {
-		logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity, err)
+		logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner), tok.Type, tok.Quantity, err)
 		return "", nil, false
 	}
 	if owner.Type != ScriptType {
-		logger.Debugf("Is Mine [%s,%s,%s]? No, owner type is [%s] instead of [%s]", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity, owner.Type, ScriptType)
+		logger.Debugf("Is Mine [%s,%s,%s]? No, owner type is [%s] instead of [%s]", view.Identity(tok.Owner), tok.Type, tok.Quantity, owner.Type, ScriptType)
 		return "", nil, false
 	}
 	script := &Script{}
 	if err := json.Unmarshal(owner.Identity, script); err != nil {
-		logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity, err)
+		logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner), tok.Type, tok.Quantity, err)
 		return "", nil, false
 	}
 	if script.Sender.IsNone() || script.Recipient.IsNone() {
-		logger.Debugf("Is Mine [%s,%s,%s]? No, invalid content [%v]", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity, script)
+		logger.Debugf("Is Mine [%s,%s,%s]? No, invalid content [%v]", view.Identity(tok.Owner), tok.Type, tok.Quantity, script)
 		return "", nil, false
 	}
 
 	var ids []string
 	// I'm either the sender
-	logger.Debugf("Is Mine [%s,%s,%s] as a sender?", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity)
+	logger.Debugf("Is Mine [%s,%s,%s] as a sender?", view.Identity(tok.Owner), tok.Type, tok.Quantity)
 	if wallet, err := s.WalletService.OwnerWallet(script.Sender); err == nil {
-		logger.Debugf("Is Mine [%s,%s,%s] as a sender? Yes", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity)
+		logger.Debugf("Is Mine [%s,%s,%s] as a sender? Yes", view.Identity(tok.Owner), tok.Type, tok.Quantity)
 		ids = append(ids, senderWallet(wallet))
 	}
 
 	// or the recipient
-	logger.Debugf("Is Mine [%s,%s,%s] as a recipient?", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity)
+	logger.Debugf("Is Mine [%s,%s,%s] as a recipient?", view.Identity(tok.Owner), tok.Type, tok.Quantity)
 	if wallet, err := s.WalletService.OwnerWallet(script.Recipient); err == nil {
-		logger.Debugf("Is Mine [%s,%s,%s] as a recipient? Yes", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity)
+		logger.Debugf("Is Mine [%s,%s,%s] as a recipient? Yes", view.Identity(tok.Owner), tok.Type, tok.Quantity)
 		ids = append(ids, recipientWallet(wallet))
 	}
 
-	logger.Debugf("Is Mine [%s,%s,%s]? %b", len(ids) != 0, view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity)
+	logger.Debugf("Is Mine [%s,%s,%s]? %b", len(ids) != 0, view.Identity(tok.Owner), tok.Type, tok.Quantity)
 	return "", ids, len(ids) != 0
 }
 

--- a/token/services/interop/htlc/transaction.go
+++ b/token/services/interop/htlc/transaction.go
@@ -200,7 +200,7 @@ func (t *Transaction) Reclaim(wallet *token.OwnerWallet, tok *token2.UnspentToke
 	if err != nil {
 		return errors.Wrapf(err, "failed to convert quantity [%s]", tok.Quantity)
 	}
-	owner, err := identity.UnmarshalTypedIdentity(tok.Owner.Raw)
+	owner, err := identity.UnmarshalTypedIdentity(tok.Owner)
 	if err != nil {
 		return err
 	}
@@ -225,14 +225,14 @@ func (t *Transaction) Reclaim(wallet *token.OwnerWallet, tok *token2.UnspentToke
 	}
 	logger.Debugf("registering signer for reclaim...")
 	if err := sigService.RegisterSigner(
-		tok.Owner.Raw,
+		tok.Owner,
 		signer,
 		verifier,
 	); err != nil {
 		return err
 	}
 
-	if err := t.Binder.Bind(script.Sender, tok.Owner.Raw); err != nil {
+	if err := t.Binder.Bind(script.Sender, tok.Owner); err != nil {
 		return err
 	}
 
@@ -250,7 +250,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		return errors.Wrapf(err, "failed to convert quantity [%s]", tok.Quantity)
 	}
 
-	owner, err := identity.UnmarshalTypedIdentity(tok.Owner.Raw)
+	owner, err := identity.UnmarshalTypedIdentity(tok.Owner)
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		return err
 	}
 	if err := sigService.RegisterSigner(
-		tok.Owner.Raw,
+		tok.Owner,
 		&ClaimSigner{
 			Recipient: recipientSigner,
 			Preimage:  preImage,
@@ -300,7 +300,7 @@ func (t *Transaction) Claim(wallet *token.OwnerWallet, tok *token2.UnspentToken,
 		return err
 	}
 
-	if err := t.Binder.Bind(script.Recipient, tok.Owner.Raw); err != nil {
+	if err := t.Binder.Bind(script.Recipient, tok.Owner); err != nil {
 		return err
 	}
 

--- a/token/services/interop/htlc/wallet.go
+++ b/token/services/interop/htlc/wallet.go
@@ -357,22 +357,22 @@ func (f *FilteredIterator) Next() (*token2.UnspentToken, error) {
 			logger.Debugf("no more tokens!")
 			return nil, nil
 		}
-		owner, err := identity.UnmarshalTypedIdentity(tok.Owner.Raw)
+		owner, err := identity.UnmarshalTypedIdentity(tok.Owner)
 		if err != nil {
-			logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner.Raw), tok.Type, tok.Quantity, err)
+			logger.Debugf("Is Mine [%s,%s,%s]? No, failed unmarshalling [%s]", view.Identity(tok.Owner), tok.Type, tok.Quantity, err)
 			continue
 		}
 		if owner.Type == ScriptType {
 			script := &Script{}
 			if err := json.Unmarshal(owner.Identity, script); err != nil {
-				logger.Debugf("token [%s,%s,%s,%s] contains a script? No", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+				logger.Debugf("token [%s,%s,%s,%s] contains a script? No", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 				continue
 			}
 			if script.Sender.IsNone() {
-				logger.Debugf("token [%s,%s,%s,%s] contains a script? No", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+				logger.Debugf("token [%s,%s,%s,%s] contains a script? No", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 				continue
 			}
-			logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+			logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 
 			pickItem, err := f.selector(tok, script)
 			if err != nil {

--- a/token/services/interop/htlc/wallet_filter.go
+++ b/token/services/interop/htlc/wallet_filter.go
@@ -25,7 +25,7 @@ type PreImageSelector struct {
 }
 
 func (f *PreImageSelector) Filter(tok *token.UnspentToken, script *Script) (bool, error) {
-	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 
 	if !script.HashInfo.HashFunc.Available() {
 		logger.Errorf("script hash function not available [%d]", script.HashInfo.HashFunc)
@@ -46,7 +46,7 @@ func (f *PreImageSelector) Filter(tok *token.UnspentToken, script *Script) (bool
 	}
 
 	// does the preimage match?
-	logger.Debugf("token [%s,%s,%s,%s] does hashes match?", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity,
+	logger.Debugf("token [%s,%s,%s,%s] does hashes match?", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity,
 		base64.StdEncoding.EncodeToString(h), base64.StdEncoding.EncodeToString(script.HashInfo.Hash))
 
 	return bytes.Equal(h, script.HashInfo.Hash), nil
@@ -54,7 +54,7 @@ func (f *PreImageSelector) Filter(tok *token.UnspentToken, script *Script) (bool
 
 // SelectExpired selects expired htlc-tokens
 func SelectExpired(tok *token.UnspentToken, script *Script) (bool, error) {
-	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 	now := time.Now()
 	logger.Debugf("[%v]<=[%v], sender [%s], recipient [%s]?", script.Deadline, now, script.Sender.UniqueID(), script.Recipient.UniqueID())
 	return script.Deadline.Before(now), nil
@@ -73,7 +73,7 @@ type ExpiredAndHashSelector struct {
 }
 
 func (s *ExpiredAndHashSelector) Select(tok *token.UnspentToken, script *Script) (bool, error) {
-	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner.Raw).UniqueID(), tok.Type, tok.Quantity)
+	logger.Debugf("token [%s,%s,%s,%s] contains a script? Yes", tok.Id, view.Identity(tok.Owner).UniqueID(), tok.Type, tok.Quantity)
 	now := time.Now()
 	logger.Debugf("[%v]<=[%v], sender [%s], recipient [%s]?", script.Deadline, now, script.Sender.UniqueID(), script.Recipient.UniqueID())
 	return script.Deadline.Before(now) && bytes.Equal(script.HashInfo.Hash, s.Hash), nil

--- a/token/services/nfttx/filter.go
+++ b/token/services/nfttx/filter.go
@@ -90,7 +90,7 @@ func (s *filter) selectByFilter(filter Filter, q string) ([]*token2.ID, token2.Q
 		selected := filter.ContainsToken(t)
 		if !selected {
 			if logger.IsEnabledFor(zapcore.DebugLevel) {
-				logger.Debugf("token [%s,%s,%v] owner does not belong to the passed wallet", view.Identity(t.Owner.Raw), q, selected)
+				logger.Debugf("token [%s,%s,%v] owner does not belong to the passed wallet", view.Identity(t.Owner), q, selected)
 			}
 			continue
 		}

--- a/token/services/selector/benchmark_test.go
+++ b/token/services/selector/benchmark_test.go
@@ -123,7 +123,7 @@ func BenchmarkSelectorParallel(b *testing.B) {
 func setup(s *Setting) {
 
 	walletID := "wallet0"
-	walletOwner := &token2.Owner{Raw: []byte(walletID)}
+	walletOwner := []byte(walletID)
 
 	walletIDByRawIdentity := func(rawIdentity []byte) string {
 		return string(rawIdentity)
@@ -145,7 +145,7 @@ func setup(s *Setting) {
 			Quantity: q.Decimal(),
 		}
 
-		k := fmt.Sprintf("etoken.%s.%s.%s.%d", string(walletOwner.Raw), testutils.TokenType, t.Id.TxId, t.Id.Index)
+		k := fmt.Sprintf("etoken.%s.%s.%s.%d", string(walletOwner), testutils.TokenType, t.Id.TxId, t.Id.Index)
 		qs.Add(k, t)
 	}
 

--- a/token/services/selector/testutils/test_cases.go
+++ b/token/services/selector/testutils/test_cases.go
@@ -27,7 +27,7 @@ const defaultCurrency = "CHF"
 
 var (
 	logger                    = flogging.MustGetLogger("token-sdk.selector.tests")
-	defaultWalletOwner        = &token.Owner{Raw: []byte{1, 2, 3}}
+	defaultWalletOwner        = []byte{1, 2, 3}
 	defaultTokenFilter        = &TokenFilter{Wallet: defaultWalletOwner}
 	txId               uint32 = 0
 )
@@ -158,7 +158,7 @@ func (m *enhancedManager) UpdateTokens(deleted []*token.ID, added []token.Unspen
 				TxID:           t.Id.TxId,
 				Index:          t.Id.Index,
 				IssuerRaw:      []byte{},
-				OwnerRaw:       t.Owner.Raw,
+				OwnerRaw:       t.Owner,
 				OwnerType:      "idemix",
 				OwnerIdentity:  []byte{},
 				Ledger:         []byte("ledger"),

--- a/token/services/selector/testutils/testutils.go
+++ b/token/services/selector/testutils/testutils.go
@@ -90,12 +90,12 @@ func (q *MockQueryService) Add(key string, t *token2.UnspentToken) {
 }
 
 func (q *MockQueryService) WarmupCache(walletID, tokenType string) {
-	//fmt.Printf("try to find by %s %s\n", walletID, tokenType)
+	// fmt.Printf("try to find by %s %s\n", walletID, tokenType)
 	keys := make([]string, 0, len(q.kvs))
 	for k := range q.kvs {
 		// do some filtering
 		if strings.Contains(k, walletID) && strings.Contains(k, tokenType) {
-			//fmt.Printf("filter key=%s\n", k)
+			// fmt.Printf("filter key=%s\n", k)
 			keys = append(keys, k)
 		}
 	}
@@ -134,7 +134,7 @@ func (q *MockQueryService) SpendableTokensIteratorBy(ctx context.Context, wallet
 	return collections.Map(it, func(ut *token2.UnspentToken) (*token2.UnspentTokenInWallet, error) {
 		return &token2.UnspentTokenInWallet{
 			Id:       ut.Id,
-			WalletID: string(ut.Owner.Raw),
+			WalletID: string(ut.Owner),
 			Type:     ut.Type,
 			Quantity: ut.Quantity,
 		}, nil
@@ -181,7 +181,7 @@ func (n *NoLock) IsLocked(id *token2.ID) bool {
 }
 
 type TokenFilter struct {
-	Wallet   *token2.Owner
+	Wallet   []byte
 	WalletID string
 }
 
@@ -190,5 +190,5 @@ func (c *TokenFilter) ID() string {
 }
 
 func (c *TokenFilter) ContainsToken(token *token2.UnspentToken) bool {
-	return bytes.Equal(token.Owner.Raw, c.Wallet.Raw)
+	return bytes.Equal(token.Owner, c.Wallet)
 }

--- a/token/services/tokens/storage.go
+++ b/token/services/tokens/storage.go
@@ -139,7 +139,7 @@ func (t *transaction) AppendToken(ctx context.Context, tta TokenToAppend) error 
 			TxID:           tta.txID,
 			Index:          tta.index,
 			IssuerRaw:      tta.issuer,
-			OwnerRaw:       tta.tok.Owner.Raw,
+			OwnerRaw:       tta.tok.Owner,
 			OwnerType:      tta.ownerType,
 			OwnerIdentity:  tta.ownerIdentity,
 			OwnerWalletID:  tta.ownerWalletID,

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -279,7 +279,7 @@ func (t *Tokens) parse(auth driver.Authorization, txID string, md MetaData, is *
 			continue
 		}
 
-		ownerType, ownerIdentity, err := auth.OwnerType(tok.Owner.Raw)
+		ownerType, ownerIdentity, err := auth.OwnerType(tok.Owner)
 		if err != nil {
 			logger.Errorf("could not unmarshal identity when storing token: %s", err.Error())
 			continue

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -28,7 +28,7 @@ func (a authMock) Issued(issuer driver.Identity, tok *token2.Token) bool {
 	return false
 }
 func (a authMock) IsMine(tok *token2.Token) (string, []string, bool) {
-	return "", []string{string(tok.Owner.Raw)}, true
+	return "", []string{string(tok.Owner)}, true
 }
 func (a authMock) AmIAnAuditor() bool {
 	return false
@@ -53,9 +53,7 @@ func (md mdMock) GetToken(raw []byte) (*token2.Token, token.Identity, []byte, er
 		parsed = strings.Split(string(raw), ",")
 	}
 	return &token2.Token{
-		Owner: &token2.Owner{
-			Raw: []byte(parsed[0]),
-		},
+		Owner:    []byte(parsed[0]),
 		Type:     parsed[1],
 		Quantity: parsed[2],
 	}, []byte{}, []byte{}, nil

--- a/token/token/token.go
+++ b/token/token/token.go
@@ -25,16 +25,10 @@ func (id ID) String() string {
 	return fmt.Sprintf("[%s:%d]", id.TxId, id.Index)
 }
 
-// Owner holds the identity of a token owner
-type Owner struct {
-	// Raw is the serialization of the identity
-	Raw []byte `protobuf:"bytes,2,opt,name=raw,proto3" json:"raw,omitempty"`
-}
-
 // Token is the result of issue and transfer transactions
 type Token struct {
 	// Owner is the token owner
-	Owner *Owner `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
+	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity is the number of units of Type carried in the token.
@@ -46,14 +40,14 @@ type IssuedToken struct {
 	// Id is used to uniquely identify the token in the ledger
 	Id *ID `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Owner is the token owner
-	Owner *Owner `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
+	Owner []byte `protobuf:"bytes,1,opt,name=owner,proto3" json:"owner,omitempty"`
 	// Type is the type of the token
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
 	// Quantity represents the number of units of Type that this unspent token holds.
 	// It is formatted in decimal representation
 	Quantity string `protobuf:"bytes,3,opt,name=quantity,proto3" json:"quantity,omitempty"`
-
-	Issuer *Owner
+	// Issuer is the issuer of this token
+	Issuer []byte
 }
 
 type IssuedTokens struct {
@@ -104,7 +98,7 @@ type UnspentToken struct {
 	// Id is used to uniquely identify the token in the ledger
 	Id *ID
 	// Owner is the token owner
-	Owner *Owner
+	Owner []byte
 	// Type is the type of the token
 	Type string
 	// Quantity represents the number of units of Type that this unspent token holds.

--- a/token/vault_test.go
+++ b/token/vault_test.go
@@ -45,7 +45,7 @@ func TestQueryEngine_ListAuditTokens(t *testing.T) {
 	mockQE := &mock.QueryEngine{}
 	expectedIDs := []*token.ID{{TxId: "a_transaction", Index: 0}}
 	expectedTokens := []*token.Token{{
-		Owner:    &token.Owner{Raw: []byte("some_owner")},
+		Owner:    []byte("some_owner"),
 		Type:     "some_type",
 		Quantity: "some_quantity",
 	}}
@@ -73,7 +73,7 @@ func TestQueryEngine_ListAuditTokens_IsPendingTrue(t *testing.T) {
 	mockQE := &mock.QueryEngine{}
 	expectedIDs := []*token.ID{{TxId: "a_transaction", Index: 0}}
 	expectedTokens := []*token.Token{{
-		Owner:    &token.Owner{Raw: []byte("some_owner")},
+		Owner:    []byte("some_owner"),
 		Type:     "some_type",
 		Quantity: "some_quantity",
 	}}
@@ -196,7 +196,7 @@ func TestQueryEngine_PublicParams_Error(t *testing.T) {
 func TestQueryEngine_GetTokens(t *testing.T) {
 	mockQE := &mock.QueryEngine{}
 	expectedTokens := []*token.Token{{
-		Owner:    &token.Owner{Raw: []byte("some_owner")},
+		Owner:    []byte("some_owner"),
 		Type:     "some_type",
 		Quantity: "some_quantity",
 	}}


### PR DESCRIPTION
This PR does the following: It removes the Owner struct from the `token` package. 
The struct was of no help and required a check for nil that didn't serve anything.