### PR TITLE
log error but don't fail hard if there are no configured identities

### DIFF
--- a/token/services/identity/common/lm.go
+++ b/token/services/identity/common/lm.go
@@ -251,7 +251,8 @@ func (l *LocalMembership) registerIdentityConfiguration(identity *driver.Identit
 		l.logger.Warnf("failed to load local identity at [%s]:[%s]", identity.URL, err)
 		// Does path correspond to a folder containing multiple identities?
 		if err := l.registerLocalIdentities(identity); err != nil {
-			return errors.WithMessage(err, "failed to register local identity")
+			// we don't return the error so that the token manager can still load
+			l.logger.Errorf("failed to register local identity from folder: %s", err.Error())
 		}
 	}
 	return nil

--- a/token/services/identitydb/db.go
+++ b/token/services/identitydb/db.go
@@ -54,8 +54,8 @@ func NewManager(drivers []db.NamedDriver[driver.IdentityDBDriver], cp driver.Con
 		identityDrivers[i] = db.NamedDriver[*identityDBDriver]{Name: driver.Name, Driver: &identityDBDriver{IdentityDBDriver: driver.Driver}}
 		walletDrivers[i] = db.NamedDriver[*walletDBDriver]{Name: driver.Name, Driver: &walletDBDriver{IdentityDBDriver: driver.Driver}}
 	}
-	identityHolder := db.NewDriverHolder[driver.IdentityDB, driver.IdentityDB, *identityDBDriver](utils.IdentityFunc[driver.IdentityDB](), identityDrivers...)
-	walletHolder := db.NewDriverHolder[driver.WalletDB, driver.WalletDB, *walletDBDriver](utils.IdentityFunc[driver.WalletDB](), walletDrivers...)
+	identityHolder := db.NewDriverHolder(utils.IdentityFunc[driver.IdentityDB](), identityDrivers...)
+	walletHolder := db.NewDriverHolder(utils.IdentityFunc[driver.WalletDB](), walletDrivers...)
 	return &Manager{
 		identityManager: identityHolder.NewManager(cp, config),
 		walletManager:   walletHolder.NewManager(cp, config),


### PR DESCRIPTION
Currently, the identity setup returns an error if there is an issue with loading identities. While that makes sense, it seems that we also need TMS to be able to register a new identity. And TMS doesn't load if the identity setup fails, so it can lead to a catch 22 situation. It's possible that there's a nicer solution (do we really need the larger TMS component to register identities?) but for now just logging the error seems a valid approach too.