### PR TITLE
Redeem: validate that TransferAction for Redeem has an issuer

### DIFF
--- a/token/core/fabtoken/v1/actions/transfer.go
+++ b/token/core/fabtoken/v1/actions/transfer.go
@@ -117,6 +117,16 @@ func (t *TransferAction) IsRedeemAt(index int) bool {
 	return t.Outputs[index].IsRedeem()
 }
 
+// IsRedeem checks if this action is a Redeem Transfer
+func (t *TransferAction) IsRedeem() bool {
+	for _, output := range t.Outputs {
+		if output.IsRedeem() {
+			return true
+		}
+	}
+	return false
+}
+
 // IsGraphHiding returns false, indicating that fabtoken does not hide the transaction graph
 func (t *TransferAction) IsGraphHiding() bool {
 	return false
@@ -203,6 +213,9 @@ func (t *TransferAction) Validate() error {
 		if len(out.Quantity) == 0 {
 			return errors.Errorf("invalid output's quantity at index [%d], output quantity is empty", i)
 		}
+	}
+	if t.IsRedeem() && (t.Issuer == nil) {
+		return errors.Errorf("Expected Issuer for a Redeem action (to validate)")
 	}
 	return nil
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -218,6 +218,16 @@ func (t *Action) IsRedeemAt(index int) bool {
 	return t.Outputs[index].IsRedeem()
 }
 
+// IsRedeem checks if this action is a Redeem Transfer
+func (t *Action) IsRedeem() bool {
+	for _, output := range t.Outputs {
+		if output.IsRedeem() {
+			return true
+		}
+	}
+	return false
+}
+
 // SerializeOutputAt marshals the output in the Action at the passed index
 func (t *Action) SerializeOutputAt(index int) ([]byte, error) {
 	return t.Outputs[index].Serialize()
@@ -289,6 +299,9 @@ func (t *Action) Validate() error {
 		if err := out.Validate(false); err != nil {
 			return errors.Wrapf(err, "invalid output at index [%d]", i)
 		}
+	}
+	if t.IsRedeem() && (t.Issuer == nil) {
+		return errors.Errorf("Expected Issuer for a Redeem action (to validate)")
 	}
 	return nil
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -301,7 +301,7 @@ func (t *Action) Validate() error {
 		}
 	}
 	if t.IsRedeem() && (t.Issuer == nil) {
-		return errors.Errorf("Expected Issuer for a Redeem action (to validate)")
+		return errors.Errorf("Expected Issuer for a Redeem action")
 	}
 	return nil
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/action_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action_test.go
@@ -354,6 +354,37 @@ func TestAction_Validate(t *testing.T) {
 			expectedError: "invalid output at index [0]: token data cannot be empty",
 		},
 		{
+			name: "A Redeem action must have an issuer",
+			action: &Action{
+				Inputs: []*ActionInput{
+					{
+						ID: &token.ID{TxId: "txid"},
+						Token: &token2.Token{
+							Owner: []byte("owner"),
+							Data:  &math.G1{},
+						},
+						UpgradeWitness: &token2.UpgradeWitness{
+							FabToken: &fabtokenv1.Output{
+								Owner:    []byte("owner"),
+								Type:     "type",
+								Quantity: "10",
+							},
+							BlindingFactor: &math.Zr{},
+						},
+					},
+				},
+				Outputs: []*token2.Token{
+					{
+						Owner: []byte(nil),
+						Data:  &math.G1{},
+					},
+				},
+				Issuer: []byte(nil),
+			},
+			wantErr:       true,
+			expectedError: "Expected Issuer for a Redeem action",
+		},
+		{
 			name: "",
 			action: &Action{
 				Inputs: []*ActionInput{


### PR DESCRIPTION
Implementing Issue #1065 
Update the Validate function of the actions to ensure the Issuer identity is there for Redeem TransferActions.