### PR TITLE
add configurable maxIdleConns and maxIdleTime

### DIFF
--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -48,20 +48,20 @@ token:
       # shared db configuration. The `unity` driver is used as provider.  
       db:
         persistence:
-          # configuration for the unity db driver. It uses sql as backend
+          # configuration for the unity db driver. It uses sql as backend. See also https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/core-fabric.md
           type: unity
           opts:
-            createSchema: true
             driver: sqlite
-            maxOpenConns: 10
+            maxOpenConns: 20  # optional: max open read connections to the database. Defaults to unlimited. See https://go.dev/doc/database/manage-connections.
+            maxIdleConns: 20  # optional: max idle read connections to the database. Defaults to 2.
+            maxIdleTime: 30s  # optional: max duration a connection can be idle before it is closed. Defaults to 1 minute.
             dataSource: /some/path/unitydb
+      # optional separate configuration for ttxdb, tokendb, auditdb, and identitydb
       tokendb:
         persistence:
           type: sql
           opts:
-            createSchema: true 
-            driver: sqlite    
-            maxOpenConns: 10
+            driver: sqlite
             dataSource: /some/path/tokendb
 
       services:

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -44,9 +44,7 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true 
             driver: sqlite    
-            maxOpenConns: 10
             dataSource: /some/path/tokendb
 ```
 
@@ -65,11 +63,11 @@ token:
           # configuration for the unity db driver. It uses sql as backend
           type: unity
           opts:
-            createSchema: true
             driver: sqlite
-            maxOpenConns: 10
             dataSource: /some/path/unitydb
 ```
 
 The specific driver used by the application will ultimately determine the available deployment options.
 Don't forget to import the driver that you are ultimately using with a blank import in your executable.  
+
+For the list of options to configure sql datasources, refer to the [Fabric Smart Client documentation](https://github.com/hyperledger-labs/fabric-smart-client/blob/main/docs/core-fabric.md).

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241211130358-b88ab0ceb637
+	github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241212193429-55ffb2edb9d0
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.sum
+++ b/go.sum
@@ -1070,8 +1070,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241211130358-b88ab0ceb637 h1:MZCpeJx1D2TUni7l20xQujbY+aKofxIqQJBtKG4mWxk=
-github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241211130358-b88ab0ceb637/go.mod h1:TZNUlhR7V3xEUkJLZHi348o+L+bmgOqX/TjjcTXqSL8=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241212193429-55ffb2edb9d0 h1:rLwxWZo3ZlNukBcRUWcldDKNmg2+jiOe6JSZTfT1qnk=
+github.com/hyperledger-labs/fabric-smart-client v0.3.1-0.20241212193429-55ffb2edb9d0/go.mod h1:Fcz6IOEmwXihzi/Hn8fxuyAbyJxhe706+TJsQwLHRME=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/integration/nwo/token/fabric/template.go
+++ b/integration/nwo/token/fabric/template.go
@@ -41,7 +41,6 @@ token:
         persistence:
           type: unity
           opts:
-            createSchema: true 
             driver: {{ SQLDriver }}    
             maxOpenConns: 200
             dataSource: {{ SQLDataSource }}
@@ -50,7 +49,6 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true 
             tablePrefix: tokens  
             driver: {{ TokensSQLDriver }}    
             maxOpenConns: 200

--- a/integration/nwo/token/orion/template.go
+++ b/integration/nwo/token/orion/template.go
@@ -33,7 +33,6 @@ token:
         persistence:
           type: unity
           opts:
-            createSchema: true 
             driver: {{ SQLDriver }}    
             maxOpenConns: 200
             dataSource: {{ SQLDataSource }}
@@ -42,7 +41,6 @@ token:
         persistence:
           type: sql
           opts:
-            createSchema: true 
             tablePrefix: tokens  
             driver: {{ TokensSQLDriver }}    
             maxOpenConns: 200

--- a/token/services/db/memorydriver.go
+++ b/token/services/db/memorydriver.go
@@ -9,6 +9,7 @@ package db
 import (
 	"crypto/sha256"
 	"fmt"
+	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
 	sql2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql"
@@ -39,6 +40,8 @@ func (d *MemoryDriver[D]) Open(_ driver.ConfigProvider, tmsID token.TMSID) (D, e
 		SkipCreateTable: false,
 		SkipPragmas:     false,
 		MaxOpenConns:    10,
+		MaxIdleConns:    10,
+		MaxIdleTime:     time.Minute,
 	}
 	return d.dbOpener(opts)
 }

--- a/token/services/db/sql/postgres/identity.go
+++ b/token/services/db/sql/postgres/identity.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OpenIdentityDB(k common.Opts) (driver.IdentityDB, error) {
-	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns)
+	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/postgres/tokenlock.go
+++ b/token/services/db/sql/postgres/tokenlock.go
@@ -21,7 +21,7 @@ type TokenLockDB struct {
 }
 
 func OpenTokenLockDB(k common.Opts) (driver.TokenLockDB, error) {
-	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns)
+	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/postgres/transactions.go
+++ b/token/services/db/sql/postgres/transactions.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OpenAuditTransactionDB(k common.Opts) (driver.AuditTransactionDB, error) {
-	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns)
+	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func NewAuditTransactionDB(db *sql.DB, opts common.NewDBOpts) (driver.AuditTrans
 }
 
 func OpenTransactionDB(k common.Opts) (driver.TokenTransactionDB, error) {
-	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns)
+	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/postgres/wallet.go
+++ b/token/services/db/sql/postgres/wallet.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OpenWalletDB(k common.Opts) (driver.WalletDB, error) {
-	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns)
+	db, err := postgres.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/sqlite/identity.go
+++ b/token/services/db/sql/sqlite/identity.go
@@ -15,7 +15,7 @@ import (
 )
 
 func NewCachedIdentityDB(k common.Opts) (driver.IdentityDB, error) {
-	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.SkipPragmas)
+	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime, k.SkipPragmas)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/sqlite/tokenlock.go
+++ b/token/services/db/sql/sqlite/tokenlock.go
@@ -39,7 +39,7 @@ func (db *TokenLockDB) Cleanup(leaseExpiry time.Duration) error {
 }
 
 func OpenTokenLockDB(k common.Opts) (driver.TokenLockDB, error) {
-	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.SkipPragmas)
+	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime, k.SkipPragmas)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/sqlite/transactions.go
+++ b/token/services/db/sql/sqlite/transactions.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OpenAuditTransactionDB(k common.Opts) (driver.AuditTransactionDB, error) {
-	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.SkipPragmas)
+	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime, k.SkipPragmas)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func NewAuditTransactionDB(db *sql.DB, opts common.NewDBOpts) (driver.AuditTrans
 }
 
 func OpenTransactionDB(k common.Opts) (driver.TokenTransactionDB, error) {
-	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.SkipPragmas)
+	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime, k.SkipPragmas)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/db/sql/sqlite/wallet.go
+++ b/token/services/db/sql/sqlite/wallet.go
@@ -15,7 +15,7 @@ import (
 )
 
 func OpenWalletDB(k common.Opts) (driver.WalletDB, error) {
-	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.SkipPragmas)
+	db, err := sqlite.OpenDB(k.DataSource, k.MaxOpenConns, k.MaxIdleConns, k.MaxIdleTime, k.SkipPragmas)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/network/driver/lm.go
+++ b/token/services/network/driver/lm.go
@@ -16,5 +16,5 @@ type LocalMembership interface {
 	DefaultIdentity() view.Identity
 
 	// AnonymousIdentity returns a fresh anonymous identity
-	AnonymousIdentity() view.Identity
+	AnonymousIdentity() (view.Identity, error)
 }

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -54,7 +54,7 @@ func (n *lm) DefaultIdentity() view.Identity {
 	return n.lm.DefaultIdentity()
 }
 
-func (n *lm) AnonymousIdentity() view.Identity {
+func (n *lm) AnonymousIdentity() (view.Identity, error) {
 	return n.lm.AnonymousIdentity()
 }
 

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -248,7 +248,7 @@ func (l *LocalMembership) DefaultIdentity() view.Identity {
 	return l.lm.DefaultIdentity()
 }
 
-func (l *LocalMembership) AnonymousIdentity() view.Identity {
+func (l *LocalMembership) AnonymousIdentity() (view.Identity, error) {
 	return l.lm.AnonymousIdentity()
 }
 
@@ -308,7 +308,7 @@ func (n *Network) Broadcast(context context.Context, blob interface{}) error {
 }
 
 // AnonymousIdentity returns a fresh anonymous identity
-func (n *Network) AnonymousIdentity() view.Identity {
+func (n *Network) AnonymousIdentity() (view.Identity, error) {
 	return n.n.LocalMembership().AnonymousIdentity()
 }
 

--- a/token/services/network/orion/lm.go
+++ b/token/services/network/orion/lm.go
@@ -20,6 +20,6 @@ func (n *lm) DefaultIdentity() view.Identity {
 	return n.ip.DefaultIdentity()
 }
 
-func (n *lm) AnonymousIdentity() view.Identity {
-	return view.Identity(n.lm.Me())
+func (n *lm) AnonymousIdentity() (view.Identity, error) {
+	return view.Identity(n.lm.Me()), nil
 }

--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -76,7 +76,7 @@ func startManagers(t *testing.T, number int, backoff time.Duration, maxRetries i
 }
 
 func createManager(pgConnStr string, backoff time.Duration, maxRetries int) (testutils.EnhancedManager, error) {
-	db, err := postgres2.OpenDB(pgConnStr, 10)
+	db, err := postgres2.OpenDB(pgConnStr, 10, 2, time.Minute)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -48,11 +48,16 @@ func NewAnonymousTransaction(context view.Context, opts ...TxOption) (*Transacti
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed compiling tx options")
 	}
-	return NewTransaction(
-		context,
-		network.GetInstance(context, txOpts.TMSID.Network, txOpts.TMSID.Channel).AnonymousIdentity(),
-		opts...,
-	)
+	net := network.GetInstance(context, txOpts.TMSID.Network, txOpts.TMSID.Channel)
+	if net == nil {
+		return nil, errors.New("failed to get network")
+	}
+	id, err := net.AnonymousIdentity()
+	if err != nil {
+		return nil, errors.WithMessage(err, "failed getting anonymous identity for transaction")
+	}
+
+	return NewTransaction(context, id, opts...)
 }
 
 // NewTransaction returns a new token transaction customized with the passed opts that will be signed by the passed signer.


### PR DESCRIPTION
Allows for use case specific tuning of database parameters.

```
    maxOpenConns: 20  # optional: max open read connections to the database. Defaults to unlimited. See https://go.dev/doc/database/manage-connections.
    maxIdleConns: 20  # optional: max idle read connections to the database. Defaults to 2.
    maxIdleTime: 30s  # optional: max duration a connection can be idle before it is closed. Defaults to 1 minute.
```

Refers to the commit in FSC of https://github.com/hyperledger-labs/fabric-smart-client/pull/713