### PR TITLE
Auditor signatures should be verified when len(pp.Auditor) != 0 #1223

### DIFF
--- a/token/core/common/validator_auditing.go
+++ b/token/core/common/validator_auditing.go
@@ -14,13 +14,22 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 )
 
+var (
+	ErrAuditorSignaturesMissing = errors.New("auditor signatures missing")
+	ErrAuditorSignaturesPresent = errors.New("auditor signatures present")
+)
+
 func AuditingSignaturesValidate[P driver.PublicParameters, T any, TA driver.TransferAction, IA driver.IssueAction, DS driver.Deserializer](c context.Context, ctx *Context[P, T, TA, IA, DS]) error {
 	if len(ctx.PP.Auditors()) == 0 {
 		// enforce no auditor signatures are attached
 		if len(ctx.TokenRequest.AuditorSignatures) != 0 {
-			return errors.New("auditor signatures are not empty")
+			return ErrAuditorSignaturesPresent
 		}
 		return nil
+	}
+
+	if len(ctx.TokenRequest.AuditorSignatures) == 0 {
+		return ErrAuditorSignaturesMissing
 	}
 
 	auditors := ctx.PP.Auditors()

--- a/token/core/common/validator_auditing_test.go
+++ b/token/core/common/validator_auditing_test.go
@@ -31,7 +31,7 @@ func TestAuditingSignaturesValidate(t *testing.T) {
 		{
 			name:   "No auditors but token requests with auditor signatures",
 			err:    true,
-			errMsg: "auditor signatures are not empty",
+			errMsg: ErrAuditorSignaturesPresent.Error(),
 			context: func() (*TestContext, TestCheck) {
 				pp := &mock.PublicParameters{}
 				pp.AuditorsReturns(nil)
@@ -101,6 +101,30 @@ func TestAuditingSignaturesValidate(t *testing.T) {
 						},
 					},
 					Deserializer: des,
+				}, nil
+			},
+		},
+		{
+			name:   "it is an auditor but no signatures to verify",
+			err:    true,
+			errMsg: ErrAuditorSignaturesMissing.Error(),
+			context: func() (*TestContext, TestCheck) {
+				auditor := driver.Identity("auditor")
+				pp := &mock.PublicParameters{}
+				pp.AuditorsReturns([]identity.Identity{auditor})
+				ver := &mock.Verifier{}
+				ver.VerifyReturns(errors.New("signature is not valid"))
+				des := &mock.Deserializer{}
+				des.GetAuditorVerifierReturns(ver, nil)
+				sp := &mock.SignatureProvider{}
+				sp.HasBeenSignedByReturns(nil, errors.New("signature is not valid"))
+				return &TestContext{
+					PP: pp,
+					TokenRequest: &driver.TokenRequest{
+						AuditorSignatures: nil,
+					},
+					Deserializer:      des,
+					SignatureProvider: sp,
 				}, nil
 			},
 		},


### PR DESCRIPTION
This PR makes sure that if auditors are in the public parameters, the token request must have at least one auditor signature