### PR TITLE
config: clarify minimal token-sdk configuration and required fields

### DIFF
--- a/docs/core-token.md
+++ b/docs/core-token.md
@@ -1,3 +1,25 @@
+## Minimal Token-SDK Configuration
+
+The Token SDK can start with the following minimal configuration:
+
+```yaml
+token:
+  enabled: true
+  tms:
+    default:
+      network: mynetwork
+      namespace: mynamespace
+```
+
+### Required Fields
+
+The following fields are strictly required:
+
+- `network`
+- `namespace`
+
+All other configuration sections are optional and use sensible defaults.
+
 # Example core.yaml section
 
 The following example provides descriptions for the various keys required by the Token SDK.

--- a/token/services/config/configuration.go
+++ b/token/services/config/configuration.go
@@ -41,10 +41,10 @@ func NewConfiguration(cp Provider, keyID string, tmsID driver.TMSID) *Configurat
 func (m *Configuration) Validate() error {
 	// check TMS ID
 	if len(m.tmsID.Network) == 0 {
-		return errors.New("missing network id")
+		return errors.New("token-sdk configuration error: missing required field 'network'")
 	}
 	if len(m.tmsID.Namespace) == 0 {
-		return errors.New("missing namespace id")
+		return errors.New("token-sdk configuration error: missing required field 'namespace'")
 	}
 
 	for _, validator := range m.validators {


### PR DESCRIPTION
This PR clarifies the minimal configuration required to start the token-sdk.

The SDK requires only:
- network
- namespace

All other configuration sections are optional and use default values.

Changes:
- Improved validation error messages for required fields.
- Added a documented minimal configuration example to docs/core-token.md.

No functional changes.

Fixes #852