### PR TITLE
benchmark for sig service and improvements

### DIFF
--- a/token/services/identity/sig/sigservice_test.go
+++ b/token/services/identity/sig/sigservice_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sig
 
 import (
@@ -6,7 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/postgres"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs/mock"
-	registry2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	kvs2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
@@ -41,7 +47,7 @@ func BenchmarkRegisterSigner(b *testing.B) {
 		Name:    "hw",
 		ConnStr: pgConnStr,
 	}
-	registry := registry2.New()
+	registry := registry.New()
 	cp := &mock.ConfigProvider{}
 	backend, err := kvs.NewWithConfig(d, "", cp)
 	assert.NoError(b, err)

--- a/token/services/identity/sig/sigservice_test.go
+++ b/token/services/identity/sig/sigservice_test.go
@@ -1,0 +1,64 @@
+package sig
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql/postgres"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs/mock"
+	registry2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	kvs2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/kvs"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/stretchr/testify/assert"
+)
+
+type Signer struct {
+	ID string
+}
+
+func (s *Signer) Sign(message []byte) ([]byte, error) {
+	// TODO implement me
+	panic("implement me")
+}
+
+type Verifier struct {
+	ID string
+}
+
+func (v *Verifier) Verify(message, sigma []byte) error {
+
+	// TODO implement me
+	panic("implement me")
+}
+
+func BenchmarkRegisterSigner(b *testing.B) {
+	b.StopTimer()
+	terminate, pgConnStr, err := postgres.StartPostgres(b, false)
+	assert.NoError(b, err)
+	defer terminate()
+	d := &postgres.TestDriver{
+		Name:    "hw",
+		ConnStr: pgConnStr,
+	}
+	registry := registry2.New()
+	cp := &mock.ConfigProvider{}
+	backend, err := kvs.NewWithConfig(d, "", cp)
+	assert.NoError(b, err)
+	err = registry.RegisterService(backend)
+	assert.NoError(b, err)
+	sigService := NewService(NewMultiplexDeserializer(), kvs2.NewIdentityDB(backend, token.TMSID{Network: "pineapple"}))
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Code to be benchmarked
+		b.StopTimer()
+		nonce, err := htlc.CreateNonce()
+		assert.NoError(b, err)
+		signer := &Signer{ID: string(nonce)}
+		verifier := &Verifier{ID: string(nonce)}
+		b.StartTimer()
+
+		assert.NoError(b, sigService.RegisterSigner(nonce, signer, verifier, nil))
+	}
+}


### PR DESCRIPTION
This PR does the following:
- Resolve a lock-related bug in RegisterVerifier
- It moves out from the critical zone the storage of the identity