### PR TITLE
flaky tests: fix interop-t4

### DIFF
--- a/integration/token/interop/views/htlc/claim.go
+++ b/integration/token/interop/views/htlc/claim.go
@@ -55,7 +55,7 @@ func (r *ClaimView) Call(context view.Context) (res interface{}, err error) {
 	}()
 
 	preImage := r.PreImage
-	if len(preImage) == 0 {
+	if len(preImage) == 0 && r.Script != nil {
 		// Scan for the pre-image
 		var err error
 		preImage, err = htlc.ScanForPreImage(

--- a/token/services/ttx/endorse.go
+++ b/token/services/ttx/endorse.go
@@ -11,6 +11,7 @@ import (
 	errors2 "errors"
 	"fmt"
 	"reflect"
+	"runtime/debug"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
@@ -747,6 +748,7 @@ func (f *ReceiveTransactionView) Call(context view.Context) (interface{}, error)
 	}
 	if len(msg) == 0 {
 		info := context.Session().Info()
+		logger.Errorf("received empty message, session closed [%s:%v]: [%s]", info.ID, info.Closed, string(debug.Stack()))
 		return nil, errors.Errorf("received empty message, session closed [%s:%v]", info.ID, info.Closed)
 	}
 	tx, err := NewTransactionFromBytes(context, msg)

--- a/token/services/ttx/multisig/spend.go
+++ b/token/services/ttx/multisig/spend.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package multisig
 
 import (
+	"runtime/debug"
 	"slices"
 	"time"
 
@@ -77,6 +78,7 @@ func (f *ReceiveSpendRequestView) Call(context view.Context) (interface{}, error
 	}
 	if len(msg) == 0 {
 		info := context.Session().Info()
+		logger.Errorf("received empty message, session closed [%s:%v], [%s]", info.ID, info.Closed, string(debug.Stack()))
 		return nil, errors.Errorf("received empty message, session closed [%s:%v]", info.ID, info.Closed)
 	}
 	tx, err := NewSpendRequestFromBytes(msg)


### PR DESCRIPTION
In the fast exchange test, the auditor is contacted multiple time in the same context. To do that, the CollectEndorsmentView close the connection to the auditor after completion. Sometimes this does not happen timely and the connection is closed when is still used. We avoid this issue by putting the last transaction in its own fresh context.