### PR TITLE
Fix: handle NOT_VALIDATED status in ledger.Status()

### DIFF
--- a/token/services/network/fabricx/ledger.go
+++ b/token/services/network/fabricx/ledger.go
@@ -41,7 +41,7 @@ func NewLedger(ch *fabric.Channel, keyTranslator translator.KeyTranslator, execu
 
 // Status returns the validation code of the transaction with the given ID.
 // It retrieves the transaction from the Fabric ledger and maps its internal
-// validation code to a driver.ValidationCode (Valid or Invalid).
+// validation code to a driver.ValidationCode (Unknown, Valid, or Invalid).
 func (l *ledger) Status(id string) (driver.ValidationCode, error) {
 	tx, err := l.l.GetTransactionByID(id)
 	if err != nil {
@@ -50,6 +50,8 @@ func (l *ledger) Status(id string) (driver.ValidationCode, error) {
 	logger.Debugf("ledger status of [%s] is [%d]", id, tx.ValidationCode())
 
 	switch protoblocktx.Status(tx.ValidationCode()) {
+	case protoblocktx.Status_NOT_VALIDATED:
+		return driver.Unknown, nil
 	case protoblocktx.Status_COMMITTED:
 		return driver.Valid, nil
 	default:


### PR DESCRIPTION
### Problem

I noticed that `ledger.Status()` in the FabricX package doesn’t handle the `NOT_VALIDATED` state. When a transaction is still waiting to be committed (which can happen during normal block processing or orderer delays), it falls into the default case and gets marked as `Invalid` , even though it hasn’t failed.

```go
// Before - NOT_VALIDATED falls into default
switch protoblocktx.Status(tx.ValidationCode()) {
case protoblocktx.Status_COMMITTED:
    return driver.Valid, nil
default:
    return driver.Invalid, nil
}
```

Interestingly, the finality service in the same package already handles this correctly:

```go
case protoblocktx.Status_NOT_VALIDATED:
    return fdriver.Unknown
```

So right now two parts of the system interpret the same state differently.

---

### Impact

* Pending transactions **may be reported as `Invalid`** even though they are still in-flight
* The consistency checker **could potentially raise warnings** like *“transaction record is valid for vault but not for the ledger”* for transactions that haven’t finalized yet
* Callers of `Ledger.Status()` **might interpret the result as a failure**, even though the transaction is simply not validated yet

---

### Fix

I added the missing `NOT_VALIDATED` case so pending transactions return `Unknown`. It’s a small change but keeps `ledger.Status()` consistent with the finality service and avoids false failure signals.
