### PR TITLE
enhanced redeem: make issuer signature optional #1134

### DIFF
--- a/cmd/tokengen/cobra/pp/fabtokenv1/gen.go
+++ b/cmd/tokengen/cobra/pp/fabtokenv1/gen.go
@@ -103,6 +103,12 @@ func Gen(args *GeneratorArgs) ([]byte, error) {
 	if err := common.SetupIssuersAndAuditors(pp, args.Auditors, args.Issuers); err != nil {
 		return nil, err
 	}
+
+	// warn in case no issuers are specified
+	if len(pp.Issuers()) == 0 {
+		fmt.Println("No issuers specified. The public parameters allow anyone to create tokens.")
+	}
+
 	// Store Public Params
 	raw, err := pp.Serialize()
 	if err != nil {

--- a/cmd/tokengen/cobra/pp/zkatdlognoghv1/gen.go
+++ b/cmd/tokengen/cobra/pp/zkatdlognoghv1/gen.go
@@ -149,6 +149,11 @@ func Gen(args *GeneratorArgs) ([]byte, error) {
 		return nil, errors.Wrapf(err, "failed to validate public parameters")
 	}
 
+	// warn in case no issuers are specified
+	if len(pp.Issuers()) == 0 {
+		fmt.Println("No issuers specified. The public parameters allow anyone to create tokens.")
+	}
+
 	// Store Public Params
 	raw, err := pp.Serialize()
 	if err != nil {

--- a/token/core/common/ppm.go
+++ b/token/core/common/ppm.go
@@ -44,6 +44,9 @@ func NewPublicParamsManager[T driver.PublicParameters](
 	if err := pp.Validate(); err != nil {
 		return nil, errors.WithMessagef(err, "invalid public parameters")
 	}
+	if len(pp.Issuers()) == 0 {
+		logger.Warnf("no issuers definied in the public parameters")
+	}
 	ppm.publicParameters = pp
 	ppm.ppHash = utils.Hashable(ppRaw).Raw()
 
@@ -53,6 +56,9 @@ func NewPublicParamsManager[T driver.PublicParameters](
 func NewPublicParamsManagerFromParams[T driver.PublicParameters](pp T) (*PublicParamsManager[T], error) {
 	if err := pp.Validate(); err != nil {
 		return nil, errors.WithMessagef(err, "invalid public parameters")
+	}
+	if len(pp.Issuers()) == 0 {
+		logger.Warnf("no issuers definied in the public parameters")
 	}
 	return &PublicParamsManager[T]{
 		publicParameters: pp,

--- a/token/core/common/transfer.go
+++ b/token/core/common/transfer.go
@@ -16,6 +16,10 @@ import (
 // If opts specify an FSC issuer identity, then we expect to find the opts also the public key to add in the transfer action.
 // Otherwise, the first public key in the public params is used.
 func SelectIssuerForRedeem(issuers []driver.Identity, opts *driver.TransferOptions) (driver.Identity, error) {
+	if len(issuers) == 0 {
+		// nothing to do here
+		return nil, nil
+	}
 	issuerNetworkIdentity, err := ttx.GetFSCIssuerIdentityFromOpts(opts.Attributes)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get issuer network identity")

--- a/token/core/common/transfer_test.go
+++ b/token/core/common/transfer_test.go
@@ -36,7 +36,7 @@ func TestSelectIssuerForRedeem(t *testing.T) {
 				ttx.IssuerPublicParamsPublicKey: issuerPPPublicKey,
 			},
 			expectError:    false,
-			expectIdentity: issuerPPPublicKey,
+			expectIdentity: nil,
 		},
 		{
 			name:    "opts with FSC issuer identity but no public key",
@@ -44,7 +44,7 @@ func TestSelectIssuerForRedeem(t *testing.T) {
 			attributes: map[interface{}]interface{}{
 				ttx.IssuerFSCIdentityKey: issuerFSCIdentity,
 			},
-			expectError:    true,
+			expectError:    false,
 			expectIdentity: nil,
 		},
 		{
@@ -58,7 +58,7 @@ func TestSelectIssuerForRedeem(t *testing.T) {
 			name:           "opts with no FSC issuer identity, no issuers",
 			issuers:        []driver.Identity{},
 			attributes:     map[interface{}]interface{}{},
-			expectError:    true,
+			expectError:    false,
 			expectIdentity: nil,
 		},
 		{
@@ -67,7 +67,7 @@ func TestSelectIssuerForRedeem(t *testing.T) {
 			attributes: map[interface{}]interface{}{
 				ttx.IssuerFSCIdentityKey: 1234,
 			},
-			expectError:    true,
+			expectError:    false,
 			expectIdentity: nil,
 		},
 		{
@@ -77,7 +77,7 @@ func TestSelectIssuerForRedeem(t *testing.T) {
 				ttx.IssuerFSCIdentityKey:        issuerFSCIdentity,
 				ttx.IssuerPublicParamsPublicKey: 1234,
 			},
-			expectError:    true,
+			expectError:    false,
 			expectIdentity: nil,
 		},
 	}

--- a/token/core/fabtoken/v1/setup/setup.go
+++ b/token/core/fabtoken/v1/setup/setup.go
@@ -233,7 +233,8 @@ func (p *PublicParams) Precision() uint64 {
 	return p.QuantityPrecision
 }
 
-// Validate validates the public parameters
+// Validate validates the public parameters.
+// The list of issues can be empty meaning that anyone can create tokens.
 func (p *PublicParams) Validate() error {
 	if p.QuantityPrecision > 64 {
 		return errors.Errorf("invalid precision [%d], must be less than 64", p.QuantityPrecision)
@@ -244,9 +245,6 @@ func (p *PublicParams) Validate() error {
 	maxTokenValue := uint64(1<<p.Precision()) - 1
 	if p.MaxToken > maxTokenValue {
 		return errors.Errorf("max token value is invalid [%d]>[%d]", p.MaxToken, maxTokenValue)
-	}
-	if len(p.IssuerIDs) == 0 {
-		return errors.New("invalid public parameters: empty list of issuers")
 	}
 	return nil
 }

--- a/token/core/fabtoken/v1/setup/setup_test.go
+++ b/token/core/fabtoken/v1/setup/setup_test.go
@@ -57,7 +57,6 @@ func TestPublicParams_Validate_Valid(t *testing.T) {
 	pp.IssuerIDs = []driver.Identity{[]byte("issuer1"), []byte("issuer2")}
 	err = pp.Validate()
 	assert.NoError(t, err)
-
 }
 
 func TestPublicParams_Validate_InvalidPrecision(t *testing.T) {

--- a/token/core/fabtoken/v1/setup/setup_test.go
+++ b/token/core/fabtoken/v1/setup/setup_test.go
@@ -48,10 +48,16 @@ func TestPublicParams_Validate_Valid(t *testing.T) {
 		DriverName:        FabTokenDriverName,
 		QuantityPrecision: 32,
 		MaxToken:          1<<32 - 1,
-		IssuerIDs:         []driver.Identity{[]byte("issuer1"), []byte("issuer2")},
 	}
+	// without issuers
 	err := pp.Validate()
 	assert.NoError(t, err)
+
+	// with issuers
+	pp.IssuerIDs = []driver.Identity{[]byte("issuer1"), []byte("issuer2")}
+	err = pp.Validate()
+	assert.NoError(t, err)
+
 }
 
 func TestPublicParams_Validate_InvalidPrecision(t *testing.T) {

--- a/token/core/fabtoken/v1/validator/validator_transfer.go
+++ b/token/core/fabtoken/v1/validator/validator_transfer.go
@@ -50,34 +50,32 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 		}
 		ctx.Signatures = append(ctx.Signatures, sigma)
 	}
-
-	var isRedeem bool
-	for _, output := range ctx.TransferAction.Outputs {
-		if output.Owner == nil {
-			isRedeem = true
-			break
+	if len(ctx.PP.Issuers()) > 0 {
+		// In this case we must ensure that an issuer signed as well if the action redeems tokens as well
+		var isRedeem bool
+		for _, output := range ctx.TransferAction.Outputs {
+			if output.Owner == nil {
+				isRedeem = true
+				break
+			}
 		}
-	}
-
-	// If transfer action is a redeem, verify the signature of the issuer
-	if isRedeem {
-		ctx.Logger.Infof("action is a redeem, verify the signature of the issuer")
-
-		issuer := ctx.TransferAction.GetIssuer()
-		if issuer == nil {
-			return errors.Errorf("On Redeem action, must have at least one issuer")
+		// If transfer action is a redeem, verify the signature of the issuer
+		if isRedeem {
+			ctx.Logger.Infof("action is a redeem, verify the signature of the issuer")
+			issuer := ctx.TransferAction.GetIssuer()
+			if issuer == nil {
+				return errors.Errorf("On Redeem action, must have at least one issuer")
+			}
+			issuerVerifier, err := ctx.Deserializer.GetIssuerVerifier(c, issuer)
+			if err != nil {
+				return errors.Wrapf(err, "failed deserializing issuer [%s]", issuer.UniqueID())
+			}
+			sigma, err := ctx.SignatureProvider.HasBeenSignedBy(c, issuer, issuerVerifier)
+			if err != nil {
+				return errors.Wrapf(err, "failed signature verification [%s]", issuer.UniqueID())
+			}
+			ctx.Signatures = append(ctx.Signatures, sigma)
 		}
-
-		issuerVerifier, err := ctx.Deserializer.GetIssuerVerifier(c, issuer)
-		if err != nil {
-			return errors.Wrapf(err, "failed deserializing issuer [%s]", issuer.UniqueID())
-		}
-
-		sigma, err := ctx.SignatureProvider.HasBeenSignedBy(c, issuer, issuerVerifier)
-		if err != nil {
-			return errors.Wrapf(err, "failed signature verification [%s]", issuer.UniqueID())
-		}
-		ctx.Signatures = append(ctx.Signatures, sigma)
 	}
 
 	ctx.InputTokens = inputToken

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -476,10 +476,9 @@ func (p *PublicParams) String() string {
 	return string(res)
 }
 
+// Validate validates the public parameters.
+// The list of issues can be empty meaning that anyone can create tokens.
 func (p *PublicParams) Validate() error {
-	// if p.DriverVersion != ProtocolV1 {
-	// 	return errors.Errorf("invalid version [%d], expected [%d]", p.DriverVersion, ProtocolV1)
-	// }
 	if int(p.Curve) > len(mathlib.Curves)-1 {
 		return errors.Errorf("invalid public parameters: invalid curveID [%d > %d]", int(p.Curve), len(mathlib.Curves)-1)
 	}
@@ -519,9 +518,6 @@ func (p *PublicParams) Validate() error {
 	maxToken := p.ComputeMaxTokenValue()
 	if maxToken != p.MaxToken {
 		return errors.Errorf("invalid maxt token, [%d]!=[%d]", maxToken, p.MaxToken)
-	}
-	if len(p.IssuerIDs) == 0 {
-		return errors.New("invalid public parameters: empty list of issuers")
 	}
 	return nil
 }

--- a/token/core/zkatdlog/nogh/v1/setup/setup_test.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup_test.go
@@ -36,8 +36,10 @@ func TestSerialization(t *testing.T) {
 	assert.Equal(t, pp, pp2)
 	assert.Equal(t, ser, ser2)
 
-	assert.Error(t, pp.Validate())
+	// no issuers
+	assert.NoError(t, pp.Validate())
 
+	// with issuers
 	pp.IssuerIDs = []driver.Identity{[]byte("issuer")}
 	assert.NoError(t, pp.Validate())
 }

--- a/token/core/zkatdlog/nogh/v1/transfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer.go
@@ -123,7 +123,6 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 		return nil, nil, errors.Wrapf(err, "failed to prepare inputs")
 	}
 
-	var isRedeem bool
 	// get sender
 	pp := s.PublicParametersManager.PublicParams()
 	sender, err := transfer.NewSender(nil, prepareInputs.Tokens(), ids, prepareInputs.Metadata(), pp)
@@ -132,6 +131,7 @@ func (s *TransferService) Transfer(ctx context.Context, anchor driver.TokenReque
 	}
 	values := make([]uint64, 0, len(outputs))
 	owners := make([][]byte, 0, len(outputs))
+	var isRedeem bool
 	// get values and owners of outputs
 	s.Logger.DebugfContext(ctx, "Prepare %d output tokens", len(outputs))
 	for i, output := range outputs {

--- a/token/provider.go
+++ b/token/provider.go
@@ -185,7 +185,10 @@ func (p *ManagementServiceProvider) managementService(opts ...ServiceOption) (*M
 			deserializer:     tokenService.Deserializer(),
 			identityProvider: tokenService.IdentityProvider(),
 		},
-		publicParametersManager: &PublicParametersManager{ppm: tokenService.PublicParamsManager()},
+		publicParametersManager: &PublicParametersManager{
+			ppm: tokenService.PublicParamsManager(),
+			pp:  &PublicParameters{PublicParameters: tokenService.PublicParamsManager().PublicParameters()},
+		},
 	}
 	if err := ms.init(); err != nil {
 		return nil, errors.WithMessagef(err, "failed to initialize token management service")

--- a/token/publicparams.go
+++ b/token/publicparams.go
@@ -14,47 +14,6 @@ type PPHash = driver.PPHash
 
 type PublicParameters struct {
 	driver.PublicParameters
-	ppm driver.PublicParamsManager
-}
-
-// Precision returns the precision used to represent the token quantity
-func (c *PublicParameters) Precision() uint64 {
-	return c.PublicParameters.Precision()
-}
-
-// CertificationDriver return the certification driver used to certify that tokens exist
-func (c *PublicParameters) CertificationDriver() string {
-	return c.PublicParameters.CertificationDriver()
-}
-
-// GraphHiding returns true if graph hiding is enabled
-func (c *PublicParameters) GraphHiding() bool {
-	return c.PublicParameters.GraphHiding()
-}
-
-// TokenDataHiding returns true if data hiding is enabled
-func (c *PublicParameters) TokenDataHiding() bool {
-	return c.PublicParameters.TokenDataHiding()
-}
-
-// MaxTokenValue returns the maximum value a token can contain
-func (c *PublicParameters) MaxTokenValue() uint64 {
-	return c.PublicParameters.MaxTokenValue()
-}
-
-// Serialize returns the public parameters in their serialized form
-func (c *PublicParameters) Serialize() ([]byte, error) {
-	return c.PublicParameters.Serialize()
-}
-
-// Identifier returns the identifier of the public parameters
-func (c *PublicParameters) TokenDriverName() driver.TokenDriverName {
-	return c.PublicParameters.TokenDriverName()
-}
-
-// Auditors returns the list of auditors' identities
-func (c *PublicParameters) Auditors() []Identity {
-	return c.PublicParameters.Auditors()
 }
 
 // PublicParamsFetcher models the public parameters fetcher
@@ -66,15 +25,12 @@ type PublicParamsFetcher interface {
 // PublicParametersManager exposes methods to manage the public parameters
 type PublicParametersManager struct {
 	ppm driver.PublicParamsManager
+	pp  *PublicParameters
 }
 
 // PublicParameters returns the public parameters, nil if not set yet.
 func (c *PublicParametersManager) PublicParameters() *PublicParameters {
-	pp := c.ppm.PublicParameters()
-	if pp == nil {
-		return nil
-	}
-	return &PublicParameters{PublicParameters: pp, ppm: c.ppm}
+	return c.pp
 }
 
 func (c *PublicParametersManager) PublicParamsHash() PPHash {

--- a/token/publicparams_test.go
+++ b/token/publicparams_test.go
@@ -124,12 +124,16 @@ func TestPublicParametersManager_PublicParameters(t *testing.T) {
 	ppm := &PublicParametersManager{
 		ppm: &mock.PublicParamsManager{},
 	}
-
-	mockPPM := ppm.ppm.(*mock.PublicParamsManager)
-	mockPPM.PublicParametersReturns(&mock.PublicParameters{})
-
 	pp := ppm.PublicParameters()
+	assert.Nil(t, pp)
 
+	ppm = &PublicParametersManager{
+		ppm: &mock.PublicParamsManager{},
+		pp: &PublicParameters{
+			PublicParameters: &mock.PublicParameters{},
+		},
+	}
+	pp = ppm.PublicParameters()
 	assert.NotNil(t, pp)
 }
 


### PR DESCRIPTION
This PR allows the developer to define public parameters without issuers for the two available token drivers.
In this case, the redeem will not require an additional signature from the issuer.