### PR TITLE
use json with DisallowUnknownFields for token/core

### DIFF
--- a/token/core/common/encoding/json/json.go
+++ b/token/core/common/encoding/json/json.go
@@ -1,0 +1,24 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// Unmarshal is json.Unmarshal with unknown fields disallowed.
+func Unmarshal(data []byte, v interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(v)
+}
+
+var (
+	Marshal       = json.Marshal
+	MarshalIndent = json.MarshalIndent
+)

--- a/token/core/fabtoken/actions.go
+++ b/token/core/fabtoken/actions.go
@@ -7,8 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
-	"encoding/json"
-
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/core/fabtoken"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"

--- a/token/core/fabtoken/setup.go
+++ b/token/core/fabtoken/setup.go
@@ -7,8 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
-	"encoding/json"
-
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	pp2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver/protos-go/pp"
 	"github.com/pkg/errors"

--- a/token/core/fabtoken/validator_transfer.go
+++ b/token/core/fabtoken/validator_transfer.go
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package fabtoken
 
 import (
-	"encoding/json"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity"
 	htlc2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/interop/htlc"

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -8,7 +8,6 @@ package audit
 
 import (
 	"context"
-	"encoding/asn1"
 
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -8,10 +8,12 @@ package audit
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/asn1"
 
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/issue"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/transfer"

--- a/token/core/zkatdlog/crypto/audit/auditor.go
+++ b/token/core/zkatdlog/crypto/audit/auditor.go
@@ -13,7 +13,6 @@ import (
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/hash"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/issue"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/transfer"

--- a/token/core/zkatdlog/crypto/audit/auditor_test.go
+++ b/token/core/zkatdlog/crypto/audit/auditor_test.go
@@ -8,7 +8,6 @@ package audit_test
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/kvs"
 	registry2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/registry"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/audit"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/audit/mock"

--- a/token/core/zkatdlog/crypto/issue/issue.go
+++ b/token/core/zkatdlog/crypto/issue/issue.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package issue
 
 import (
-	"encoding/json"
-
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/rp"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"

--- a/token/core/zkatdlog/crypto/issue/sametype.go
+++ b/token/core/zkatdlog/crypto/issue/sametype.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package issue
 
 import (
-	"encoding/json"
-
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"

--- a/token/core/zkatdlog/crypto/rp/ipa.go
+++ b/token/core/zkatdlog/crypto/rp/ipa.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package rp
 
 import (
-	"encoding/json"
-
 	mathlib "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	"github.com/pkg/errors"
 )

--- a/token/core/zkatdlog/crypto/setup.go
+++ b/token/core/zkatdlog/crypto/setup.go
@@ -8,13 +8,13 @@ package crypto
 
 import (
 	"crypto/sha256"
-	"encoding/json"
 	"math/bits"
 	"strconv"
 
 	mathlib "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
-	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/math"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/math"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	pp2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver/protos-go/pp"
 	"github.com/pkg/errors"
@@ -53,16 +53,16 @@ func (rpp *RangeProofParams) Validate(curveID mathlib.CurveID) error {
 	if len(rpp.LeftGenerators) != len(rpp.RightGenerators) {
 		return errors.Errorf("invalid range proof parameters: the size of the left generators does not match the size of the right generators [%d vs, %d]", len(rpp.LeftGenerators), len(rpp.RightGenerators))
 	}
-	if err := math2.CheckElement(rpp.Q, curveID); err != nil {
+	if err := math.CheckElement(rpp.Q, curveID); err != nil {
 		return errors.Wrapf(err, "invalid range proof parameters: generator Q is invalid")
 	}
-	if err := math2.CheckElement(rpp.P, curveID); err != nil {
+	if err := math.CheckElement(rpp.P, curveID); err != nil {
 		return errors.Wrapf(err, "invalid range proof parameters: generator P is invalid")
 	}
-	if err := math2.CheckElements(rpp.LeftGenerators, curveID, rpp.BitLength); err != nil {
+	if err := math.CheckElements(rpp.LeftGenerators, curveID, rpp.BitLength); err != nil {
 		return errors.Wrap(err, "invalid range proof parameters, left generators is invalid")
 	}
-	if err := math2.CheckElements(rpp.RightGenerators, curveID, rpp.BitLength); err != nil {
+	if err := math.CheckElements(rpp.RightGenerators, curveID, rpp.BitLength); err != nil {
 		return errors.Wrap(err, "invalid range proof parameters, right generators is invalid")
 	}
 
@@ -289,7 +289,7 @@ func (pp *PublicParams) Validate() error {
 			return errors.Errorf("invalid public parameters: invalid idemix curveID [%d > %d]", int(pp.Curve), len(mathlib.Curves)-1)
 		}
 	}
-	if err := math2.CheckElements(pp.PedersenGenerators, pp.Curve, 3); err != nil {
+	if err := math.CheckElements(pp.PedersenGenerators, pp.Curve, 3); err != nil {
 		return errors.Wrapf(err, "invalid pedersen generators")
 	}
 	if pp.RangeProofParams == nil {

--- a/token/core/zkatdlog/crypto/token/token.go
+++ b/token/core/zkatdlog/crypto/token/token.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package token
 
 import (
-	"encoding/json"
-
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens/core/comm"

--- a/token/core/zkatdlog/crypto/transfer/sender.go
+++ b/token/core/zkatdlog/crypto/transfer/sender.go
@@ -8,9 +8,9 @@ package transfer
 
 import (
 	"context"
-	"encoding/json"
 
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"

--- a/token/core/zkatdlog/crypto/transfer/transfer.go
+++ b/token/core/zkatdlog/crypto/transfer/transfer.go
@@ -7,10 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package transfer
 
 import (
-	"encoding/json"
 	"sync"
 
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/rp"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"

--- a/token/core/zkatdlog/crypto/transfer/typeandsum.go
+++ b/token/core/zkatdlog/crypto/transfer/typeandsum.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package transfer
 
 import (
-	"encoding/json"
-
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	crypto "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/pkg/errors"

--- a/token/core/zkatdlog/crypto/validator/validator_transfer.go
+++ b/token/core/zkatdlog/crypto/validator/validator_transfer.go
@@ -8,10 +8,10 @@ package validator
 
 import (
 	"bytes"
-	"encoding/json"
 	"time"
 
 	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/json"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/crypto/transfer"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"

--- a/token/services/utils/json/decoder.go
+++ b/token/services/utils/json/decoder.go
@@ -1,0 +1,19 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalWithDisallowUnknownFields is json.Unmarshal with unknown fields disallowed.
+func UnmarshalWithDisallowUnknownFields(data []byte, v interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(v)
+}

--- a/token/services/utils/json/decoder_test.go
+++ b/token/services/utils/json/decoder_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package json
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Test cases for UnmarshalWithDisallowUnknownFields
+func TestUnmarshalWithDisallowUnknownFields(t *testing.T) {
+	type TestStruct struct {
+		Name string `json:"name"`
+	}
+
+	tests := []struct {
+		name     string
+		jsonData []byte
+		wantErr  bool
+	}{
+		{
+			name:     "Valid JSON without unknown fields",
+			jsonData: []byte(`{"name": "test"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "JSON with unknown field",
+			jsonData: []byte(`{"name": "test", "age": 30}`),
+			wantErr:  true,
+		},
+		{
+			name:     "Invalid JSON",
+			jsonData: []byte(`invalid json`),
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result TestStruct
+			err := UnmarshalWithDisallowUnknownFields(tt.jsonData, &result)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalWithDisallowUnknownFields() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Benchmark comparing UnmarshalWithDisallowUnknownFields to json.Unmarshal
+func BenchmarkUnmarshal(b *testing.B) {
+	type TestStruct struct {
+		Name string `json:"name"`
+	}
+
+	jsonData := []byte(`{"name": "benchmark"}`)
+
+	b.Run("With DisallowUnknownFields", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var result TestStruct
+			err := UnmarshalWithDisallowUnknownFields(jsonData, &result)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Standard json.Unmarshal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var result TestStruct
+			err := json.Unmarshal(jsonData, &result)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
This change slow down the unmarshalling process. Nevertheless, this validation is essential to make sure data is properly unmarshalled.