### PR TITLE
make the transfer and issuance metadata available in the db

### DIFF
--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -246,6 +247,10 @@ func matchTransactionRecord(tx *ttxdb.TransactionRecord, txExpected TransactionR
 	if tx.Amount.Cmp(txExpected.Amount) != 0 {
 		return errors.Errorf("tx [%d] tx.Amount: %d, txExpected.Amount: %d", i, tx.Amount, txExpected.Amount)
 	}
+	if len(txExpected.PublicMetadata) > 0 && !reflect.DeepEqual(tx.PublicMetadata, txExpected.PublicMetadata) {
+		return errors.Errorf("tx [%d] tx.PublicMetadata: %+v, txExpected.PublicMetadata: %+v", i, tx.PublicMetadata, txExpected.PublicMetadata)
+	}
+
 	return nil
 }
 

--- a/token/request.go
+++ b/token/request.go
@@ -136,9 +136,13 @@ func WithRestRecipientIdentity(recipientData *RecipientData) TransferOption {
 // AuditRecord models the audit record returned by the audit command
 // It contains the token request's anchor, inputs (with Type and Quantity), and outputs
 type AuditRecord struct {
-	Anchor     string
-	Inputs     *InputStream
-	Outputs    *OutputStream
+	// Anchor is used to bind the Actions to a given Transaction
+	Anchor string
+	// Inputs represent the input tokens of the transaction
+	Inputs *InputStream
+	// Outputs represent the output tokens of the transaction
+	Outputs *OutputStream
+	// Attributes are metadata which are stored on the public ledger as part of the transaction Actions.
 	Attributes map[string][]byte
 }
 

--- a/token/services/auditdb/db.go
+++ b/token/services/auditdb/db.go
@@ -185,6 +185,7 @@ func (d *DB) Append(req tokenRequest) error {
 		record.Anchor,
 		raw,
 		req.AllApplicationMetadata(),
+		record.Attributes,
 		req.PublicParamsHash(),
 	); err != nil {
 		w.Rollback()

--- a/token/services/db/dbtest/tokenlock.go
+++ b/token/services/db/dbtest/tokenlock.go
@@ -27,7 +27,7 @@ var TokenLockDBCases = []struct {
 func TestFully(t *testing.T, tokenLockDB driver.TokenLockDB, tokenTransactionDB driver.TokenTransactionDB) {
 	tx, err := tokenTransactionDB.BeginAtomicWrite()
 	assert.NoError(t, err)
-	assert.NoError(t, tx.AddTokenRequest("apple", []byte("apple_tx_content"), nil, driver2.PPHash("tr")))
+	assert.NoError(t, tx.AddTokenRequest("apple", []byte("apple_tx_content"), nil, nil, driver2.PPHash("tr")))
 	assert.NoError(t, tx.Commit())
 
 	assert.NoError(t, tokenLockDB.Lock(&token.ID{TxId: "apple", Index: 0}, "pineapple"))

--- a/token/services/db/dbtest/transactions.go
+++ b/token/services/db/dbtest/transactions.go
@@ -97,7 +97,7 @@ func TStatus(t *testing.T, db driver.TokenTransactionDB) {
 
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err, "begin")
-	assert.NoError(t, w.AddTokenRequest("tx1", []byte("request"), map[string][]byte{}, driver2.PPHash("tr")), "add token request")
+	assert.NoError(t, w.AddTokenRequest("tx1", []byte("request"), map[string][]byte{}, nil, driver2.PPHash("tr")), "add token request")
 	assert.NoError(t, w.AddTransaction(&tx))
 	assert.NoError(t, w.AddValidationRecord("tx1", nil), "add validation record")
 	assert.NoError(t, w.AddMovement(&mv))
@@ -136,7 +136,7 @@ func TStatus(t *testing.T, db driver.TokenTransactionDB) {
 func TStoresTimestamp(t *testing.T, db driver.TokenTransactionDB) {
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
-	assert.NoError(t, w.AddTokenRequest("tx1", []byte(""), map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest("tx1", []byte(""), map[string][]byte{}, nil, driver2.PPHash("tr")))
 	assert.NoError(t, w.AddTransaction(&driver.TransactionRecord{
 		TxID:         "tx1",
 		ActionType:   driver.Transfer,
@@ -166,9 +166,9 @@ func TStoresTimestamp(t *testing.T, db driver.TokenTransactionDB) {
 func TMovements(t *testing.T, db driver.TokenTransactionDB) {
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
-	assert.NoError(t, w.AddTokenRequest("0", []byte{}, map[string][]byte{}, driver2.PPHash("tr")))
-	assert.NoError(t, w.AddTokenRequest("1", []byte{}, map[string][]byte{}, driver2.PPHash("tr")))
-	assert.NoError(t, w.AddTokenRequest("2", []byte{}, map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest("0", []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest("1", []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest("2", []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")))
 	assert.NoError(t, w.AddMovement(&driver.MovementRecord{
 		TxID:         "0",
 		EnrollmentID: "alice",
@@ -246,7 +246,7 @@ func TTransaction(t *testing.T, db driver.TokenTransactionDB) {
 		ApplicationMetadata: map[string][]byte{},
 		Timestamp:           lastYear,
 	}
-	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), map[string][]byte{}, nil, driver2.PPHash("tr")))
 	assert.NoError(t, w.AddTransaction(tr1))
 
 	for i := 0; i < 20; i++ {
@@ -264,7 +264,7 @@ func TTransaction(t *testing.T, db driver.TokenTransactionDB) {
 				"this is the second key": []byte("with some text as the value " + fmt.Sprintf("tx%d", i)),
 			},
 		}
-		assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), tr1.ApplicationMetadata, driver2.PPHash("tr")))
+		assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), tr1.ApplicationMetadata, nil, driver2.PPHash("tr")))
 		assert.NoError(t, w.AddTransaction(tr1))
 		txs = append(txs, tr1)
 	}
@@ -334,7 +334,7 @@ func TTransaction(t *testing.T, db driver.TokenTransactionDB) {
 		ApplicationMetadata: map[string][]byte{},
 		Timestamp:           lastYear,
 	}
-	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte(fmt.Sprintf("token request for %s", tr1.TxID)), map[string][]byte{}, nil, driver2.PPHash("tr")))
 	assert.NoError(t, w.AddTransaction(tr1))
 	assert.NoError(t, w.Commit())
 	noChange := getTransactions(t, db, driver.QueryTransactionsParams{ExcludeToSelf: true})
@@ -371,10 +371,10 @@ func TTokenRequest(t *testing.T, db driver.TokenTransactionDB) {
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
 	tr1 := []byte("arbitrary bytes")
-	err = w.AddTokenRequest("id1", tr1, map[string][]byte{}, []byte("tr"))
+	err = w.AddTokenRequest("id1", tr1, map[string][]byte{}, nil, []byte("tr"))
 	assert.NoError(t, err)
 	tr2 := []byte("arbitrary bytes 2")
-	err = w.AddTokenRequest("id2", tr2, map[string][]byte{}, []byte("tr"))
+	err = w.AddTokenRequest("id2", tr2, map[string][]byte{}, nil, []byte("tr"))
 	assert.NoError(t, err)
 	assert.NoError(t, w.Commit())
 	assert.NoError(t, db.SetStatus(context.TODO(), "id2", driver.Confirmed, ""))
@@ -496,7 +496,7 @@ func TAllowsSameTxID(t *testing.T, db driver.TokenTransactionDB) {
 	}
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
-	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte{}, map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest(tr1.TxID, []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")))
 	assert.NoError(t, w.AddTransaction(tr1))
 	assert.NoError(t, w.AddTransaction(tr2))
 	assert.NoError(t, w.Commit())
@@ -510,7 +510,7 @@ func TAllowsSameTxID(t *testing.T, db driver.TokenTransactionDB) {
 func TRollback(t *testing.T, db driver.TokenTransactionDB) {
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
-	assert.NoError(t, w.AddTokenRequest("1", []byte("arbitrary bytes"), map[string][]byte{}, driver2.PPHash("tr")))
+	assert.NoError(t, w.AddTokenRequest("1", []byte("arbitrary bytes"), map[string][]byte{}, nil, driver2.PPHash("tr")))
 
 	mr1 := &driver.MovementRecord{
 		TxID:         "1",
@@ -755,7 +755,7 @@ func TTransactionQueries(t *testing.T, db driver.TokenTransactionDB) {
 	var previous string
 	for _, r := range tr {
 		if r.TxID != previous {
-			assert.NoError(t, w.AddTokenRequest(r.TxID, []byte{}, map[string][]byte{}, driver2.PPHash("tr")))
+			assert.NoError(t, w.AddTokenRequest(r.TxID, []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")))
 		}
 		assert.NoError(t, w.AddTransaction(&r))
 		previous = r.TxID
@@ -827,7 +827,7 @@ func TValidationRecordQueries(t *testing.T, db driver.TokenTransactionDB) {
 	w, err := db.BeginAtomicWrite()
 	assert.NoError(t, err)
 	for _, e := range exp {
-		assert.NoError(t, w.AddTokenRequest(e.TxID, e.TokenRequest, map[string][]byte{}, driver2.PPHash("tr")))
+		assert.NoError(t, w.AddTokenRequest(e.TxID, e.TokenRequest, map[string][]byte{}, nil, driver2.PPHash("tr")))
 		assert.NoError(t, w.AddValidationRecord(e.TxID, e.Metadata), "AddValidationRecord "+e.TxID)
 	}
 	assert.NoError(t, w.Commit(), "Commit")
@@ -914,7 +914,7 @@ func createTestTransaction(t *testing.T, db driver.TokenTransactionDB, txID stri
 	if err != nil {
 		t.Fatalf("error creating transaction while trying to test something else: %s", err)
 	}
-	if err := w.AddTokenRequest(txID, []byte{}, map[string][]byte{}, driver2.PPHash("tr")); err != nil {
+	if err := w.AddTokenRequest(txID, []byte{}, map[string][]byte{}, nil, driver2.PPHash("tr")); err != nil {
 		t.Fatalf("error creating token request while trying to test something else: %s", err)
 	}
 	tr1 := &driver.TransactionRecord{

--- a/token/services/db/driver/common.go
+++ b/token/services/db/driver/common.go
@@ -120,6 +120,9 @@ type TransactionRecord struct {
 	// ApplicationMetadata is the metadata sent by the application in the
 	// transient field. It is not validated or recorded on the ledger.
 	ApplicationMetadata map[string][]byte
+	// PublicMetadata is the metadata that is stored on the ledger as part
+	// of an Issuance or Transfer Action (for instance the HTLC hash).
+	PublicMetadata map[string][]byte
 }
 
 func (t *TransactionRecord) String() string {

--- a/token/services/db/driver/ttx.go
+++ b/token/services/db/driver/ttx.go
@@ -31,7 +31,7 @@ type AtomicWrite interface {
 	Rollback()
 
 	// AddTokenRequest binds the passed transaction id to the passed token request
-	AddTokenRequest(txID string, tr []byte, applicationMetadata map[string][]byte, ppHash driver.PPHash) error
+	AddTokenRequest(txID string, tr []byte, applicationMetadata, publicMetadata map[string][]byte, ppHash driver.PPHash) error
 
 	// AddMovement adds a movement record to the database transaction.
 	// Each token transaction can be seen as a list of movements.

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -272,7 +272,7 @@ func (t *Transaction) Inputs() (*token.InputStream, error) {
 	return t.TokenRequest.Inputs()
 }
 
-func (t *Transaction) InputsAndOutputs() (*token.InputStream, *token.OutputStream, error) {
+func (t *Transaction) InputsAndOutputs() (*token.InputStream, *token.OutputStream, map[string][]byte, error) {
 	return t.TokenRequest.InputsAndOutputs()
 }
 


### PR DESCRIPTION
This PR makes the public metadata of Issuance and Transfer actions, which are stored on the ledger, available to the user via the database (on the sender, recipient, and auditor side). At the moment this includes the hash and preimage of HTLC lock and claim, which can be used to display to the end user or for reporting.

The user can already add this kind of metadata to a Transfer with the opt:`tkn.WithTransferMetadata("user.x."+tx.ID(), []byte("this is metadata"))`. At the moment this causes the validation to fail, but that can be fixed if we add a new `ValidateTransferFunc`, somewhat like the following:

```go
func TransferExtraDataValidate(ctx *validator.Context) error {
	for key, val := range ctx.TransferAction.Metadata {
		if strings.HasPrefix(key, "user.") {
                        // TBD: validation?
			ctx.CountMetadataKey(key)
		}
	}
	return nil
}
```

It would add some useful tools to the toolbox. For instance you could share metadata privately with the counterparty and optionally an auditor in the ApplicationMetadata, and a hash of that data on the public ledger, all tied to the same transaction. Or link it to external data, or create another custom validator for additional proofs. It would be the responsibility of the user to make sure that privacy is protected.

> [!IMPORTANT]
> This change is not backwards compatible due to changing the database schema. It would require a manual `ALTER TABLE ... ADD COLUMN public_metadata JSONB NOT NULL;` before upgrading. Until we have a common method for database migrations, I couldn't find a good way to handle it.

Looking forward to feedback on this PR and the idea for the followup.