### PR TITLE
fix flaky FAIL: TestSufficientTokensBigDenominationsOneReplica #1363

### DIFF
--- a/token/services/selector/sherdlock/manager_test.go
+++ b/token/services/selector/sherdlock/manager_test.go
@@ -35,7 +35,7 @@ func TestSufficientTokensOneReplicaNoRetry(t *testing.T) {
 }
 
 func TestSufficientTokensBigDenominationsOneReplica(t *testing.T) {
-	replicas, terminate := startManagers(t, 1, time.Second, 5)
+	replicas, terminate := startManagers(t, 1, time.Second, 20)
 	defer terminate()
 	testutils.TestSufficientTokensBigDenominationsOneReplica(t, replicas[0])
 }

--- a/token/services/selector/testutils/test_cases.go
+++ b/token/services/selector/testutils/test_cases.go
@@ -221,9 +221,9 @@ func parallelSelect(t *testing.T, replicas []EnhancedManager, quantities []token
 					assert.NotEmpty(t, tokens)
 					require.NoError(t, deleteTokensAndStoreChange(replica, tokens, change))
 				}
-				if tokenSum, err := replica.TokenSum(); err == nil {
-					logger.Infof("Current sum of tokens in the DB: %s", tokenSum.Decimal())
-				}
+				// if tokenSum, err := replica.TokenSum(); err == nil {
+				// 	logger.Infof("Current sum of tokens in the DB: %s", tokenSum.Decimal())
+				// }
 				wg.Done()
 			}()
 		}


### PR DESCRIPTION
The fix consists of increase the number of retries. Running with race condition detection introduces slow downs that might require more chances to retry.