### PR TITLE
introduce nocache and ristretto-based cache #1173

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/IBM/idemix v0.0.2-0.20250313153527-832db18b9478
 	github.com/IBM/idemix/bccsp/types v0.0.0-20250313153527-832db18b9478
 	github.com/IBM/mathlib v0.0.3-0.20241219051532-81539b287cf5
+	github.com/dgraph-io/ristretto/v2 v2.2.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gobuffalo/packr/v2 v2.7.1
 	github.com/hashicorp/go-uuid v1.0.3
@@ -34,6 +35,7 @@ require (
 	go.uber.org/dig v1.18.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.38.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v2 v2.4.0
 	modernc.org/sqlite v1.33.1
@@ -274,7 +276,6 @@ require (
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	golang.org/x/time v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -761,6 +761,10 @@ github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5il
 github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnNEcHYvcCuK6dPZSg=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
+github.com/dgraph-io/ristretto/v2 v2.2.0 h1:bkY3XzJcXoMuELV8F+vS8kzNgicwQFAaGINAEJdWGOM=
+github.com/dgraph-io/ristretto/v2 v2.2.0/go.mod h1:RZrm63UmcBAaYWC1DotLYBmTvgkrs0+XhBd7Npn7/zI=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
+github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v27.2.0+incompatible h1:Rk9nIVdfH3+Vz4cyI/uhbINhEZ/oLmc+CBXmH6fbNk4=

--- a/token/services/db/sql/common/identity.go
+++ b/token/services/db/sql/common/identity.go
@@ -25,6 +25,7 @@ import (
 	tdriver "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/db/driver"
 	driver3 "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/driver"
+	cache2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/cache"
 	"github.com/pkg/errors"
 )
 
@@ -69,6 +70,17 @@ func NewCachedIdentityStore(readDB, writeDB *sql.DB, tables TableNames, ci commo
 		tables,
 		secondcache.NewTyped[bool](1000),
 		secondcache.NewTyped[[]byte](1000),
+		ci,
+	)
+}
+
+func NewNoCacheIdentityStore(readDB, writeDB *sql.DB, tables TableNames, ci common3.CondInterpreter) (*IdentityStore, error) {
+	return NewIdentityStore(
+		readDB,
+		writeDB,
+		tables,
+		cache2.NewNoCache[bool](),
+		cache2.NewNoCache[[]byte](),
 		ci,
 	)
 }

--- a/token/services/utils/cache/nocache.go
+++ b/token/services/utils/cache/nocache.go
@@ -1,0 +1,30 @@
+package cache
+
+type NoCache[T any] struct {
+}
+
+func NewNoCache[T any]() *NoCache[T] {
+	return &NoCache[T]{}
+}
+
+func (n *NoCache[T]) Get(key string) (T, bool) {
+	return Zero[T](), false
+}
+
+func (n *NoCache[T]) GetOrLoad(key string, loader func() (T, error)) (T, bool, error) {
+	v, err := loader()
+	return v, false, err
+}
+
+func (n *NoCache[T]) Add(key string, value T) {
+	return
+}
+
+func (n *NoCache[T]) Delete(key string) {
+	return
+}
+
+func Zero[T any]() T {
+	var result T
+	return result
+}

--- a/token/services/utils/cache/nocache.go
+++ b/token/services/utils/cache/nocache.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package cache
 
 type NoCache[T any] struct {

--- a/token/services/utils/cache/nocache.go
+++ b/token/services/utils/cache/nocache.go
@@ -23,11 +23,9 @@ func (n *NoCache[T]) GetOrLoad(key string, loader func() (T, error)) (T, bool, e
 }
 
 func (n *NoCache[T]) Add(key string, value T) {
-	return
 }
 
 func (n *NoCache[T]) Delete(key string) {
-	return
 }
 
 func Zero[T any]() T {

--- a/token/services/utils/cache/nocache.go
+++ b/token/services/utils/cache/nocache.go
@@ -6,15 +6,21 @@ SPDX-License-Identifier: Apache-2.0
 
 package cache
 
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils"
+)
+
+// NoCache implements a dummy cache that does nothing
 type NoCache[T any] struct {
 }
 
+// NewNoCache returns a new instance of NoCache
 func NewNoCache[T any]() *NoCache[T] {
 	return &NoCache[T]{}
 }
 
 func (n *NoCache[T]) Get(key string) (T, bool) {
-	return Zero[T](), false
+	return utils.Zero[T](), false
 }
 
 func (n *NoCache[T]) GetOrLoad(key string, loader func() (T, error)) (T, bool, error) {
@@ -26,9 +32,4 @@ func (n *NoCache[T]) Add(key string, value T) {
 }
 
 func (n *NoCache[T]) Delete(key string) {
-}
-
-func Zero[T any]() T {
-	var result T
-	return result
 }

--- a/token/services/utils/cache/nocache_test.go
+++ b/token/services/utils/cache/nocache_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoCache_Get_Int(t *testing.T) {
+	cache := NewNoCache[int]()
+
+	val, found := cache.Get("pineapple")
+
+	require.False(t, found)
+	require.Equal(t, 0, val)
+}
+
+func TestNoCache_Get_String(t *testing.T) {
+	cache := NewNoCache[string]()
+
+	val, found := cache.Get("pineapple")
+
+	require.False(t, found)
+	require.Equal(t, "", val)
+}
+
+func TestNoCache_GetOrLoad_Success(t *testing.T) {
+	cache := NewNoCache[string]()
+
+	loader := func() (string, error) {
+		return "loaded", nil
+	}
+
+	val, found, err := cache.GetOrLoad("key", loader)
+
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, "loaded", val)
+}
+
+func TestNoCache_GetOrLoad_Error(t *testing.T) {
+	cache := NewNoCache[float64]()
+
+	expectedErr := errors.New("load failed")
+
+	loader := func() (float64, error) {
+		return 0.0, expectedErr
+	}
+
+	val, found, err := cache.GetOrLoad("key", loader)
+
+	require.ErrorIs(t, err, expectedErr)
+	require.False(t, found)
+	require.Equal(t, 0.0, val)
+}
+
+func TestNoCache_Add_DoesNothing(t *testing.T) {
+	cache := NewNoCache[bool]()
+
+	cache.Add("key", true)
+
+	val, found := cache.Get("key")
+	require.False(t, found)
+	require.Equal(t, false, val)
+}
+
+func TestNoCache_Delete_DoesNothing(t *testing.T) {
+	cache := NewNoCache[string]()
+
+	cache.Delete("key")
+
+	val, found := cache.Get("key")
+	require.False(t, found)
+	require.Equal(t, "", val)
+}

--- a/token/services/utils/cache/ristretto.go
+++ b/token/services/utils/cache/ristretto.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"github.com/dgraph-io/ristretto/v2"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	// ZeroCost with this ristretto uses the Cost function defined in its configuration
+	ZeroCost = 0
+)
+
+// ristrettoCache is our implementation using Ristretto v2.
+type ristrettoCache[T any] struct {
+	cache *ristretto.Cache[string, T]
+	sfg   singleflight.Group
+}
+
+// NewRistrettoCache creates and returns a new ristretto-based cache implementation.
+func NewRistrettoCache[T any](config *ristretto.Config[string, T]) (*ristrettoCache[T], error) {
+	rCache, err := ristretto.NewCache[string, T](config)
+	if err != nil {
+		return nil, err
+	}
+	return &ristrettoCache[T]{
+		cache: rCache,
+	}, nil
+}
+
+func NewDefaultRistrettoCache[T any]() (*ristrettoCache[T], error) {
+	return NewRistrettoCache[T](&ristretto.Config[string, T]{
+		NumCounters: 1e6, // 1 million
+		MaxCost:     1e8, // 100 million
+		BufferItems: 64,
+		Cost: func(value T) int64 {
+			return 1
+		},
+	})
+}
+
+func (c *ristrettoCache[T]) Get(key string) (T, bool) {
+	return c.cache.Get(key)
+}
+
+func (c *ristrettoCache[T]) Add(key string, value T) {
+	c.cache.Set(key, value, ZeroCost)
+	c.cache.Wait()
+}
+
+func (c *ristrettoCache[T]) Delete(key string) {
+	c.cache.Del(key)
+	c.cache.Wait()
+}
+
+func (c *ristrettoCache[T]) GetOrLoad(key string, loader func() (T, error)) (T, bool, error) {
+	var zero T
+
+	if value, found := c.Get(key); found {
+		return value, true, nil
+	}
+
+	// If not found, use singleflight to prevent thundering herds.
+	res, err, _ := c.sfg.Do(key, func() (interface{}, error) {
+		newValue, loadErr := loader()
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		c.Add(key, newValue)
+		return newValue, nil
+	})
+	if err != nil {
+		return zero, false, err
+	}
+	return res.(T), false, nil
+}

--- a/token/services/utils/cache/ristretto_test.go
+++ b/token/services/utils/cache/ristretto_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cache
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAndGet(t *testing.T) {
+	t.Parallel()
+	c, err := NewDefaultRistrettoCache[string]()
+	require.NoError(t, err)
+
+	key := "pineapple"
+	value := "test-value"
+
+	_, found := c.Get(key)
+	require.False(t, found)
+
+	c.Add(key, value)
+	retrieved, found := c.Get(key)
+	require.True(t, found)
+	require.Equal(t, value, retrieved)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	c, err := NewDefaultRistrettoCache[int]()
+	require.NoError(t, err)
+
+	key := "pineapple"
+	value := 123
+
+	c.Add(key, value)
+	c.Delete(key)
+
+	_, found := c.Get(key)
+	require.False(t, found)
+}
+
+func TestGetOrLoad(t *testing.T) {
+	t.Parallel()
+	c, err := NewDefaultRistrettoCache[string]()
+	require.NoError(t, err)
+
+	key := "pineapple"
+	expectedValue := "loaded-value"
+	loaderCalls := 0
+
+	loader := func() (string, error) {
+		loaderCalls++
+		return expectedValue, nil
+	}
+
+	// 1. First call: should trigger the loader, return the value, and not report a cache hit.
+	val, found, err := c.GetOrLoad(key, loader)
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, expectedValue, val)
+	require.Equal(t, 1, loaderCalls)
+
+	// 2. Second call: should NOT trigger the loader, return the value, and report a cache hit.
+	val, found, err = c.GetOrLoad(key, loader)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, expectedValue, val)
+	require.Equal(t, 1, loaderCalls)
+}
+
+func TestGetOrLoadError(t *testing.T) {
+	t.Parallel()
+	c, err := NewDefaultRistrettoCache[string]()
+	require.NoError(t, err)
+
+	key := "pineapple"
+	loaderErr := errors.New("database is down")
+	loader := func() (string, error) {
+		return "", loaderErr
+	}
+	// The loader error should be returned.
+	_, _, err = c.GetOrLoad(key, loader)
+	require.Equal(t, loaderErr, err)
+
+	// The key should not have been added to the cache.
+	_, found := c.Get(key)
+	require.False(t, found)
+}
+
+func TestGetOrLoadConcurrency(t *testing.T) {
+	t.Parallel()
+	c, err := NewDefaultRistrettoCache[int]()
+	require.NoError(t, err)
+
+	key := "pineapple"
+	expectedValue := 42
+	var loaderCalls int32
+
+	loader := func() (int, error) {
+		atomic.AddInt32(&loaderCalls, 1)
+		// Simulate a slow data source.
+		time.Sleep(100 * time.Millisecond)
+		return expectedValue, nil
+	}
+
+	numGoroutines := 50
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			val, _, loadErr := c.GetOrLoad(key, loader)
+			require.NoError(t, loadErr)
+			require.Equal(t, expectedValue, val)
+		}()
+	}
+
+	wg.Wait()
+
+	// the loader should have been called exactly once still.
+	require.Equal(t, 1, int(atomic.LoadInt32(&loaderCalls)))
+}


### PR DESCRIPTION
This PR does the following:
- introduce a NoCache instance
- Remove the extra synchronization in `token/services/db/sql/common/identity.go`
- Replace `isMeCache` with a cache interface.
- When caching TokenRequest, in the cache it is added also the message to sign that is later compared during the commit phase.