### PR TITLE
check owner to identify redeemed tokens

### DIFF
--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		// LibP2PNoReplication,
-		// WebSocketWithReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
 	}
 )
 

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -60,8 +60,8 @@ var (
 
 	AllTestTypes = []*InfrastructureType{
 		WebSocketNoReplication,
-		LibP2PNoReplication,
-		WebSocketWithReplication,
+		// LibP2PNoReplication,
+		// WebSocketWithReplication,
 	}
 )
 

--- a/token/services/tokens/tokens.go
+++ b/token/services/tokens/tokens.go
@@ -396,7 +396,7 @@ func (t *Tokens) parse(
 	for _, output := range os.Outputs() {
 
 		// if this is a redeem, then skip
-		if len(output.Owner) == 0 {
+		if len(output.Token.Owner) == 0 {
 			logger.Debugf("output [%s:%d] is a redeem", txID, output.Index)
 			continue
 		}

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -75,7 +75,8 @@ func TestParse(t *testing.T) {
 	is := token.NewInputStream(qsMock{}, []*token.Input{input1}, 64)
 	os := token.NewOutputStream([]*token.Output{output1}, 64)
 
-	spend, store := tokens.parse(&authMock{}, "tx1", md, is, os, false, 64, false)
+	spend, store, err := tokens.parse(&authMock{}, "tx1", md, is, os, false, 64, false)
+	assert.NoError(t, err)
 
 	assert.Len(t, spend, 1)
 	assert.Equal(t, "in", spend[0].TxId)
@@ -94,7 +95,8 @@ func TestParse(t *testing.T) {
 	// no ledger output -> spend
 	output1.LedgerOutput = []byte{}
 	os = token.NewOutputStream([]*token.Output{output1}, 64)
-	spend, store = tokens.parse(&authMock{}, "tx1", md, is, os, false, 64, false)
+	spend, store, err = tokens.parse(&authMock{}, "tx1", md, is, os, false, 64, false)
+	assert.NoError(t, err)
 	assert.Len(t, spend, 2)
 	assert.Len(t, store, 0)
 
@@ -144,7 +146,8 @@ func TestParse(t *testing.T) {
 	is = token.NewInputStream(qsMock{}, []*token.Input{input1, input2}, 64)
 	os = token.NewOutputStream([]*token.Output{output1, output2}, 64)
 
-	spend, store = tokens.parse(&authMock{}, "tx2", md, is, os, false, 64, false)
+	spend, store, err = tokens.parse(&authMock{}, "tx2", md, is, os, false, 64, false)
+	assert.NoError(t, err)
 	assert.Len(t, spend, 2)
 	assert.Equal(t, "in1", spend[0].TxId)
 	assert.Equal(t, uint64(1), spend[0].Index)

--- a/token/services/tokens/tokens_test.go
+++ b/token/services/tokens/tokens_test.go
@@ -63,7 +63,8 @@ func TestParse(t *testing.T) {
 	}
 	output1 := &token.Output{
 		Token: token2.Token{
-			Type: "TOK",
+			Type:  "TOK",
+			Owner: []byte("alice"),
 		},
 		ActionIndex:  0,
 		Index:        0,
@@ -92,12 +93,12 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, uint64(64), store[0].precision)
 	assert.Equal(t, output1.Type, store[0].tok.Type)
 
-	// no ledger output -> spend
-	output1.LedgerOutput = []byte{}
+	// no owner, then a redeemed token
+	output1.Token.Owner = []byte{}
 	os = token.NewOutputStream([]*token.Output{output1}, 64)
 	spend, store, err = tokens.parse(&authMock{}, "tx1", md, is, os, false, 64, false)
 	assert.NoError(t, err)
-	assert.Len(t, spend, 2)
+	assert.Len(t, spend, 1)
 	assert.Len(t, store, 0)
 
 	// transfer with several inputs and outputs
@@ -123,7 +124,8 @@ func TestParse(t *testing.T) {
 	}
 	output1 = &token.Output{
 		Token: token2.Token{
-			Type: "TOK",
+			Type:  "TOK",
+			Owner: []byte("alice"),
 		},
 		ActionIndex:  0,
 		Index:        0,
@@ -134,7 +136,8 @@ func TestParse(t *testing.T) {
 	}
 	output2 := &token.Output{
 		Token: token2.Token{
-			Type: "TOK",
+			Type:  "TOK",
+			Owner: []byte("bob"),
 		},
 		ActionIndex:  0,
 		Index:        1,


### PR DESCRIPTION
This PR fixes the parsing the token request's inputs and outputs. Namely: We clearly identify when an output is redeemed and we don't include it in the list of tokens to be created in the db. We return an error in case of a failure of any sort.