### PR TITLE
lookup listener manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131090019-8858e980b696
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131143658-e9d6f8900239
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.sum
+++ b/go.sum
@@ -1070,8 +1070,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131090019-8858e980b696 h1:/+BERXfRtOPmqe3laJGS29uSVVlPOulA7BWqFXpWxWU=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131090019-8858e980b696/go.mod h1:+yKIFyakvYG5/OL1n38u/xQzqm2CmgWz0o7OkPs6l8M=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131143658-e9d6f8900239 h1:0krJ/LiVpBE7Hg3SxbZD6cNgHJP+pdr7KWQfPgosfUw=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250131143658-e9d6f8900239/go.mod h1:+yKIFyakvYG5/OL1n38u/xQzqm2CmgWz0o7OkPs6l8M=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/integration/nwo/token/platform.go
+++ b/integration/nwo/token/platform.go
@@ -260,6 +260,7 @@ func (p *Platform) UpdatePublicParams(tms *topology2.TMS, publicParams []byte) {
 func (p *Platform) GenerateExtension(node *sfcnode.Node) {
 	t, err := template.New("peer").Funcs(template.FuncMap{
 		"TokenSelector": func() string { return p.Topology.TokenSelector },
+		"FinalityType":  func() string { return p.Topology.FinalityType },
 	}).Parse(Extension)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/integration/nwo/token/platform.go
+++ b/integration/nwo/token/platform.go
@@ -260,7 +260,7 @@ func (p *Platform) UpdatePublicParams(tms *topology2.TMS, publicParams []byte) {
 func (p *Platform) GenerateExtension(node *sfcnode.Node) {
 	t, err := template.New("peer").Funcs(template.FuncMap{
 		"TokenSelector": func() string { return p.Topology.TokenSelector },
-		"FinalityType":  func() string { return p.Topology.FinalityType },
+		"FinalityType":  func() string { return string(p.Topology.FinalityType) },
 	}).Parse(Extension)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/integration/nwo/token/template.go
+++ b/integration/nwo/token/template.go
@@ -13,7 +13,7 @@ token:
   selector:
     driver: {{ TokenSelector }}
   finality:
-    type: delivery
+    type: {{ FinalityType }}
     delivery:
       mapperParallelism: 10
       lruSize: 100

--- a/integration/nwo/token/topology.go
+++ b/integration/nwo/token/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	. "github.com/onsi/gomega"
 )
@@ -32,7 +33,7 @@ type Topology struct {
 	TopologyType string `yaml:"type,omitempty"`
 
 	TokenSelector string
-	FinalityType  string
+	FinalityType  config.ManagerType
 	TMSs          []*topology.TMS
 }
 

--- a/integration/nwo/token/topology.go
+++ b/integration/nwo/token/topology.go
@@ -32,14 +32,17 @@ type Topology struct {
 	TopologyType string `yaml:"type,omitempty"`
 
 	TokenSelector string
+	FinalityType  string
 	TMSs          []*topology.TMS
 }
 
 func NewTopology() *Topology {
 	return &Topology{
-		TopologyName: TopologyName,
-		TopologyType: TopologyName,
-		TMSs:         []*topology.TMS{},
+		TopologyName:  TopologyName,
+		TopologyType:  TopologyName,
+		TokenSelector: "",
+		FinalityType:  "delivery",
+		TMSs:          []*topology.TMS{},
 	}
 }
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		LibP2PNoReplication,
-		WebSocketWithReplication,
+		// LibP2PNoReplication,
+		// WebSocketWithReplication,
 	}
 )
 

--- a/integration/token/common/topology.go
+++ b/integration/token/common/topology.go
@@ -42,6 +42,7 @@ type Opts struct {
 	OnlyUnity           bool
 	FSCBasedEndorsement bool
 	ExtraTMSs           []TMSOpts
+	FinalityType        string
 }
 
 func SetDefaultParams(tms *topology.TMS, opts TMSOpts) {

--- a/integration/token/common/topology.go
+++ b/integration/token/common/topology.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/generators/dlog"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
 	. "github.com/onsi/gomega"
 )
 
@@ -42,7 +43,7 @@ type Opts struct {
 	OnlyUnity           bool
 	FSCBasedEndorsement bool
 	ExtraTMSs           []TMSOpts
-	FinalityType        string
+	FinalityType        config.ManagerType
 }
 
 func SetDefaultParams(tms *topology.TMS, opts TMSOpts) {

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common/sdk/fodlog"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common/sdk/odlog"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/interop"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
 	. "github.com/onsi/ginkgo/v2"
 )
 
@@ -104,7 +105,7 @@ func newTestSuiteNoCrossClaimFabric(commType fsc.P2PCommunicationType, factor in
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fdlog.SDK{}},
 		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
-		FinalityType: "committer",
+		FinalityType: config.Committer,
 	}))
 	return ts, selector
 }
@@ -117,7 +118,7 @@ func newTestSuiteNoCrossClaimOrion(commType fsc.P2PCommunicationType, factor int
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fodlog.SDK{}},
 		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:view-sdk=debug:info",
-		FinalityType: "committer", // we need committer here because we exercise
+		FinalityType: config.Committer, // we need committer here because we exercise
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -91,6 +91,7 @@ func newTestSuiteTwoFabric(commType fsc.P2PCommunicationType, factor int, names 
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fdlog.SDK{}},
+		FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -103,7 +103,8 @@ func newTestSuiteNoCrossClaimFabric(commType fsc.P2PCommunicationType, factor in
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fdlog.SDK{}},
-		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:view-sdk=debug:info",
+		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
+		FinalityType: "committer",
 	}))
 	return ts, selector
 }
@@ -116,6 +117,7 @@ func newTestSuiteNoCrossClaimOrion(commType fsc.P2PCommunicationType, factor int
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fodlog.SDK{}},
 		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:view-sdk=debug:info",
+		FinalityType: "committer", // we need committer here because we exercise
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/dlog/dlog_test.go
+++ b/integration/token/interop/dlog/dlog_test.go
@@ -91,7 +91,7 @@ func newTestSuiteTwoFabric(commType fsc.P2PCommunicationType, factor int, names 
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog"},
 		SDKs:            []api2.SDK{&fdlog.SDK{}},
-		FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
+		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/fabtoken/fabtoken_test.go
+++ b/integration/token/interop/fabtoken/fabtoken_test.go
@@ -114,7 +114,8 @@ func newTestSuiteNoCrossClaimOrion(commType fsc.P2PCommunicationType, factor int
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "fabtoken"},
 		SDKs:            []api2.SDK{&fofabtoken.SDK{}},
-		FinalityType:    "committer",
+		// FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
+		FinalityType: "committer",
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/fabtoken/fabtoken_test.go
+++ b/integration/token/interop/fabtoken/fabtoken_test.go
@@ -102,6 +102,7 @@ func newTestSuiteNoCrossClaimFabric(commType fsc.P2PCommunicationType, factor in
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "fabtoken"},
 		SDKs:            []api2.SDK{&ffabtoken.SDK{}},
+		FinalityType:    "committer",
 	}))
 	return ts, selector
 }
@@ -113,6 +114,7 @@ func newTestSuiteNoCrossClaimOrion(commType fsc.P2PCommunicationType, factor int
 		ReplicationOpts: opts,
 		DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "fabtoken"},
 		SDKs:            []api2.SDK{&fofabtoken.SDK{}},
+		FinalityType:    "committer",
 	}))
 	return ts, selector
 }

--- a/integration/token/interop/tests.go
+++ b/integration/token/interop/tests.go
@@ -274,9 +274,9 @@ func TestHTLCNoCrossClaimTwoNetworks(network *integration.Infrastructure, sel *t
 
 	scan(network, bob, hash, crypto.SHA256, bobLockTxID, true, token.WithTMSID(beta))
 	start := time.Now()
-	scanWithError(network, alice, hash, crypto.SHA256, txID, []string{"context done"}, true, token.WithTMSID(alpha))
+	scanWithError(network, alice, hash, crypto.SHA256, txID, []string{"reached, stop scan."}, true, token.WithTMSID(alpha))
 	Expect(time.Since(start)).To(BeNumerically("<", time.Second*30), "scan should be canceled on last tx, before timeout")
-	scanWithError(network, alice, hash, crypto.SHA256, txID, []string{"timeout reached"}, false, token.WithTMSID(alpha))
+	scanWithError(network, alice, hash, crypto.SHA256, txID, []string{"context done"}, false, token.WithTMSID(alpha))
 
 	CheckPublicParams(network, token.TMSID{}, alice, bob)
 	CheckPublicParams(network, alpha, issuer, auditor)

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -288,6 +288,9 @@ func HTLCNoCrossClaimWithOrionTopology(opts common.Opts) []api.Topology {
 		AddOptions(opts.ReplicationOpts.For("custodian")...)
 
 	tokenTopology := token.NewTopology()
+	if len(opts.FinalityType) != 0 {
+		tokenTopology.FinalityType = opts.FinalityType
+	}
 
 	// TMS for the Fabric Network
 	tmsFabric := tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "alice"), f1Topology, f1Topology.Channels[0].Name, opts.DefaultTMSOpts.TokenSDKDriver)

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -215,6 +215,9 @@ func HTLCNoCrossClaimTopology(opts common.Opts) []api.Topology {
 		RegisterViewFactory("htlc.scan", &htlc.ScanViewFactory{})
 
 	tokenTopology := token.NewTopology()
+	if len(opts.FinalityType) != 0 {
+		tokenTopology.FinalityType = opts.FinalityType
+	}
 	tms := tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "alice"), f1Topology, f1Topology.Channels[0].Name, opts.DefaultTMSOpts.TokenSDKDriver)
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -31,7 +31,7 @@ func HTLCSingleFabricNetworkTopology(opts common.Opts) []api.Topology {
 
 	// FSC
 	fscTopology := fsc.NewTopology()
-	// fscTopology.SetLogging("token-sdk=debug:fabric-sdk=debug:info", "")
+	fscTopology.SetLogging(opts.FSCLogSpec, "")
 	fscTopology.P2PCommunicationType = opts.CommType
 
 	addIssuer(fscTopology).
@@ -68,7 +68,7 @@ func HTLCSingleOrionNetworkTopology(opts common.Opts) []api.Topology {
 
 	// FSC
 	fscTopology := fsc.NewTopology()
-	// fscTopology.SetLogging("debug", "")
+	fscTopology.SetLogging(opts.FSCLogSpec, "")
 	fscTopology.P2PCommunicationType = opts.CommType
 
 	addIssuer(fscTopology).
@@ -248,7 +248,7 @@ func HTLCNoCrossClaimWithOrionTopology(opts common.Opts) []api.Topology {
 
 	// FSC
 	fscTopology := fsc.NewTopology()
-	// fscTopology.SetLogging("db.driver.badger=info:debug", "")
+	fscTopology.SetLogging(opts.FSCLogSpec, "")
 	fscTopology.P2PCommunicationType = opts.CommType
 
 	addIssuer(fscTopology).

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -116,7 +116,7 @@ func HTLCTwoFabricNetworksTopology(opts common.Opts) []api.Topology {
 
 	// FSC
 	fscTopology := fsc.NewTopology()
-	// fscTopology.SetLogging("debug", "")
+	fscTopology.SetLogging(opts.FSCLogSpec, "")
 	fscTopology.P2PCommunicationType = opts.CommType
 
 	addIssuer(fscTopology).

--- a/token/services/network/common/rws/keys/keys.go
+++ b/token/services/network/common/rws/keys/keys.go
@@ -88,6 +88,10 @@ func (t *Translator) CreateTransferActionMetadataKey(key string) (translator.Key
 	return createCompositeKey(TransferActionMetadataPrefix, []string{key})
 }
 
+func (t *Translator) TransferActionMetadataKeyPrefix() (translator.Key, error) {
+	return createCompositeKey(TransferActionMetadataPrefix, nil)
+}
+
 // createCompositeKey and its related functions and consts copied from core/chaincode/shim/chaincode.go
 func createCompositeKey(objectType string, attributes []string) (translator.Key, error) {
 	if err := validateCompositeKeyAttribute(objectType); err != nil {

--- a/token/services/network/common/rws/translator/rwset.go
+++ b/token/services/network/common/rws/translator/rwset.go
@@ -42,6 +42,8 @@ type KeyTranslator interface {
 	CreateTransferActionMetadataKey(subkey string) (Key, error)
 	// GetTransferMetadataSubKey returns the subkey in the given transfer action metadata key
 	GetTransferMetadataSubKey(k string) (Key, error)
+	// TransferActionMetadataKeyPrefix TODO
+	TransferActionMetadataKeyPrefix() (Key, error)
 }
 
 // RWSet interface, used to read from, and write to, a rwset.
@@ -197,6 +199,11 @@ func (h *HashedKeyTranslator) CreateTransferActionMetadataKey(key Key) (Key, err
 		return "", err
 	}
 	return h.hash(8, k)
+}
+
+func (h *HashedKeyTranslator) TransferActionMetadataKeyPrefix() (Key, error) {
+	// TODO:
+	return "", nil
 }
 
 func (h *HashedKeyTranslator) hash(code byte, k string) (Key, error) {

--- a/token/services/network/fabric/config/config.go
+++ b/token/services/network/fabric/config/config.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package finality
+package config
 
 import (
 	"fmt"

--- a/token/services/network/fabric/driver.go
+++ b/token/services/network/fabric/driver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/keys"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	config3 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/endorsement"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/finality"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
@@ -77,7 +78,7 @@ func NewGenericDriver(
 		NewTokenExecutorProvider(fnsProvider),
 		NewSpentTokenExecutorProvider(fnsProvider, keyTranslator),
 		keyTranslator,
-		finality.NewListenerManagerProvider(fnsProvider, tracerProvider, keyTranslator, finality.NewListenerManagerConfig(configService)),
+		finality.NewListenerManagerProvider(fnsProvider, tracerProvider, keyTranslator, config3.NewListenerManagerConfig(configService)),
 		endorsement.NewServiceProvider(fnsProvider, configProvider, viewManager, viewRegistry, identityProvider, keyTranslator),
 		config2.GenericDriver,
 	)

--- a/token/services/network/fabric/endorsement/fsc.go
+++ b/token/services/network/fabric/endorsement/fsc.go
@@ -54,7 +54,7 @@ func NewFSCService(
 	}
 	committer := ch.Committer()
 	if configuration.GetBool(AmIAnEndorserKey) {
-		logger.Info("this node is an endorser, prepare it...")
+		logger.Debug("this node is an endorser, prepare it...")
 		// if I'm an endorser, I need to process all token transactions
 		if err := committer.ProcessNamespace(tmsID.Namespace); err != nil {
 			return nil, errors.WithMessagef(err, "failed to add namespace to committer [%s]", tmsID.Namespace)
@@ -66,7 +66,7 @@ func NewFSCService(
 			return nil, errors.WithMessagef(err, "failed to register approval view for [%s]", tmsID)
 		}
 	} else {
-		logger.Infof("this node is an not endorser, is key set? [%v].", configuration.IsSet(AmIAnEndorserKey))
+		logger.Debugf("this node is an not endorser, is key set? [%v].", configuration.IsSet(AmIAnEndorserKey))
 	}
 
 	policyType := configuration.GetString(PolicyType)
@@ -78,7 +78,7 @@ func NewFSCService(
 	if err := configuration.UnmarshalKey(EndorsersKey, &endorserIDs); err != nil {
 		return nil, errors.WithMessage(err, "failed to load endorsers")
 	}
-	logger.Infof("defined [%s] as endorsers for [%s]", endorserIDs, tmsID)
+	logger.Debugf("defined [%s] as endorsers for [%s]", endorserIDs, tmsID)
 	if len(endorserIDs) == 0 {
 		return nil, errors.Errorf("no endorsers found for [%s]", tmsID)
 	}

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -83,11 +83,11 @@ func (l *loader) load(tmsID token2.TMSID) (Service, error) {
 	}
 
 	if !configuration.IsSet(FSCEndorsementKey) {
-		logger.Infof("chaincode endorsement enabled...")
+		logger.Debugf("chaincode endorsement enabled...")
 		return NewChaincodeEndorsementService(tmsID), nil
 	}
 
-	logger.Infof("FSC endorsement enabled...")
+	logger.Debugf("FSC endorsement enabled...")
 	return NewFSCService(
 		l.fnsp,
 		tmsID,

--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -122,7 +122,7 @@ func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *
 		return nil, errors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
 	}
 	if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
-		logger.Warnf("Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
+		logger.Debugf("Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
 		return nil, nil
 	}
 	rwSet, err := rwset.NewEndorserTransactionReader(m.network).Read(payl, chdr)
@@ -161,9 +161,9 @@ func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string,
 		return nil, errors.Wrapf(err, "can't create for token request [%s]", txID)
 	}
 	txInfos := make(map[driver2.Namespace]TxInfo, len(rwSet.WriteSet.Writes))
-	logger.Infof("TX [%s] has %d namespaces", txID, len(rwSet.WriteSet.Writes))
+	logger.Debugf("TX [%s] has %d namespaces", txID, len(rwSet.WriteSet.Writes))
 	for ns, write := range rwSet.WriteSet.Writes {
-		logger.Infof("TX [%s:%s] has %d writes", txID, ns, len(write))
+		logger.Debugf("TX [%s:%s] has %d writes", txID, ns, len(write))
 		if requestHash, ok := write[key]; ok {
 			txInfos[ns] = TxInfo{
 				TxId:        txID,
@@ -173,7 +173,7 @@ func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string,
 				RequestHash: requestHash,
 			}
 		} else {
-			logger.Warnf("TX [%s:%s] did not have key [%s]. Found: %v", txID, ns, key, write.Keys())
+			logger.Debugf("TX [%s:%s] did not have key [%s]. Found: %v", txID, ns, key, write.Keys())
 		}
 	}
 	return txInfos, nil

--- a/token/services/network/fabric/finality/listenermanager.go
+++ b/token/services/network/fabric/finality/listenermanager.go
@@ -25,7 +25,7 @@ type ListenerManagerProvider interface {
 type ListenerManager = driver.FinalityListenerManager
 
 func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, lmConfig config.ListenerManagerConfig) ListenerManagerProvider {
-	logger.Infof("Create Finality Listener Manager provider with config: %s", lmConfig)
+	logger.Debugf("Create Finality Listener Manager provider with config: %s", lmConfig)
 	switch lmConfig.Type() {
 	case config.Delivery:
 		return newEndorserDeliveryBasedFLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{

--- a/token/services/network/fabric/lookup/channelflm.go
+++ b/token/services/network/fabric/lookup/channelflm.go
@@ -9,6 +9,7 @@ package lookup
 import (
 	"context"
 	"encoding/base64"
+	"slices"
 	"sync"
 	"time"
 
@@ -135,14 +136,7 @@ func (s *Scanner) Scan() {
 			return false, err
 		}
 
-		found := false
-		for _, ns := range rws.Namespaces() {
-			if ns == s.namespace {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if !slices.Contains(rws.Namespaces(), s.namespace) {
 			logger.Debugf("scanning [%s] does not contain namespace [%s]", tx.TxID(), s.namespace)
 			return false, nil
 		}

--- a/token/services/network/fabric/lookup/channelflm.go
+++ b/token/services/network/fabric/lookup/channelflm.go
@@ -1,0 +1,180 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lookup
+
+import (
+	"context"
+	"encoding/base64"
+	"sync"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap/zapcore"
+)
+
+type ChannelListenerManagerConfig struct {
+	MaxRetries        int
+	RetryWaitDuration time.Duration
+}
+
+type channelBasedFLMProvider struct {
+	fnsp           *fabric.NetworkServiceProvider
+	tracerProvider trace.TracerProvider
+	keyTranslator  translator.KeyTranslator
+	config         ChannelListenerManagerConfig
+}
+
+func NewChannelBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, config ChannelListenerManagerConfig) *channelBasedFLMProvider {
+	return &channelBasedFLMProvider{
+		fnsp:           fnsp,
+		tracerProvider: tracerProvider,
+		keyTranslator:  keyTranslator,
+		config:         config,
+	}
+}
+
+func (p *channelBasedFLMProvider) NewManager(network, channel string) (ListenerManager, error) {
+	net, err := p.fnsp.FabricNetworkService(network)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := net.Channel(channel)
+	if err != nil {
+		return nil, err
+	}
+	return &channelBasedLLM{
+		network:   network,
+		channel:   ch,
+		listeners: make(map[string]*Scanner),
+	}, nil
+}
+
+type channelBasedLLM struct {
+	network string
+	channel *fabric.Channel
+
+	listenersMutex sync.RWMutex
+	listeners      map[string]*Scanner
+}
+
+func (c *channelBasedLLM) AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener LookupListener) error {
+	s := &Scanner{
+		context:      nil,
+		channel:      c.channel,
+		namespace:    namespace,
+		key:          key,
+		startingTxID: startingTxID,
+		stopOnLastTx: stopOnLastTx,
+		listener:     listener,
+	}
+	c.listenersMutex.Lock()
+	c.listeners[key] = s
+	c.listenersMutex.Unlock()
+	go s.Scan()
+	return nil
+}
+
+func (c *channelBasedLLM) RemoveLookupListener(id string, listener LookupListener) error {
+	c.listenersMutex.Lock()
+	defer c.listenersMutex.Unlock()
+
+	s, ok := c.listeners[id]
+	if ok {
+		s.Stop()
+		delete(c.listeners, id)
+	}
+	return nil
+}
+
+type Scanner struct {
+	context      context.Context
+	channel      *fabric.Channel
+	namespace    string
+	key          string
+	startingTxID string
+	stopOnLastTx bool
+	listener     LookupListener
+
+	stopMutex sync.RWMutex
+	stop      bool
+}
+
+func (s *Scanner) Scan() {
+	v := s.channel.Vault()
+	var lastTxID string
+	if s.stopOnLastTx {
+		id, err := v.GetLastTxID()
+		if err != nil {
+			return
+		}
+		lastTxID = id
+	}
+
+	var keyValue []byte
+	if err := s.channel.Delivery().Scan(s.context, s.startingTxID, func(tx *fabric.ProcessedTransaction) (bool, error) {
+		s.stopMutex.RLock()
+		stop := s.stop
+		s.stopMutex.RUnlock()
+		if stop {
+			return true, nil
+		}
+
+		logger.Debugf("scanning [%s]...", tx.TxID())
+
+		rws, err := v.InspectRWSet(tx.Results())
+		if err != nil {
+			return false, err
+		}
+
+		found := false
+		for _, ns := range rws.Namespaces() {
+			if ns == s.namespace {
+				found = true
+				break
+			}
+		}
+		if !found {
+			logger.Debugf("scanning [%s] does not contain namespace [%s]", tx.TxID(), s.namespace)
+			return false, nil
+		}
+
+		ns := s.namespace
+		for i := 0; i < rws.NumWrites(ns); i++ {
+			k, v, err := rws.GetWriteAt(ns, i)
+			if err != nil {
+				return false, err
+			}
+			if k == s.key {
+				keyValue = v
+				return true, nil
+			}
+		}
+		logger.Debugf("scanning for key [%s] on [%s] not found", s.key, tx.TxID())
+		if s.stopOnLastTx && lastTxID == tx.TxID() {
+			logger.Debugf("final transaction reached on [%s]", tx.TxID())
+		}
+		return false, nil
+	}); err != nil {
+		logger.Errorf("failed scanning for key [%s]: [%s]", s.key, err)
+	}
+
+	if logger.IsEnabledFor(zapcore.DebugLevel) {
+		logger.Debugf("scanning for key [%s] found [%s]",
+			s.key,
+			base64.StdEncoding.EncodeToString(keyValue),
+		)
+	}
+	s.listener.OnStatus(s.context, s.key, keyValue)
+}
+
+func (s *Scanner) Stop() {
+	s.stopMutex.Lock()
+	defer s.stopMutex.Unlock()
+	s.stop = true
+}

--- a/token/services/network/fabric/lookup/channelflm.go
+++ b/token/services/network/fabric/lookup/channelflm.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"go.opentelemetry.io/otel/trace"
@@ -40,7 +41,7 @@ func NewChannelBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 	}
 }
 
-func (p *channelBasedFLMProvider) NewManager(network, channel string) (ListenerManager, error) {
+func (p *channelBasedFLMProvider) NewManager(network driver.Network, channel driver.Channel) (ListenerManager, error) {
 	net, err := p.fnsp.FabricNetworkService(network)
 	if err != nil {
 		return nil, err
@@ -57,14 +58,14 @@ func (p *channelBasedFLMProvider) NewManager(network, channel string) (ListenerM
 }
 
 type channelBasedLLM struct {
-	network string
+	network driver.Network
 	channel *fabric.Channel
 
 	listenersMutex sync.RWMutex
 	listeners      map[string]*Scanner
 }
 
-func (c *channelBasedLLM) AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener Listener) error {
+func (c *channelBasedLLM) AddLookupListener(namespace driver.Namespace, key driver.PKey, startingTxID string, stopOnLastTx bool, listener Listener) error {
 	s := &Scanner{
 		context:      nil,
 		channel:      c.channel,
@@ -96,8 +97,8 @@ func (c *channelBasedLLM) RemoveLookupListener(id string, listener Listener) err
 type Scanner struct {
 	context      context.Context
 	channel      *fabric.Channel
-	namespace    string
-	key          string
+	namespace    driver.Namespace
+	key          driver.PKey
 	startingTxID string
 	stopOnLastTx bool
 	listener     Listener

--- a/token/services/network/fabric/lookup/deliveryflm.go
+++ b/token/services/network/fabric/lookup/deliveryflm.go
@@ -1,0 +1,181 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lookup
+
+import (
+	"context"
+
+	vault2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault"
+	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/fabricutils"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/rwset"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/vault"
+	driver3 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type newTxInfoMapper = func(network, channel string) finality.TxInfoMapper[TxInfo]
+
+type LookupListener interface {
+	// OnStatus is called when the status of a transaction changes
+	OnStatus(ctx context.Context, key string, value []byte)
+}
+
+type listenerEntry struct {
+	namespace driver2.Namespace
+	listener  LookupListener
+}
+
+func (e *listenerEntry) OnStatus(ctx context.Context, info TxInfo) {
+	if len(e.namespace) == 0 || len(info.Namespace) == 0 || e.namespace == info.Namespace {
+		e.listener.OnStatus(ctx, info.Key, info.Value)
+	}
+}
+
+func (e *listenerEntry) Equals(other finality.ListenerEntry[TxInfo]) bool {
+	return other != nil && other.(*listenerEntry).listener == e.listener
+}
+
+type TxInfo struct {
+	Namespace driver2.Namespace
+	Key       driver2.TxID
+	Value     []byte
+}
+
+func (i TxInfo) TxID() driver2.TxID {
+	return i.Key
+}
+
+type deliveryBasedFLMProvider struct {
+	fnsp           *fabric.NetworkServiceProvider
+	tracerProvider trace.TracerProvider
+	config         finality.DeliveryListenerManagerConfig
+	newMapper      newTxInfoMapper
+}
+
+func NewDeliveryBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, config finality.DeliveryListenerManagerConfig, newMapper newTxInfoMapper) *deliveryBasedFLMProvider {
+	return &deliveryBasedFLMProvider{
+		fnsp:           fnsp,
+		tracerProvider: tracerProvider,
+		config:         config,
+		newMapper:      newMapper,
+	}
+}
+
+func newEndorserDeliveryBasedFLMProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, config finality.DeliveryListenerManagerConfig) *deliveryBasedFLMProvider {
+	return NewDeliveryBasedFLMProvider(fnsp, tracerProvider, config, func(network, _ string) finality.TxInfoMapper[TxInfo] {
+		return &endorserTxInfoMapper{
+			network:       network,
+			keyTranslator: keyTranslator,
+		}
+	})
+}
+
+func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (ListenerManager, error) {
+	net, err := p.fnsp.FabricNetworkService(network)
+	if err != nil {
+		return nil, err
+	}
+	ch, err := net.Channel(channel)
+	if err != nil {
+		return nil, err
+	}
+	flm, err := finality.NewListenerManager[TxInfo](p.config, ch.Delivery(), p.tracerProvider.Tracer("finality_listener_manager", tracing.WithMetricsOpts(tracing.MetricsOpts{
+		Namespace: network,
+	})), p.newMapper(network, channel))
+	if err != nil {
+		return nil, err
+	}
+	return &deliveryBasedFLM{flm}, nil
+}
+
+type deliveryBasedFLM struct {
+	lm finality.ListenerManager[TxInfo]
+}
+
+func (m *deliveryBasedFLM) AddLookupListener(namespace string, txID string, listener LookupListener) error {
+	return m.lm.AddFinalityListener(txID, &listenerEntry{namespace, listener})
+}
+
+func (m *deliveryBasedFLM) RemoveLookupListener(txID string, listener LookupListener) error {
+	return m.lm.RemoveFinalityListener(txID, &listenerEntry{"", listener})
+}
+
+type endorserTxInfoMapper struct {
+	network       string
+	keyTranslator translator.KeyTranslator
+}
+
+func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *common.BlockMetadata, blockNum driver2.BlockNum, txNum driver2.TxNum) (map[driver2.Namespace]TxInfo, error) {
+	_, payl, chdr, err := fabricutils.UnmarshalTx(tx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
+	}
+	if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
+		logger.Warnf("Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
+		return nil, nil
+	}
+	rwSet, err := rwset.NewEndorserTransactionReader(m.network).Read(payl, chdr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed extracting rwset")
+	}
+
+	if len(block.Metadata) < int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
+		return nil, errors.Errorf("block metadata lacks transaction filter")
+	}
+	code, message := committer.MapValidationCode(int32(committer.ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[txNum]))
+
+	return m.mapTxInfo(rwSet, chdr.TxId, code, message)
+}
+
+func (m *endorserTxInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) ([]TxInfo, error) {
+	logger.Debugf("Map processed tx [%s] with results of status [%v] and length [%d]", tx.TxID(), tx.ValidationCode(), len(tx.Results()))
+	status, message := committer.MapValidationCode(tx.ValidationCode())
+	if status == driver.Invalid {
+		return []TxInfo{}, nil
+	}
+	rwSet, err := vault.NewPopulator().Populate(tx.Results())
+	if err != nil {
+		return nil, err
+	}
+	infos, err := m.mapTxInfo(rwSet, tx.TxID(), status, message)
+	if err != nil {
+		return nil, err
+	}
+	return collections.Values(infos), nil
+}
+
+func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string, code driver3.ValidationCode, message string) (map[driver2.Namespace]TxInfo, error) {
+	key, err := m.keyTranslator.CreateTokenRequestKey(txID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "can't create for token request [%s]", txID)
+	}
+	txInfos := make(map[driver2.Namespace]TxInfo, len(rwSet.WriteSet.Writes))
+	logger.Infof("TX [%s] has %d namespaces", txID, len(rwSet.WriteSet.Writes))
+	for ns, write := range rwSet.WriteSet.Writes {
+		logger.Infof("TX [%s:%s] has %d writes", txID, ns, len(write))
+		if value, ok := write[key]; ok {
+			txInfos[ns] = TxInfo{
+				Namespace: ns,
+				Key:       key,
+				Value:     value,
+			}
+		} else {
+			logger.Warnf("TX [%s:%s] did not have key [%s]. Found: %v", txID, ns, key, write.Keys())
+		}
+	}
+	return txInfos, nil
+}

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -132,7 +132,7 @@ func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *
 		return nil, errors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
 	}
 	if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
-		logger.Warnf("Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
+		logger.Debugf("Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
 		return nil, nil
 	}
 	rwSet, err := rwset.NewEndorserTransactionReader(m.network).Read(payl, chdr)
@@ -165,12 +165,12 @@ func (m *endorserTxInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) (
 
 func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string) (map[driver2.Namespace]TxInfo, error) {
 	txInfos := make(map[driver2.Namespace]TxInfo, len(rwSet.WriteSet.Writes))
-	logger.Infof("TX [%s] has %d namespaces", txID, len(rwSet.WriteSet.Writes))
+	logger.Debugf("TX [%s] has %d namespaces", txID, len(rwSet.WriteSet.Writes))
 	for ns, writes := range rwSet.WriteSet.Writes {
-		logger.Infof("TX [%s:%s] has %d writes", txID, ns, len(writes))
+		logger.Debugf("TX [%s:%s] has %d writes", txID, ns, len(writes))
 		for key, value := range writes {
 			if strings.HasPrefix(key, m.prefix) {
-				logger.Infof("TX [%s:%s] does have key [%s].", txID, ns, key)
+				logger.Debugf("TX [%s:%s] does have key [%s].", txID, ns, key)
 				txInfos[ns] = TxInfo{
 					Namespace: ns,
 					Key:       key,

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -29,14 +29,16 @@ import (
 
 type newTxInfoMapper = func(network, channel string) finality.TxInfoMapper[TxInfo]
 
-type LookupListener interface {
-	// OnStatus is called when the status of a transaction changes
+type Listener interface {
+	// OnStatus is called when the key has been found
 	OnStatus(ctx context.Context, key string, value []byte)
+	// OnError is called when an error occurs during the search of the key
+	OnError(ctx context.Context, key string, err error)
 }
 
 type listenerEntry struct {
 	namespace driver2.Namespace
-	listener  LookupListener
+	listener  Listener
 }
 
 func (e *listenerEntry) OnStatus(ctx context.Context, info TxInfo) {
@@ -111,11 +113,11 @@ type deliveryBasedLLM struct {
 	lm finality.ListenerManager[TxInfo]
 }
 
-func (m *deliveryBasedLLM) AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener LookupListener) error {
+func (m *deliveryBasedLLM) AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener Listener) error {
 	return m.lm.AddFinalityListener(key, &listenerEntry{namespace, listener})
 }
 
-func (m *deliveryBasedLLM) RemoveLookupListener(key string, listener LookupListener) error {
+func (m *deliveryBasedLLM) RemoveLookupListener(key string, listener Listener) error {
 	return m.lm.RemoveFinalityListener(key, &listenerEntry{"", listener})
 }
 

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -27,7 +27,7 @@ type ListenerManager interface {
 }
 
 func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, lmConfig config.ListenerManagerConfig) ListenerManagerProvider {
-	logger.Infof("Create Lookup Listener Manager provider with config: %s", lmConfig)
+	logger.Debugf("Create Lookup Listener Manager provider with config: %s", lmConfig)
 	switch lmConfig.Type() {
 	case config.Delivery:
 		return newEndorserDeliveryBasedLLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -4,25 +4,27 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package finality
+package lookup
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
 	"go.opentelemetry.io/otel/trace"
 )
 
-var logger = logging.MustGetLogger("token-sdk.network.fabric")
+var logger = logging.MustGetLogger("token-sdk.network.fabric.lookup")
 
 type ListenerManagerProvider interface {
 	NewManager(network, channel string) (ListenerManager, error)
 }
 
-type ListenerManager = driver.FinalityListenerManager
+type ListenerManager interface {
+	AddLookupListener(namespace string, key string, listener LookupListener) error
+	RemoveLookupListener(id string, listener LookupListener) error
+}
 
 func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, lmConfig config.ListenerManagerConfig) ListenerManagerProvider {
 	logger.Infof("Create Finality Listener Manager provider with config: %s", lmConfig)
@@ -36,10 +38,7 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 			LRUBuffer:               lmConfig.DeliveryLRUBuffer(),
 		})
 	case config.Committer:
-		return NewCommitterBasedFLMProvider(fnsp, tracerProvider, keyTranslator, CommitterListenerManagerConfig{
-			MaxRetries:        lmConfig.CommitterMaxRetries(),
-			RetryWaitDuration: lmConfig.CommitterRetryWaitDuration(),
-		})
+		panic("implement me")
 	}
 	panic("unknown config type: " + lmConfig.Type())
 }

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -27,10 +27,10 @@ type ListenerManager interface {
 }
 
 func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, lmConfig config.ListenerManagerConfig) ListenerManagerProvider {
-	logger.Infof("Create Finality Listener Manager provider with config: %s", lmConfig)
+	logger.Infof("Create Lookup Listener Manager provider with config: %s", lmConfig)
 	switch lmConfig.Type() {
 	case config.Delivery:
-		return newEndorserDeliveryBasedFLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{
+		return newEndorserDeliveryBasedLLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{
 			MapperParallelism:       lmConfig.DeliveryMapperParallelism(),
 			BlockProcessParallelism: lmConfig.DeliveryBlockProcessParallelism(),
 			ListenerTimeout:         lmConfig.DeliveryListenerTimeout(),

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -22,8 +22,8 @@ type ListenerManagerProvider interface {
 }
 
 type ListenerManager interface {
-	AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener LookupListener) error
-	RemoveLookupListener(id string, listener LookupListener) error
+	AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener Listener) error
+	RemoveLookupListener(id string, listener Listener) error
 }
 
 func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvider trace.TracerProvider, keyTranslator translator.KeyTranslator, lmConfig config.ListenerManagerConfig) ListenerManagerProvider {

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -22,7 +22,7 @@ type ListenerManagerProvider interface {
 }
 
 type ListenerManager interface {
-	AddLookupListener(namespace string, key string, listener LookupListener) error
+	AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener LookupListener) error
 	RemoveLookupListener(id string, listener LookupListener) error
 }
 
@@ -38,7 +38,10 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 			LRUBuffer:               lmConfig.DeliveryLRUBuffer(),
 		})
 	case config.Committer:
-		panic("implement me")
+		return NewChannelBasedFLMProvider(fnsp, tracerProvider, keyTranslator, ChannelListenerManagerConfig{
+			MaxRetries:        lmConfig.CommitterMaxRetries(),
+			RetryWaitDuration: lmConfig.CommitterRetryWaitDuration(),
+		})
 	}
 	panic("unknown config type: " + lmConfig.Type())
 }

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -324,7 +324,11 @@ func (n *Network) LookupTransferMetadataKey(namespace string, startingTxID strin
 	if err := n.llm.AddLookupListener(namespace, transferMetadataKey, startingTxID, stopOnLastTx, l); err != nil {
 		return nil, errors.Wrapf(err, "failed to add lookup listener")
 	}
-	defer n.llm.RemoveLookupListener(key, l)
+	defer func() {
+		if err := n.llm.RemoveLookupListener(transferMetadataKey, l); err != nil {
+			logger.Warnf("failed to remove lookup listener [%s]: %v", transferMetadataKey, err)
+		}
+	}()
 	waitTimeout(wg, timeout)
 	logger.Debugf("lookup transfer metadata key [%s] from [%s] in namespace [%s], done, value [%s]", key, transferMetadataKey, namespace, l.value)
 	return l.value, nil

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -326,7 +326,7 @@ func (n *Network) LookupTransferMetadataKey(namespace string, startingTxID strin
 	}
 	defer func() {
 		if err := n.llm.RemoveLookupListener(transferMetadataKey, l); err != nil {
-			logger.Warnf("failed to remove lookup listener [%s]: %v", transferMetadataKey, err)
+			logger.Debugf("failed to remove lookup listener [%s]: %v", transferMetadataKey, err)
 		}
 	}()
 	if err := waitTimeout(wg, timeout); err != nil {

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -71,7 +71,7 @@ type TokenChaincode struct {
 }
 
 func (cc *TokenChaincode) Init(stub shim.ChaincodeStubInterface) pb.Response {
-	logger.Infof("init token chaincode...")
+	logger.Debugf("init token chaincode...")
 
 	ppRaw, err := cc.Params(Params)
 	if err != nil {
@@ -94,7 +94,7 @@ func (cc *TokenChaincode) Invoke(stub shim.ChaincodeStubInterface) (res pb.Respo
 			res = shim.Error(fmt.Sprintf("failed responding [%s]", r))
 		} else {
 			if res.Status == 200 {
-				logger.Infof("[%s] OK", txID)
+				logger.Debugf("[%s] OK", txID)
 			} else {
 				logger.Errorf("[%s] %d: %s", txID, res.Status, res.Message)
 			}
@@ -106,7 +106,7 @@ func (cc *TokenChaincode) Invoke(stub shim.ChaincodeStubInterface) (res pb.Respo
 	case 0:
 		return shim.Error("missing parameters")
 	default:
-		logger.Infof("[%s] %s", txID, string(args[0]))
+		logger.Debugf("[%s] %s", txID, string(args[0]))
 		switch f := string(args[0]); f {
 		case InvokeFunction:
 			if len(args) != 1 {
@@ -173,16 +173,16 @@ func (cc *TokenChaincode) GetValidator(builtInParams string) (Validator, error) 
 }
 
 func (cc *TokenChaincode) Initialize(builtInParams string) error {
-	logger.Infof("reading public parameters...")
+	logger.Debugf("reading public parameters...")
 
 	ppRaw, err := cc.Params(builtInParams)
 	if err != nil {
 		return errors.WithMessagef(err, "failed reading public parameters")
 	}
 
-	logger.Infof("instantiate public parameter manager and validator...")
+	logger.Debugf("instantiate public parameter manager and validator...")
 	ppm, validator, err := cc.TokenServicesFactory(ppRaw)
-	logger.Infof("instantiate public parameter manager and validator done with err [%v]", err)
+	logger.Debugf("instantiate public parameter manager and validator done with err [%v]", err)
 	if err != nil {
 		return errors.Wrap(err, "failed to instantiate public parameter manager and validator")
 	}
@@ -199,7 +199,7 @@ func (cc *TokenChaincode) ReadParamsFromFile() string {
 		return ""
 	}
 
-	logger.Infof("reading %s ...", publicParamsPath)
+	logger.Debugf("reading %s ...", publicParamsPath)
 	paramsAsBytes, err := os.ReadFile(publicParamsPath)
 	if err != nil {
 		logger.Errorf(
@@ -258,7 +258,7 @@ func (cc *TokenChaincode) QueryPublicParams(stub shim.ChaincodeStubInterface) pb
 		return shim.Error("need to initialize public parameters")
 	}
 
-	logger.Infof("query public params, size [%d]", len(raw))
+	logger.Debugf("query public params, size [%d]", len(raw))
 
 	return shim.Success(raw)
 }
@@ -270,7 +270,7 @@ func (cc *TokenChaincode) QueryTokens(idsRaw []byte, stub shim.ChaincodeStubInte
 		return shim.Error(err.Error())
 	}
 
-	logger.Infof("query tokens [%v]...", ids)
+	logger.Debugf("query tokens [%v]...", ids)
 
 	w := translator.New(
 		stub.GetTxID(),

--- a/token/services/network/orion/driver.go
+++ b/token/services/network/orion/driver.go
@@ -121,7 +121,7 @@ func (d *Driver) New(network, _ string) (driver.Network, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed checking if custodian is enabled")
 	}
-	logger.Infof("Orion Custodian enabled: %t", enabled)
+	logger.Debugf("Orion Custodian enabled: %t", enabled)
 	dbManager := NewDBManager(d.onsProvider, d.configProvider, enabled)
 	statusCache := secondcache.NewTyped[*TxStatusResponse](1000)
 	if enabled {

--- a/token/services/network/orion/statusfetcher.go
+++ b/token/services/network/orion/statusfetcher.go
@@ -51,7 +51,7 @@ func (r *StatusFetcher) FetchStatus(network, namespace string, txID driver.TxID)
 	}
 	trRef, err := r.fetch(func() ([]byte, error) { return tx.Get(namespace, reqKey) }, code)
 	if err == nil {
-		logger.Infof("Found with DataTx(txID) [%s]", txID)
+		logger.Debugf("Found with DataTx(txID) [%s]", txID)
 	}
 
 	if err != nil {
@@ -62,7 +62,7 @@ func (r *StatusFetcher) FetchStatus(network, namespace string, txID driver.TxID)
 		}
 		trRef, err = r.fetch(func() ([]byte, error) { return qe.Get(reqKey) }, code)
 		if err == nil {
-			logger.Infof("Found with query executor: [%s]", txID)
+			logger.Debugf("Found with query executor: [%s]", txID)
 		}
 	}
 

--- a/token/services/network/orion/txstatus.go
+++ b/token/services/network/orion/txstatus.go
@@ -51,7 +51,7 @@ func (r *RequestTxStatusView) Call(context view.Context) (interface{}, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get session to custodian [%s]", custodian)
 	}
-	logger.Infof("request tx status for [%s]", r.TxID)
+	logger.Debugf("request tx status for [%s]", r.TxID)
 
 	// TODO: Should we sign the txStatus request?
 	request := &TxStatusRequest{
@@ -68,7 +68,7 @@ func (r *RequestTxStatusView) Call(context view.Context) (interface{}, error) {
 	if err := session.Receive(response); err != nil {
 		return nil, errors.Wrapf(err, "failed to receive response from custodian [%s]", custodian)
 	}
-	logger.Infof("got tx status response for [%s]: [%d]", r.TxID, response.Status)
+	logger.Debugf("got tx status response for [%s]: [%d]", r.TxID, response.Status)
 	return response, nil
 }
 


### PR DESCRIPTION
This PR does the following: Similarly to the listener manager, the fabric network driver uses a lookup listener manager to implement `LookupTransferMetadataKey`. This way one can choose which strategy to use for the looking up of the key.