### PR TITLE
use the new FSC events listener

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250217142201-92b4951a08ec
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250210153725-90e0fbb00133
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
-	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c
+	github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157
 	github.com/hyperledger-labs/orion-sdk-go v0.2.10
 	github.com/hyperledger-labs/orion-server v0.2.10
 	github.com/hyperledger/fabric v1.4.0-rc1.0.20230405174026-695dd57e01c2

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c h1:Z2ozA9rctUaoI2/DRlvqV6E2qSglom9mjhP2zFnStHs=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157 h1:nv32gdDv1n/ICiHFTCJrX1CQicrFVO75+yP+XNb7q1Y=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250210153725-90e0fbb00133 h1:UTyfnN+H+K9kK6TZw8ccal0+viXlf/RBHc7YiEY0XiU=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250210153725-90e0fbb00133/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c h1:Z2ozA9rctUaoI2/DRlvqV6E2qSglom9mjhP2zFnStHs=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213145353-9b1f9b38aa5c/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157 h1:nv32gdDv1n/ICiHFTCJrX1CQicrFVO75+yP+XNb7q1Y=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250213182503-543f72422157/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad h1:tG516lDRzkK45gAG7Md2/ihSJNjpjLKp14iHjqyscBM=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1 h1:VB5bA7u7CPSXGvNEWrVEj2qRqnrVJq7D+YV1yAu7k20=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250217142201-92b4951a08ec h1:W77dWrEk2lViqV/F4x9GOyPaKRQkGKuAdVl1oRqMH8M=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250217142201-92b4951a08ec/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/go.sum
+++ b/go.sum
@@ -1057,8 +1057,8 @@ github.com/hidal-go/hidalgo v0.0.0-20201109092204-05749a6d73df/go.mod h1:bPkrxDl
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad h1:tG516lDRzkK45gAG7Md2/ihSJNjpjLKp14iHjqyscBM=
-github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214055839-7d5b5ffc30ad/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1 h1:VB5bA7u7CPSXGvNEWrVEj2qRqnrVJq7D+YV1yAu7k20=
+github.com/hyperledger-labs/fabric-smart-client v0.4.1-0.20250214133530-c1156da661a1/go.mod h1:EdiA1cY2eOOZjqPlutIlFPkueUMMJOxLoiRH5KwOW1c=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10 h1:lFgWgxyvngIhWnIqymYGBmtmq9D6uC5d0uLG9cbyh5s=
 github.com/hyperledger-labs/orion-sdk-go v0.2.10/go.mod h1:iN2xZB964AqwVJwL+EnwPOs8z1EkMEbbIg/qYeC7gDY=
 github.com/hyperledger-labs/orion-server v0.2.10 h1:G4zbQEL5Egk0Oj+TwHCZWdTOLDBHOjaAEvYOT4G7ozw=

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		LibP2PNoReplication,
-		WebSocketWithReplication,
+		// LibP2PNoReplication,
+		// WebSocketWithReplication,
 	}
 )
 

--- a/token/services/network/fabric/finality/committerflm.go
+++ b/token/services/network/fabric/finality/committerflm.go
@@ -146,7 +146,7 @@ func (t *FinalityListener) OnStatus(ctx context.Context, txID string, status int
 		time.Sleep(t.retryWaitDuration)
 	}
 	if err := qe.Done(); err != nil {
-		logger.Warnf("failed closing query executor for tx [%s]: [%s]", txID, err)
+		logger.Warnf("failed to close query executor for tx [%s]: [%s]", txID, err)
 	}
 	if err != nil {
 		panic(fmt.Sprintf("can't get state [%s][%s]", txID, key))

--- a/token/services/network/fabric/finality/delivery.go
+++ b/token/services/network/fabric/finality/delivery.go
@@ -1,0 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+)
+
+type Delivery struct {
+	*fabric.Delivery
+}
+
+func (d *Delivery) ScanBlock(background context.Context, callback fabric.BlockCallback) error {
+	return d.Delivery.ScanBlock(background, callback)
+}

--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -108,7 +108,7 @@ func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (Listener
 	flm, err := events.NewListenerManager[TxInfo](
 		logging.MustGetLogger("token-sdk.network.fabric.finality"),
 		p.config,
-		ch.Delivery(),
+		&Delivery{Delivery: ch.Delivery()},
 		&DeliveryScanQueryByID{
 			Delivery: ch.Delivery(),
 			Ledger:   ch.Ledger(),

--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/vault"
 	driver3 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/tracing"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 	"github.com/hyperledger/fabric-protos-go/common"
@@ -105,6 +106,7 @@ func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (Listener
 	}
 	mapper := p.newMapper(network, channel)
 	flm, err := events.NewListenerManager[TxInfo](
+		logging.MustGetLogger("token-sdk.network.fabric.finality"),
 		p.config,
 		ch.Delivery(),
 		&DeliveryScanQueryByID{

--- a/token/services/network/fabric/finality/deliveryqs.go
+++ b/token/services/network/fabric/finality/deliveryqs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	events2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
 	"go.uber.org/zap"
 )
@@ -26,10 +27,10 @@ const (
 type DeliveryScanQueryByID struct {
 	Delivery *fabric.Delivery
 	Ledger   *fabric.Ledger
-	Mapper   finality.TxInfoMapper[TxInfo]
+	Mapper   events2.EventInfoMapper[TxInfo]
 }
 
-func (q *DeliveryScanQueryByID) QueryByID(ctx context.Context, lastBlock driver.BlockNum, evicted map[driver.TxID][]finality.ListenerEntry[TxInfo]) (<-chan []TxInfo, error) {
+func (q *DeliveryScanQueryByID) QueryByID(ctx context.Context, lastBlock driver.BlockNum, evicted map[driver.TxID][]events2.ListenerEntry[TxInfo]) (<-chan []TxInfo, error) {
 	keys := collections.Keys(evicted)
 	ch := make(chan []TxInfo, len(keys))
 	go q.queryByID(ctx, keys, ch, lastBlock)

--- a/token/services/network/fabric/finality/listenermanager.go
+++ b/token/services/network/fabric/finality/listenermanager.go
@@ -8,7 +8,7 @@ package finality
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
@@ -28,7 +28,7 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 	logger.Debugf("Create Finality Listener Manager provider with config: %s", lmConfig)
 	switch lmConfig.Type() {
 	case config.Delivery:
-		return newEndorserDeliveryBasedFLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{
+		return newEndorserDeliveryBasedFLMProvider(fnsp, tracerProvider, keyTranslator, events.DeliveryListenerManagerConfig{
 			MapperParallelism:       lmConfig.DeliveryMapperParallelism(),
 			BlockProcessParallelism: lmConfig.DeliveryBlockProcessParallelism(),
 			ListenerTimeout:         lmConfig.DeliveryListenerTimeout(),

--- a/token/services/network/fabric/lookup/channelllm.go
+++ b/token/services/network/fabric/lookup/channelllm.go
@@ -66,6 +66,14 @@ type channelBasedLLM struct {
 	listeners      map[string]*Scanner
 }
 
+func (c *channelBasedLLM) PermanentLookupListenerSupported() bool {
+	return false
+}
+
+func (c *channelBasedLLM) AddPermanentLookupListener(namespace string, key string, listener Listener) error {
+	panic("implement me")
+}
+
 func (c *channelBasedLLM) AddLookupListener(namespace driver.Namespace, key driver.PKey, startingTxID string, stopOnLastTx bool, listener Listener) error {
 	s := &Scanner{
 		context:      context.Background(),

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -30,9 +30,9 @@ import (
 type newTxInfoMapper = func(network, channel string) events.EventInfoMapper[KeyInfo]
 
 type EventsListenerManager interface {
-	AddPermanentEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
-	AddEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
-	RemoveEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
+	AddPermanentEventListener(key string, e events.ListenerEntry[KeyInfo]) error
+	AddEventListener(key string, e events.ListenerEntry[KeyInfo]) error
+	RemoveEventListener(key string, e events.ListenerEntry[KeyInfo]) error
 }
 
 type Listener interface {

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -30,6 +30,7 @@ import (
 type newTxInfoMapper = func(network, channel string) events.EventInfoMapper[KeyInfo]
 
 type EventsListenerManager interface {
+	AddPermanentEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
 	AddEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
 	RemoveEventListener(txID string, e events.ListenerEntry[KeyInfo]) error
 }
@@ -128,6 +129,14 @@ func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (Listener
 
 type deliveryBasedLLM struct {
 	lm EventsListenerManager
+}
+
+func (c *deliveryBasedLLM) PermanentLookupListenerSupported() bool {
+	return true
+}
+
+func (m *deliveryBasedLLM) AddPermanentLookupListener(namespace string, key string, listener Listener) error {
+	return m.lm.AddPermanentEventListener(key, &listenerEntry{namespace, listener})
 }
 
 func (m *deliveryBasedLLM) AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener Listener) error {

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	finality2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/finality"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
@@ -119,7 +120,7 @@ func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (Listener
 	flm, err := events.NewListenerManager[KeyInfo](
 		logging.MustGetLogger("token-sdk.network.fabric.llm"),
 		p.config,
-		ch.Delivery(),
+		&finality2.Delivery{Delivery: ch.Delivery()},
 		&DeliveryScanQueryByID{
 			Channel: ch,
 		},

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -22,6 +22,8 @@ type ListenerManagerProvider interface {
 }
 
 type ListenerManager interface {
+	PermanentLookupListenerSupported() bool
+	AddPermanentLookupListener(namespace string, key string, listener Listener) error
 	AddLookupListener(namespace string, key string, startingTxID string, stopOnLastTx bool, listener Listener) error
 	RemoveLookupListener(id string, listener Listener) error
 }

--- a/token/services/network/fabric/lookup/manager.go
+++ b/token/services/network/fabric/lookup/manager.go
@@ -8,7 +8,7 @@ package lookup
 
 import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common/rws/translator"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/config"
@@ -30,7 +30,7 @@ func NewListenerManagerProvider(fnsp *fabric.NetworkServiceProvider, tracerProvi
 	logger.Debugf("Create Lookup Listener Manager provider with config: %s", lmConfig)
 	switch lmConfig.Type() {
 	case config.Delivery:
-		return newEndorserDeliveryBasedLLMProvider(fnsp, tracerProvider, keyTranslator, finality.DeliveryListenerManagerConfig{
+		return newEndorserDeliveryBasedLLMProvider(fnsp, tracerProvider, keyTranslator, events.DeliveryListenerManagerConfig{
 			MapperParallelism:       lmConfig.DeliveryMapperParallelism(),
 			BlockProcessParallelism: lmConfig.DeliveryBlockProcessParallelism(),
 			ListenerTimeout:         lmConfig.DeliveryListenerTimeout(),


### PR DESCRIPTION
This PR does the following: For Fabric and when possible, It uses the new FSC events listener to listen to events related to the update of setup key. This allows the token-sdk stack to avoid any dependency from the FSC's commit pipeline.