### PR TITLE
ttx service: remove the call to ProcessNamespace

### DIFF
--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -89,9 +89,6 @@ type Network interface {
 
 	// Ledger gives access to the remote ledger
 	Ledger() (Ledger, error)
-
-	// ProcessNamespace indicates to the commit pipeline to process all transaction in the passed namespace
-	ProcessNamespace(namespace string) error
 }
 
 type FinalityListenerManager interface {

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -361,13 +361,6 @@ func (n *Network) Ledger() (driver.Ledger, error) {
 	return n.ledger, nil
 }
 
-func (n *Network) ProcessNamespace(namespace string) error {
-	if err := n.ch.Committer().ProcessNamespace(namespace); err != nil {
-		return errors.WithMessagef(err, "failed to register processing of namespace [%s]", namespace)
-	}
-	return nil
-}
-
 type loader struct {
 	newVault NewVaultFunc
 	name     string

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -380,10 +380,6 @@ func (n *Network) Ledger() (*Ledger, error) {
 	return &Ledger{l: l}, nil
 }
 
-func (n *Network) ProcessNamespace(namespace string) error {
-	return n.n.ProcessNamespace(namespace)
-}
-
 func (n *Network) Normalize(opt *token.ServiceOptions) (*token.ServiceOptions, error) {
 	return n.n.Normalize(opt)
 }

--- a/token/services/network/orion/network.go
+++ b/token/services/network/orion/network.go
@@ -264,11 +264,6 @@ func (n *Network) Ledger() (driver.Ledger, error) {
 	return n.ledger, nil
 }
 
-func (n *Network) ProcessNamespace(namespace string) error {
-	// Not supported
-	return nil
-}
-
 type tokenVault struct {
 	tokenVault driver.TokenVault
 }

--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditdb"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/auditor"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/tokens"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttxdb"
 	view3 "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/view"
@@ -113,18 +112,6 @@ func (r *RegisterAuditorView) Call(context view.Context) (interface{}, error) {
 	// register responder
 	if err := view2.GetRegistry(context).RegisterResponder(r.AuditView, &AuditingViewInitiator{}); err != nil {
 		return nil, errors.Wrapf(err, "failed to register auditor view")
-	}
-	// enable processing of all token transactions for the given network and namespace
-	tms := token.GetManagementService(context, token.WithTMSID(r.TMSID))
-	if tms == nil {
-		return nil, errors.Errorf("cannot find tms for [%s]", r.TMSID)
-	}
-	net := network.GetInstance(context, tms.Network(), tms.Channel())
-	if net == nil {
-		return nil, errors.Errorf("cannot find network for [%s]", tms.ID())
-	}
-	if err := net.ProcessNamespace(tms.Namespace()); err != nil {
-		return nil, errors.WithMessagef(err, "failed to register namespace for processing [%s]", tms.Network())
 	}
 	return nil, nil
 }


### PR DESCRIPTION
We don't need the call to ProcessNamespace because the auditor can subscribe directly to all the transactions it has processed so far.