### PR TITLE
 Fix: unbounded exponential backoff in `Listener.OnStatus` permanently stalls finality pipeline

### DIFF
--- a/token/services/ttx/finality/listener.go
+++ b/token/services/ttx/finality/listener.go
@@ -61,7 +61,7 @@ func (t *Listener) OnError(ctx context.Context, txID string, err error) {
 func (t *Listener) OnStatus(ctx context.Context, txID string, status int, message string, tokenRequestHash []byte) {
 	newCtx, span := t.tracer.Start(ctx, "on_status")
 	defer span.End()
-	if err := t.retryRunner.Run(func() error {
+	if err := t.retryRunner.RunWithContext(newCtx, func() error {
 		err := t.runOnStatus(newCtx, txID, status, message, tokenRequestHash)
 		if err != nil {
 			t.logger.Errorf("finality listener on [%s] failed with error: [%+v], retrying...", txID, err)

--- a/token/services/ttx/finality/listener_test.go
+++ b/token/services/ttx/finality/listener_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx/dep/mock"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx/finality"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// stubTxDB is a minimal transactionDB implementation for testing.
+type stubTxDB struct {
+	getTokenRequestFn func(ctx context.Context, txID string) ([]byte, error)
+	setStatusFn       func(ctx context.Context, txID string, status storage.TxStatus, message string) error
+}
+
+func (s *stubTxDB) GetTokenRequest(ctx context.Context, txID string) ([]byte, error) {
+	if s.getTokenRequestFn != nil {
+		return s.getTokenRequestFn(ctx, txID)
+	}
+
+	return nil, nil
+}
+
+func (s *stubTxDB) SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error {
+	if s.setStatusFn != nil {
+		return s.setStatusFn(ctx, txID, status, message)
+	}
+
+	return nil
+}
+
+func noopTracer() trace.Tracer {
+	return noop.NewTracerProvider().Tracer("")
+}
+
+func listenerLogger() logging.Logger {
+	return logging.MustGetLogger()
+}
+
+// newTestListener builds a Listener wired with the given ttxDB stub.
+// tokens.Service is nil because the test cases below never reach the token-append path.
+func newTestListener(t *testing.T, db *stubTxDB) *finality.Listener {
+	t.Helper()
+
+	return finality.NewListener(
+		listenerLogger(),
+		&mock.Network{},
+		"test-namespace",
+		&mock.TokenManagementServiceProvider{},
+		token.TMSID{Network: "n", Channel: "c", Namespace: "ns"},
+		db,
+		nil, // tokens.Service — not accessed for network.Invalid status
+		noopTracer(),
+	)
+}
+
+// TestOnStatus_ContextCanceledDuringRetry is the primary regression test.
+//
+// Setup: ttxDB.SetStatus always returns a transient error, so the inner retryRunner
+// would spin forever under the old code (unbounded exponential backoff, no context check).
+//
+// The fix: RunWithContext is used, so canceling the context unblocks the sleeping
+// retry loop and OnStatus returns promptly.
+func TestOnStatus_ContextCanceledDuringRetry(t *testing.T) {
+	var setCalls atomic.Int32
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, _ string, _ storage.TxStatus, _ string) error {
+			setCalls.Add(1)
+
+			return errors.New("db unavailable")
+		},
+	}
+	l := newTestListener(t, db)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		// network.Invalid → runOnStatus sets txStatus=Deleted, then calls SetStatus.
+		// SetStatus always fails → retry loop engages.
+		l.OnStatus(ctx, "tx1", network.Invalid, "validation failed", nil)
+	}()
+
+	// Allow at least one SetStatus call before canceling.
+	require.Eventually(t, func() bool { return setCalls.Load() >= 1 }, time.Second, 10*time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// good: OnStatus returned after context was canceled
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnStatus did not return after context cancellation — worker goroutine would be permanently stuck")
+	}
+}
+
+// TestOnStatus_SucceedsAfterTransientError verifies that OnStatus retries correctly
+// and completes successfully once the transient error resolves.
+func TestOnStatus_SucceedsAfterTransientError(t *testing.T) {
+	var setCalls atomic.Int32
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, _ string, _ storage.TxStatus, _ string) error {
+			n := setCalls.Add(1)
+			if n < 3 {
+				return errors.New("transient db error")
+			}
+
+			return nil
+		},
+	}
+	l := newTestListener(t, db)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		l.OnStatus(t.Context(), "tx1", network.Invalid, "validation failed", nil)
+	}()
+
+	select {
+	case <-done:
+		assert.GreaterOrEqual(t, int(setCalls.Load()), 3, "should have retried at least 3 times")
+	case <-time.After(5 * time.Second):
+		t.Fatal("OnStatus did not complete after transient errors resolved")
+	}
+}
+
+// TestOnStatus_CompletesImmediatelyOnSuccess verifies the happy path:
+// when SetStatus succeeds on the first try, OnStatus returns without any retries.
+func TestOnStatus_CompletesImmediatelyOnSuccess(t *testing.T) {
+	var setCalls atomic.Int32
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, _ string, _ storage.TxStatus, _ string) error {
+			setCalls.Add(1)
+
+			return nil
+		},
+	}
+	l := newTestListener(t, db)
+
+	l.OnStatus(t.Context(), "tx1", network.Invalid, "invalid", nil)
+
+	assert.Equal(t, int32(1), setCalls.Load())
+}
+
+// TestOnStatus_ConcurrentCallsAreIndependent verifies that concurrent OnStatus calls
+// for different transactions do not interfere with each other.
+func TestOnStatus_ConcurrentCallsAreIndependent(t *testing.T) {
+	var mu sync.Mutex
+
+	statusSet := map[string]bool{}
+
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, txID string, _ storage.TxStatus, _ string) error {
+			mu.Lock()
+			statusSet[txID] = true
+			mu.Unlock()
+
+			return nil
+		},
+	}
+	l := newTestListener(t, db)
+
+	txIDs := []string{"tx1", "tx2", "tx3", "tx4", "tx5"}
+
+	var wg sync.WaitGroup
+
+	for _, txID := range txIDs {
+		wg.Add(1)
+
+		go func(id string) {
+			defer wg.Done()
+			l.OnStatus(t.Context(), id, network.Invalid, "invalid", nil)
+		}(txID)
+	}
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	for _, id := range txIDs {
+		assert.True(t, statusSet[id], "tx %s should have had its status set", id)
+	}
+}
+
+// TestOnStatus_PreCanceledContextReturnsImmediately verifies that a pre-canceled context
+// causes OnStatus to return before the first retry sleep, not after it.
+func TestOnStatus_PreCanceledContextReturnsImmediately(t *testing.T) {
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, _ string, _ storage.TxStatus, _ string) error {
+			return errors.New("always fails")
+		},
+	}
+	l := newTestListener(t, db)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before calling OnStatus
+
+	start := time.Now()
+	l.OnStatus(ctx, "tx1", network.Invalid, "invalid", nil)
+	elapsed := time.Since(start)
+
+	// Should not block for the 1s initial retry delay.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"OnStatus should return promptly when context is already canceled")
+}
+
+// TestOnStatus_StatusSetToDeletedForInvalidTx verifies that for an Invalid network
+// status, the local DB is updated to Deleted.
+func TestOnStatus_StatusSetToDeletedForInvalidTx(t *testing.T) {
+	var capturedStatus storage.TxStatus
+	db := &stubTxDB{
+		setStatusFn: func(_ context.Context, _ string, s storage.TxStatus, _ string) error {
+			capturedStatus = s
+
+			return nil
+		},
+	}
+	l := newTestListener(t, db)
+
+	l.OnStatus(t.Context(), "tx1", network.Invalid, "rejected", nil)
+
+	require.Equal(t, storage.Deleted, capturedStatus,
+		"an Invalid network status should map to Deleted in local storage")
+}

--- a/token/services/utils/retry.go
+++ b/token/services/utils/retry.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -16,15 +17,22 @@ import (
 // RetryRunner receives a function that potentially fails and retries according to the specified strategy
 type RetryRunner interface {
 	Run(func() error) error
+	// RunWithContext retries like Run but stops early if ctx is canceled.
+	RunWithContext(ctx context.Context, runner func() error) error
 }
 
 var ErrMaxRetriesExceeded = errors.New("maximum number of retries exceeded")
 
 const Infinitely = -1
 
+// defaultMaxDelay caps exponential backoff to prevent workers from sleeping for
+// unbounded durations (hours/days) after a burst of transient failures.
+const defaultMaxDelay = 30 * time.Second
+
 func NewRetryRunner(logger logging2.Logger, maxTimes int, delay time.Duration, expBackoff bool) *retryRunner {
 	return &retryRunner{
 		initialDelay: delay,
+		maxDelay:     defaultMaxDelay,
 		expBackoff:   expBackoff,
 		maxTimes:     maxTimes,
 		logger:       logger,
@@ -33,25 +41,61 @@ func NewRetryRunner(logger logging2.Logger, maxTimes int, delay time.Duration, e
 
 type retryRunner struct {
 	initialDelay time.Duration
-	expBackoff   bool
-	maxTimes     int
-	logger       logging2.Logger
+	// maxDelay caps the exponential backoff. Zero means no cap.
+	maxDelay   time.Duration
+	expBackoff bool
+	maxTimes   int
+	logger     logging2.Logger
 }
 
 func (f *retryRunner) nextDelay(delay time.Duration) time.Duration {
 	if delay == 0 || !f.expBackoff {
 		return f.initialDelay
 	}
+	next := 2 * delay
+	if f.maxDelay > 0 && next > f.maxDelay {
+		return f.maxDelay
+	}
 
-	return 2 * delay
+	return next
 }
 
+// Run retries runner until it succeeds or maxTimes is exhausted.
+// Uses context.Background() — prefer RunWithContext for cancelable retries.
 func (f *retryRunner) Run(runner func() error) error {
-	return f.RunWithErrors(func() (bool, error) {
-		err := runner()
+	return f.RunWithContext(context.Background(), runner)
+}
 
-		return err == nil, err
-	})
+// RunWithContext retries runner until it succeeds, ctx is canceled, or maxTimes
+// attempts are exhausted. The backoff sleep respects ctx cancellation so callers
+// (e.g. queue workers shutting down) are not blocked for the full sleep duration.
+func (f *retryRunner) RunWithContext(ctx context.Context, runner func() error) error {
+	var (
+		errs  []error
+		delay time.Duration
+	)
+	for i := 0; f.maxTimes < 0 || i < f.maxTimes; i++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := runner(); err == nil {
+			return nil
+		} else {
+			errs = append(errs, err)
+		}
+		delay = f.nextDelay(delay)
+		f.logger.Warnf("Will retry iteration [%d] after a delay of [%v]. %d errors returned so far", i+1, delay, len(errs))
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if len(errs) == 0 {
+		return ErrMaxRetriesExceeded
+	}
+
+	return errors.Join(errs...)
 }
 
 // RunWithErrors will retry until runner() returns true or until it returns maxTimes false.

--- a/token/services/utils/retry_test.go
+++ b/token/services/utils/retry_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package utils_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testLogger() logging.Logger {
+	return logging.MustGetLogger()
+}
+
+// TestRunWithContext_PreCanceledContext verifies that a pre-canceled context causes
+// RunWithContext to return immediately without invoking the runner at all.
+func TestRunWithContext_PreCanceledContext(t *testing.T) {
+	runner := utils.NewRetryRunner(testLogger(), utils.Infinitely, 10*time.Second, false)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before calling Run
+
+	calls := 0
+	start := time.Now()
+	err := runner.RunWithContext(ctx, func() error {
+		calls++
+
+		return errors.New("should not be reached")
+	})
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, calls, "runner should not be invoked on a pre-canceled context")
+	assert.Less(t, elapsed, 500*time.Millisecond, "should return immediately, not block on 10s sleep")
+}
+
+// TestRunWithContext_CanceledDuringBackoff verifies that canceling the context while
+// the retry loop is sleeping between attempts unblocks the caller promptly.
+// This is the core regression test for the bug: without context-aware sleep,
+// a worker goroutine would block in time.Sleep for the full (ever-growing) delay.
+func TestRunWithContext_CanceledDuringBackoff(t *testing.T) {
+	// Initial delay is long so we can observe it being interrupted.
+	runner := utils.NewRetryRunner(testLogger(), utils.Infinitely, 5*time.Second, false)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	calls := 0
+	done := make(chan error, 1)
+
+	go func() {
+		done <- runner.RunWithContext(ctx, func() error {
+			calls++
+
+			return errors.New("transient error")
+		})
+	}()
+
+	// Let the runner execute once and enter the 5s sleep.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	start := time.Now()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		require.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 1, calls, "runner should have been called exactly once before cancel")
+		assert.Less(t, elapsed, time.Second,
+			"RunWithContext should unblock within 1s of cancellation, not wait out the 5s sleep")
+	case <-time.After(6 * time.Second):
+		t.Fatal("RunWithContext did not respect context cancellation — worker would have been stuck")
+	}
+}
+
+// TestRunWithContext_BackoffDoesNotExceedCap verifies that the exponential backoff
+// delay is capped and does not grow without bound.
+// We use a tiny initial delay so the test runs fast; the cap itself is 30s by default.
+func TestRunWithContext_BackoffDoesNotExceedCap(t *testing.T) {
+	// 10 retries with 1ms initial delay, exp backoff: 1,2,4,8,16,30,30,30,30,30 ms
+	runner := utils.NewRetryRunner(testLogger(), 10, time.Millisecond, true)
+
+	var intervals []time.Duration
+	prev := time.Now()
+
+	_ = runner.RunWithContext(t.Context(), func() error {
+		now := time.Now()
+		intervals = append(intervals, now.Sub(prev))
+		prev = now
+
+		return errors.New("always fail")
+	})
+
+	// Skip the first interval (no sleep before first call).
+	// Each subsequent interval should be ≤ defaultMaxDelay + small scheduling slack.
+	const maxAllowed = 30*time.Second + 200*time.Millisecond
+	for i, d := range intervals[1:] {
+		assert.LessOrEqual(t, d, maxAllowed,
+			"backoff interval %d (%v) exceeded the 30s cap", i+1, d)
+	}
+}
+
+// TestRunWithContext_SucceedsAfterTransientFailures verifies normal retry behavior:
+// the runner is retried until it succeeds.
+func TestRunWithContext_SucceedsAfterTransientFailures(t *testing.T) {
+	runner := utils.NewRetryRunner(testLogger(), utils.Infinitely, time.Millisecond, false)
+
+	calls := 0
+	err := runner.RunWithContext(t.Context(), func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+// TestRun_DelegatesWithBackgroundContext verifies that Run (which uses context.Background)
+// still retries correctly and is not broken by the refactor.
+func TestRun_DelegatesWithBackgroundContext(t *testing.T) {
+	runner := utils.NewRetryRunner(testLogger(), 5, time.Millisecond, false)
+
+	calls := 0
+	err := runner.Run(func() error {
+		calls++
+		if calls < 2 {
+			return errors.New("transient")
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+// TestRunWithContext_MaxRetriesExhausted verifies that when maxTimes is set and
+// all retries fail, a joined error is returned.
+func TestRunWithContext_MaxRetriesExhausted(t *testing.T) {
+	runner := utils.NewRetryRunner(testLogger(), 3, time.Millisecond, false)
+
+	calls := 0
+	err := runner.RunWithContext(t.Context(), func() error {
+		calls++
+
+		return errors.New("persistent failure")
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "persistent failure")
+	assert.Equal(t, 3, calls)
+}
+
+// TestRunWithContext_SuccessOnFirstAttempt verifies zero-retry fast path.
+func TestRunWithContext_SuccessOnFirstAttempt(t *testing.T) {
+	runner := utils.NewRetryRunner(testLogger(), utils.Infinitely, time.Second, true)
+
+	calls := 0
+	err := runner.RunWithContext(t.Context(), func() error {
+		calls++
+
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}


### PR DESCRIPTION
### What's broken

`Listener.OnStatus` in `listener.go` uses a retry runner with `utils.Infinitely` and no delay cap. The loop in `retry.go` doubles the sleep on every failure ,  after ~10 consecutive failures, the next sleep is **17 minutes**. After 20, **12 days**. And there's no context check, so nothing can interrupt it:

```go
time.Sleep(delay) // unconditional, uninterruptible
```

### Why it matters

Each queue worker that hits this path gets stuck sleeping. The default pool is **10 workers** , a 30-second DB hiccup across concurrent transactions is enough to exhaust all of them. Finality stalls completely, token locks never release, clients hang forever. Shutdown doesn't help either  `eq.cancel()` fires but sleeping workers don't respond, so goroutines leak.

### Fix

Added `RunWithContext` to `retry.go` with a context-aware sleep and a 30s delay cap. Updated `OnStatus` in `listener.go` to call `RunWithContext(newCtx, ...)` instead of `Run(...)` so the queue's context flows through. Existing callers of `Run` are unaffected  it just delegates to `RunWithContext(context.Background(), ...)` now.

### Tests

13 tests across `retry_test.go` (7) and `listener_test.go` (6). The key ones: `TestRunWithContext_CanceledDuringBackoff` verifies a canceled context unblocks the caller immediately instead of waiting out the full sleep, and `TestOnStatus_ContextCanceledDuringRetry` confirms the worker goroutine exits within 5s of cancellation end-to-end.

<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/ffb9bcc9-5439-4490-a4b0-6a3129a8d249" />
