### PR TITLE
Translator: Switch from Any to Latest

### DIFF
--- a/token/services/network/common/rws/translator/rwset.go
+++ b/token/services/network/common/rws/translator/rwset.go
@@ -55,8 +55,8 @@ type RWSet interface {
 type KeyVersion = int
 
 const (
-	// Any value, any version of the key would work
-	Any KeyVersion = iota
+	// Latest value, latest version of the key known to the node
+	Latest KeyVersion = iota
 	// VersionZero value,  version `zero` of the key
 	VersionZero
 )

--- a/token/services/network/common/rws/translator/rwset.go
+++ b/token/services/network/common/rws/translator/rwset.go
@@ -72,6 +72,7 @@ type ExRWSet interface {
 	// StateMustNotExist adds a read dependency that enforces that the passed key does not exist
 	StateMustNotExist(key Key) error
 	// StateMustExist adds a read dependency that enforces that the passed key does exist
+	// When using VersionZero, this method should be called only for keys that are guaranteed to be used only once.
 	StateMustExist(key Key, version KeyVersion) error
 }
 
@@ -109,6 +110,9 @@ func (w *RWSetWrapper) StateMustNotExist(key Key) error {
 }
 
 func (w *RWSetWrapper) StateMustExist(key Key, version KeyVersion) error {
+	// This wrapper assumes the following:
+	// When StateMustExist is called on VersionZero, Latest behaviour is used instead.
+	// This works under the assumption that keys are used only once.
 	h, err := w.RWSet.GetState(w.Namespace, key)
 	if err != nil {
 		return errors.Wrapf(err, "failed to read state [%s:%s] for [%s]", w.Namespace, key, w.TxID)

--- a/token/services/network/common/rws/translator/translator.go
+++ b/token/services/network/common/rws/translator/translator.go
@@ -116,7 +116,7 @@ func (w *Translator) AddPublicParamsDependency() error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to create setup key")
 	}
-	if err := w.RWSet.StateMustExist(setupKey, Any); err != nil {
+	if err := w.RWSet.StateMustExist(setupKey, Latest); err != nil {
 		return errors.Wrapf(err, "failed to add public params dependency")
 	}
 	return nil

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/keys"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/pkg/errors"
@@ -86,7 +87,22 @@ func (l *loader) load(tmsID token2.TMSID) (Service, error) {
 	}
 
 	logger.Infof("FSC endorsement enabled...")
-	return NewFSCService(l.fns, tmsID, configuration, l.viewRegistry, l.viewManager, l.identityProvider)
+	return NewFSCService(
+		l.fns,
+		tmsID,
+		configuration,
+		l.viewRegistry,
+		l.viewManager,
+		l.identityProvider,
+		&keys.Translator{},
+		func(txID string, namespace string, rws *fabric.RWSet) (Translator, error) {
+			return translator.New(
+				txID,
+				translator.NewRWSetWrapper(&RWSWrapper{Stub: rws}, namespace, txID),
+				&keys.Translator{},
+			), nil
+		},
+	)
 }
 
 func key(tmsID token2.TMSID) string {


### PR DESCRIPTION
With these add-ons:
- pass to the approval responder view a translator provider. This will simplify the possibility to change the transaltor.