### PR TITLE
dlog v1 finalization: enforce at least one issuer

### DIFF
--- a/cmd/tokengen/cobra/pp/dlog/gen.go
+++ b/cmd/tokengen/cobra/pp/dlog/gen.go
@@ -97,6 +97,7 @@ var cobraCommand = &cobra.Command{
 			Aries:             Aries,
 		})
 		if err != nil {
+			fmt.Printf("failed to generate public parameters [%s]\n", err)
 			return errors.Wrap(err, "failed to generate public parameters")
 		}
 		// generate the chaincode package
@@ -115,7 +116,7 @@ func Gen(args *GeneratorArgs) ([]byte, error) {
 	// Load Idemix Issuer Public Key
 	_, ipkBytes, err := idemix.LoadIssuerPublicKey(args.IdemixMSPDir)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to load issuer public key")
 	}
 
 	// Setup
@@ -129,11 +130,11 @@ func Gen(args *GeneratorArgs) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed setting up public parameters")
 	}
+	if err := common.SetupIssuersAndAuditors(pp, args.Auditors, args.Issuers); err != nil {
+		return nil, errors.Wrap(err, "failed to setup issuer and auditors")
+	}
 	if err := pp.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "failed to validate public parameters")
-	}
-	if err := common.SetupIssuersAndAuditors(pp, args.Auditors, args.Issuers); err != nil {
-		return nil, err
 	}
 
 	// Store Public Params

--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -265,6 +265,6 @@ func testGenRunWithError(gt *WithT, tokengen string, args []string, errMsg strin
 }
 
 func testGenRun(gt *WithT, tokengen string, args []string) {
-	_, err := exec.Command(tokengen, args...).CombinedOutput()
-	gt.Expect(err).ToNot(HaveOccurred(), "failed running tokengen [%s:%v]", tokengen, args)
+	output, err := exec.Command(tokengen, args...).CombinedOutput()
+	gt.Expect(err).ToNot(HaveOccurred(), "failed running tokengen [%s:%v] with output \n[%s]", tokengen, args, string(output))
 }

--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -14,9 +14,6 @@ import (
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/cmd/tokengen/cobra/pp/common"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core"
-	fabtoken "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/driver"
-	dlog "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/driver"
 	v1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/slices"
 	. "github.com/onsi/gomega"

--- a/cmd/tokengen/samples/topology/fungible.go
+++ b/cmd/tokengen/samples/topology/fungible.go
@@ -102,6 +102,7 @@ func Topology(tokenSDKDriver string, sdks ...api2.SDK) []api.Topology {
 	fabric2.SetOrgs(tms, "Org1")
 	tms.SetTokenGenPublicParams("16")
 	tms.AddAuditor(auditor)
+	tms.AddIssuer(issuer)
 
 	for _, sdk := range sdks {
 		fscTopology.AddSDK(sdk)

--- a/integration/nwo/token/common/ppmgen.go
+++ b/integration/nwo/token/common/ppmgen.go
@@ -152,9 +152,6 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *topolog
 	if err != nil {
 		return nil, err
 	}
-	if err := pp.Validate(); err != nil {
-		return nil, errors.Wrapf(err, "failed to validate public parameters")
-	}
 
 	keyStore := x509.NewKeyStore(kvs.NewTrackedMemory())
 	if len(tms.Auditors) != 0 {
@@ -205,11 +202,16 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *topolog
 		}
 	}
 
+	// validate before serialization
+	if err := pp.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "failed to validate public parameters")
+	}
+
+	// finalization
 	ppRaw, err := pp.Serialize()
 	if err != nil {
 		return nil, err
 	}
-
 	tms.Wallets = wallets
 
 	return ppRaw, nil

--- a/integration/nwo/token/common/ppmgen.go
+++ b/integration/nwo/token/common/ppmgen.go
@@ -13,6 +13,7 @@ import (
 
 	msp "github.com/IBM/idemix"
 	math3 "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/generators/dlog"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/topology"
 	fabtokenv1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/core"
@@ -79,6 +80,7 @@ func (f *FabTokenPublicParamsGenerator) Generate(tms *topology.TMS, wallets *top
 		if len(wallets.Issuers) == 0 {
 			return nil, errors.Errorf("no issuer wallets provided")
 		}
+		issuersSet := collections.NewSet(tms.Issuers...)
 		for _, issuer := range wallets.Issuers {
 			// Build an MSP Identity
 			km, _, err := x509.NewKeyManager(issuer.Path, nil, issuer.Opts, keyStore)
@@ -89,7 +91,7 @@ func (f *FabTokenPublicParamsGenerator) Generate(tms *topology.TMS, wallets *top
 			if err != nil {
 				return nil, errors.WithMessage(err, "failed to get identity")
 			}
-			if tms.Issuers[0] == issuer.ID {
+			if issuersSet.Contains(issuer.ID) {
 				wrap, err := identity.WrapWithType(x509.IdentityType, id)
 				if err != nil {
 					return nil, errors.WithMessagef(err, "failed to create x509 identity for auditor [%v]", issuer)
@@ -182,6 +184,7 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *topolog
 		if len(wallets.Issuers) == 0 {
 			return nil, errors.Errorf("no issuer wallets provided")
 		}
+		issuersSet := collections.NewSet(tms.Issuers...)
 		for _, issuer := range wallets.Issuers {
 			// Build an MSP Identity
 			km, _, err := x509.NewKeyManager(issuer.Path, nil, issuer.Opts, keyStore)
@@ -192,7 +195,7 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *topolog
 			if err != nil {
 				return nil, errors.WithMessage(err, "failed to get identity")
 			}
-			if tms.Issuers[0] == issuer.ID {
+			if issuersSet.Contains(issuer.ID) {
 				wrap, err := identity.WrapWithType(x509.IdentityType, id)
 				if err != nil {
 					return nil, errors.WithMessagef(err, "failed to create x509 identity for issuer [%v]", issuer)

--- a/integration/nwo/token/orion/orion.go
+++ b/integration/nwo/token/orion/orion.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	sfcnode "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc/node"
 	orion2 "github.com/hyperledger-labs/fabric-smart-client/integration/nwo/orion"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	sql2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/db/driver/sql"
 	common2 "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/generators"
@@ -34,7 +35,6 @@ import (
 	"github.com/hyperledger-labs/orion-sdk-go/pkg/config"
 	logger2 "github.com/hyperledger-labs/orion-server/pkg/logger"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 

--- a/integration/nwo/token/topology/topology.go
+++ b/integration/nwo/token/topology/topology.go
@@ -85,6 +85,11 @@ func (t *TMS) AddIssuer(issuer *node.Node) *TMS {
 	return t
 }
 
+func (t *TMS) AddIssuerByID(id string) *TMS {
+	t.Issuers = append(t.Issuers, id)
+	return t
+}
+
 func (t *TMS) SetTokenGenPublicParams(publicParamsGenArgs ...string) {
 	t.PublicParamsGenArgs = publicParamsGenArgs
 }

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		LibP2PNoReplication,
-		WebSocketWithReplication,
+		// LibP2PNoReplication,
+		// WebSocketWithReplication,
 	}
 )
 

--- a/integration/token/dvp/topology.go
+++ b/integration/token/dvp/topology.go
@@ -118,6 +118,9 @@ func Topology(opts Opts) []api.Topology {
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
+	tms.AddIssuerByID("cash_issuer")
+	tms.AddIssuerByID("house_issuer")
 
 	for _, sdk := range opts.SDKs {
 		fscTopology.AddSDK(sdk)

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -39,7 +39,7 @@ var _ = Describe("EndToEnd", func() {
 			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
 		})
 
-		Describe("Extras with websockets and replicas", t.Label, func() {
+		Describe("Extras with websockets", t.Label, func() {
 			ts, selector := newTestSuite(t.CommType, Aries|WebEnabled, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -7,13 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package dlog
 
 import (
-	"os"
-
-	"github.com/hyperledger-labs/fabric-smart-client/integration"
 	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/api"
 	integration2 "github.com/hyperledger-labs/fabric-token-sdk/integration"
-	"github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/integration/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common/sdk/fdlog"
@@ -22,7 +18,6 @@ import (
 	dlognoghv1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 const None = 0
@@ -52,7 +47,7 @@ var _ = Describe("EndToEnd", func() {
 				fungible.TestPublicParamsUpdate(
 					ts.II,
 					"newAuditor",
-					PrepareUpdatedPublicParams(ts.II, "newAuditor", "default"),
+					fungible.PrepareUpdatedPublicParams(ts.II, "newAuditor", "default"),
 					"default",
 					false,
 					selector,
@@ -72,7 +67,7 @@ var _ = Describe("EndToEnd", func() {
 				fungible.TestPublicParamsUpdate(
 					ts.II,
 					"newIssuer",
-					PrepareUpdatedPublicParams(ts.II, "newIssuer", "default"),
+					fungible.PrepareUpdatedPublicParams(ts.II, "newIssuer", "default"),
 					"default",
 					true,
 					selector,
@@ -118,32 +113,6 @@ var _ = Describe("EndToEnd", func() {
 		})
 	}
 })
-
-func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor string, networkName string) []byte {
-	tms := fungible.GetTMSByNetworkName(network, networkName)
-	auditorId := fungible.GetAuditorIdentity(tms, auditor)
-	issuerId := fungible.GetIssuerIdentity(tms, "newIssuer.id1")
-
-	tokenPlatform, ok := network.Ctx.PlatformsByName["token"].(*token.Platform)
-	Expect(ok).To(BeTrue(), "failed to get token platform from context")
-
-	// Deserialize current params
-	ppBytes, err := os.ReadFile(tokenPlatform.PublicParametersFile(tms))
-	Expect(err).NotTo(HaveOccurred())
-	pp, err := dlognoghv1.NewPublicParamsFromBytes(ppBytes, dlognoghv1.DLogPublicParameters)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(pp.Validate()).NotTo(HaveOccurred())
-
-	// Update publicParameters
-	pp.Auditor = auditorId
-	pp.IssuerIDs = []driver.Identity{issuerId}
-
-	// Serialize
-	ppBytes, err = pp.Serialize()
-	Expect(err).NotTo(HaveOccurred())
-
-	return ppBytes
-}
 
 func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, tokenSelector string, names ...string) (*token2.TestSuite, *token2.ReplicaSelector) {
 	opts, selector := token2.NewReplicationOptions(factor, names...)

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -36,7 +36,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, Aries, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, false, selector) })
 		})
 
 		Describe("Extras with websockets", t.Label, func() {
@@ -62,7 +62,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, Aries|AuditorAsIssuer, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T6"), func() { fungible.TestAll(ts.II, "issuer", nil, true, selector) })
+			It("succeeded", Label("T6"), func() { fungible.TestAll(ts.II, "issuer", nil, true, false, selector) })
 			It("Update public params", Label("T7"), func() {
 				fungible.TestPublicParamsUpdate(
 					ts.II,
@@ -79,7 +79,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, None, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T8"), func() { fungible.TestAll(ts.II, "auditor", nil, false, selector) })
+			It("succeeded", Label("T8"), func() { fungible.TestAll(ts.II, "auditor", nil, false, false, selector) })
 		})
 
 		Describe("Malicious Transactions", t.Label, func() {
@@ -93,7 +93,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, Aries|WithEndorsers, t.ReplicationFactor, "", "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T10"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", Label("T10"), func() { fungible.TestAll(ts.II, "auditor", nil, true, false, selector) })
 		})
 
 		Describe("Multisig", t.Label, func() {

--- a/integration/token/fungible/dlog/dlog_test.go
+++ b/integration/token/fungible/dlog/dlog_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common/sdk/fdlog"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/topology"
-	dlognoghv1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/setup"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	. "github.com/onsi/ginkgo/v2"
 )
 

--- a/integration/token/fungible/dloghsm/dlog_test.go
+++ b/integration/token/fungible/dloghsm/dlog_test.go
@@ -32,7 +32,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, Aries|HSM, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, false, selector) })
 		})
 
 		Describe("Fungible with Auditor = Issuer", t.Label, func() {

--- a/integration/token/fungible/dloghsm/dlog_test.go
+++ b/integration/token/fungible/dloghsm/dlog_test.go
@@ -39,7 +39,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, Aries|HSM|AuditorAsIssuer, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T2"), func() { fungible.TestAll(ts.II, "issuer", nil, true, selector) })
+			It("succeeded", Label("T2"), func() { fungible.TestAll(ts.II, "issuer", nil, true, false, selector) })
 		})
 	}
 })

--- a/integration/token/fungible/fabtoken/fabtoken_test.go
+++ b/integration/token/fungible/fabtoken/fabtoken_test.go
@@ -30,7 +30,7 @@ var _ = Describe("EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, false, selector) })
 			It("Update public params", Label("T2"), func() { UpdatePublicParams(ts.II, selector) })
 			It("Test Identity Revocation", Label("T3"), func() { fungible.TestRevokeIdentity(ts.II, "auditor", selector) })
 			It("Test Remote Wallet (GRPC)", Label("T4"), func() { fungible.TestRemoteOwnerWallet(ts.II, "auditor", selector, false) })

--- a/integration/token/fungible/fabtoken/fabtoken_test.go
+++ b/integration/token/fungible/fabtoken/fabtoken_test.go
@@ -42,7 +42,7 @@ var _ = Describe("EndToEnd", func() {
 func UpdatePublicParams(network *integration.Infrastructure, selector *token2.ReplicaSelector) {
 	tms := fungible.GetTMSByNetworkName(network, "default")
 	auditorId := fungible.GetAuditorIdentity(tms, "newAuditor")
-	issuerId := fungible.GetIssuerIdentity(tms, "newIssuer.id1")
+	issuerId := fungible.GetIssuerIdentity(tms, "newIssuer")
 	publicParam := fabtokenv1.PublicParams{
 		Label:             "fabtoken",
 		QuantityPrecision: uint64(64),

--- a/integration/token/fungible/mixed/topology.go
+++ b/integration/token/fungible/mixed/topology.go
@@ -99,7 +99,7 @@ func Topology(opts common.Opts) []api.Topology {
 	fabric2.SetOrgs(fabTokenTms, "Org2")
 
 	dlogTms.AddAuditor(auditor1)
-	dlogTms.AddIssuer(issuer2)
+	dlogTms.AddIssuer(issuer1)
 	fabTokenTms.AddAuditor(auditor2)
 	fabTokenTms.AddIssuer(issuer2)
 

--- a/integration/token/fungible/mixed/topology.go
+++ b/integration/token/fungible/mixed/topology.go
@@ -99,7 +99,9 @@ func Topology(opts common.Opts) []api.Topology {
 	fabric2.SetOrgs(fabTokenTms, "Org2")
 
 	dlogTms.AddAuditor(auditor1)
+	dlogTms.AddIssuer(issuer2)
 	fabTokenTms.AddAuditor(auditor2)
+	fabTokenTms.AddIssuer(issuer2)
 
 	// FSC topology
 	fscTopology.SetBootstrapNode(fscTopology.AddNodeByName("lib-p2p-bootstrap-node"))

--- a/integration/token/fungible/odlog/dlog_test.go
+++ b/integration/token/fungible/odlog/dlog_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Orion EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", func() { fungible.TestAll(ts.II, "auditor", nil, true, true, selector) })
 		})
 	}
 })

--- a/integration/token/fungible/odlog/dlog_test.go
+++ b/integration/token/fungible/odlog/dlog_test.go
@@ -33,12 +33,11 @@ func newTestSuite(commType fsc.P2PCommunicationType, factor int, names ...string
 	opts, selector := token2.NewReplicationOptions(factor, names...)
 	ts := token2.NewTestSuite(StartPortDlog, topology.Topology(
 		common.Opts{
-			Backend:        "orion",
-			CommType:       commType,
-			DefaultTMSOpts: common.TMSOpts{TokenSDKDriver: "dlog", Aries: true},
-			SDKs:           []api.SDK{&odlog.SDK{}},
-			// FSCLogSpec:      "token-sdk=debug:orion-sdk=debug:info",
-			// FSCLogSpec:      "token-sdk=debug:orion-sdk=debug:view-sdk.services.comm=debug:info",
+			Backend:         "orion",
+			CommType:        commType,
+			DefaultTMSOpts:  common.TMSOpts{TokenSDKDriver: "dlog", Aries: true},
+			SDKs:            []api.SDK{&odlog.SDK{}},
+			FSCLogSpec:      "token-sdk=debug:fabric-sdk=debug:info",
 			ReplicationOpts: opts,
 			OnlyUnity:       true,
 		},

--- a/integration/token/fungible/ofabtoken/fabtoken_test.go
+++ b/integration/token/fungible/ofabtoken/fabtoken_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Orion EndToEnd", func() {
 			ts, selector := newTestSuite(t.CommType, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)
 			AfterEach(ts.TearDown)
-			It("succeeded", func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+			It("succeeded", func() { fungible.TestAll(ts.II, "auditor", nil, true, true, selector) })
 		})
 	}
 })

--- a/integration/token/fungible/sdk/auditor/sdk.go
+++ b/integration/token/fungible/sdk/auditor/sdk.go
@@ -48,6 +48,7 @@ func (p *SDK) Install() error {
 			registry.RegisterFactory("DoesWalletExist", &views.DoesWalletExistViewFactory{}),
 			registry.RegisterFactory("TxFinality", &views1.TxFinalityViewFactory{}),
 			registry.RegisterFactory("GetPublicParams", &views.GetPublicParamsViewFactory{}),
+			registry.RegisterFactory("FetchAndUpdatePublicParams", &views.UpdatePublicParamsViewFactory{}),
 		)
 	}); err != nil {
 		return errors.WithMessage(err, "failed to install auditor's views")

--- a/integration/token/fungible/sdk/custodian/sdk.go
+++ b/integration/token/fungible/sdk/custodian/sdk.go
@@ -1,0 +1,43 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package custodian
+
+import (
+	errors2 "errors"
+
+	dig2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/views"
+	"github.com/pkg/errors"
+)
+
+type SDK struct {
+	dig2.SDK
+}
+
+func NewFrom(sdk dig2.SDK) *SDK {
+	return &SDK{SDK: sdk}
+}
+
+func (p *SDK) Install() error {
+	// get dig from registry, this was installed by the FTS's sdk
+	if err := p.SDK.Install(); err != nil {
+		return err
+	}
+
+	if err := p.SDK.Container().Invoke(func(
+		registry *view.Registry,
+	) error {
+		return errors2.Join(
+			registry.RegisterFactory("GetPublicParams", &views.GetPublicParamsViewFactory{}),
+			registry.RegisterFactory("FetchAndUpdatePublicParams", &views.UpdatePublicParamsViewFactory{}),
+		)
+	}); err != nil {
+		return errors.WithMessage(err, "failed to install endorser's views")
+	}
+	return nil
+}

--- a/integration/token/fungible/sdk/custodian/sdk_test.go
+++ b/integration/token/fungible/sdk/custodian/sdk_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package custodian
+
+import (
+	"testing"
+
+	dig2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/sdk/dig"
+	fabricsdk "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/sdk/dig"
+	orionsdk "github.com/hyperledger-labs/fabric-smart-client/platform/orion/sdk/dig"
+	sdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
+	tokensdk "github.com/hyperledger-labs/fabric-token-sdk/token/sdk/dig"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllWiring(t *testing.T) {
+	assert.NoError(t, sdk.DryRunWiring(
+		func(sdk dig2.SDK) *SDK { return NewFrom(tokensdk.NewFrom(orionsdk.NewFrom(fabricsdk.NewFrom(sdk)))) },
+		sdk.WithBool("token.enabled", true),
+	))
+}

--- a/integration/token/fungible/sdk/endorser/sdk.go
+++ b/integration/token/fungible/sdk/endorser/sdk.go
@@ -36,6 +36,7 @@ func (p *SDK) Install() error {
 		return errors2.Join(
 			registry.RegisterFactory("GetPublicParams", &views.GetPublicParamsViewFactory{}),
 			registry.RegisterFactory("EndorserFinality", &endorser.FinalityViewFactory{}),
+			registry.RegisterFactory("FetchAndUpdatePublicParams", &views.UpdatePublicParamsViewFactory{}),
 		)
 	}); err != nil {
 		return errors.WithMessage(err, "failed to install endorser's views")

--- a/integration/token/fungible/sdk/issuer/sdk.go
+++ b/integration/token/fungible/sdk/issuer/sdk.go
@@ -52,6 +52,7 @@ func (p *SDK) Install() error {
 			registry.RegisterFactory("DoesWalletExist", &views.DoesWalletExistViewFactory{}),
 			registry.RegisterFactory("TxFinality", &views1.TxFinalityViewFactory{}),
 			registry.RegisterFactory("issue", &views.IssueCashViewFactory{}),
+			registry.RegisterFactory("FetchAndUpdatePublicParams", &views.UpdatePublicParamsViewFactory{}),
 			registry.RegisterResponder(&views.WithdrawalResponderView{}, &views.WithdrawalInitiatorView{}),
 			registry.RegisterResponder(&views.TokensUpgradeResponderView{}, &views.TokensUpgradeInitiatorView{}),
 		)

--- a/integration/token/fungible/sdk/party/sdk.go
+++ b/integration/token/fungible/sdk/party/sdk.go
@@ -66,6 +66,7 @@ func (p *SDK) Install() error {
 			registry.RegisterFactory("TokenSelectorUnlock", &views.TokenSelectorUnlockViewFactory{}),
 			registry.RegisterFactory("FinalityWithTimeout", &views.FinalityWithTimeoutViewFactory{}),
 			registry.RegisterFactory("GetRevocationHandle", &views.GetRevocationHandleViewFactory{}),
+			registry.RegisterFactory("GetPublicParams", &views.GetPublicParamsViewFactory{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.IssueCashView{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.TransferView{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.TransferWithSelectorView{}),

--- a/integration/token/fungible/sdk/party/sdk.go
+++ b/integration/token/fungible/sdk/party/sdk.go
@@ -67,6 +67,7 @@ func (p *SDK) Install() error {
 			registry.RegisterFactory("FinalityWithTimeout", &views.FinalityWithTimeoutViewFactory{}),
 			registry.RegisterFactory("GetRevocationHandle", &views.GetRevocationHandleViewFactory{}),
 			registry.RegisterFactory("GetPublicParams", &views.GetPublicParamsViewFactory{}),
+			registry.RegisterFactory("FetchAndUpdatePublicParams", &views.UpdatePublicParamsViewFactory{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.IssueCashView{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.TransferView{}),
 			registry.RegisterResponder(&views.AcceptCashView{}, &views.TransferWithSelectorView{}),

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -942,10 +942,11 @@ func GetPublicParams(network *integration.Infrastructure, id *token3.NodeReferen
 	return pp.([]byte)
 }
 
-func FetchAndUpdatePublicParams(network *integration.Infrastructure, id *token3.NodeReference) []byte {
-	pp, err := network.Client(id.ReplicaName()).CallView("FetchAndUpdatePublicParams", common.JSONMarshall(&views.UpdatePublicParams{}))
-	Expect(err).NotTo(HaveOccurred())
-	return pp.([]byte)
+func FetchAndUpdatePublicParams(network *integration.Infrastructure, id *token3.NodeReference) {
+	for _, name := range id.AllNames() {
+		_, err := network.Client(name).CallView("FetchAndUpdatePublicParams", common.JSONMarshall(&views.UpdatePublicParams{}))
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 func DoesWalletExist(network *integration.Infrastructure, id *token3.NodeReference, wallet string, walletType int) bool {

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -30,7 +30,7 @@ import (
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/pp"
 	fabtokenv1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/core"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto"
+	dlognoghv1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/storage/kvs"
@@ -1392,8 +1392,8 @@ func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor str
 	}
 	var pp PP
 	switch genericPP.Identifier {
-	case crypto.DLogPublicParameters:
-		pp, err = crypto.NewPublicParamsFromBytes(ppBytes, crypto.DLogPublicParameters)
+	case dlognoghv1.DLogPublicParameters:
+		pp, err = dlognoghv1.NewPublicParamsFromBytes(ppBytes, dlognoghv1.DLogPublicParameters)
 		Expect(err).NotTo(HaveOccurred())
 	case fabtokenv1.PublicParameters:
 		pp, err = fabtokenv1.NewPublicParamsFromBytes(ppBytes, fabtokenv1.PublicParameters)
@@ -1439,8 +1439,8 @@ func PreparePublicParamsWithNewIssuer(network *integration.Infrastructure, issue
 	}
 	var pp PP
 	switch genericPP.Identifier {
-	case crypto.DLogPublicParameters:
-		pp, err = crypto.NewPublicParamsFromBytes(ppBytes, crypto.DLogPublicParameters)
+	case dlognoghv1.DLogPublicParameters:
+		pp, err = dlognoghv1.NewPublicParamsFromBytes(ppBytes, dlognoghv1.DLogPublicParameters)
 		Expect(err).NotTo(HaveOccurred())
 	case fabtokenv1.PublicParameters:
 		pp, err = fabtokenv1.NewPublicParamsFromBytes(ppBytes, fabtokenv1.PublicParameters)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -1384,7 +1384,7 @@ func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor str
 		Expect(err).NotTo(HaveOccurred())
 		return ppBytes
 	case fabtokenv1.PublicParameters:
-		pp, err := fabtokenv1.NewPublicParamsFromBytes(ppBytes, crypto.DLogPublicParameters)
+		pp, err := fabtokenv1.NewPublicParamsFromBytes(ppBytes, fabtokenv1.PublicParameters)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pp.Validate()).NotTo(HaveOccurred())
 
@@ -1435,7 +1435,7 @@ func PreparePublicParamsWithNewIssuer(network *integration.Infrastructure, issue
 		Expect(err).NotTo(HaveOccurred())
 		return ppBytes
 	case fabtokenv1.PublicParameters:
-		pp, err := fabtokenv1.NewPublicParamsFromBytes(ppBytes, crypto.DLogPublicParameters)
+		pp, err := fabtokenv1.NewPublicParamsFromBytes(ppBytes, fabtokenv1.PublicParameters)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pp.Validate()).NotTo(HaveOccurred())
 

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -927,6 +927,10 @@ func UpdatePublicParamsAndWait(network *integration.Infrastructure, publicParams
 	for _, node := range nodes {
 		if orion {
 			FetchAndUpdatePublicParams(network, node)
+		} else {
+			if node.Id() == "custodian" {
+				continue
+			}
 		}
 		Eventually(GetPublicParams).WithArguments(network, node).WithTimeout(30 * time.Second).WithPolling(15 * time.Second).Should(Equal(publicParams))
 	}

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -1361,7 +1361,7 @@ func MultiSigSpendCashForTMSID(network *integration.Infrastructure, sender *toke
 func PrepareUpdatedPublicParams(network *integration.Infrastructure, auditor string, networkName string) []byte {
 	tms := GetTMSByNetworkName(network, networkName)
 	auditorId := GetAuditorIdentity(tms, auditor)
-	issuerId := GetIssuerIdentity(tms, "newIssuer.id1")
+	issuerId := GetIssuerIdentity(tms, "newIssuer")
 
 	tokenPlatform, ok := network.Ctx.PlatformsByName["token"].(*tplatform.Platform)
 	Expect(ok).To(BeTrue(), "failed to get token platform from context")

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -357,7 +357,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	RegisterIssuerIdentity(network, issuer, "newIssuerWallet", newIssuerWalletPath)
 	// Update public parameters
 	networkName := "default"
-	if !orion {
+	if orion {
 		networkName = "orion"
 	}
 	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, networkName)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -282,6 +282,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	charlie := sel.Get("charlie")
 	manager := sel.Get("manager")
 	endorsers := GetEndorsers(network, sel)
+	custodian := sel.Get("custodian")
 	RegisterAuditor(network, auditor)
 
 	// give some time to the nodes to get the public parameters
@@ -289,6 +290,9 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 
 	SetKVSEntry(network, issuer, "auditor", auditor.Id())
 	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
+	if orion {
+		FetchAndUpdatePublicParams(network, custodian)
+	}
 
 	t0 := time.Now()
 	Eventually(DoesWalletExist).WithArguments(network, issuer, "", views.IssuerWallet).WithTimeout(1 * time.Minute).WithPolling(15 * time.Second).Should(Equal(true))
@@ -361,7 +365,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 		networkName = "orion"
 	}
 	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, networkName)
-	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, networkName), orion, alice, bob, charlie, manager, issuer, auditor)
+	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, networkName), orion, alice, bob, charlie, manager, issuer, auditor, custodian)
 	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
 
 	// Issuer tokens with this new wallet

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -346,6 +346,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	Expect(h.Count()).To(BeEquivalentTo(0))
 
 	// Register a new issuer wallet and issue with that wallet
+	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
 	tokenPlatform := token.GetPlatform(network.Ctx, "token")
 	Expect(tokenPlatform).ToNot(BeNil(), "cannot find token platform in context")
 	Expect(tokenPlatform.GetTopology()).ToNot(BeNil(), "invalid token topology, it is nil")
@@ -357,6 +358,8 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	// Update public parameters
 	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, "default")
 	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, "default"), alice, bob, charlie, manager, issuer, auditor)
+	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
+
 	// Issuer tokens with this new wallet
 	t4 := time.Now()
 	IssueCash(network, "newIssuerWallet", "EUR", 10, bob, auditor, false, issuer)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -357,7 +357,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	RegisterIssuerIdentity(network, issuer, "newIssuerWallet", newIssuerWalletPath)
 	// Update public parameters
 	networkName := "default"
-	if orion {
+	if !orion {
 		networkName = "orion"
 	}
 	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, networkName)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -361,7 +361,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 		networkName = "orion"
 	}
 	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, networkName)
-	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, networkName), alice, bob, charlie, manager, issuer, auditor)
+	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, networkName), orion, alice, bob, charlie, manager, issuer, auditor)
 	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
 
 	// Issuer tokens with this new wallet

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -839,8 +839,8 @@ func TestSelector(network *integration.Infrastructure, auditorId string, sel *to
 	TransferCash(network, alice, "", "USD", 160, bob, auditor, "insufficient funds, only [150] tokens of type [USD] are available")
 }
 
-func TestPublicParamsUpdate(network *integration.Infrastructure, auditorId string, ppBytes []byte, networkName string, issuerAsAuditor bool, sel *token3.ReplicaSelector) {
-	newAuditor := sel.Get(auditorId)
+func TestPublicParamsUpdate(network *integration.Infrastructure, newAuditorID string, ppBytes []byte, networkName string, issuerAsAuditor bool, sel *token3.ReplicaSelector) {
+	newAuditor := sel.Get(newAuditorID)
 	tms := GetTMSByNetworkName(network, networkName)
 	newIssuer := sel.Get("newIssuer")
 	issuer := sel.Get("issuer")
@@ -860,6 +860,7 @@ func TestPublicParamsUpdate(network *integration.Infrastructure, auditorId strin
 	UpdatePublicParams(network, ppBytes, tms)
 
 	Eventually(GetPublicParams).WithArguments(network, newIssuer).WithTimeout(30 * time.Second).WithPolling(15 * time.Second).Should(Equal(ppBytes))
+	Eventually(GetPublicParams).WithArguments(network, issuer).WithTimeout(30 * time.Second).WithPolling(15 * time.Second).Should(Equal(ppBytes))
 	if !issuerAsAuditor {
 		Eventually(GetPublicParams).WithArguments(network, newAuditor).WithTimeout(30 * time.Second).WithPolling(15 * time.Second).Should(Equal(ppBytes))
 	}

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -847,7 +847,7 @@ func TestPublicParamsUpdate(network *integration.Infrastructure, auditorId strin
 	alice := sel.Get("alice")
 	manager := sel.Get("manager")
 	auditor := sel.Get("auditor")
-	errorMessage := "issuer wallet [] not found"
+	errorMessage := "is not in issuers"
 	if issuerAsAuditor {
 		auditor = issuer
 	}

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -354,6 +354,9 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	newIssuerWalletPath := tokenPlatform.GenIssuerCryptoMaterial(tokenPlatform.GetTopology().TMSs[0].BackendTopology.Name(), issuer.Id(), "issuer.ExtraId")
 	// Register it
 	RegisterIssuerIdentity(network, issuer, "newIssuerWallet", newIssuerWalletPath)
+	// Update public parameters
+	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, "default")
+	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, "default"), alice, bob, charlie, manager, issuer, auditor)
 	// Issuer tokens with this new wallet
 	t4 := time.Now()
 	IssueCash(network, "newIssuerWallet", "EUR", 10, bob, auditor, false, issuer)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -274,7 +274,7 @@ var BobAcceptedTransactions = []TransactionRecord{
 
 type OnRestartFunc = func(*integration.Infrastructure, string)
 
-func TestAll(network *integration.Infrastructure, auditorId string, onRestart OnRestartFunc, aries bool, sel *token3.ReplicaSelector) {
+func TestAll(network *integration.Infrastructure, auditorId string, onRestart OnRestartFunc, aries bool, orion bool, sel *token3.ReplicaSelector) {
 	auditor := sel.Get(auditorId)
 	issuer := sel.Get("issuer")
 	alice := sel.Get("alice")
@@ -356,8 +356,12 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	// Register it
 	RegisterIssuerIdentity(network, issuer, "newIssuerWallet", newIssuerWalletPath)
 	// Update public parameters
-	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, "default")
-	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, "default"), alice, bob, charlie, manager, issuer, auditor)
+	networkName := "default"
+	if orion {
+		networkName = "orion"
+	}
+	newPP := PreparePublicParamsWithNewIssuer(network, newIssuerWalletPath, networkName)
+	UpdatePublicParamsAndWait(network, newPP, GetTMSByNetworkName(network, networkName), alice, bob, charlie, manager, issuer, auditor)
 	CheckPublicParams(network, issuer, auditor, alice, bob, charlie, manager)
 
 	// Issuer tokens with this new wallet

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -194,6 +194,7 @@ func Topology(opts common.Opts) []api.Topology {
 		common2.WithOnlyUnity(tms)
 	}
 	tms.AddIssuer(issuer)
+	tms.AddIssuerByID("issuer.id1")
 
 	if len(opts.SDKs) > 0 {
 		// business SDKs

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -21,6 +21,7 @@ import (
 	orion2 "github.com/hyperledger-labs/fabric-token-sdk/integration/nwo/token/orion"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/common"
 	auditor2 "github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/sdk/auditor"
+	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/sdk/custodian"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/sdk/endorser"
 	issuer2 "github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/sdk/issuer"
 	"github.com/hyperledger-labs/fabric-token-sdk/integration/token/fungible/sdk/party"
@@ -226,7 +227,7 @@ func Topology(opts common.Opts) []api.Topology {
 
 		// additional nodes that are backend specific
 		if opts.Backend == "orion" {
-			fscTopology.ListNodes("custodian")[0].AddSDK(opts.SDKs[0])
+			fscTopology.ListNodes("custodian")[0].AddSDKWithBase(opts.SDKs[0], &custodian.SDK{})
 		} else {
 			fscTopology.ListNodes("lib-p2p-bootstrap-node")[0].AddSDK(opts.SDKs[0])
 		}

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -250,6 +250,8 @@ func Topology(opts common.Opts) []api.Topology {
 		if !opts.NoAuditor {
 			tms.AddAuditor(auditor)
 		}
+		tms.AddIssuer(issuer)
+		tms.AddIssuerByID("issuer.id1")
 	}
 
 	if opts.Monitoring {

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -193,6 +193,7 @@ func Topology(opts common.Opts) []api.Topology {
 	if opts.OnlyUnity {
 		common2.WithOnlyUnity(tms)
 	}
+	tms.AddIssuer(issuer)
 
 	if len(opts.SDKs) > 0 {
 		// business SDKs

--- a/integration/token/fungible/views/info.go
+++ b/integration/token/fungible/views/info.go
@@ -177,7 +177,7 @@ func (p *UpdatePublicParamsView) Call(context view.Context) (interface{}, error)
 	assert.NotNil(tms.PublicParametersManager().PublicParameters(), "failed to validate local public parameters")
 	fetchedPPRaw, err := network.GetInstance(context, tms.Network(), tms.Channel()).FetchPublicParameters(tms.Namespace())
 	assert.NoError(err, "failed to fetch public parameters")
-	assert.NoError(token.GetManagementServiceProvider(context).Update(p.TMSID, fetchedPPRaw), "failed to update public parameters")
+	assert.NoError(token.GetManagementServiceProvider(context).Update(tms.ID(), fetchedPPRaw), "failed to update public parameters")
 	return nil, nil
 }
 

--- a/integration/token/interop/topology.go
+++ b/integration/token/interop/topology.go
@@ -52,6 +52,7 @@ func HTLCSingleFabricNetworkTopology(opts common.Opts) []api.Topology {
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	fscTopology.SetBootstrapNode(fscTopology.AddNodeByName("lib-p2p-bootstrap-node"))
 
@@ -91,6 +92,7 @@ func HTLCSingleOrionNetworkTopology(opts common.Opts) []api.Topology {
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 	orion2.SetCustodian(tms, custodian.Name)
 
 	orionTopology.AddDB(tms.Namespace, "custodian", "issuer", "auditor", "alice", "bob")
@@ -152,11 +154,13 @@ func HTLCTwoFabricNetworksTopology(opts common.Opts) []api.Topology {
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	tms = tokenTopology.AddTMS(fscTopology.ListNodes(), f2Topology, f2Topology.Channels[0].Name, opts.DefaultTMSOpts.TokenSDKDriver)
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org3")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	for _, sdk := range opts.SDKs {
 		fscTopology.AddSDK(sdk)
@@ -222,11 +226,13 @@ func HTLCNoCrossClaimTopology(opts common.Opts) []api.Topology {
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org1")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	tms = tokenTopology.AddTMS(fscTopology.ListNodes("auditor", "issuer", "bob"), f2Topology, f2Topology.Channels[0].Name, opts.DefaultTMSOpts.TokenSDKDriver)
 	common.SetDefaultParams(tms, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tms, "Org3")
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	for _, sdk := range opts.SDKs {
 		fscTopology.AddSDK(sdk)
@@ -297,11 +303,13 @@ func HTLCNoCrossClaimWithOrionTopology(opts common.Opts) []api.Topology {
 	common.SetDefaultParams(tmsFabric, opts.DefaultTMSOpts)
 	fabric2.SetOrgs(tmsFabric, "Org1")
 	tmsFabric.AddAuditor(auditor)
+	tmsFabric.AddIssuerByID("issuer")
 
 	// TMS for the Orion Network
 	tmsOrion := tokenTopology.AddTMS(fscTopology.ListNodes("custodian", "auditor", "issuer", "bob"), orionTopology, "", opts.DefaultTMSOpts.TokenSDKDriver)
 	common.SetDefaultParams(tmsOrion, opts.DefaultTMSOpts)
 	tmsOrion.AddAuditor(auditor)
+	tmsOrion.AddIssuerByID("issuer")
 	orion2.SetCustodian(tmsOrion, custodian.Name)
 
 	orionTopology.AddDB(tmsOrion.Namespace, "custodian", "issuer", "auditor", "bob")

--- a/integration/token/nft/topology.go
+++ b/integration/token/nft/topology.go
@@ -111,6 +111,7 @@ func Topology(opts common.Opts) []api.Topology {
 	}
 
 	tms.AddAuditor(auditor)
+	tms.AddIssuerByID("issuer")
 
 	for _, sdk := range opts.SDKs {
 		fscTopology.AddSDK(sdk)

--- a/token/core/fabtoken/v1/core/setup.go
+++ b/token/core/fabtoken/v1/core/setup.go
@@ -66,117 +66,127 @@ func NewPublicParamsFromBytes(raw []byte, label string) (*PublicParams, error) {
 
 // Identifier returns the label associated with the PublicParams
 // todo shall we used Identifier instead of Label?
-func (pp *PublicParams) Identifier() string {
-	return pp.Label
+func (p *PublicParams) Identifier() string {
+	return p.Label
 }
 
-func (pp *PublicParams) Version() string {
-	return pp.Ver
+func (p *PublicParams) Version() string {
+	return p.Ver
 }
 
 // TokenDataHiding indicates if the PublicParams corresponds to a driver that hides token data
 // fabtoken does not hide token data, hence, TokenDataHiding returns false
-func (pp *PublicParams) TokenDataHiding() bool {
+func (p *PublicParams) TokenDataHiding() bool {
 	return false
 }
 
 // CertificationDriver returns the label of the PublicParams
 // From the label, one can deduce what certification process will be used if any.
-func (pp *PublicParams) CertificationDriver() string {
-	return pp.Label
+func (p *PublicParams) CertificationDriver() string {
+	return p.Label
 }
 
 // GraphHiding indicates if the PublicParams corresponds to a driver that hides the transaction graph
 // fabtoken does not hide the graph, hence, GraphHiding returns false
-func (pp *PublicParams) GraphHiding() bool {
+func (p *PublicParams) GraphHiding() bool {
 	return false
 }
 
 // MaxTokenValue returns the maximum value that a token can hold according to PublicParams
-func (pp *PublicParams) MaxTokenValue() uint64 {
-	return pp.MaxToken
+func (p *PublicParams) MaxTokenValue() uint64 {
+	return p.MaxToken
 }
 
 // Bytes marshals PublicParams
-func (pp *PublicParams) Bytes() ([]byte, error) {
-	return json.Marshal(pp)
+func (p *PublicParams) Bytes() ([]byte, error) {
+	return json.Marshal(p)
 }
 
 // Serialize marshals a wrapper around PublicParams (SerializedPublicParams)
-func (pp *PublicParams) Serialize() ([]byte, error) {
-	raw, err := json.Marshal(pp)
+func (p *PublicParams) Serialize() ([]byte, error) {
+	raw, err := json.Marshal(p)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(&pp2.PublicParameters{
-		Identifier: pp.Label,
+		Identifier: p.Label,
 		Raw:        raw,
 	})
 }
 
 // Deserialize un-marshals the passed bytes into PublicParams
-func (pp *PublicParams) Deserialize(raw []byte) error {
+func (p *PublicParams) Deserialize(raw []byte) error {
 	publicParams := &pp2.PublicParameters{}
 	if err := json.Unmarshal(raw, publicParams); err != nil {
 		return err
 	}
-	if publicParams.Identifier != pp.Label {
+	if publicParams.Identifier != p.Label {
 		return errors.Errorf("invalid identifier, expecting 'fabtoken', got [%s]", publicParams.Raw)
 	}
-	return json.Unmarshal(publicParams.Raw, pp)
+	return json.Unmarshal(publicParams.Raw, p)
 }
 
 // AuditorIdentity returns the auditor identity encoded in PublicParams
-func (pp *PublicParams) AuditorIdentity() driver.Identity {
-	return pp.Auditor
+func (p *PublicParams) AuditorIdentity() driver.Identity {
+	return p.Auditor
 }
 
 // AddAuditor sets the Auditor field in PublicParams to the passed identity
-func (pp *PublicParams) AddAuditor(auditor driver.Identity) {
-	pp.Auditor = auditor
+func (p *PublicParams) AddAuditor(auditor driver.Identity) {
+	p.Auditor = auditor
 }
 
 // AddIssuer adds the passed issuer to the array of Issuers in PublicParams
-func (pp *PublicParams) AddIssuer(issuer driver.Identity) {
-	pp.IssuerIDs = append(pp.IssuerIDs, issuer)
+func (p *PublicParams) AddIssuer(issuer driver.Identity) {
+	p.IssuerIDs = append(p.IssuerIDs, issuer)
+}
+
+// SetIssuers sets the issuers to the passed identities
+func (p *PublicParams) SetIssuers(ids []driver.Identity) {
+	p.IssuerIDs = ids
+}
+
+// SetAuditors sets the auditors to the passed identities
+func (p *PublicParams) SetAuditors(ids []driver.Identity) {
+	p.Auditor = ids[0]
 }
 
 // Auditors returns the list of authorized auditors
 // fabtoken only supports a single auditor
-func (pp *PublicParams) Auditors() []driver.Identity {
-	if len(pp.Auditor) == 0 {
+func (p *PublicParams) Auditors() []driver.Identity {
+	if len(p.Auditor) == 0 {
 		return []driver.Identity{}
 	}
-	return []driver.Identity{pp.Auditor}
+	return []driver.Identity{p.Auditor}
 }
 
 // Issuers returns the list of authorized issuers
-func (pp *PublicParams) Issuers() []driver.Identity {
-	return pp.IssuerIDs
+func (p *PublicParams) Issuers() []driver.Identity {
+	return p.IssuerIDs
 }
 
 // Precision returns the quantity precision encoded in PublicParams
-func (pp *PublicParams) Precision() uint64 {
-	return pp.QuantityPrecision
+func (p *PublicParams) Precision() uint64 {
+	return p.QuantityPrecision
 }
 
 // Validate validates the public parameters
-func (pp *PublicParams) Validate() error {
-	if pp.QuantityPrecision > 64 {
-		return errors.Errorf("invalid precision [%d], must be less than 64", pp.QuantityPrecision)
+func (p *PublicParams) Validate() error {
+	if p.QuantityPrecision > 64 {
+		return errors.Errorf("invalid precision [%d], must be less than 64", p.QuantityPrecision)
 	}
-	if pp.QuantityPrecision == 0 {
+	if p.QuantityPrecision == 0 {
 		return errors.New("invalid precision, must be greater than 0")
 	}
-	maxTokenValue := uint64(1<<pp.Precision()) - 1
-	if pp.MaxToken > maxTokenValue {
-		return errors.Errorf("max token value is invalid [%d]>[%d]", pp.MaxToken, maxTokenValue)
+	maxTokenValue := uint64(1<<p.Precision()) - 1
+	if p.MaxToken > maxTokenValue {
+		return errors.Errorf("max token value is invalid [%d]>[%d]", p.MaxToken, maxTokenValue)
 	}
 	return nil
 }
 
-func (pp *PublicParams) String() string {
-	res, err := json.MarshalIndent(pp, " ", "  ")
+func (p *PublicParams) String() string {
+	res, err := json.MarshalIndent(p, " ", "  ")
 	if err != nil {
 		return err.Error()
 	}

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -100,6 +100,15 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze public params manager")
 	}
+	// log information about the public params
+	pp := publicParamsManager.PublicParams()
+	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]", tmsID, pp.Identifier(), pp.Version())
+	for _, issuer := range pp.Issuers() {
+		logger.Debugf("issuer is [%s]", issuer.String())
+	}
+	for _, auditor := range pp.Auditors() {
+		logger.Debugf("auditor is [%s]", auditor.String())
+	}
 
 	networkLocalMembership := n.LocalMembership()
 	qe := vault.QueryEngine()

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -100,15 +100,9 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze public params manager")
 	}
-	// log information about the public params
+
 	pp := publicParamsManager.PublicParams()
-	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]", tmsID, pp.Identifier(), pp.Version())
-	for _, issuer := range pp.Issuers() {
-		logger.Debugf("issuer is [%s]", issuer.String())
-	}
-	for _, auditor := range pp.Auditors() {
-		logger.Debugf("auditor is [%s]", auditor.String())
-	}
+	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]: [%s]", tmsID, pp.Identifier(), pp.Version(), pp)
 
 	networkLocalMembership := n.LocalMembership()
 	qe := vault.QueryEngine()

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -102,15 +102,9 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze public params manager")
 	}
-	// log information about the public params
+
 	pp := ppm.PublicParams()
-	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]", tmsID, pp.Identifier(), pp.Version())
-	for _, issuer := range pp.Issuers() {
-		logger.Debugf("issuer is [%s]", issuer.String())
-	}
-	for _, auditor := range pp.Auditors() {
-		logger.Debugf("auditor is [%s]", auditor.String())
-	}
+	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]: [%s]", tmsID, pp.Identifier(), pp.Version(), pp)
 
 	qe := vault.QueryEngine()
 	ws, err := d.newWalletService(

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -102,6 +102,15 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze public params manager")
 	}
+	// log information about the public params
+	pp := ppm.PublicParams()
+	logger.Infof("new token driver for tms id [%s] with label and version [%s:%s]", tmsID, pp.Identifier(), pp.Version())
+	for _, issuer := range pp.Issuers() {
+		logger.Debugf("issuer is [%s]", issuer.String())
+	}
+	for _, auditor := range pp.Auditors() {
+		logger.Debugf("auditor is [%s]", auditor.String())
+	}
 
 	qe := vault.QueryEngine()
 	ws, err := d.newWalletService(

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -482,9 +482,9 @@ func (p *PublicParams) Validate() error {
 	if maxToken != p.MaxToken {
 		return errors.Errorf("invalid maxt token, [%d]!=[%d]", maxToken, p.MaxToken)
 	}
-	// if len(pp.Issuers) == 0 {
-	//	return errors.New("invalid public parameters: empty list of issuers")
-	// }
+	if len(p.IssuerIDs) == 0 {
+		return errors.New("invalid public parameters: empty list of issuers")
+	}
 	return nil
 }
 

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -413,6 +413,16 @@ func (p *PublicParams) AddIssuer(id driver.Identity) {
 	p.IssuerIDs = append(p.IssuerIDs, id)
 }
 
+// SetIssuers sets the issuers to the passed identities
+func (p *PublicParams) SetIssuers(ids []driver.Identity) {
+	p.IssuerIDs = ids
+}
+
+// SetAuditors sets the auditors to the passed identities
+func (p *PublicParams) SetAuditors(ids []driver.Identity) {
+	p.Auditor = ids[0]
+}
+
 func (p *PublicParams) ComputeHash() ([]byte, error) {
 	raw, err := p.Bytes()
 	if err != nil {

--- a/token/core/zkatdlog/nogh/v1/setup/setup_test.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup_test.go
@@ -6,24 +6,13 @@ SPDX-License-Identifier: Apache-2.0
 package setup
 
 import (
-	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	math3 "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestSetup(t *testing.T) {
-	s := time.Now()
-	_, err := Setup(32, []byte("issuerPK"), math3.FP256BN_AMCL)
-	e := time.Now()
-	fmt.Printf("elapsed %d", e.Sub(s).Milliseconds())
-	assert.NoError(t, err)
-
-}
 
 func TestSerialization(t *testing.T) {
 	issuerPK, err := os.ReadFile("./testdata/idemix/msp/IssuerPublicKey")
@@ -47,11 +36,10 @@ func TestSerialization(t *testing.T) {
 	assert.Equal(t, pp, pp2)
 	assert.Equal(t, ser, ser2)
 
-	assert.NoError(t, pp.Validate())
+	assert.Error(t, pp.Validate())
 
 	pp.IssuerIDs = []driver.Identity{[]byte("issuer")}
 	assert.NoError(t, pp.Validate())
-
 }
 
 func TestComputeMaxTokenValue(t *testing.T) {

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -400,9 +400,11 @@ func (l *LocalMembership) addLocalIdentity(config *driver.IdentityConfiguration,
 	if keyManager.Anonymous() || len(l.targetIdentities) == 0 {
 		l.logger.Debugf("no target identity check needed, skip it")
 	} else if found := slices.ContainsFunc(l.targetIdentities, identity.Equal); !found {
-		l.logger.Debugf("identity [%s:%s] not in target identities, ignore it", name, config.URL)
-		return nil
+		// the identity is not in the target identities, we should give it a lower priority
+		l.logger.Debugf("identity [%s:%s] not in target identities", name, config.URL)
 	} else {
+		// give it high priority
+		priority = -1
 		l.logger.Debugf("identity [%s:%s][%s] in target identities", name, config.URL, identity)
 	}
 


### PR DESCRIPTION
We start by adding the check that at least one issuer identity is specified in the `Validate` function of the public parameters. From there, we make sure the rest still works.
Many of the integration tests were assuming that anyone could issue, therefore we had to change the test to update the public parameters with the identities of who needed to issue.