### PR TITLE
ci: add bench-check job to validate benchmark compilation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,7 +169,7 @@ jobs:
           make fxconfig configtxgen fabricx-docker-images
 
       - name: Run ${{ matrix.tests }}
-      
+
         run: |
           mkdir -p covdata
           GOCOVERDIR=$(realpath covdata) make integration-tests-${{ matrix.tests }}
@@ -191,7 +191,7 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           parallel-finished: true
-        run: make integration-tests-${{ matrix.tests }}
+        
   bench-check:
     needs: checks
     runs-on: ubuntu-latest
@@ -211,4 +211,4 @@ jobs:
 
       - name: Compile benchmarks (do not run)
         run: go test ./... -run=^$ -bench=^$
-ecb1d261 (ci: add bench-check job to compile benchmarks in CI without executing them)
+


### PR DESCRIPTION
## Description

This PR adds a `bench-check` job to the CI pipeline to ensure that benchmark files compile successfully without executing them.

As discussed in #1300, we do not want to run benchmarks in CI to measure performance. Instead, we only validate that:

- All benchmark functions compile correctly
- No build errors are introduced in benchmark code

## Changes

- Added a new `bench-check` job in `.github/workflows/tests.yml`
- The job runs:

  ```bash
  go test ./... -run=^$ -bench=^$