### PR TITLE
fix(gha): pin docker version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,14 @@ jobs:
         ]
 
     steps:
+      - run: docker version
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v4
+        with:
+          version: 28.5.2 # we pin the docker version temporary until the release of fabric v3.1.4
+          set-host: true
+      - run: docker version
+        
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Docker v29 causes some issue with current Fabric versions. This commit pins the version of docker used in GHA temporary until a new release of Fabric is available.