### PR TITLE
Redeem: Issuer parameter

### DIFF
--- a/integration/token/fungible/mixed/mixed_test.go
+++ b/integration/token/fungible/mixed/mixed_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 var _ = Describe("EndToEnd", func() {
-	for _, t := range integration.AllTestTypes {
+	for _, t := range integration.WebSocketNoReplicationOnly {
 		Describe("Fungible with Auditor ne Issuer", t.Label, func() {
 			ts, selector := newTestSuite(t.CommType, t.ReplicationFactor, "alice", "bob")
 			BeforeEach(ts.Setup)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -830,36 +830,49 @@ func TransferCashWithSelector(network *integration.Infrastructure, sender *token
 	}
 }
 
-func RedeemCash(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference) {
-	RedeemCashForTMSID(network, id, wallet, typ, amount, auditor, issuer, nil)
+func RedeemCash(network *integration.Infrastructure, networkName string, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference) {
+	RedeemCashForTMSID(network, networkName, id, wallet, typ, amount, auditor, issuer, nil)
 }
 
-func RedeemCashForTMSID(network *integration.Infrastructure, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, tmsID *token2.TMSID) {
+func RedeemCashForTMSID(network *integration.Infrastructure, networkName string, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, tmsID *token2.TMSID) {
 	issuerName := ""
+	var issuerSigningKey view.Identity = nil
 	if issuer != nil {
 		issuerName = issuer.Id()
+		tms := GetTMSByNetworkName(network, networkName)
+		issuerSigningKey = GetIssuerIdentity(tms, issuer.Id())
 	}
 
 	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
-		Auditor: auditor.Id(),
-		Issuer:  issuerName,
-		Wallet:  wallet,
-		Type:    typ,
-		Amount:  amount,
-		TMSID:   tmsID,
+		Auditor:          auditor.Id(),
+		Issuer:           issuerName,
+		IssuerSigningKey: issuerSigningKey,
+		Wallet:           wallet,
+		Type:             typ,
+		Amount:           amount,
+		TMSID:            tmsID,
 	}))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), tmsID, false)
 }
 
-func RedeemCashByIDs(network *integration.Infrastructure, id *token3.NodeReference, wallet string, ids []*token.ID, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference) {
+func RedeemCashByIDs(network *integration.Infrastructure, networkName string, id *token3.NodeReference, wallet string, ids []*token.ID, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference) {
+	issuerName := ""
+	var issuerSigningKey view.Identity = nil
+	if issuer != nil {
+		issuerName = issuer.Id()
+		tms := GetTMSByNetworkName(network, networkName)
+		issuerSigningKey = GetIssuerIdentity(tms, issuer.Id())
+	}
+
 	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
-		Auditor:  auditor.Id(),
-		Issuer:   issuer.Id(),
-		Wallet:   wallet,
-		Type:     "",
-		TokenIDs: ids,
-		Amount:   amount,
+		Auditor:          auditor.Id(),
+		Issuer:           issuerName,
+		IssuerSigningKey: issuerSigningKey,
+		Wallet:           wallet,
+		Type:             "",
+		TokenIDs:         ids,
+		Amount:           amount,
 	}))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), nil, false)

--- a/integration/token/fungible/support.go
+++ b/integration/token/fungible/support.go
@@ -836,24 +836,24 @@ func RedeemCash(network *integration.Infrastructure, networkName string, id *tok
 
 func RedeemCashForTMSID(network *integration.Infrastructure, networkName string, id *token3.NodeReference, wallet string, typ token.Type, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference, tmsID *token2.TMSID) {
 	issuerName := ""
-	var issuerSigningKey view.Identity = nil
+	var issuerPublicParamsPublicKey view.Identity = nil
 	if issuer != nil {
 		issuerName = issuer.Id()
 		tms := GetTMSByNetworkName(network, networkName)
-		issuerSigningKey = GetIssuerIdentity(tms, issuer.Id())
+		issuerPublicParamsPublicKey = GetIssuerIdentity(tms, issuer.Id())
 	}
 
-	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
-		Auditor:          auditor.Id(),
-		Issuer:           issuerName,
-		IssuerSigningKey: issuerSigningKey,
-		Wallet:           wallet,
-		Type:             typ,
-		Amount:           amount,
-		TMSID:            tmsID,
+	txID, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
+		Auditor:                     auditor.Id(),
+		Issuer:                      issuerName,
+		IssuerPublicParamsPublicKey: issuerPublicParamsPublicKey,
+		Wallet:                      wallet,
+		Type:                        typ,
+		Amount:                      amount,
+		TMSID:                       tmsID,
 	}))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), tmsID, false)
+	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txID), tmsID, false)
 }
 
 func RedeemCashByIDs(network *integration.Infrastructure, networkName string, id *token3.NodeReference, wallet string, ids []*token.ID, amount uint64, auditor *token3.NodeReference, issuer *token3.NodeReference) {
@@ -866,13 +866,13 @@ func RedeemCashByIDs(network *integration.Infrastructure, networkName string, id
 	}
 
 	txid, err := network.Client(id.ReplicaName()).CallView("redeem", common.JSONMarshall(&views.Redeem{
-		Auditor:          auditor.Id(),
-		Issuer:           issuerName,
-		IssuerSigningKey: issuerSigningKey,
-		Wallet:           wallet,
-		Type:             "",
-		TokenIDs:         ids,
-		Amount:           amount,
+		Auditor:                     auditor.Id(),
+		Issuer:                      issuerName,
+		IssuerPublicParamsPublicKey: issuerSigningKey,
+		Wallet:                      wallet,
+		Type:                        "",
+		TokenIDs:                    ids,
+		Amount:                      amount,
 	}))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	common2.CheckFinality(network, auditor, common.JSONUnmarshalString(txid), nil, false)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -415,7 +415,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	gomega.Expect(ut.Sum(64).ToBigInt().Cmp(big.NewInt(111))).To(gomega.BeEquivalentTo(0), "got [%d], expected 111", ut.Sum(64).ToBigInt())
 	gomega.Expect(ut.ByType("USD").Count()).To(gomega.BeEquivalentTo(ut.Count()))
 
-	RedeemCash(network, bob, "", "USD", 11, auditor, issuer)
+	RedeemCash(network, networkName, bob, "", "USD", 11, auditor, issuer)
 	t10 := time.Now()
 	CheckAcceptedTransactions(network, bob, "", BobAcceptedTransactions[:6], nil, nil, nil)
 	CheckAcceptedTransactions(network, bob, "", BobAcceptedTransactions[5:6], nil, nil, nil, ttxdb.Redeem)
@@ -471,7 +471,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 	// so the endorsement process could automatically idntify the issuer
 	// that needs to sign the Redeem.
 	BindIssuerNetworkAndSigningIdentities(network, issuer, GetIssuerIdentity(GetTMSByNetworkName(network, networkName), issuer.Id()), bob)
-	RedeemCash(network, bob, "", "USD", 10, auditor, nil)
+	RedeemCash(network, networkName, bob, "", "USD", 10, auditor, nil)
 	CheckBalanceAndHolding(network, bob, "", "USD", 110, auditor)
 	CheckSpending(network, bob, "", "USD", auditor, 21)
 
@@ -766,7 +766,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 		WhoDeletedToken(network, alice, []*token2.ID{{TxId: txID1, Index: 0}}, txID2)
 		WhoDeletedToken(network, auditor, []*token2.ID{{TxId: txID1, Index: 0}}, txID2)
 		// redeem newly created token
-		RedeemCashByIDs(network, bob, "", []*token2.ID{{TxId: txID2, Index: 0}}, 17, auditor, issuer)
+		RedeemCashByIDs(network, networkName, bob, "", []*token2.ID{{TxId: txID2, Index: 0}}, 17, auditor, issuer)
 	}
 
 	PruneInvalidUnspentTokens(network, issuer, auditor, alice, bob, charlie, manager)
@@ -979,7 +979,7 @@ func TestMixed(network *integration.Infrastructure, onRestart OnRestartFunc, sel
 	TransferCashForTMSID(network, alice, "", "USD", 20, bob, auditor1, dlogId)
 	TransferCashForTMSID(network, alice, "", "USD", 30, bob, auditor2, fabTokenId)
 
-	RedeemCashForTMSID(network, bob, "", "USD", 11, auditor1, issuer1, dlogId)
+	RedeemCashForTMSID(network, DLogNamespace, bob, "", "USD", 11, auditor1, issuer1, dlogId)
 	CheckSpendingForTMSID(network, bob, "", "USD", auditor1, 11, dlogId)
 
 	CheckBalanceAndHoldingForTMSID(network, alice, "", "USD", 90, auditor1, dlogId)

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -468,7 +468,7 @@ func TestAll(network *integration.Infrastructure, auditorId string, onRestart On
 
 	// The following RedeemCash doesn't specify the issuer's network id so
 	// it must be preceded by binding this network id with the issuer's signing id
-	// so the endorsement process could automatically idntify the issuer
+	// so the endorsement process could automatically identify the issuer
 	// that needs to sign the Redeem.
 	BindIssuerNetworkAndSigningIdentities(network, issuer, GetIssuerIdentity(GetTMSByNetworkName(network, networkName), issuer.Id()), bob)
 	RedeemCash(network, networkName, bob, "", "USD", 10, auditor, nil)

--- a/integration/token/fungible/views/redeem.go
+++ b/integration/token/fungible/views/redeem.go
@@ -24,8 +24,8 @@ type Redeem struct {
 	Auditor string
 	// Issuer is the name of the issuer that must be contacted to approve the operation
 	Issuer string
-	// IssuerSigningKey is the signing PK of the issuers that is to sign the Redeem action
-	IssuerSigningKey view.Identity
+	// IssuerPublicParamsPublicKey is the public key of the issuer against which the issuer signature in the Redeem action will be checked.
+	IssuerPublicParamsPublicKey view.Identity
 	// Wallet is the identifier of the wallet that owns the tokens to redeem
 	Wallet string
 	// TokenIDs contains a list of token ids to redeem. If empty, tokens are selected on the spot.
@@ -73,7 +73,7 @@ func (t *RedeemView) Call(context view.Context) (interface{}, error) {
 	opts := []token2.TransferOption{token2.WithTokenIDs(t.TokenIDs...)}
 	if t.Issuer != "" {
 		opts = append(opts, ttx.WithFSCIssuerIdentity(view2.GetIdentityProvider(context).Identity(t.Issuer)))
-		opts = append(opts, ttx.WithIssuerSigningKey(t.IssuerSigningKey))
+		opts = append(opts, ttx.WithIssuerPublicParamsPublicKey(t.IssuerPublicParamsPublicKey))
 	}
 	err = tx.Redeem(
 		senderWallet,

--- a/integration/token/fungible/views/redeem.go
+++ b/integration/token/fungible/views/redeem.go
@@ -24,6 +24,8 @@ type Redeem struct {
 	Auditor string
 	// Issuer is the name of the issuer that must be contacted to approve the operation
 	Issuer string
+	// IssuerSigningKey is the signing PK of the issuers that is to sign the Redeem action
+	IssuerSigningKey view.Identity
 	// Wallet is the identifier of the wallet that owns the tokens to redeem
 	Wallet string
 	// TokenIDs contains a list of token ids to redeem. If empty, tokens are selected on the spot.
@@ -71,6 +73,7 @@ func (t *RedeemView) Call(context view.Context) (interface{}, error) {
 	opts := []token2.TransferOption{token2.WithTokenIDs(t.TokenIDs...)}
 	if t.Issuer != "" {
 		opts = append(opts, ttx.WithFSCIssuerIdentity(view2.GetIdentityProvider(context).Identity(t.Issuer)))
+		opts = append(opts, ttx.WithIssuerSigningKey(t.IssuerSigningKey))
 	}
 	err = tx.Redeem(
 		senderWallet,

--- a/token/core/common/transfer.go
+++ b/token/core/common/transfer.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	"github.com/pkg/errors"
+)
+
+// SelectIssuerForRedeem return the issuer's public key to use for a redeem.
+// If opts specify an FSC issuer identity, then we expect to find the opts also the public key to add in the transfer action.
+// Otherwise, the first public key in the public params is used.
+func SelectIssuerForRedeem(issuers []driver.Identity, opts *driver.TransferOptions) (driver.Identity, error) {
+	issuerNetworkIdentity, err := ttx.GetFSCIssuerIdentityFromOpts(opts.Attributes)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get issuer network identity")
+	}
+	if !issuerNetworkIdentity.IsNone() {
+		issuerSigningKey, err := ttx.GetIssuerPublicParamsPublicKeyFromOpts(opts.Attributes)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get issuer public params public key")
+		}
+		if issuerSigningKey.IsNone() {
+			return nil, errors.New("issuer public params public key not found in opts")
+		}
+		return issuerSigningKey, nil
+	}
+
+	if len(issuers) < 1 {
+		return nil, errors.New("no issuer found")
+	}
+	return issuers[0], nil
+}

--- a/token/core/common/transfer_test.go
+++ b/token/core/common/transfer_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectIssuerForRedeem(t *testing.T) {
+	type testCase struct {
+		name           string
+		issuers        []driver.Identity
+		attributes     map[interface{}]interface{}
+		expectError    bool
+		expectIdentity driver.Identity
+	}
+
+	issuerFSCIdentity := view.Identity("fsc-identity")
+	issuerPPPublicKey := view.Identity("pp-public-key")
+
+	testCases := []testCase{
+		{
+			name:    "opts with FSC issuer identity and public key",
+			issuers: nil,
+			attributes: map[interface{}]interface{}{
+				ttx.IssuerFSCIdentityKey:        issuerFSCIdentity,
+				ttx.IssuerPublicParamsPublicKey: issuerPPPublicKey,
+			},
+			expectError:    false,
+			expectIdentity: issuerPPPublicKey,
+		},
+		{
+			name:    "opts with FSC issuer identity but no public key",
+			issuers: nil,
+			attributes: map[interface{}]interface{}{
+				ttx.IssuerFSCIdentityKey: issuerFSCIdentity,
+			},
+			expectError:    true,
+			expectIdentity: nil,
+		},
+		{
+			name:           "opts with no FSC issuer identity, issuers present",
+			issuers:        []driver.Identity{issuerFSCIdentity, issuerPPPublicKey},
+			attributes:     map[interface{}]interface{}{},
+			expectError:    false,
+			expectIdentity: issuerFSCIdentity,
+		},
+		{
+			name:           "opts with no FSC issuer identity, no issuers",
+			issuers:        []driver.Identity{},
+			attributes:     map[interface{}]interface{}{},
+			expectError:    true,
+			expectIdentity: nil,
+		},
+		{
+			name:    "IssuerFSCIdentityKey is not a view Identity",
+			issuers: nil,
+			attributes: map[interface{}]interface{}{
+				ttx.IssuerFSCIdentityKey: 1234,
+			},
+			expectError:    true,
+			expectIdentity: nil,
+		},
+		{
+			name:    "IssuerPublicParamsPublicKey is not a view Identity",
+			issuers: nil,
+			attributes: map[interface{}]interface{}{
+				ttx.IssuerFSCIdentityKey:        issuerFSCIdentity,
+				ttx.IssuerPublicParamsPublicKey: 1234,
+			},
+			expectError:    true,
+			expectIdentity: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, err := SelectIssuerForRedeem(tc.issuers, &driver.TransferOptions{Attributes: tc.attributes})
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, id)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectIdentity, id)
+			}
+		})
+	}
+}

--- a/token/core/fabtoken/v1/transfer.go
+++ b/token/core/fabtoken/v1/transfer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -169,23 +168,9 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 	}
 
 	if isRedeem {
-		var issuer driver.Identity
-		issuerNetworkIdentity, err := ttx.GetFSCIssuerIdentityFromOpts(opts.Attributes)
+		issuer, err := common.SelectIssuerForRedeem(s.PublicParametersManager.PublicParameters().Issuers(), opts)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to get issuer network identity")
-		}
-		if !issuerNetworkIdentity.IsNone() {
-			issuerSigningKey, err := ttx.GetIssuerSigningKeyFromOpts(opts.Attributes)
-			if (err != nil) || (issuerSigningKey == nil) {
-				return nil, nil, errors.Wrap(err, "failed to get issuer signing key")
-			}
-			issuer = issuerSigningKey
-		} else {
-			issuers := s.PublicParametersManager.PublicParameters().Issuers()
-			if len(issuers) < 1 {
-				return nil, nil, errors.New("no issuer found")
-			}
-			issuer = issuers[0]
+			return nil, nil, errors.Wrap(err, "failed to select issuer for redeem")
 		}
 		transfer.Issuer = issuer
 		transferMetadata.Issuer = issuer

--- a/token/core/fabtoken/v1/transfer.go
+++ b/token/core/fabtoken/v1/transfer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 )
@@ -168,12 +169,24 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 	}
 
 	if isRedeem {
-		issuers := s.PublicParametersManager.PublicParameters().Issuers()
-		if len(issuers) < 1 {
-			return nil, nil, errors.New("no issuer found")
+		var issuer driver.Identity
+		issuerNetworkIdentity, err := ttx.GetFSCIssuerIdentityFromOpts(opts.Attributes)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to get issuer network identity")
 		}
-		issuer := issuers[0]
-
+		if !issuerNetworkIdentity.IsNone() {
+			issuerSigningKey, err := ttx.GetIssuerSigningKeyFromOpts(opts.Attributes)
+			if (err != nil) || (issuerSigningKey == nil) {
+				return nil, nil, errors.Wrap(err, "failed to get issuer signing key")
+			}
+			issuer = issuerSigningKey
+		} else {
+			issuers := s.PublicParametersManager.PublicParameters().Issuers()
+			if len(issuers) < 1 {
+				return nil, nil, errors.New("no issuer found")
+			}
+			issuer = issuers[0]
+		}
 		transfer.Issuer = issuer
 		transferMetadata.Issuer = issuer
 	}

--- a/token/core/zkatdlog/nogh/v1/transfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/transfer"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
@@ -254,23 +253,9 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 	}
 
 	if isRedeem {
-		var issuer driver.Identity
-		issuerNetworkIdentity, err := ttx.GetFSCIssuerIdentityFromOpts(opts.Attributes)
+		issuer, err := common.SelectIssuerForRedeem(pp.Issuers(), opts)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to get issuer network identity")
-		}
-		if !issuerNetworkIdentity.IsNone() {
-			issuerSigningKey, err := ttx.GetIssuerSigningKeyFromOpts(opts.Attributes)
-			if (err != nil) || (issuerSigningKey == nil) {
-				return nil, nil, errors.Wrap(err, "failed to get issuer signing key")
-			}
-			issuer = issuerSigningKey
-		} else {
-			issuers := s.PublicParametersManager.PublicParameters().Issuers()
-			if len(issuers) < 1 {
-				return nil, nil, errors.New("no issuer found")
-			}
-			issuer = issuers[0]
+			return nil, nil, errors.Wrap(err, "failed to select issuer for redeem")
 		}
 		transfer.Issuer = issuer
 		transferMetadata.Issuer = issuer

--- a/token/services/ttx/transfer_opts.go
+++ b/token/services/ttx/transfer_opts.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	IssuerFSCIdentityKey = "IssuerFSCIdentityKey"
+	IssuerSigningKey     = "IssuerSigningKey"
 )
 
 // WithFSCIssuerIdentity takes an issuer's node Identity
@@ -43,6 +44,31 @@ func GetFSCIssuerIdentityFromOpts(attributes map[interface{}]interface{}) (view.
 	id, ok := idBoxed.(view.Identity)
 	if !ok {
 		return nil, errors.Errorf("expected identity, found [%s]", reflect.TypeOf(idBoxed))
+	}
+	return id, nil
+}
+
+func WithIssuerSigningKey(issuerSigningKey view.Identity) token.TransferOption {
+	return func(options *token.TransferOptions) error {
+		if options.Attributes == nil {
+			options.Attributes = make(map[interface{}]interface{})
+		}
+		options.Attributes[IssuerSigningKey] = issuerSigningKey
+		return nil
+	}
+}
+
+func GetIssuerSigningKeyFromOpts(attributes map[interface{}]interface{}) (view.Identity, error) {
+	if attributes == nil {
+		return nil, nil
+	}
+	idBoxed, ok := attributes[IssuerSigningKey]
+	if !ok {
+		return nil, nil
+	}
+	id, ok := idBoxed.(view.Identity)
+	if !ok {
+		return nil, errors.Errorf("expected signing key, found [%s]", reflect.TypeOf(idBoxed))
 	}
 	return id, nil
 }

--- a/token/services/ttx/transfer_opts.go
+++ b/token/services/ttx/transfer_opts.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	IssuerFSCIdentityKey = "IssuerFSCIdentityKey"
-	IssuerSigningKey     = "IssuerSigningKey"
+	IssuerFSCIdentityKey        = "IssuerFSCIdentityKey"
+	IssuerPublicParamsPublicKey = "IssuerPublicParamsPublicKey"
 )
 
 // WithFSCIssuerIdentity takes an issuer's node Identity
@@ -48,21 +48,21 @@ func GetFSCIssuerIdentityFromOpts(attributes map[interface{}]interface{}) (view.
 	return id, nil
 }
 
-func WithIssuerSigningKey(issuerSigningKey view.Identity) token.TransferOption {
+func WithIssuerPublicParamsPublicKey(issuerSigningKey view.Identity) token.TransferOption {
 	return func(options *token.TransferOptions) error {
 		if options.Attributes == nil {
 			options.Attributes = make(map[interface{}]interface{})
 		}
-		options.Attributes[IssuerSigningKey] = issuerSigningKey
+		options.Attributes[IssuerPublicParamsPublicKey] = issuerSigningKey
 		return nil
 	}
 }
 
-func GetIssuerSigningKeyFromOpts(attributes map[interface{}]interface{}) (view.Identity, error) {
+func GetIssuerPublicParamsPublicKeyFromOpts(attributes map[interface{}]interface{}) (view.Identity, error) {
 	if attributes == nil {
 		return nil, nil
 	}
-	idBoxed, ok := attributes[IssuerSigningKey]
+	idBoxed, ok := attributes[IssuerPublicParamsPublicKey]
 	if !ok {
 		return nil, nil
 	}


### PR DESCRIPTION
This PR implements issue #905:
If an issuer is passed as a parameter to Redeem then it must be selected when creating the transaction (otherwise use the first issuer from the public params as today).