### PR TITLE
OnwerWallet GetRecipientData

### DIFF
--- a/integration/token/fungible/update/update_test.go
+++ b/integration/token/fungible/update/update_test.go
@@ -60,7 +60,7 @@ func newTestSuite(commType fsc.P2PCommunicationType, fabtokenPrecision int, extr
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "fabtoken", PublicParamsGenArgs: []string{strconv.Itoa(fabtokenPrecision)}},
 		OnlyUnity:       true,
 		ExtraTMSs:       extraTMSs,
-		FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
+		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
 	}))
 	return ts, selector
 }

--- a/token/core/fabtoken/wallet.go
+++ b/token/core/fabtoken/wallet.go
@@ -42,7 +42,10 @@ func (w *WalletFactory) NewWallet(id string, role driver.IdentityRole, walletReg
 	var newWallet driver.Wallet
 	switch role {
 	case driver.OwnerRole:
-		newWallet = common.NewLongTermOwnerWallet(w.identityProvider, w.tokenVault, idInfoIdentity, id, info)
+		newWallet, err = common.NewLongTermOwnerWallet(w.identityProvider, w.tokenVault, id, info)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "failed to create owner wallet [%s]", id)
+		}
 	case driver.IssuerRole:
 		newWallet = common.NewIssuerWallet(w.logger, w.identityProvider, w.tokenVault, id, idInfoIdentity)
 	case driver.AuditorRole:

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -59,6 +59,9 @@ type OwnerWallet interface {
 	// - TokenIdentityMetadata via GetTokenMetadataAuditInfo.
 	GetRecipientIdentity() (Identity, error)
 
+	// GetRecipientData returns a recipient data struct, it does not include the token metadata audit info
+	GetRecipientData() (*RecipientData, error)
+
 	// GetAuditInfo returns auditing information for the passed identity
 	GetAuditInfo(id Identity) ([]byte, error)
 

--- a/token/services/ttx/recipients.go
+++ b/token/services/ttx/recipients.go
@@ -253,6 +253,7 @@ func (s *RespondRequestRecipientIdentityView) Call(context view.Context) (interf
 			logger.Errorf("failed to get recipient identity: [%s]", err)
 			return nil, errors.Wrapf(err, "failed to get recipient identity")
 		}
+		recipientIdentity = recipientData.Identity
 	}
 	recipientDataRaw, err := RecipientDataBytes(recipientData)
 	if err != nil {

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -246,6 +246,11 @@ func (o *OwnerWallet) GetRecipientIdentity() (Identity, error) {
 	return o.w.GetRecipientIdentity()
 }
 
+// GetRecipientData return the owner recipient identity, it does not include token metadata audit info
+func (o *OwnerWallet) GetRecipientData() (*RecipientData, error) {
+	return o.w.GetRecipientData()
+}
+
 // GetAuditInfo returns auditing information for the passed identity
 func (o *OwnerWallet) GetAuditInfo(id Identity) ([]byte, error) {
 	return o.w.GetAuditInfo(id)


### PR DESCRIPTION
introduce GetRecipientData for owner wallet to avoid to retrieve audt info and token related metadata in seperated calls