### PR TITLE
Add WithRaceDetection flag to integration tests

### DIFF
--- a/integration/token/fungible/dlogx/dlog_test.go
+++ b/integration/token/fungible/dlogx/dlog_test.go
@@ -96,6 +96,7 @@ func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, token
 		i.RegisterPlatformFactory(fabricx.NewPlatformFactory())
 		i.RegisterPlatformFactory(token.NewPlatformFactory(i))
 		i.Generate()
+		
 		return i, nil
 	})
 

--- a/integration/token/fungible/dlogx/dlog_test.go
+++ b/integration/token/fungible/dlogx/dlog_test.go
@@ -89,11 +89,14 @@ func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, token
 			FSCLogSpec:          "grpc=error:info",
 			TokenSelector:       tokenSelector,
 		})...)
+		if err != nil {
+			return nil, err
+		}
+		i.EnableRaceDetector()
 		i.RegisterPlatformFactory(fabricx.NewPlatformFactory())
 		i.RegisterPlatformFactory(token.NewPlatformFactory(i))
 		i.Generate()
-
-		return i, err
+		return i, nil
 	})
 
 	return ts, selector

--- a/integration/token/fungible/dlogx/dlog_test.go
+++ b/integration/token/fungible/dlogx/dlog_test.go
@@ -96,7 +96,7 @@ func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, token
 		i.RegisterPlatformFactory(fabricx.NewPlatformFactory())
 		i.RegisterPlatformFactory(token.NewPlatformFactory(i))
 		i.Generate()
-		
+
 		return i, nil
 	})
 

--- a/integration/token/test_utils.go
+++ b/integration/token/test_utils.go
@@ -120,6 +120,7 @@ func NewTestSuite(startPort func() int, topologies []api.Topology) *TestSuite {
 				return nil, err
 			}
 			i.EnableRaceDetector()
+
 			return i, nil
 		},
 	}
@@ -136,6 +137,7 @@ func NewLocalTestSuite(startPort func() int, topologies []api.Topology) *TestSui
 			}
 			i.EnableRaceDetector()
 			i.DeleteOnStop = false
+			
 			return i, nil
 		},
 	}

--- a/integration/token/test_utils.go
+++ b/integration/token/test_utils.go
@@ -137,7 +137,7 @@ func NewLocalTestSuite(startPort func() int, topologies []api.Topology) *TestSui
 			}
 			i.EnableRaceDetector()
 			i.DeleteOnStop = false
-			
+
 			return i, nil
 		},
 	}

--- a/integration/token/test_utils.go
+++ b/integration/token/test_utils.go
@@ -115,7 +115,12 @@ func replicaName(name string, idx int) string {
 func NewTestSuite(startPort func() int, topologies []api.Topology) *TestSuite {
 	return &TestSuite{
 		generator: func() (*integration.Infrastructure, error) {
-			return integration.New(startPort(), "", topologies...)
+			i, err := integration.New(startPort(), "", topologies...)
+			if err != nil {
+				return nil, err
+			}
+			i.EnableRaceDetector()
+			return i, nil
 		},
 	}
 }
@@ -126,9 +131,12 @@ func NewLocalTestSuite(startPort func() int, topologies []api.Topology) *TestSui
 	return &TestSuite{
 		generator: func() (*integration.Infrastructure, error) {
 			i, err := integration.New(startPort(), "./testdata", topologies...)
+			if err != nil {
+				return nil, err
+			}
+			i.EnableRaceDetector()
 			i.DeleteOnStop = false
-
-			return i, err
+			return i, nil
 		},
 	}
 }


### PR DESCRIPTION
- Use EnableRaceDetector() after integration.New() to enable race detection
- This approach allows platform factories to be registered before Generate() is called

This solves [#1151](https://github.com/hyperledger-labs/fabric-token-sdk/issues/1151)