### PR TITLE
Fix: Panic in finality notifications due to send on closed channel

### DIFF
--- a/token/services/storage/db/common/status.go
+++ b/token/services/storage/db/common/status.go
@@ -93,6 +93,25 @@ func (c *StatusSupport) Notify(event StatusEvent) {
 	c.mutex.RUnlock()
 
 	for _, listener := range clone {
-		listener <- event
+		c.safeSend(event, listener)
+	}
+}
+
+// safeSend sends the event to the listener channel without blocking indefinitely
+// and without panicking if the channel has been concurrently closed by its consumer.
+// After the RLock in Notify is released, a consumer may call DeleteStatusListener
+// followed by close(ch). A bare send would panic on a closed channel, and a blocking
+// send without a context guard could block forever if the buffer is full and the
+// consumer has departed. This method handles both cases.
+func (c *StatusSupport) safeSend(event StatusEvent, listener chan StatusEvent) {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.WarnfContext(event.Ctx, "listener channel closed for tx [%s], skipping", event.TxID)
+		}
+	}()
+	select {
+	case listener <- event:
+	case <-event.Ctx.Done():
+		logger.WarnfContext(event.Ctx, "context canceled while notifying listener for tx [%s]", event.TxID)
 	}
 }

--- a/token/services/storage/db/common/status_test.go
+++ b/token/services/storage/db/common/status_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -183,6 +184,89 @@ func TestMapCleanupAfterManyTransactions(t *testing.T) {
 	}
 
 	t.Logf("Map properly cleaned up: %d entries (expected 0)", mapSize)
+}
+
+func TestNotifyClosedChannelDoesNotPanic(t *testing.T) {
+	// Regression test: Notify must not panic when a consumer closes its channel
+	// after the listener slice is cloned but before the send executes.
+	ss := NewStatusSupport()
+	txID := "txClosedCh"
+
+	ch1 := make(chan StatusEvent, 1)
+	ch2 := make(chan StatusEvent, 1)
+	ss.AddStatusListener(txID, ch1)
+	ss.AddStatusListener(txID, ch2)
+
+	// Simulate the consumer departing: close ch1 before Notify sends to it.
+	// Delete from map first (as dbFinality's defer does), then close.
+	ss.DeleteStatusListener(txID, ch1)
+	close(ch1)
+
+	event := StatusEvent{
+		Ctx:               t.Context(),
+		TxID:              txID,
+		ValidationCode:    0,
+		ValidationMessage: "should not panic",
+	}
+
+	// Notify should not panic even though ch1 is closed.
+	// ch1 is still in the clone because DeleteStatusListener races with Notify
+	// in production; here we force the issue by keeping ch1 in the slice via
+	// a second AddStatusListener call with a fresh reference.
+	// Instead, directly call safeSend to prove it handles closed channels.
+	ss.safeSend(event, ch1) // must not panic
+
+	// ch2 must still receive the event when Notify is called.
+	go ss.Notify(event)
+	select {
+	case e := <-ch2:
+		if e.TxID != txID {
+			t.Fatalf("Unexpected TxID: %s", e.TxID)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("ch2 should have received the event")
+	}
+
+	ss.DeleteStatusListener(txID, ch2)
+}
+
+func TestNotifyContextCanceled(t *testing.T) {
+	// Notify must not block forever if the context is canceled and the channel
+	// buffer is full.
+	ss := NewStatusSupport()
+	txID := "txCtxCancel"
+
+	ch := make(chan StatusEvent, 1)
+	ss.AddStatusListener(txID, ch)
+
+	// Fill the buffer so the next send would block.
+	ch <- StatusEvent{TxID: "filler"}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel immediately
+
+	event := StatusEvent{
+		Ctx:               ctx,
+		TxID:              txID,
+		ValidationCode:    0,
+		ValidationMessage: "ctx done",
+	}
+
+	// Notify should return promptly because ctx is already canceled.
+	done := make(chan struct{})
+	go func() {
+		ss.Notify(event)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// success — Notify did not block
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Notify blocked despite canceled context")
+	}
+
+	ss.DeleteStatusListener(txID, ch)
 }
 
 func TestMapGrowthWithMultipleListenersPerTx(t *testing.T) {


### PR DESCRIPTION
### Summary

While working on the finality notification path, I found a race condition where `StatusSupport.Notify` could send on a channel that was concurrently closed by the consumer. This leads to a **panic (`send on closed channel`)**, which crashes the event worker and drops notifications for remaining listeners.

---

### Impact

This issue is more than just a panic:

* A single closed channel **aborts the entire Notify loop**, so other listeners never receive the event.
* The panic **propagates up the finality event pipeline**, crashing the worker (no recovery in retry runner).
* The DB state is already updated, but the notification is lost → **inconsistent behavior** (e.g., transaction committed but reported as failed).
* The blocking send (`listener <- event`) can **deadlock workers** if the channel buffer is full.

---

### Root Cause

The core issue is **unsynchronized channel ownership**:

* Producer (`Notify`) sends on channels
* Consumer (`dbFinality`) closes them
* After releasing the lock, there’s **no guarantee the channel is still open**

The RWMutex only protects the map, **not the channel lifecycle**.

---

### Fix

I replaced the unsafe blocking send with a guarded helper (`safeSend`) that:

* Recovers from `send on closed channel`
* Avoids indefinite blocking using context cancellation

```go
func safeSend(ctx context.Context, ch chan StatusEvent, event StatusEvent) {
    defer func() {
        if r := recover(); r != nil {
            logger.Warnf("listener channel closed, skipping")
        }
    }()

    select {
    case ch <- event:
    case <-ctx.Done():
    }
}
```

And in `Notify`:

```go
for _, listener := range clone {
    safeSend(event.Ctx, listener, event)
}
```

---

### Result

With this change:

* No more panics from closed channels
* Each listener is handled independently (no cascade failure)
* Workers don’t get stuck on blocked sends
* Notification delivery becomes **best-effort and resilient**