### PR TITLE
Enhance the validator context with the anchor #1075

### DIFF
--- a/integration/token/fungible/views/utils.go
+++ b/integration/token/fungible/views/utils.go
@@ -29,7 +29,7 @@ func AssertTokens(sp token.ServiceProvider, tx *ttx.Transaction, outputs *token.
 	db, err := tokendb.GetByTMSId(sp, tx.TokenService().ID())
 	assert.NoError(err, "failed to get token db for [%s]", tx.TokenService().ID())
 	for _, output := range outputs.Outputs() {
-		tokenID := output.ID(tx.ID())
+		tokenID := output.ID(token.RequestAnchor(tx.ID()))
 		if output.Owner.Equal(id) || tx.TokenService().SigService().IsMe(ctx, output.Owner) {
 			// check it exists
 			toks, err := db.GetTokens(ctx, tokenID)

--- a/token/core/common/validator_test.go
+++ b/token/core/common/validator_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnchorInContext checks that the anchor is set in the context
+func TestAnchorInContext(t *testing.T) {
+	anchor := driver.TokenRequestAnchor("hello world")
+	anotherAnchor := driver.TokenRequestAnchor("another anchor")
+	v := NewValidator[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer](
+		nil,
+		nil,
+		nil,
+		nil,
+		[]ValidateTransferFunc[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			func(ctx *Context[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
+				if anchor != ctx.Anchor {
+					return fmt.Errorf("transfer, anchor does not match, expected %s, got %s", anchor, ctx.Anchor)
+				}
+				return nil
+			},
+		},
+		[]ValidateIssueFunc[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			func(ctx *Context[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
+				if anchor != ctx.Anchor {
+					return fmt.Errorf("issue, anchor does not match, expected %s, got %s", anchor, ctx.Anchor)
+				}
+				return nil
+			},
+		},
+		[]ValidateAuditingFunc[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			func(ctx *Context[driver.PublicParameters, any, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
+				if anchor != ctx.Anchor {
+					return fmt.Errorf("audit, anchor does not match, expected %s, got %s", anchor, ctx.Anchor)
+				}
+				return nil
+			},
+		},
+	)
+
+	// check anchor in the context for an issue action
+	err := v.VerifyIssue(anchor, nil, &mock.IssueAction{}, nil, nil, nil)
+	require.NoError(t, err)
+	err = v.VerifyIssue(anotherAnchor, nil, &mock.IssueAction{}, nil, nil, nil)
+	require.Error(t, err)
+	assert.EqualError(t, err, "issue, anchor does not match, expected hello world, got another anchor")
+
+	// check anchor in the context for a transfer action
+	err = v.VerifyTransfer(anchor, nil, &mock.TransferAction{}, nil, nil, nil)
+	require.NoError(t, err)
+	err = v.VerifyTransfer(anotherAnchor, nil, &mock.TransferAction{}, nil, nil, nil)
+	require.Error(t, err)
+	assert.EqualError(t, err, "transfer, anchor does not match, expected hello world, got another anchor")
+
+	// check anchor in the context for a transfer action
+	err = v.VerifyAuditing(anchor, nil, nil, nil, nil)
+	require.NoError(t, err)
+	err = v.VerifyAuditing(anotherAnchor, nil, nil, nil, nil)
+	require.Error(t, err)
+	assert.EqualError(t, err, "audit, anchor does not match, expected hello world, got another anchor")
+}

--- a/token/core/fabtoken/v1/auditor.go
+++ b/token/core/fabtoken/v1/auditor.go
@@ -21,6 +21,6 @@ func NewAuditorService() *AuditorService {
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
 // fabtoken does not make use of AuditorCheck as the token request contains token
 // information in the clear
-func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor string) error {
+func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor driver.TokenRequestAnchor) error {
 	return nil
 }

--- a/token/core/fabtoken/v1/transfer.go
+++ b/token/core/fabtoken/v1/transfer.go
@@ -45,9 +45,9 @@ func NewTransferService(
 
 // Transfer returns a TransferAction as a function of the passed arguments
 // It also returns the corresponding TransferMetadata
-func (s *TransferService) Transfer(ctx context.Context, _ string, _ driver.OwnerWallet, tokenIDs []*token.ID, Outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenRequestAnchor, wallet driver.OwnerWallet, ids []*token.ID, outputs []*token.Token, opts *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	// select inputs
-	inputTokens, err := s.TokenLoader.GetTokens(ctx, tokenIDs)
+	inputTokens, err := s.TokenLoader.GetTokens(ctx, ids)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "failed to load tokens")
 	}
@@ -62,7 +62,7 @@ func (s *TransferService) Transfer(ctx context.Context, _ string, _ driver.Owner
 	// prepare outputs
 	var isRedeem bool
 	var outs []*actions.Output
-	for _, output := range Outputs {
+	for _, output := range outputs {
 		outs = append(outs, &actions.Output{
 			Owner:    output.Owner,
 			Type:     output.Type,
@@ -85,7 +85,7 @@ func (s *TransferService) Transfer(ctx context.Context, _ string, _ driver.Owner
 			return nil, nil, errors.Wrapf(err, "failed getting audit info for sender identity [%s]", driver.Identity(t.Owner).String())
 		}
 		transferInputsMetadata = append(transferInputsMetadata, &driver.TransferInputMetadata{
-			TokenID: tokenIDs[i],
+			TokenID: ids[i],
 			Senders: []*driver.AuditableIdentity{
 				{
 					Identity:  t.Owner,
@@ -147,8 +147,8 @@ func (s *TransferService) Transfer(ctx context.Context, _ string, _ driver.Owner
 	}
 
 	// return
-	actionInputs := make([]*actions.TransferActionInput, len(tokenIDs))
-	for i, id := range tokenIDs {
+	actionInputs := make([]*actions.TransferActionInput, len(ids))
+	for i, id := range ids {
 		actionInputs[i] = &actions.TransferActionInput{
 			ID:    id,
 			Input: inputs[i],

--- a/token/core/zkatdlog/nogh/v1/audit/auditor.go
+++ b/token/core/zkatdlog/nogh/v1/audit/auditor.go
@@ -137,7 +137,7 @@ func (a *Auditor) Check(
 	tokenRequest *driver.TokenRequest,
 	tokenRequestMetadata *driver.TokenRequestMetadata,
 	inputTokens [][]*token.Token,
-	txID string,
+	txID driver.TokenRequestAnchor,
 ) error {
 	// TODO: inputTokens should be checked against the actions
 	// De-obfuscate issue requests
@@ -174,7 +174,7 @@ func (a *Auditor) Check(
 }
 
 // CheckTransferRequests verifies that the commitments in transfer inputs and outputs match the information provided in the clear.
-func (a *Auditor) CheckTransferRequests(inputs [][]*InspectableToken, outputsFromTransfer [][]*InspectableToken, txID string) error {
+func (a *Auditor) CheckTransferRequests(inputs [][]*InspectableToken, outputsFromTransfer [][]*InspectableToken, txID driver.TokenRequestAnchor) error {
 
 	for k, transferred := range outputsFromTransfer {
 		err := a.InspectOutputs(transferred)
@@ -194,7 +194,7 @@ func (a *Auditor) CheckTransferRequests(inputs [][]*InspectableToken, outputsFro
 }
 
 // CheckIssueRequests verifies that the commitments in issue outputs match the information provided in the clear.
-func (a *Auditor) CheckIssueRequests(outputsFromIssue [][]*InspectableToken, txID string) error {
+func (a *Auditor) CheckIssueRequests(outputsFromIssue [][]*InspectableToken, txID driver.TokenRequestAnchor) error {
 	// Inspect
 	for k, issued := range outputsFromIssue {
 		err := a.InspectOutputs(issued)

--- a/token/core/zkatdlog/nogh/v1/auditor.go
+++ b/token/core/zkatdlog/nogh/v1/auditor.go
@@ -55,8 +55,8 @@ func NewAuditorService(
 }
 
 // AuditorCheck verifies if the passed tokenRequest matches the tokenRequestMetadata
-func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, txID string) error {
-	s.Logger.DebugfContext(ctx, "[%s] check token request validity, number of transfer actions [%d]...", txID, len(metadata.Transfers))
+func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.TokenRequest, metadata *driver.TokenRequestMetadata, anchor driver.TokenRequestAnchor) error {
+	s.Logger.DebugfContext(ctx, "[%s] check token request validity, number of transfer actions [%d]...", anchor, len(metadata.Transfers))
 
 	actionDes := &validator.ActionDeserializer{
 		PublicParams: s.PublicParametersManager.PublicParams(ctx),
@@ -68,7 +68,7 @@ func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.Token
 
 	tokenIDs := make([]*token2.ID, 0)
 	for i, transfer := range metadata.Transfers {
-		s.Logger.Debugf("[%s] transfer action [%d] contains [%d] inputs", txID, i, len(transfer.Inputs))
+		s.Logger.Debugf("[%s] transfer action [%d] contains [%d] inputs", anchor, i, len(transfer.Inputs))
 		tokenIDs = append(tokenIDs, transfer.TokenIDs()...)
 	}
 
@@ -76,7 +76,7 @@ func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.Token
 	// if err != nil {
 	// 	return errors.Wrapf(err, "failed getting token outputs to perform auditor check")
 	// }
-	s.Logger.DebugfContext(ctx, "loaded [%d] corresponding inputs for TX [%s]", len(tokenIDs), txID)
+	s.Logger.DebugfContext(ctx, "loaded [%d] corresponding inputs for TX [%s]", len(tokenIDs), anchor)
 
 	inputTokens := make([][]*token.Token, len(metadata.Transfers))
 	for i, transfer := range transfers {
@@ -98,7 +98,7 @@ func (s *AuditorService) AuditorCheck(ctx context.Context, request *driver.Token
 		request,
 		metadata,
 		inputTokens,
-		txID,
+		anchor,
 	)
 	if err != nil {
 		return errors.WithMessagef(err, "failed to perform auditor check")

--- a/token/driver/auditor.go
+++ b/token/driver/auditor.go
@@ -11,5 +11,5 @@ import "context"
 // AuditorService models the auditor service
 type AuditorService interface {
 	// AuditorCheck verifies the well-formedness of the passed request with the respect to the passed metadata and anchor
-	AuditorCheck(ctx context.Context, request *TokenRequest, metadata *TokenRequestMetadata, anchor string) error
+	AuditorCheck(ctx context.Context, request *TokenRequest, metadata *TokenRequestMetadata, anchor TokenRequestAnchor) error
 }

--- a/token/driver/mock/ts.go
+++ b/token/driver/mock/ts.go
@@ -23,11 +23,11 @@ type TransferService struct {
 		result1 driver.TransferAction
 		result2 error
 	}
-	TransferStub        func(context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)
+	TransferStub        func(context.Context, driver.TokenRequestAnchor, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)
 	transferMutex       sync.RWMutex
 	transferArgsForCall []struct {
 		arg1 context.Context
-		arg2 string
+		arg2 driver.TokenRequestAnchor
 		arg3 driver.OwnerWallet
 		arg4 []*token.ID
 		arg5 []*token.Token
@@ -43,11 +43,12 @@ type TransferService struct {
 		result2 *driver.TransferMetadata
 		result3 error
 	}
-	VerifyTransferStub        func(driver.TransferAction, []*driver.TransferOutputMetadata) error
+	VerifyTransferStub        func(context.Context, driver.TransferAction, []*driver.TransferOutputMetadata) error
 	verifyTransferMutex       sync.RWMutex
 	verifyTransferArgsForCall []struct {
-		arg1 driver.TransferAction
-		arg2 []*driver.TransferOutputMetadata
+		arg1 context.Context
+		arg2 driver.TransferAction
+		arg3 []*driver.TransferOutputMetadata
 	}
 	verifyTransferReturns struct {
 		result1 error
@@ -128,7 +129,7 @@ func (fake *TransferService) DeserializeTransferActionReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *TransferService) Transfer(arg1 context.Context, arg2 string, arg3 driver.OwnerWallet, arg4 []*token.ID, arg5 []*token.Token, arg6 *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
+func (fake *TransferService) Transfer(arg1 context.Context, arg2 driver.TokenRequestAnchor, arg3 driver.OwnerWallet, arg4 []*token.ID, arg5 []*token.Token, arg6 *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error) {
 	var arg4Copy []*token.ID
 	if arg4 != nil {
 		arg4Copy = make([]*token.ID, len(arg4))
@@ -143,7 +144,7 @@ func (fake *TransferService) Transfer(arg1 context.Context, arg2 string, arg3 dr
 	ret, specificReturn := fake.transferReturnsOnCall[len(fake.transferArgsForCall)]
 	fake.transferArgsForCall = append(fake.transferArgsForCall, struct {
 		arg1 context.Context
-		arg2 string
+		arg2 driver.TokenRequestAnchor
 		arg3 driver.OwnerWallet
 		arg4 []*token.ID
 		arg5 []*token.Token
@@ -168,13 +169,13 @@ func (fake *TransferService) TransferCallCount() int {
 	return len(fake.transferArgsForCall)
 }
 
-func (fake *TransferService) TransferCalls(stub func(context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)) {
+func (fake *TransferService) TransferCalls(stub func(context.Context, driver.TokenRequestAnchor, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) (driver.TransferAction, *driver.TransferMetadata, error)) {
 	fake.transferMutex.Lock()
 	defer fake.transferMutex.Unlock()
 	fake.TransferStub = stub
 }
 
-func (fake *TransferService) TransferArgsForCall(i int) (context.Context, string, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) {
+func (fake *TransferService) TransferArgsForCall(i int) (context.Context, driver.TokenRequestAnchor, driver.OwnerWallet, []*token.ID, []*token.Token, *driver.TransferOptions) {
 	fake.transferMutex.RLock()
 	defer fake.transferMutex.RUnlock()
 	argsForCall := fake.transferArgsForCall[i]
@@ -210,24 +211,25 @@ func (fake *TransferService) TransferReturnsOnCall(i int, result1 driver.Transfe
 	}{result1, result2, result3}
 }
 
-func (fake *TransferService) VerifyTransfer(ctx context.Context, arg1 driver.TransferAction, arg2 []*driver.TransferOutputMetadata) error {
-	var arg2Copy []*driver.TransferOutputMetadata
-	if arg2 != nil {
-		arg2Copy = make([]*driver.TransferOutputMetadata, len(arg2))
-		copy(arg2Copy, arg2)
+func (fake *TransferService) VerifyTransfer(arg1 context.Context, arg2 driver.TransferAction, arg3 []*driver.TransferOutputMetadata) error {
+	var arg3Copy []*driver.TransferOutputMetadata
+	if arg3 != nil {
+		arg3Copy = make([]*driver.TransferOutputMetadata, len(arg3))
+		copy(arg3Copy, arg3)
 	}
 	fake.verifyTransferMutex.Lock()
 	ret, specificReturn := fake.verifyTransferReturnsOnCall[len(fake.verifyTransferArgsForCall)]
 	fake.verifyTransferArgsForCall = append(fake.verifyTransferArgsForCall, struct {
-		arg1 driver.TransferAction
-		arg2 []*driver.TransferOutputMetadata
-	}{arg1, arg2Copy})
+		arg1 context.Context
+		arg2 driver.TransferAction
+		arg3 []*driver.TransferOutputMetadata
+	}{arg1, arg2, arg3Copy})
 	stub := fake.VerifyTransferStub
 	fakeReturns := fake.verifyTransferReturns
-	fake.recordInvocation("VerifyTransfer", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("VerifyTransfer", []interface{}{arg1, arg2, arg3Copy})
 	fake.verifyTransferMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -241,17 +243,17 @@ func (fake *TransferService) VerifyTransferCallCount() int {
 	return len(fake.verifyTransferArgsForCall)
 }
 
-func (fake *TransferService) VerifyTransferCalls(stub func(driver.TransferAction, []*driver.TransferOutputMetadata) error) {
+func (fake *TransferService) VerifyTransferCalls(stub func(context.Context, driver.TransferAction, []*driver.TransferOutputMetadata) error) {
 	fake.verifyTransferMutex.Lock()
 	defer fake.verifyTransferMutex.Unlock()
 	fake.VerifyTransferStub = stub
 }
 
-func (fake *TransferService) VerifyTransferArgsForCall(i int) (driver.TransferAction, []*driver.TransferOutputMetadata) {
+func (fake *TransferService) VerifyTransferArgsForCall(i int) (context.Context, driver.TransferAction, []*driver.TransferOutputMetadata) {
 	fake.verifyTransferMutex.RLock()
 	defer fake.verifyTransferMutex.RUnlock()
 	argsForCall := fake.verifyTransferArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *TransferService) VerifyTransferReturns(result1 error) {

--- a/token/driver/mock/validator.go
+++ b/token/driver/mock/validator.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
 )
 
 type Validator struct {
@@ -23,22 +22,22 @@ type Validator struct {
 		result1 []interface{}
 		result2 error
 	}
-	VerifyTokenRequestFromRawStub        func(context.Context, func(id token.ID) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)
+	VerifyTokenRequestFromRawStub        func(context.Context, driver.GetStateFnc, driver.TokenRequestAnchor, []byte) ([]interface{}, driver.ValidationAttributes, error)
 	verifyTokenRequestFromRawMutex       sync.RWMutex
 	verifyTokenRequestFromRawArgsForCall []struct {
 		arg1 context.Context
-		arg2 func(id token.ID) ([]byte, error)
-		arg3 string
+		arg2 driver.GetStateFnc
+		arg3 driver.TokenRequestAnchor
 		arg4 []byte
 	}
 	verifyTokenRequestFromRawReturns struct {
 		result1 []interface{}
-		result2 map[string][]byte
+		result2 driver.ValidationAttributes
 		result3 error
 	}
 	verifyTokenRequestFromRawReturnsOnCall map[int]struct {
 		result1 []interface{}
-		result2 map[string][]byte
+		result2 driver.ValidationAttributes
 		result3 error
 	}
 	invocations      map[string][][]interface{}
@@ -114,7 +113,7 @@ func (fake *Validator) UnmarshalActionsReturnsOnCall(i int, result1 []interface{
 	}{result1, result2}
 }
 
-func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func(id token.ID) ([]byte, error), arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
+func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 driver.GetStateFnc, arg3 driver.TokenRequestAnchor, arg4 []byte) ([]interface{}, driver.ValidationAttributes, error) {
 	var arg4Copy []byte
 	if arg4 != nil {
 		arg4Copy = make([]byte, len(arg4))
@@ -124,8 +123,8 @@ func (fake *Validator) VerifyTokenRequestFromRaw(arg1 context.Context, arg2 func
 	ret, specificReturn := fake.verifyTokenRequestFromRawReturnsOnCall[len(fake.verifyTokenRequestFromRawArgsForCall)]
 	fake.verifyTokenRequestFromRawArgsForCall = append(fake.verifyTokenRequestFromRawArgsForCall, struct {
 		arg1 context.Context
-		arg2 func(id token.ID) ([]byte, error)
-		arg3 string
+		arg2 driver.GetStateFnc
+		arg3 driver.TokenRequestAnchor
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
 	stub := fake.VerifyTokenRequestFromRawStub
@@ -147,44 +146,44 @@ func (fake *Validator) VerifyTokenRequestFromRawCallCount() int {
 	return len(fake.verifyTokenRequestFromRawArgsForCall)
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(context.Context, func(id token.ID) ([]byte, error), string, []byte) ([]interface{}, map[string][]byte, error)) {
+func (fake *Validator) VerifyTokenRequestFromRawCalls(stub func(context.Context, driver.GetStateFnc, driver.TokenRequestAnchor, []byte) ([]interface{}, driver.ValidationAttributes, error)) {
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	defer fake.verifyTokenRequestFromRawMutex.Unlock()
 	fake.VerifyTokenRequestFromRawStub = stub
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (context.Context, func(id token.ID) ([]byte, error), string, []byte) {
+func (fake *Validator) VerifyTokenRequestFromRawArgsForCall(i int) (context.Context, driver.GetStateFnc, driver.TokenRequestAnchor, []byte) {
 	fake.verifyTokenRequestFromRawMutex.RLock()
 	defer fake.verifyTokenRequestFromRawMutex.RUnlock()
 	argsForCall := fake.verifyTokenRequestFromRawArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawReturns(result1 []interface{}, result2 map[string][]byte, result3 error) {
+func (fake *Validator) VerifyTokenRequestFromRawReturns(result1 []interface{}, result2 driver.ValidationAttributes, result3 error) {
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	defer fake.verifyTokenRequestFromRawMutex.Unlock()
 	fake.VerifyTokenRequestFromRawStub = nil
 	fake.verifyTokenRequestFromRawReturns = struct {
 		result1 []interface{}
-		result2 map[string][]byte
+		result2 driver.ValidationAttributes
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *Validator) VerifyTokenRequestFromRawReturnsOnCall(i int, result1 []interface{}, result2 map[string][]byte, result3 error) {
+func (fake *Validator) VerifyTokenRequestFromRawReturnsOnCall(i int, result1 []interface{}, result2 driver.ValidationAttributes, result3 error) {
 	fake.verifyTokenRequestFromRawMutex.Lock()
 	defer fake.verifyTokenRequestFromRawMutex.Unlock()
 	fake.VerifyTokenRequestFromRawStub = nil
 	if fake.verifyTokenRequestFromRawReturnsOnCall == nil {
 		fake.verifyTokenRequestFromRawReturnsOnCall = make(map[int]struct {
 			result1 []interface{}
-			result2 map[string][]byte
+			result2 driver.ValidationAttributes
 			result3 error
 		})
 	}
 	fake.verifyTokenRequestFromRawReturnsOnCall[i] = struct {
 		result1 []interface{}
-		result2 map[string][]byte
+		result2 driver.ValidationAttributes
 		result3 error
 	}{result1, result2, result3}
 }

--- a/token/driver/request.go
+++ b/token/driver/request.go
@@ -22,6 +22,11 @@ const (
 	ProtocolV1 = 1
 )
 
+type (
+	// TokenRequestAnchor models the anchor of a token request
+	TokenRequestAnchor string
+)
+
 type AuditorSignature struct {
 	Identity  Identity
 	Signature []byte

--- a/token/driver/transfer.go
+++ b/token/driver/transfer.go
@@ -25,7 +25,7 @@ type TransferService interface {
 	// Transfer generates a TransferAction that spend the passed token ids and created the passed outputs.
 	// In addition, a set of options can be specified to further customize the transfer command.
 	// The function returns an TransferAction and the associated metadata.
-	Transfer(ctx context.Context, txID string, wallet OwnerWallet, ids []*token2.ID, Outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
+	Transfer(ctx context.Context, anchor TokenRequestAnchor, wallet OwnerWallet, ids []*token2.ID, outputs []*token2.Token, opts *TransferOptions) (TransferAction, *TransferMetadata, error)
 
 	// VerifyTransfer checks the well-formedness of the passed TransferAction with the respect to the passed output metadata
 	VerifyTransfer(ctx context.Context, tr TransferAction, outputMetadata []*TransferOutputMetadata) error

--- a/token/driver/validator.go
+++ b/token/driver/validator.go
@@ -50,5 +50,5 @@ type Validator interface {
 	// VerifyTokenRequestFromRaw verifies the passed marshalled token request against the passed ledger and anchor.
 	// The function returns additionally a map that contains information about the token request. The content of this map
 	// is driver-dependant
-	VerifyTokenRequestFromRaw(ctx context.Context, getState GetStateFnc, anchor string, raw []byte) ([]interface{}, ValidationAttributes, error)
+	VerifyTokenRequestFromRaw(ctx context.Context, getState GetStateFnc, anchor TokenRequestAnchor, raw []byte) ([]interface{}, ValidationAttributes, error)
 }

--- a/token/services/auditdb/store.go
+++ b/token/services/auditdb/store.go
@@ -170,7 +170,7 @@ func (d *StoreService) Append(ctx context.Context, req tokenRequest) error {
 	}
 	if err := w.AddTokenRequest(
 		ctx,
-		record.Anchor,
+		string(record.Anchor),
 		raw,
 		req.AllApplicationMetadata(),
 		record.Attributes,

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -89,7 +89,7 @@ func (a *Service) Audit(ctx context.Context, tx Transaction) (*token.InputStream
 	eids = append(eids, record.Inputs.EnrollmentIDs()...)
 	eids = append(eids, record.Outputs.EnrollmentIDs()...)
 	logger.Debugf("audit transaction [%s], acquire locks", tx.ID())
-	if err := a.auditDB.AcquireLocks(request.Anchor, eids...); err != nil {
+	if err := a.auditDB.AcquireLocks(string(request.Anchor), eids...); err != nil {
 		return nil, nil, err
 	}
 	logger.Debugf("audit transaction [%s], acquire locks done", tx.ID())
@@ -127,7 +127,7 @@ func (a *Service) Append(ctx context.Context, tx Transaction) error {
 
 // Release releases the lock acquired of the passed transaction.
 func (a *Service) Release(tx Transaction) {
-	a.auditDB.ReleaseLocks(tx.Request().Anchor)
+	a.auditDB.ReleaseLocks(string(tx.Request().Anchor))
 }
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status

--- a/token/services/network/common/finality.go
+++ b/token/services/network/common/finality.go
@@ -95,7 +95,7 @@ func (t *FinalityListener) runOnStatus(ctx context.Context, txID string, status 
 			message = err.Error()
 		} else {
 			t.logger.Debugf("append token request for [%s]", txID)
-			if err := t.tokens.Append(ctx, t.tmsID, txID, tr); err != nil {
+			if err := t.tokens.Append(ctx, t.tmsID, token.RequestAnchor(txID), tr); err != nil {
 				// at this stage though, we don't fail here because the commit pipeline is processing the tokens still
 				t.logger.ErrorfContext(ctx, "failed to append token request to token db [%s]: [%s]", txID, err)
 				return fmt.Errorf("failed to append token request to token db [%s]: [%s]", txID, err)

--- a/token/services/network/fabric/endorsement/approval.go
+++ b/token/services/network/fabric/endorsement/approval.go
@@ -238,7 +238,12 @@ func (r *RequestApprovalResponderView) validate(
 		return nil, nil, errors.WithMessagef(err, "failed to get validator [%s:%s]", tms.Network(), tms.Channel())
 	}
 	logger.Debugf("Unmarshal and verify with metadata for TX [%s]", tx.ID())
-	actions, meta, err := validator.UnmarshallAndVerifyWithMetadata(context.Context(), token2.NewLedgerFromGetter(getState), anchor, requestRaw)
+	actions, meta, err := validator.UnmarshallAndVerifyWithMetadata(
+		context.Context(),
+		token2.NewLedgerFromGetter(getState),
+		token2.RequestAnchor(anchor),
+		requestRaw,
+	)
 	if err != nil {
 		return nil, nil, errors.WithMessagef(err, "failed to verify token request for [%s]", tx.ID())
 	}

--- a/token/services/network/fabric/tcc/mock/validator.go
+++ b/token/services/network/fabric/tcc/mock/validator.go
@@ -5,17 +5,17 @@ import (
 	"context"
 	"sync"
 
-	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/fabric/tcc"
 )
 
 type Validator struct {
-	UnmarshallAndVerifyWithMetadataStub        func(context.Context, driver.ValidatorLedger, string, []byte) ([]interface{}, map[string][]byte, error)
+	UnmarshallAndVerifyWithMetadataStub        func(context.Context, token.Ledger, token.RequestAnchor, []byte) ([]interface{}, map[string][]byte, error)
 	unmarshallAndVerifyWithMetadataMutex       sync.RWMutex
 	unmarshallAndVerifyWithMetadataArgsForCall []struct {
 		arg1 context.Context
-		arg2 driver.ValidatorLedger
-		arg3 string
+		arg2 token.Ledger
+		arg3 token.RequestAnchor
 		arg4 []byte
 	}
 	unmarshallAndVerifyWithMetadataReturns struct {
@@ -32,7 +32,7 @@ type Validator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 context.Context, arg2 driver.ValidatorLedger, arg3 string, arg4 []byte) ([]interface{}, map[string][]byte, error) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 context.Context, arg2 token.Ledger, arg3 token.RequestAnchor, arg4 []byte) ([]interface{}, map[string][]byte, error) {
 	var arg4Copy []byte
 	if arg4 != nil {
 		arg4Copy = make([]byte, len(arg4))
@@ -42,8 +42,8 @@ func (fake *Validator) UnmarshallAndVerifyWithMetadata(arg1 context.Context, arg
 	ret, specificReturn := fake.unmarshallAndVerifyWithMetadataReturnsOnCall[len(fake.unmarshallAndVerifyWithMetadataArgsForCall)]
 	fake.unmarshallAndVerifyWithMetadataArgsForCall = append(fake.unmarshallAndVerifyWithMetadataArgsForCall, struct {
 		arg1 context.Context
-		arg2 driver.ValidatorLedger
-		arg3 string
+		arg2 token.Ledger
+		arg3 token.RequestAnchor
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
 	stub := fake.UnmarshallAndVerifyWithMetadataStub
@@ -65,13 +65,13 @@ func (fake *Validator) UnmarshallAndVerifyWithMetadataCallCount() int {
 	return len(fake.unmarshallAndVerifyWithMetadataArgsForCall)
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadataCalls(stub func(context.Context, driver.ValidatorLedger, string, []byte) ([]interface{}, map[string][]byte, error)) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataCalls(stub func(context.Context, token.Ledger, token.RequestAnchor, []byte) ([]interface{}, map[string][]byte, error)) {
 	fake.unmarshallAndVerifyWithMetadataMutex.Lock()
 	defer fake.unmarshallAndVerifyWithMetadataMutex.Unlock()
 	fake.UnmarshallAndVerifyWithMetadataStub = stub
 }
 
-func (fake *Validator) UnmarshallAndVerifyWithMetadataArgsForCall(i int) (context.Context, driver.ValidatorLedger, string, []byte) {
+func (fake *Validator) UnmarshallAndVerifyWithMetadataArgsForCall(i int) (context.Context, token.Ledger, token.RequestAnchor, []byte) {
 	fake.unmarshallAndVerifyWithMetadataMutex.RLock()
 	defer fake.unmarshallAndVerifyWithMetadataMutex.RUnlock()
 	argsForCall := fake.unmarshallAndVerifyWithMetadataArgsForCall[i]

--- a/token/services/network/fabric/tcc/tcc.go
+++ b/token/services/network/fabric/tcc/tcc.go
@@ -53,7 +53,7 @@ func (a *SetupAction) GetSetupParameters() ([]byte, error) {
 //go:generate counterfeiter -o mock/validator.go -fake-name Validator . Validator
 
 type Validator interface {
-	UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger token.Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error)
+	UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger token.Ledger, anchor token.RequestAnchor, raw []byte) ([]interface{}, map[string][]byte, error)
 }
 
 //go:generate counterfeiter -o mock/public_parameters_manager.go -fake-name PublicParametersManager . PublicParametersManager
@@ -227,7 +227,7 @@ func (cc *TokenChaincode) ProcessRequest(raw []byte, stub shim.ChaincodeStubInte
 	actions, attributes, err := validator.UnmarshallAndVerifyWithMetadata(
 		context.Background(),
 		&ledger{stub: stub, keyTranslator: &keys.Translator{}},
-		stub.GetTxID(),
+		token.RequestAnchor(stub.GetTxID()),
 		raw,
 	)
 	if err != nil {

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -111,7 +111,7 @@ func NewTransaction(context view.Context, signer view.Identity, opts ...TxOption
 		txID = network.TxID{Creator: signer}
 	}
 	id := networkService.ComputeTxID(&txID)
-	tr, err := tms.NewRequest(id)
+	tr, err := tms.NewRequest(token.RequestAnchor(id))
 	if err != nil {
 		return nil, errors.WithMessage(err, "failed init token request")
 	}
@@ -160,7 +160,7 @@ func NewTransactionFromBytes(context view.Context, raw []byte) (*Transaction, er
 	tx.TMS = tms
 	tx.NetworkProvider = networkProvider
 	tx.TokenRequest.SetTokenService(tms)
-	if tx.ID() != tx.TokenRequest.ID() {
+	if tx.ID() != string(tx.TokenRequest.ID()) {
 		return nil, errors.Errorf("invalid transaction, transaction ids do not match [%s][%s]", tx.ID(), tx.TokenRequest.ID())
 	}
 	context.OnError(tx.Release)

--- a/token/services/ttxdb/store.go
+++ b/token/services/ttxdb/store.go
@@ -237,10 +237,11 @@ func (d *StoreService) AppendTransactionRecord(ctx context.Context, req *token.R
 	if err != nil {
 		return errors.WithMessagef(err, "begin update for txid [%s] failed", record.Anchor)
 	}
-	d.cache.Add(record.Anchor, raw)
+	anchor := string(record.Anchor)
+	d.cache.Add(anchor, raw)
 	if err := w.AddTokenRequest(
 		ctx,
-		record.Anchor,
+		anchor,
 		raw,
 		req.AllApplicationMetadata(),
 		record.Attributes,
@@ -387,7 +388,7 @@ func TransactionRecords(record *token.AuditRecord, timestamp time.Time) (txs []T
 				}
 
 				txs = append(txs, driver.TransactionRecord{
-					TxID:         record.Anchor,
+					TxID:         string(record.Anchor),
 					SenderEID:    inEID,
 					RecipientEID: outEID,
 					TokenType:    tokenType,
@@ -427,7 +428,7 @@ func Movements(record *token.AuditRecord, created time.Time) (mv []MovementRecor
 
 			logger.Debugf("adding movement [%s:%d]", eID, diff.Int64())
 			mv = append(mv, driver.MovementRecord{
-				TxID:         record.Anchor,
+				TxID:         string(record.Anchor),
 				EnrollmentID: eID,
 				Amount:       diff,
 				TokenType:    tokenType,

--- a/token/services/ttxdb/store_test.go
+++ b/token/services/ttxdb/store_test.go
@@ -91,7 +91,7 @@ func TestTransactionRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.TransactionRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "bob",
@@ -111,7 +111,7 @@ func TestTransactionRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.TransactionRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "bob",
@@ -121,7 +121,7 @@ func TestTransactionRecords(t *testing.T) {
 			Status:       driver.Pending,
 		},
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			ActionType:   driver.Transfer,
 			SenderEID:    "alice",
 			RecipientEID: "alice",
@@ -139,7 +139,7 @@ func TestTransactionRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.TransactionRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			ActionType:   driver.Issue,
 			SenderEID:    "",
 			RecipientEID: "bob",
@@ -156,7 +156,7 @@ func TestTransactionRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.TransactionRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			ActionType:   driver.Redeem,
 			SenderEID:    "alice",
 			RecipientEID: "",
@@ -177,7 +177,7 @@ func TestMovementRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.MovementRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "alice",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(-10),
@@ -185,7 +185,7 @@ func TestMovementRecords(t *testing.T) {
 			Status:       driver.Pending,
 		},
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "bob",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(10),
@@ -199,7 +199,7 @@ func TestMovementRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.MovementRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "alice",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(-10),
@@ -207,7 +207,7 @@ func TestMovementRecords(t *testing.T) {
 			Status:       driver.Pending,
 		},
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "bob",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(10),
@@ -223,7 +223,7 @@ func TestMovementRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.MovementRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "bob",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(10),
@@ -238,7 +238,7 @@ func TestMovementRecords(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []driver.MovementRecord{
 		{
-			TxID:         input.Anchor,
+			TxID:         string(input.Anchor),
 			EnrollmentID: "alice",
 			TokenType:    "TOK",
 			Amount:       big.NewInt(-10),

--- a/token/stream.go
+++ b/token/stream.go
@@ -49,8 +49,8 @@ type Output struct {
 	Issuer driver.Identity
 }
 
-func (o Output) ID(txID string) *token.ID {
-	return &token.ID{TxId: txID, Index: o.Index}
+func (o Output) ID(anchor RequestAnchor) *token.ID {
+	return &token.ID{TxId: string(anchor), Index: o.Index}
 }
 
 // OutputStream models a stream over a set of outputs (Output).

--- a/token/stream_test.go
+++ b/token/stream_test.go
@@ -40,7 +40,7 @@ func TestOutput_ID(t *testing.T) {
 	}
 	expectedID := &token.ID{TxId: txID, Index: index}
 
-	assert.Equal(t, expectedID, output.ID(txID))
+	assert.Equal(t, expectedID, output.ID(RequestAnchor(txID)))
 }
 
 func TestOutputStream_Filter(t *testing.T) {

--- a/token/tms.go
+++ b/token/tms.go
@@ -64,13 +64,13 @@ func (t *ManagementService) Namespace() string {
 }
 
 // NewRequest returns a new Token Request whose anchor is the passed id
-func (t *ManagementService) NewRequest(id string) (*Request, error) {
+func (t *ManagementService) NewRequest(id RequestAnchor) (*Request, error) {
 	return NewRequest(t, id), nil
 }
 
 // NewRequestFromBytes returns a new Token Request for the passed anchor, and whose actions and metadata are
 // unmarshalled from the passed bytes
-func (t *ManagementService) NewRequestFromBytes(anchor string, actions []byte, meta []byte) (*Request, error) {
+func (t *ManagementService) NewRequestFromBytes(anchor RequestAnchor, actions []byte, meta []byte) (*Request, error) {
 	return NewRequestFromBytes(t, anchor, actions, meta)
 }
 

--- a/token/validator.go
+++ b/token/validator.go
@@ -31,7 +31,7 @@ func (c *Validator) UnmarshalActions(raw []byte) ([]interface{}, error) {
 }
 
 // UnmarshallAndVerify unmarshalls the token request and verifies it against the passed ledger and anchor
-func (c *Validator) UnmarshallAndVerify(ctx context.Context, ledger Ledger, anchor string, raw []byte) ([]interface{}, error) {
+func (c *Validator) UnmarshallAndVerify(ctx context.Context, ledger Ledger, anchor RequestAnchor, raw []byte) ([]interface{}, error) {
 	actions, _, err := c.backend.VerifyTokenRequestFromRaw(ctx, ledger.GetState, anchor, raw)
 	if err != nil {
 		return nil, err
@@ -44,7 +44,7 @@ func (c *Validator) UnmarshallAndVerify(ctx context.Context, ledger Ledger, anch
 
 // UnmarshallAndVerifyWithMetadata behaves as UnmarshallAndVerify. In addition, it returns the metadata extracts from the token request
 // in the form of map.
-func (c *Validator) UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger Ledger, anchor string, raw []byte) ([]interface{}, map[string][]byte, error) {
+func (c *Validator) UnmarshallAndVerifyWithMetadata(ctx context.Context, ledger Ledger, anchor RequestAnchor, raw []byte) ([]interface{}, map[string][]byte, error) {
 	actions, meta, err := c.backend.VerifyTokenRequestFromRaw(ctx, ledger.GetState, anchor, raw)
 	if err != nil {
 		return nil, nil, err

--- a/token/validator_test.go
+++ b/token/validator_test.go
@@ -44,7 +44,7 @@ func TestValidator_UnmarshallAndVerify(t *testing.T) {
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(expectedActions, nil, nil)
 
-	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, anchor, raw)
+	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, RequestAnchor(anchor), raw)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedActions, actions)
@@ -62,7 +62,7 @@ func TestValidator_UnmarshallAndVerifyWithMetadata(t *testing.T) {
 	expectedMetadata := map[string][]byte{"key1": []byte("value1"), "key2": []byte("value2")}
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(expectedActions, expectedMetadata, nil)
-	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, anchor, raw)
+	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, RequestAnchor(anchor), raw)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedActions, actions)
@@ -95,7 +95,7 @@ func TestValidator_UnmarshallAndVerify_Error(t *testing.T) {
 
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(nil, nil, errors.New("mocked error"))
-	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, anchor, raw)
+	actions, err := validator.UnmarshallAndVerify(context.TODO(), mockLedger, RequestAnchor(anchor), raw)
 
 	assert.Error(t, err)
 	assert.Nil(t, actions)
@@ -111,7 +111,7 @@ func TestValidator_UnmarshallAndVerifyWithMetadata_Error(t *testing.T) {
 
 	mockValidator := validator.backend.(*mock.Validator)
 	mockValidator.VerifyTokenRequestFromRawReturns(nil, nil, errors.New("mocked error"))
-	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, anchor, raw)
+	actions, metadata, err := validator.UnmarshallAndVerifyWithMetadata(context.TODO(), mockLedger, RequestAnchor(anchor), raw)
 	assert.Error(t, err)
 	assert.Nil(t, actions)
 	assert.Nil(t, metadata)


### PR DESCRIPTION
This PR adds to the validator context also the anchor in such a way this can be used by a validation function.
To make sure the anchor is non confused, a type `TokenRequestAnchor` has been introduced