### PR TITLE
fix panic error - DeliveryScanQueryByID, ScanFromBlock function

### DIFF
--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -127,7 +127,8 @@ func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (Listener
 			Logger:   logger,
 		},
 		&DeliveryScanQueryByID{
-			Channel: ch,
+			Delivery: ch.Delivery(),
+			Channel:  ch,
 		},
 		p.tracerProvider.Tracer("finality_listener_manager", tracing.WithMetricsOpts(tracing.MetricsOpts{})),
 		p.newMapper(network, channel),


### PR DESCRIPTION
Fix #1224

In `DeliveryScanQueryByID` (`token/services/network/fabric/lookup/deliveryqs.go`), Delivery is not set and can lead to a panic error.