### PR TITLE
fix(ci): coveralls is down

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,11 +75,13 @@ jobs:
           ./ci/scripts/filter-coverage.sh profile.cov profile.cov
 
       - name: Send coverage to Coveralls
-        uses: shogo82148/actions-goveralls@v1
+        uses: coverallsapp/github-action@v2
         with:
-          path-to-profile: profile.cov
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: profile.cov
           flag-name: utest-${{ matrix.tests }}
           parallel: true
+          fail-on-error: false
 
       - name: Run ${{ matrix.tests }}
         run: make ${{ matrix.tests }}
@@ -177,20 +179,24 @@ jobs:
           ./ci/scripts/filter-coverage.sh coverage.profile coverage.profile
 
       - name: Send coverage to Coveralls
-        uses: shogo82148/actions-goveralls@v1
+        uses: coverallsapp/github-action@v2
         with:
-          path-to-profile: coverage.profile
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.profile
           flag-name: itest-${{ matrix.tests }}
           parallel: true
+          fail-on-error: false
 
   publish-coverage:
     needs: [ utest, itest ]
     runs-on: ubuntu-latest
     steps:
       - name: Finish coverage report
-        uses: shogo82148/actions-goveralls@v1
+        uses: coverallsapp/github-action@v2
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
+          fail-on-error: false
         
   bench-check:
     needs: checks


### PR DESCRIPTION
This PR fixes the current issue with coveralls (https://status.coveralls.io/). 
The PR switches to `coverallsapp/github-action@v2` and set `fail-on-error: false`.