### PR TITLE
fabtoken v1 finalization: enforce at least one issuer

### DIFF
--- a/token/core/fabtoken/v1/setup/setup.go
+++ b/token/core/fabtoken/v1/setup/setup.go
@@ -229,6 +229,9 @@ func (p *PublicParams) Validate() error {
 	if p.MaxToken > maxTokenValue {
 		return errors.Errorf("max token value is invalid [%d]>[%d]", p.MaxToken, maxTokenValue)
 	}
+	if len(p.IssuerIDs) == 0 {
+		return errors.New("invalid public parameters: empty list of issuers")
+	}
 	return nil
 }
 

--- a/token/core/fabtoken/v1/setup/setup_test.go
+++ b/token/core/fabtoken/v1/setup/setup_test.go
@@ -9,6 +9,7 @@ package setup
 import (
 	"testing"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -47,6 +48,7 @@ func TestPublicParams_Validate_Valid(t *testing.T) {
 		Label:             "fabtoken",
 		QuantityPrecision: 32,
 		MaxToken:          1<<32 - 1,
+		IssuerIDs:         []driver.Identity{[]byte("issuer1"), []byte("issuer2")},
 	}
 	err := pp.Validate()
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR makes sure that the validation of the fabtoken public params fails when no issuers are set.