### PR TITLE
github action: golangci-lint v2.8 

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,5 +27,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.8
           args: --timeout=30m


### PR DESCRIPTION
This PR moves to golangci-lint v2.8 in the relative github action