### PR TITLE
Performance changes to the range proof verifier:

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/ipa.go
@@ -40,7 +40,6 @@ func (ipa *IPA) Serialize() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to serialize R")
 	}
-
 	return asn1.MarshalMath(ipa.Left, ipa.Right, lArray, rArray)
 }
 
@@ -65,7 +64,6 @@ func (ipa *IPA) Deserialize(raw []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to deserialize R")
 	}
-
 	return nil
 }
 
@@ -88,7 +86,6 @@ func (ipa *IPA) Validate(curve mathlib.CurveID) error {
 	if err := math.CheckZrElements(ipa.R, curve, uint64(len(ipa.R))); err != nil {
 		return errors.Wrapf(err, "invalid IPA proof: invalid R elements")
 	}
-
 	return nil
 }
 
@@ -169,7 +166,6 @@ func (p *ipaProver) Prove() (*IPA, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return &IPA{Left: left, Right: right, R: RArray, L: LArray}, nil
 }
 
@@ -225,7 +221,6 @@ func (p *ipaProver) reduce(X, com *mathlib.G1) (*mathlib.Zr, *mathlib.Zr, []*mat
 		// com = L^{x^2}*com*R^{1/x^2}
 		com = CPrime
 	}
-
 	return left[0], right[0], LArray, RArray, nil
 }
 
@@ -301,7 +296,13 @@ func (v *ipaVerifier) Verify(proof *IPA) error {
 	X := v.Q.Mul(x)
 
 	leftGen, rightGen := cloneGenerators(v.LeftGenerators, v.RightGenerators)
+	xSquareList := make([]*mathlib.Zr, v.NumberOfRounds)
+	xSquareInvList := make([]*mathlib.Zr, v.NumberOfRounds)
+	xList := make([]*mathlib.Zr, v.NumberOfRounds)
 
+	// Verifier will not fold the generators in each round, and will instead
+	// compute the challenge determined folded generators in the final round.
+	// See: Page 17, Section 3, https://eprint.iacr.org/2017/1066.pdf
 	for i := range v.NumberOfRounds {
 		// check well-formedness
 		if proof.L[i] == nil || proof.R[i] == nil {
@@ -314,29 +315,54 @@ func (v *ipaVerifier) Verify(proof *IPA) error {
 			return err
 		}
 		x = v.Curve.HashToZr(raw)
+		xList[i] = x.Copy()
 		// 1/x
 		xInv := x.Copy()
 		xInv.InvModOrder()
 
 		// x^2
 		xSquare := v.Curve.ModMul(x, x, v.Curve.GroupOrder)
+		xSquareList[i] = xSquare.Copy()
+		xSquareList[i].Neg()
 		// 1/x^2
 		xSquareInv := xSquare.Copy()
 		xSquareInv.InvModOrder()
-		// compute a commitment to the reduced vectors and their inner product
-		CPrime := proof.L[i].Mul2(xSquare, proof.R[i], xSquareInv)
-		CPrime.Add(C)
-		C = CPrime.Copy()
-		// reduce the generators by 1/2, as a function of the old generators and x and 1/x
-		leftGen, rightGen = reduceGenerators(leftGen, rightGen, x, xInv)
+		xSquareInvList[i] = xSquareInv.Copy()
+		xSquareInvList[i].Neg()
 	}
-	// compute a commitment to left, right and their product
-	CPrime := leftGen[0].Mul2(proof.Left, rightGen[0], proof.Right)
-	CPrime.Add(X.Mul(v.Curve.ModMul(proof.Left, proof.Right, v.Curve.GroupOrder)))
+	// Prepare final MSM to compute folded generators
+	// - generators: leftGen||rightGen||proof.L||proof.R||X
+	// - scalars:    proof.Left.s || proof.Right.s^{-1} || xsquareInvList || xSqureList || proof.Left * proof.Right
+	generators := make([]*mathlib.G1, len(leftGen)+len(rightGen)+len(proof.L)+len(proof.R)+1)
+	scalars := make([]*mathlib.Zr, len(generators))
+	s, sInv := computeSVector(1<<v.NumberOfRounds, xList, v.Curve)
+	for i := 0; i < len(s); i++ {
+		s[i] = v.Curve.ModMul(s[i], proof.Left, v.Curve.GroupOrder)
+		sInv[i] = v.Curve.ModMul(sInv[i], proof.Right, v.Curve.GroupOrder)
+	}
+	idx := 0
+	copy(generators[idx:], leftGen)
+	copy(scalars[idx:], s)
+	idx += len(leftGen)
+
+	copy(generators[idx:], rightGen)
+	copy(scalars[idx:], sInv)
+	idx += len(rightGen)
+
+	copy(generators[idx:], proof.L)
+	copy(scalars[idx:], xSquareList)
+	idx += len(proof.L)
+
+	copy(generators[idx:], proof.R)
+	copy(scalars[idx:], xSquareInvList)
+	idx += len(proof.R)
+
+	generators[idx] = X.Copy()
+	scalars[idx] = v.Curve.ModMul(proof.Left, proof.Right, v.Curve.GroupOrder)
+	CPrime := v.Curve.MultiScalarMul(generators, scalars)
 	if !CPrime.Equals(C) {
 		return errors.New("invalid IPA")
 	}
-
 	return nil
 }
 
@@ -346,7 +372,7 @@ func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Cu
 	l := len(left) / 2
 	leftPrime := make([]*mathlib.Zr, l)
 	rightPrime := make([]*mathlib.Zr, l)
-	for i := range l {
+	for i := 0; i < l; i++ {
 		// a_i = a_ix + a_{i+len(left)/2}x^{-1}
 		leftPrime[i] = c.ModAddMul2(left[i], x, left[i+l], xInv, c.GroupOrder)
 
@@ -361,13 +387,12 @@ func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Cu
 // as a function of the old generators,  x and 1/x
 func reduceGenerators(leftGen, rightGen []*mathlib.G1, x, xInv *mathlib.Zr) ([]*mathlib.G1, []*mathlib.G1) {
 	l := len(leftGen) / 2
-	for i := range l {
-		// G_i = G_i^x*G_{i+len(left)/2}^{1/x}
+	for i := 0; i < l; i++ {
+		// G_i = G_i^{x_inv}*G_{i+len(left)/2}^x
 		leftGen[i].Mul2InPlace(xInv, leftGen[i+l], x)
-		// H_i = H_i^{1/x}*H_{i+len(right)/2}^{x}
+		// H_i = H_i^{x}*H_{i+len(right)/2}^{x_inv}
 		rightGen[i].Mul2InPlace(x, rightGen[i+l], xInv)
 	}
-
 	return leftGen[:l], rightGen[:l]
 }
 
@@ -417,13 +442,96 @@ func commitVectorPlusOne(
 
 func cloneGenerators(LeftGenerators, RightGenerators []*mathlib.G1) ([]*mathlib.G1, []*mathlib.G1) {
 	leftGen := make([]*mathlib.G1, len(LeftGenerators))
-	for i := range LeftGenerators {
+	for i := 0; i < len(LeftGenerators); i++ {
 		leftGen[i] = LeftGenerators[i].Copy()
 	}
 	rightGen := make([]*mathlib.G1, len(RightGenerators))
-	for i := range RightGenerators {
+	for i := 0; i < len(RightGenerators); i++ {
 		rightGen[i] = RightGenerators[i].Copy()
 	}
-
 	return leftGen, rightGen
+}
+
+// computeSVector computes the s vector and its entry-wise inverse of s as detailed below:
+// b(i,j) = 1 if (logn - j)^{th} bit of i-1 is 1, else its -1
+// s[i] = \prod_{j=1}^{\log n} x_j^{bits(i,j)}
+// sInv[i] = s[i].Inverse
+// Input: n, challenges = [x_1,\ldots,x_{\log n}]
+// Returns (s, sInv) where sInv[i] = s[i]^{-1}, computed via batch inversion.
+func computeSVector(n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, []*mathlib.Zr) {
+	log2n := len(challenges)
+
+	// Verify n is consistent with number of challenges
+	if 1<<log2n != n {
+		panic("n must equal 2^(number of challenges)")
+	}
+
+	// Precompute challenge inverses (log2n inversions instead of O(n*log2n))
+	challengeInvs := BatchInverse(challenges, curve)
+
+	s := make([]*mathlib.Zr, n)
+
+	for i := 1; i <= n; i++ {
+		// Start with s_i = 1
+		si := curve.NewZrFromInt(1)
+
+		// Compute product over j=1 to log2(n).
+		// At round j the generator fold splits on bit (log2n - j) of the
+		// 0-based index: first half (bit=0) picks up x_j^{-1}, second
+		// half (bit=1) picks up x_j — matching reduceGenerators.
+		for j := 1; j <= log2n; j++ {
+			bitPosition := log2n - j
+			iMinus1 := i - 1
+			bitIsSet := (iMinus1 >> bitPosition) & 1
+
+			var factor *mathlib.Zr
+			if bitIsSet == 1 {
+				// second half at round j => x_j
+				factor = challenges[j-1]
+			} else {
+				// first half at round j => x_j^{-1}
+				factor = challengeInvs[j-1]
+			}
+
+			// Multiply: s_i *= factor
+			si = curve.ModMul(si, factor, curve.GroupOrder)
+		}
+
+		s[i-1] = si
+	}
+	sInv := BatchInverse(s, curve)
+	return s, sInv
+}
+
+// BatchInverse computes the entry-wise modular inverse of elems using
+// Montgomery's trick: a single InvModOrder call plus O(n) multiplications.
+// todo! Perhaps this can be added to mathlib.
+func BatchInverse(elems []*mathlib.Zr, curve *mathlib.Curve) []*mathlib.Zr {
+	n := len(elems)
+	if n == 0 {
+		return nil
+	}
+
+	inv := make([]*mathlib.Zr, n)
+
+	// Forward pass: build prefix products
+	// prefixProd[i] = elems[0] * elems[1] * ... * elems[i]
+	prefixProd := make([]*mathlib.Zr, n)
+	prefixProd[0] = elems[0].Copy()
+	for i := 1; i < n; i++ {
+		prefixProd[i] = curve.ModMul(prefixProd[i-1], elems[i], curve.GroupOrder)
+	}
+
+	// Single inversion of the total product
+	acc := prefixProd[n-1].Copy()
+	acc.InvModOrder()
+
+	// Backward pass: extract individual inverses
+	for i := n - 1; i >= 1; i-- {
+		inv[i] = curve.ModMul(prefixProd[i-1], acc, curve.GroupOrder)
+		acc = curve.ModMul(acc, elems[i], curve.GroupOrder)
+	}
+	inv[0] = acc
+
+	return inv
 }


### PR DESCRIPTION
- During the inner product argument (ipa.go) verification, we save group-exponentiations by delaying verifier's computation of folded generators. Instead of folding in each round which incurs 4n group-exp, we do a final MSM of size 2n + 2\log n.
- Auxiliary functions to help efficiency: Batch modular inversion and computation of scalar vector for final MSM (computeSVector).
- Speeds up verifier by around a factor of 2x