### PR TITLE
driver cleanup

### DIFF
--- a/token/driver/publicparams.go
+++ b/token/driver/publicparams.go
@@ -6,10 +6,6 @@ SPDX-License-Identifier: Apache-2.0
 
 package driver
 
-import (
-	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
-)
-
 // PPHash is used to model the hash of the raw public parameters.
 // This should avoid confusion between the bytes of the public params themselves and its hash.
 type PPHash []byte
@@ -28,12 +24,6 @@ func (pp *SerializedPublicParameters) Deserialize(raw []byte) error {
 		return err
 	}
 	return nil
-}
-
-// NetworkPublicParamsFetcher models a public parameters fetcher per network.
-type NetworkPublicParamsFetcher interface {
-	// Fetch fetches the public parameters for the given network, channel, and namespace
-	Fetch(network driver.Network, channel driver.Channel, namespace driver.Namespace) ([]byte, error)
 }
 
 // PublicParamsFetcher models a public parameters fetcher.

--- a/token/services/network/fabric/driver.go
+++ b/token/services/network/fabric/driver.go
@@ -9,12 +9,12 @@ package fabric
 import (
 	"slices"
 
+	driver4 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	config2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
-	driver3 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	vault2 "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/vault"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
@@ -30,6 +30,12 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// NetworkPublicParamsFetcher models a public parameters fetcher per network.
+type NetworkPublicParamsFetcher interface {
+	// Fetch fetches the public parameters for the given network, channel, and namespace
+	Fetch(network driver4.Network, channel driver4.Channel, namespace driver4.Namespace) ([]byte, error)
+}
+
 type Driver struct {
 	fnsProvider                     *fabric.NetworkServiceProvider
 	vaultProvider                   driver.TokenVaultProvider
@@ -41,7 +47,7 @@ type Driver struct {
 	tmsProvider                     *token.ManagementServiceProvider
 	identityProvider                driver2.IdentityProvider
 	tracerProvider                  trace.TracerProvider
-	defaultPublicParamsFetcher      driver3.NetworkPublicParamsFetcher
+	defaultPublicParamsFetcher      NetworkPublicParamsFetcher
 	tokenQueryExecutorProvider      driver.TokenQueryExecutorProvider
 	spentTokenQueryExecutorProvider driver.SpentTokenQueryExecutorProvider
 	supportedDrivers                []string
@@ -98,7 +104,7 @@ func NewDriver(
 	tmsProvider *token.ManagementServiceProvider,
 	tracerProvider trace.TracerProvider,
 	identityProvider driver2.IdentityProvider,
-	defaultPublicParamsFetcher driver3.NetworkPublicParamsFetcher,
+	defaultPublicParamsFetcher NetworkPublicParamsFetcher,
 	tokenQueryExecutorProvider driver.TokenQueryExecutorProvider,
 	spentTokenQueryExecutorProvider driver.SpentTokenQueryExecutorProvider,
 	keyTranslator translator.KeyTranslator,

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
-	driver3 "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	common2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
@@ -115,7 +114,7 @@ type Network struct {
 	tokenVaultLazyCache        lazy.Provider[string, driver.TokenVault]
 	flm                        finality.ListenerManager
 	llm                        lookup.ListenerManager
-	defaultPublicParamsFetcher driver3.NetworkPublicParamsFetcher
+	defaultPublicParamsFetcher NetworkPublicParamsFetcher
 	tokenQueryExecutor         driver.TokenQueryExecutor
 	spentTokenQueryExecutor    driver.SpentTokenQueryExecutor
 	endorsementServiceProvider EndorsementServiceProvider
@@ -134,7 +133,7 @@ func NewNetwork(
 	endorsementServiceProvider EndorsementServiceProvider,
 	tokenQueryExecutor driver.TokenQueryExecutor,
 	tracerProvider trace.TracerProvider,
-	defaultPublicParamsFetcher driver3.NetworkPublicParamsFetcher,
+	defaultPublicParamsFetcher NetworkPublicParamsFetcher,
 	spentTokenQueryExecutor driver.SpentTokenQueryExecutor,
 	keyTranslator translator.KeyTranslator,
 	flm finality.ListenerManager,


### PR DESCRIPTION
This PR does the following:
- It remove an interface from the driver package that was only used in fabric network service