### PR TITLE
upgredability: check that a token is spendable

### DIFF
--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -952,10 +952,12 @@ func CheckOwnerDB(network *integration.Infrastructure, errorCheck func([]string)
 		for _, replicaName := range id.AllNames() {
 			errorMessagesBoxed, err := network.Client(replicaName).CallView("CheckTTXDB", common.JSONMarshall(&views.CheckTTXDB{}))
 			Expect(err).NotTo(HaveOccurred())
+			var errorMessages []string
+			common.JSONUnmarshal(errorMessagesBoxed.([]byte), &errorMessages)
 			if errorCheck != nil {
-				var errorMessages []string
-				common.JSONUnmarshal(errorMessagesBoxed.([]byte), &errorMessages)
 				Expect(errorCheck(errorMessages)).NotTo(HaveOccurred(), "failed to check errors")
+			} else {
+				Expect(len(errorMessages)).To(BeZero(), "expected zero errors, got [%v]", errorMessages)
 			}
 		}
 	}
@@ -967,14 +969,12 @@ func CheckAuditorDB(network *integration.Infrastructure, auditor *token3.NodeRef
 		AuditorWalletID: walletID,
 	}))
 	Expect(err).NotTo(HaveOccurred())
+	var errorMessages []string
+	common.JSONUnmarshal(errorMessagesBoxed.([]byte), &errorMessages)
 	if errorCheck != nil {
-		var errorMessages []string
-		common.JSONUnmarshal(errorMessagesBoxed.([]byte), &errorMessages)
 		Expect(errorCheck(errorMessages)).NotTo(HaveOccurred(), "failed to check errors")
 	} else {
-		var errorMessages []string
-		common.JSONUnmarshal(errorMessagesBoxed.([]byte), &errorMessages)
-		Expect(len(errorMessages)).To(Equal(0), "expected 0 error messages, got [% v]", errorMessages)
+		Expect(len(errorMessages)).To(BeZero(), "expected zero errors, got [%v]", errorMessages)
 	}
 }
 

--- a/token/core/fabtoken/v1/tokens.go
+++ b/token/core/fabtoken/v1/tokens.go
@@ -37,7 +37,7 @@ func NewTokensService(pp *core.PublicParams, identityDeserializer driver.Deseria
 	}, nil
 }
 
-func (s *TokensService) Recipients(output []byte) ([]driver.Identity, error) {
+func (s *TokensService) Recipients(output driver.TokenOutput) ([]driver.Identity, error) {
 	tok := &core.Output{}
 	if err := tok.Deserialize(output); err != nil {
 		return nil, errors.Wrap(err, "failed unmarshalling token")
@@ -50,7 +50,7 @@ func (s *TokensService) Recipients(output []byte) ([]driver.Identity, error) {
 }
 
 // Deobfuscate returns a deserialized token and the identity of its issuer
-func (s *TokensService) Deobfuscate(output []byte, outputMetadata []byte) (*token2.Token, driver.Identity, []driver.Identity, token2.Format, error) {
+func (s *TokensService) Deobfuscate(output driver.TokenOutput, outputMetadata driver.TokenOutputMetadata) (*token2.Token, driver.Identity, []driver.Identity, token2.Format, error) {
 	tok := &core.Output{}
 	if err := tok.Deserialize(output); err != nil {
 		return nil, nil, nil, "", errors.Wrap(err, "failed unmarshalling token")

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -113,7 +113,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 
 	metricsProvider := metrics.NewTMSProvider(tmsConfig.ID(), d.metricsProvider)
 	driverMetrics := v1.NewMetrics(metricsProvider)
-	tokensService, err := v1.NewTokensService(ppm, deserializer)
+	tokensService, err := v1.NewTokensService(logger, ppm, deserializer)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze token service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}

--- a/token/core/zkatdlog/nogh/v1/tokens.go
+++ b/token/core/zkatdlog/nogh/v1/tokens.go
@@ -229,7 +229,7 @@ func (s *TokensService) getOutput(outputRaw []byte, checkOwner bool) (*token2.To
 	return output, nil
 }
 
-func supportedTokenFormat(pp *noghv1.PublicParams, precision uint64) (token.Format, error) {
+func supportedTokenFormat(pp *crypto.PublicParams, precision uint64) (token.Format, error) {
 	hasher := utils2.NewSHA256Hasher()
 	if err := errors2.Join(
 		hasher.AddInt32(comm.Type),

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -170,6 +170,19 @@ type QueryEngine struct {
 		result1 []byte
 		result2 error
 	}
+	UnspentLedgerTokensIteratorByStub        func(context.Context) (driver.LedgerTokensIterator, error)
+	unspentLedgerTokensIteratorByMutex       sync.RWMutex
+	unspentLedgerTokensIteratorByArgsForCall []struct {
+		arg1 context.Context
+	}
+	unspentLedgerTokensIteratorByReturns struct {
+		result1 driver.LedgerTokensIterator
+		result2 error
+	}
+	unspentLedgerTokensIteratorByReturnsOnCall map[int]struct {
+		result1 driver.LedgerTokensIterator
+		result2 error
+	}
 	UnspentTokensIteratorStub        func() (driver.UnspentTokensIterator, error)
 	unspentTokensIteratorMutex       sync.RWMutex
 	unspentTokensIteratorArgsForCall []struct {
@@ -984,6 +997,70 @@ func (fake *QueryEngine) PublicParamsReturnsOnCall(i int, result1 []byte, result
 	}{result1, result2}
 }
 
+func (fake *QueryEngine) UnspentLedgerTokensIteratorBy(arg1 context.Context) (driver.LedgerTokensIterator, error) {
+	fake.unspentLedgerTokensIteratorByMutex.Lock()
+	ret, specificReturn := fake.unspentLedgerTokensIteratorByReturnsOnCall[len(fake.unspentLedgerTokensIteratorByArgsForCall)]
+	fake.unspentLedgerTokensIteratorByArgsForCall = append(fake.unspentLedgerTokensIteratorByArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.UnspentLedgerTokensIteratorByStub
+	fakeReturns := fake.unspentLedgerTokensIteratorByReturns
+	fake.recordInvocation("UnspentLedgerTokensIteratorBy", []interface{}{arg1})
+	fake.unspentLedgerTokensIteratorByMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *QueryEngine) UnspentLedgerTokensIteratorByCallCount() int {
+	fake.unspentLedgerTokensIteratorByMutex.RLock()
+	defer fake.unspentLedgerTokensIteratorByMutex.RUnlock()
+	return len(fake.unspentLedgerTokensIteratorByArgsForCall)
+}
+
+func (fake *QueryEngine) UnspentLedgerTokensIteratorByCalls(stub func(context.Context) (driver.LedgerTokensIterator, error)) {
+	fake.unspentLedgerTokensIteratorByMutex.Lock()
+	defer fake.unspentLedgerTokensIteratorByMutex.Unlock()
+	fake.UnspentLedgerTokensIteratorByStub = stub
+}
+
+func (fake *QueryEngine) UnspentLedgerTokensIteratorByArgsForCall(i int) context.Context {
+	fake.unspentLedgerTokensIteratorByMutex.RLock()
+	defer fake.unspentLedgerTokensIteratorByMutex.RUnlock()
+	argsForCall := fake.unspentLedgerTokensIteratorByArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *QueryEngine) UnspentLedgerTokensIteratorByReturns(result1 driver.LedgerTokensIterator, result2 error) {
+	fake.unspentLedgerTokensIteratorByMutex.Lock()
+	defer fake.unspentLedgerTokensIteratorByMutex.Unlock()
+	fake.UnspentLedgerTokensIteratorByStub = nil
+	fake.unspentLedgerTokensIteratorByReturns = struct {
+		result1 driver.LedgerTokensIterator
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *QueryEngine) UnspentLedgerTokensIteratorByReturnsOnCall(i int, result1 driver.LedgerTokensIterator, result2 error) {
+	fake.unspentLedgerTokensIteratorByMutex.Lock()
+	defer fake.unspentLedgerTokensIteratorByMutex.Unlock()
+	fake.UnspentLedgerTokensIteratorByStub = nil
+	if fake.unspentLedgerTokensIteratorByReturnsOnCall == nil {
+		fake.unspentLedgerTokensIteratorByReturnsOnCall = make(map[int]struct {
+			result1 driver.LedgerTokensIterator
+			result2 error
+		})
+	}
+	fake.unspentLedgerTokensIteratorByReturnsOnCall[i] = struct {
+		result1 driver.LedgerTokensIterator
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *QueryEngine) UnspentTokensIterator() (driver.UnspentTokensIterator, error) {
 	fake.unspentTokensIteratorMutex.Lock()
 	ret, specificReturn := fake.unspentTokensIteratorReturnsOnCall[len(fake.unspentTokensIteratorArgsForCall)]
@@ -1200,6 +1277,8 @@ func (fake *QueryEngine) Invocations() map[string][][]interface{} {
 	defer fake.listUnspentTokensMutex.RUnlock()
 	fake.publicParamsMutex.RLock()
 	defer fake.publicParamsMutex.RUnlock()
+	fake.unspentLedgerTokensIteratorByMutex.RLock()
+	defer fake.unspentLedgerTokensIteratorByMutex.RUnlock()
 	fake.unspentTokensIteratorMutex.RLock()
 	defer fake.unspentTokensIteratorMutex.RUnlock()
 	fake.unspentTokensIteratorByMutex.RLock()

--- a/token/driver/mock/tss.go
+++ b/token/driver/mock/tss.go
@@ -25,11 +25,11 @@ type TokensService struct {
 		result1 bool
 		result2 error
 	}
-	DeobfuscateStub        func([]byte, []byte) (*token.Token, identity.Identity, []identity.Identity, token.Format, error)
+	DeobfuscateStub        func(driver.TokenOutput, driver.TokenOutputMetadata) (*token.Token, identity.Identity, []identity.Identity, token.Format, error)
 	deobfuscateMutex       sync.RWMutex
 	deobfuscateArgsForCall []struct {
-		arg1 []byte
-		arg2 []byte
+		arg1 driver.TokenOutput
+		arg2 driver.TokenOutputMetadata
 	}
 	deobfuscateReturns struct {
 		result1 *token.Token
@@ -44,19 +44,6 @@ type TokensService struct {
 		result3 []identity.Identity
 		result4 token.Format
 		result5 error
-	}
-	RecipientsStub        func([]byte) ([]identity.Identity, error)
-	recipientsMutex       sync.RWMutex
-	recipientsArgsForCall []struct {
-		arg1 []byte
-	}
-	recipientsReturns struct {
-		result1 []identity.Identity
-		result2 error
-	}
-	recipientsReturnsOnCall map[int]struct {
-		result1 []identity.Identity
-		result2 error
 	}
 	GenUpgradeProofStub        func(driver.TokensUpgradeChallenge, []token.LedgerToken) ([]byte, error)
 	genUpgradeProofMutex       sync.RWMutex
@@ -82,6 +69,19 @@ type TokensService struct {
 	}
 	newUpgradeChallengeReturnsOnCall map[int]struct {
 		result1 driver.TokensUpgradeChallenge
+		result2 error
+	}
+	RecipientsStub        func(driver.TokenOutput) ([]identity.Identity, error)
+	recipientsMutex       sync.RWMutex
+	recipientsArgsForCall []struct {
+		arg1 driver.TokenOutput
+	}
+	recipientsReturns struct {
+		result1 []identity.Identity
+		result2 error
+	}
+	recipientsReturnsOnCall map[int]struct {
+		result1 []identity.Identity
 		result2 error
 	}
 	SupportedTokenFormatsStub        func() []token.Format
@@ -169,26 +169,16 @@ func (fake *TokensService) CheckUpgradeProofReturnsOnCall(i int, result1 bool, r
 	}{result1, result2}
 }
 
-func (fake *TokensService) Deobfuscate(arg1 []byte, arg2 []byte) (*token.Token, identity.Identity, []identity.Identity, token.Format, error) {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	var arg2Copy []byte
-	if arg2 != nil {
-		arg2Copy = make([]byte, len(arg2))
-		copy(arg2Copy, arg2)
-	}
+func (fake *TokensService) Deobfuscate(arg1 driver.TokenOutput, arg2 driver.TokenOutputMetadata) (*token.Token, identity.Identity, []identity.Identity, token.Format, error) {
 	fake.deobfuscateMutex.Lock()
 	ret, specificReturn := fake.deobfuscateReturnsOnCall[len(fake.deobfuscateArgsForCall)]
 	fake.deobfuscateArgsForCall = append(fake.deobfuscateArgsForCall, struct {
-		arg1 []byte
-		arg2 []byte
-	}{arg1Copy, arg2Copy})
+		arg1 driver.TokenOutput
+		arg2 driver.TokenOutputMetadata
+	}{arg1, arg2})
 	stub := fake.DeobfuscateStub
 	fakeReturns := fake.deobfuscateReturns
-	fake.recordInvocation("Deobfuscate", []interface{}{arg1Copy, arg2Copy})
+	fake.recordInvocation("Deobfuscate", []interface{}{arg1, arg2})
 	fake.deobfuscateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -205,13 +195,13 @@ func (fake *TokensService) DeobfuscateCallCount() int {
 	return len(fake.deobfuscateArgsForCall)
 }
 
-func (fake *TokensService) DeobfuscateCalls(stub func([]byte, []byte) (*token.Token, identity.Identity, []identity.Identity, token.Format, error)) {
+func (fake *TokensService) DeobfuscateCalls(stub func(driver.TokenOutput, driver.TokenOutputMetadata) (*token.Token, identity.Identity, []identity.Identity, token.Format, error)) {
 	fake.deobfuscateMutex.Lock()
 	defer fake.deobfuscateMutex.Unlock()
 	fake.DeobfuscateStub = stub
 }
 
-func (fake *TokensService) DeobfuscateArgsForCall(i int) ([]byte, []byte) {
+func (fake *TokensService) DeobfuscateArgsForCall(i int) (driver.TokenOutput, driver.TokenOutputMetadata) {
 	fake.deobfuscateMutex.RLock()
 	defer fake.deobfuscateMutex.RUnlock()
 	argsForCall := fake.deobfuscateArgsForCall[i]
@@ -251,75 +241,6 @@ func (fake *TokensService) DeobfuscateReturnsOnCall(i int, result1 *token.Token,
 		result4 token.Format
 		result5 error
 	}{result1, result2, result3, result4, result5}
-}
-
-func (fake *TokensService) Recipients(arg1 []byte) ([]identity.Identity, error) {
-	var arg1Copy []byte
-	if arg1 != nil {
-		arg1Copy = make([]byte, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.recipientsMutex.Lock()
-	ret, specificReturn := fake.recipientsReturnsOnCall[len(fake.recipientsArgsForCall)]
-	fake.recipientsArgsForCall = append(fake.recipientsArgsForCall, struct {
-		arg1 []byte
-	}{arg1Copy})
-	stub := fake.RecipientsStub
-	fakeReturns := fake.recipientsReturns
-	fake.recordInvocation("Recipients", []interface{}{arg1Copy})
-	fake.recipientsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *TokensService) RecipientsCallCount() int {
-	fake.recipientsMutex.RLock()
-	defer fake.recipientsMutex.RUnlock()
-	return len(fake.recipientsArgsForCall)
-}
-
-func (fake *TokensService) RecipientsCalls(stub func([]byte) ([]identity.Identity, error)) {
-	fake.recipientsMutex.Lock()
-	defer fake.recipientsMutex.Unlock()
-	fake.RecipientsStub = stub
-}
-
-func (fake *TokensService) RecipientsArgsForCall(i int) []byte {
-	fake.recipientsMutex.RLock()
-	defer fake.recipientsMutex.RUnlock()
-	argsForCall := fake.recipientsArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *TokensService) RecipientsReturns(result1 []identity.Identity, result2 error) {
-	fake.recipientsMutex.Lock()
-	defer fake.recipientsMutex.Unlock()
-	fake.RecipientsStub = nil
-	fake.recipientsReturns = struct {
-		result1 []identity.Identity
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *TokensService) RecipientsReturnsOnCall(i int, result1 []identity.Identity, result2 error) {
-	fake.recipientsMutex.Lock()
-	defer fake.recipientsMutex.Unlock()
-	fake.RecipientsStub = nil
-	if fake.recipientsReturnsOnCall == nil {
-		fake.recipientsReturnsOnCall = make(map[int]struct {
-			result1 []identity.Identity
-			result2 error
-		})
-	}
-	fake.recipientsReturnsOnCall[i] = struct {
-		result1 []identity.Identity
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *TokensService) GenUpgradeProof(arg1 driver.TokensUpgradeChallenge, arg2 []token.LedgerToken) ([]byte, error) {
@@ -448,6 +369,70 @@ func (fake *TokensService) NewUpgradeChallengeReturnsOnCall(i int, result1 drive
 	}{result1, result2}
 }
 
+func (fake *TokensService) Recipients(arg1 driver.TokenOutput) ([]identity.Identity, error) {
+	fake.recipientsMutex.Lock()
+	ret, specificReturn := fake.recipientsReturnsOnCall[len(fake.recipientsArgsForCall)]
+	fake.recipientsArgsForCall = append(fake.recipientsArgsForCall, struct {
+		arg1 driver.TokenOutput
+	}{arg1})
+	stub := fake.RecipientsStub
+	fakeReturns := fake.recipientsReturns
+	fake.recordInvocation("Recipients", []interface{}{arg1})
+	fake.recipientsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *TokensService) RecipientsCallCount() int {
+	fake.recipientsMutex.RLock()
+	defer fake.recipientsMutex.RUnlock()
+	return len(fake.recipientsArgsForCall)
+}
+
+func (fake *TokensService) RecipientsCalls(stub func(driver.TokenOutput) ([]identity.Identity, error)) {
+	fake.recipientsMutex.Lock()
+	defer fake.recipientsMutex.Unlock()
+	fake.RecipientsStub = stub
+}
+
+func (fake *TokensService) RecipientsArgsForCall(i int) driver.TokenOutput {
+	fake.recipientsMutex.RLock()
+	defer fake.recipientsMutex.RUnlock()
+	argsForCall := fake.recipientsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *TokensService) RecipientsReturns(result1 []identity.Identity, result2 error) {
+	fake.recipientsMutex.Lock()
+	defer fake.recipientsMutex.Unlock()
+	fake.RecipientsStub = nil
+	fake.recipientsReturns = struct {
+		result1 []identity.Identity
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TokensService) RecipientsReturnsOnCall(i int, result1 []identity.Identity, result2 error) {
+	fake.recipientsMutex.Lock()
+	defer fake.recipientsMutex.Unlock()
+	fake.RecipientsStub = nil
+	if fake.recipientsReturnsOnCall == nil {
+		fake.recipientsReturnsOnCall = make(map[int]struct {
+			result1 []identity.Identity
+			result2 error
+		})
+	}
+	fake.recipientsReturnsOnCall[i] = struct {
+		result1 []identity.Identity
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *TokensService) SupportedTokenFormats() []token.Format {
 	fake.supportedTokenFormatsMutex.Lock()
 	ret, specificReturn := fake.supportedTokenFormatsReturnsOnCall[len(fake.supportedTokenFormatsArgsForCall)]
@@ -508,12 +493,12 @@ func (fake *TokensService) Invocations() map[string][][]interface{} {
 	defer fake.checkUpgradeProofMutex.RUnlock()
 	fake.deobfuscateMutex.RLock()
 	defer fake.deobfuscateMutex.RUnlock()
-	fake.recipientsMutex.RLock()
-	defer fake.recipientsMutex.RUnlock()
 	fake.genUpgradeProofMutex.RLock()
 	defer fake.genUpgradeProofMutex.RUnlock()
 	fake.newUpgradeChallengeMutex.RLock()
 	defer fake.newUpgradeChallengeMutex.RUnlock()
+	fake.recipientsMutex.RLock()
+	defer fake.recipientsMutex.RUnlock()
 	fake.supportedTokenFormatsMutex.RLock()
 	defer fake.supportedTokenFormatsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/token/driver/tokens.go
+++ b/token/driver/tokens.go
@@ -13,6 +13,11 @@ import "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 type (
 	TokensUpgradeChallenge []byte
 	TokensUpgradeProof     []byte
+
+	// TokenOutput models an output on the edger
+	TokenOutput []byte
+	// TokenOutputMetadata models the metadata of an output on the ledger
+	TokenOutputMetadata []byte
 )
 
 // TokensUpgradeService models the token update service
@@ -37,8 +42,8 @@ type TokensService interface {
 	// - its issuer (if any),
 	// - the recipients defined by Token.Owner,
 	// = and the output format
-	Deobfuscate(output []byte, outputMetadata []byte) (*token.Token, Identity, []Identity, token.Format, error)
+	Deobfuscate(output TokenOutput, outputMetadata TokenOutputMetadata) (*token.Token, Identity, []Identity, token.Format, error)
 
 	// Recipients returns the recipients of the passed output
-	Recipients(output []byte) ([]Identity, error)
+	Recipients(output TokenOutput) ([]Identity, error)
 }

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -47,6 +47,11 @@ type UnsupportedTokensIterator interface {
 	Next() (*token.LedgerToken, error)
 }
 
+type LedgerTokensIterator interface {
+	Close()
+	Next() (*token.LedgerToken, error)
+}
+
 type Vault interface {
 	QueryEngine() QueryEngine
 	CertificationStorage() CertificationStorage
@@ -70,6 +75,8 @@ type QueryEngine interface {
 	IsMine(id *token.ID) (bool, error)
 	// UnspentTokensIterator returns an iterator over all unspent tokens
 	UnspentTokensIterator() (UnspentTokensIterator, error)
+	// UnspentLedgerTokensIteratorBy returns an iterator over all unspent ledger tokens
+	UnspentLedgerTokensIteratorBy(ctx context.Context) (LedgerTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator of unspent tokens owned by the passed id and whose type is the passed on.
 	// The token type can be empty. In that case, tokens of any type are returned.
 	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.Type) (UnspentTokensIterator, error)

--- a/token/services/db/driver/token.go
+++ b/token/services/db/driver/token.go
@@ -149,6 +149,8 @@ type TokenDB interface {
 	IsMine(txID string, index uint64) (bool, error)
 	// UnspentTokensIterator returns an iterator over all owned tokens
 	UnspentTokensIterator() (driver.UnspentTokensIterator, error)
+	// LedgerTokensIteratorBy returns an iterator over all unspent ledger tokens
+	UnspentLedgerTokensIteratorBy(ctx context.Context) (driver.LedgerTokensIterator, error)
 	// UnspentTokensIteratorBy returns an iterator over all tokens owned by the passed wallet identifier and of a given type
 	UnspentTokensIteratorBy(ctx context.Context, walletID string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	// SpendableTokensIteratorBy returns an iterator over all tokens owned solely by the passed wallet identifier and of a given type

--- a/token/tokens.go
+++ b/token/tokens.go
@@ -30,3 +30,8 @@ func (t *TokensService) NewUpgradeChallenge() ([]byte, error) {
 func (t *TokensService) GenUpgradeProof(id []byte, tokens []token.LedgerToken) ([]byte, error) {
 	return t.ts.GenUpgradeProof(id, tokens)
 }
+
+// SupportedTokenFormats returns the supported token formats
+func (t *TokensService) SupportedTokenFormats() []token.Format {
+	return t.ts.SupportedTokenFormats()
+}


### PR DESCRIPTION
This PR brings the following:
- DLog Token Format is computed excluding the issuer public key
- A new db check verifies the spendability of tokens in the tokens db. If a token is not spendable, a message is reported.