### PR TITLE
CI docker fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,14 +139,6 @@ jobs:
         ]
 
     steps:
-      - run: docker version
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-        with:
-          version: 28.5.2 # we pin the docker version temporary until the release of fabric v3.1.4
-          set-host: true
-      - run: docker version
-        
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # pinned versions
-FABRIC_VERSION ?= 3.1.1
+FABRIC_VERSION ?= 3.1.4
 FABRIC_CA_VERSION ?= 1.5.7
 FABRIC_TWO_DIGIT_VERSION = $(shell echo $(FABRIC_VERSION) | cut -d '.' -f 1,2)
 FABRIC_X_TOOLS_VERSION ?= v0.0.6


### PR DESCRIPTION
This PR switches to Fabric 3.1.4 that doesn't have the problem with the CI docker version. So we don't need to override the docker version used in the CI.
