### PR TITLE
AcceptView may expose a signing oracle #1233

### DIFF
--- a/token/services/ttx/errors.go
+++ b/token/services/ttx/errors.go
@@ -1,0 +1,18 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ttx
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+var (
+	// ErrFailedCompilingOptions signals a failure when compiling the options
+	ErrFailedCompilingOptions = errors.New("failed to compiling options")
+	// ErrInvalidInput signals that the input is invalid
+	ErrInvalidInput = errors.New("invalid input")
+)

--- a/token/services/ttx/transaction.go
+++ b/token/services/ttx/transaction.go
@@ -35,10 +35,12 @@ type Payload struct {
 type Transaction struct {
 	*Payload
 
-	TMS              *token.ManagementService
-	NetworkProvider  GetNetworkFunc
-	Opts             *TxOptions
-	Context          context.Context
+	TMS             *token.ManagementService
+	NetworkProvider GetNetworkFunc
+	Opts            *TxOptions
+	Context         context.Context
+	// FromRaw contains the raw material used to unmarshall this transaction.
+	// It is nil if the transaction was created from scratch.
 	FromRaw          []byte
 	EndpointResolver *endpoint.Service
 }


### PR DESCRIPTION
This PR reworks `AcceptView`. This view must be used only when no signature is required by the acceptor of tokens.

In another PR we will rework `EndorseView` that is supposed to generate signatures and @ale-linux 's comments are relevant.