### PR TITLE
add support for issue metadata

### DIFF
--- a/token/core/common/meta/metadata.go
+++ b/token/core/common/meta/metadata.go
@@ -11,19 +11,34 @@ import (
 )
 
 const (
+	// TransferMetadataPrefix is the prefix for the metadata of a transfer action
 	TransferMetadataPrefix = "TransferMetadataPrefix"
+	// IssueMetadataPrefix is the prefix for the metadata of an issue action
+	IssueMetadataPrefix = "IssueMetadataPrefix"
 )
 
 // TransferActionMetadata extracts the transfer metadata from the passed attributes and
 // sets them to the passed metadata
 func TransferActionMetadata(attrs map[interface{}]interface{}) map[string][]byte {
+	return ActionMetadata(attrs, TransferMetadataPrefix)
+}
+
+// IssueActionMetadata extracts the transfer metadata from the passed attributes and
+// sets them to the passed metadata
+func IssueActionMetadata(attrs map[interface{}]interface{}) map[string][]byte {
+	return ActionMetadata(attrs, IssueMetadataPrefix)
+}
+
+// ActionMetadata extracts the metadata that has the passed prefix from the passed attributes and
+// sets them to the passed metadata
+func ActionMetadata(attrs map[interface{}]interface{}, prefix string) map[string][]byte {
 	metadata := map[string][]byte{}
 	for key, value := range attrs {
 		k, ok1 := key.(string)
 		v, ok2 := value.([]byte)
 		if ok1 && ok2 {
-			if strings.HasPrefix(k, TransferMetadataPrefix) {
-				mKey := strings.TrimPrefix(k, TransferMetadataPrefix)
+			if strings.HasPrefix(k, prefix) {
+				mKey := strings.TrimPrefix(k, prefix)
 				metadata[mKey] = v
 			}
 		}

--- a/token/core/common/meta/metadata_test.go
+++ b/token/core/common/meta/metadata_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package meta
 
 import (

--- a/token/core/common/meta/metadata_test.go
+++ b/token/core/common/meta/metadata_test.go
@@ -1,0 +1,48 @@
+package meta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionMetadata(t *testing.T) {
+	attrs := map[interface{}]interface{}{
+		"TransferMetadataPrefixfoo": []byte("bar"),
+		"TransferMetadataPrefixbaz": []byte("qux"),
+		"IssueMetadataPrefixabc":    []byte("def"),
+		123:                         []byte("should be ignored"),
+		"TransferMetadataPrefixbad": "not a []byte", // should be ignored
+	}
+
+	expectedTransfer := map[string][]byte{
+		"foo": []byte("bar"),
+		"baz": []byte("qux"),
+	}
+	expectedIssue := map[string][]byte{
+		"abc": []byte("def"),
+	}
+
+	transfer := TransferActionMetadata(attrs)
+	assert.Equal(t, expectedTransfer, transfer)
+
+	issue := IssueActionMetadata(attrs)
+	assert.Equal(t, expectedIssue, issue)
+
+	// Test ActionMetadata directly with a custom prefix
+	attrs2 := map[interface{}]interface{}{
+		"CustomPrefixkey": []byte("val"),
+		"CustomPrefixx":   []byte("y"),
+		"OtherPrefixz":    []byte("should be ignored"),
+	}
+	expectedCustom := map[string][]byte{
+		"key": []byte("val"),
+		"x":   []byte("y"),
+	}
+	custom := ActionMetadata(attrs2, "CustomPrefix")
+	assert.Equal(t, expectedCustom, custom)
+
+	// Test empty attrs
+	empty := ActionMetadata(map[interface{}]interface{}{}, "AnyPrefix")
+	assert.Empty(t, empty)
+}

--- a/token/core/fabtoken/v1/issue.go
+++ b/token/core/fabtoken/v1/issue.go
@@ -9,6 +9,7 @@ package v1
 import (
 	"context"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/meta"
 	v1 "github.com/hyperledger-labs/fabric-token-sdk/token/core/fabtoken/v1/actions"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -85,7 +86,14 @@ func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity
 		return nil, nil, errors.Wrapf(err, "failed to get audit info for issuer identity")
 	}
 
-	action := &v1.IssueAction{Issuer: issuerIdentity, Outputs: outs}
+	action := &v1.IssueAction{
+		Issuer:  issuerIdentity,
+		Outputs: outs,
+	}
+	// add issuer action's metadata
+	if opts != nil {
+		action.Metadata = meta.IssueActionMetadata(opts.Attributes)
+	}
 
 	meta := &driver.IssueMetadata{
 		Issuer: driver.AuditableIdentity{

--- a/token/core/fabtoken/v1/transfer.go
+++ b/token/core/fabtoken/v1/transfer.go
@@ -155,10 +155,12 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 		}
 	}
 	transfer := &actions.TransferAction{
-		Inputs:   actionInputs,
-		Outputs:  outs,
-		Metadata: meta.TransferActionMetadata(opts.Attributes),
-		Issuer:   nil,
+		Inputs:  actionInputs,
+		Outputs: outs,
+		Issuer:  nil,
+	}
+	if opts != nil {
+		transfer.Metadata = meta.TransferActionMetadata(opts.Attributes)
 	}
 	transferMetadata := &driver.TransferMetadata{
 		Inputs:       transferInputsMetadata,

--- a/token/core/zkatdlog/nogh/v1/issue.go
+++ b/token/core/zkatdlog/nogh/v1/issue.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	common2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/common"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/meta"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/upgrade"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/issue"
@@ -174,6 +175,11 @@ func (s *IssueService) Issue(ctx context.Context, issuerIdentity driver.Identity
 	}
 
 	s.Logger.Debugf("issue with [%d] inputs", len(issueAction.Inputs))
+
+	// add issuer action's metadata
+	if opts != nil {
+		issueAction.Metadata = meta.IssueActionMetadata(opts.Attributes)
+	}
 
 	meta := &driver.IssueMetadata{
 		Issuer: driver.AuditableIdentity{

--- a/token/request.go
+++ b/token/request.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	TransferMetadataPrefix = meta.TransferMetadataPrefix
+	IssueMetadataPrefix    = meta.IssueMetadataPrefix
 )
 
 type Binder interface {
@@ -106,6 +107,11 @@ func WithTokenSelector(selector Selector) TransferOption {
 // WithTransferMetadata sets transfer action metadata
 func WithTransferMetadata(key string, value []byte) TransferOption {
 	return WithTransferAttribute(TransferMetadataPrefix+key, value)
+}
+
+// WithIssueMetadata sets issue action metadata
+func WithIssueMetadata(key string, value []byte) TransferOption {
+	return WithTransferAttribute(IssueMetadataPrefix+key, value)
 }
 
 // WithTokenIDs sets the tokens ids to transfer

--- a/token/request.go
+++ b/token/request.go
@@ -71,6 +71,11 @@ func WithIssueAttribute(attr, value interface{}) IssueOption {
 	}
 }
 
+// WithIssueMetadata sets issue action metadata
+func WithIssueMetadata(key string, value []byte) IssueOption {
+	return WithIssueAttribute(IssueMetadataPrefix+key, value)
+}
+
 // TransferOptions models the options that can be passed to the transfer command
 type TransferOptions struct {
 	// Attributes is a container of generic options that might be driver specific
@@ -107,11 +112,6 @@ func WithTokenSelector(selector Selector) TransferOption {
 // WithTransferMetadata sets transfer action metadata
 func WithTransferMetadata(key string, value []byte) TransferOption {
 	return WithTransferAttribute(TransferMetadataPrefix+key, value)
-}
-
-// WithIssueMetadata sets issue action metadata
-func WithIssueMetadata(key string, value []byte) TransferOption {
-	return WithTransferAttribute(IssueMetadataPrefix+key, value)
 }
 
 // WithTokenIDs sets the tokens ids to transfer


### PR DESCRIPTION
This PR makes it possible for the developer to specify `issue action metadata`. These are keys that will be stored on the ledger with uniqueness guarantees. By using `WithIssueMetadata`, the developer can specify a metadata to be stored on the ledger. This is similar to the already existing use of `WithTransferMetadata`.