### PR TITLE
Optimisations to IPA verifier. Defer folding of generators until fina…

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/ipa.go
@@ -36,6 +36,7 @@ func (ipa *IPA) Serialize() ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to serialize R")
 	}
+
 	return asn1.MarshalMath(ipa.Left, ipa.Right, lArray, rArray)
 }
 
@@ -61,6 +62,7 @@ func (ipa *IPA) Deserialize(raw []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to deserialize R")
 	}
+
 	return nil
 }
 
@@ -84,6 +86,7 @@ func (ipa *IPA) Validate(curve mathlib.CurveID) error {
 	if err := math.CheckZrElements(ipa.R, curve, uint64(len(ipa.R))); err != nil {
 		return errors.Wrapf(err, "invalid IPA proof: invalid R elements")
 	}
+
 	return nil
 }
 
@@ -161,6 +164,7 @@ func (p *ipaProver) Prove() (*IPA, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &IPA{Left: left, Right: right, R: RArray, L: LArray}, nil
 }
 
@@ -216,6 +220,7 @@ func (p *ipaProver) reduce(X, com *mathlib.G1) (*mathlib.Zr, *mathlib.Zr, []*mat
 		// com = L^{x^2}*com*R^{1/x^2}
 		com = CPrime
 	}
+
 	return left[0], right[0], LArray, RArray, nil
 }
 
@@ -355,6 +360,7 @@ func (v *ipaVerifier) Verify(proof *IPA) error {
 	if !CPrime.Equals(C) {
 		return errors.New("invalid IPA")
 	}
+
 	return nil
 }
 
@@ -364,7 +370,7 @@ func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Cu
 	l := len(left) / 2
 	leftPrime := make([]*mathlib.Zr, l)
 	rightPrime := make([]*mathlib.Zr, l)
-	for i := 0; i < l; i++ {
+	for i := range l {
 		// a_i = a_ix + a_{i+len(left)/2}x^{-1}
 		leftPrime[i] = c.ModAddMul2(left[i], x, left[i+l], xInv, c.GroupOrder)
 
@@ -379,12 +385,13 @@ func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Cu
 // as a function of the old generators,  x and 1/x
 func reduceGenerators(leftGen, rightGen []*mathlib.G1, x, xInv *mathlib.Zr) ([]*mathlib.G1, []*mathlib.G1) {
 	l := len(leftGen) / 2
-	for i := 0; i < l; i++ {
+	for i := range l {
 		// G_i = G_i^{x_inv}*G_{i+len(left)/2}^x
 		leftGen[i].Mul2InPlace(xInv, leftGen[i+l], x)
 		// H_i = H_i^{x}*H_{i+len(right)/2}^{x_inv}
 		rightGen[i].Mul2InPlace(x, rightGen[i+l], xInv)
 	}
+
 	return leftGen[:l], rightGen[:l]
 }
 
@@ -434,13 +441,14 @@ func commitVectorPlusOne(
 
 func cloneGenerators(LeftGenerators, RightGenerators []*mathlib.G1) ([]*mathlib.G1, []*mathlib.G1) {
 	leftGen := make([]*mathlib.G1, len(LeftGenerators))
-	for i := 0; i < len(LeftGenerators); i++ {
+	for i := range LeftGenerators {
 		leftGen[i] = LeftGenerators[i].Copy()
 	}
 	rightGen := make([]*mathlib.G1, len(RightGenerators))
-	for i := 0; i < len(RightGenerators); i++ {
+	for i := range RightGenerators {
 		rightGen[i] = RightGenerators[i].Copy()
 	}
+
 	return leftGen, rightGen
 }
 
@@ -492,6 +500,7 @@ func computeSVector(n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*m
 		s[i-1] = si
 	}
 	sInv := BatchInverse(s, curve)
+
 	return s, sInv
 }
 


### PR DESCRIPTION
Defer folding of generators in IPA verifier to final round. Use 2n sized MSM to compute folded generators instead of 4n group-exp while folding with rounds. Gives about 2x speed-up