### PR TITLE
feat(metrics): add duration histograms to ttx transaction lifecycle

### DIFF
--- a/token/services/ttx/auditor.go
+++ b/token/services/ttx/auditor.go
@@ -278,6 +278,7 @@ func NewAuditApproveView(w *token.AuditorWallet, tx *Transaction) *AuditApproveV
 }
 
 func (a *AuditApproveView) Call(context view.Context) (interface{}, error) {
+	start := time.Now()
 	// Append audit records
 	if err := auditor.Get(context, a.w).Append(context.Context(), a.tx); err != nil {
 		return nil, errors.Wrapf(err, "failed appending audit records for transaction %s", a.tx.ID())
@@ -301,7 +302,9 @@ func (a *AuditApproveView) Call(context view.Context) (interface{}, error) {
 		"channel", a.tx.Channel(),
 		"namespace", a.tx.Namespace(),
 	}
-	GetMetrics(context).AuditApprovedTransactions.With(labels...).Add(1)
+	metrics := GetMetrics(context)
+	metrics.AuditApprovedTransactions.With(labels...).Add(1)
+	metrics.AuditApprovalDuration.With(labels...).Observe(time.Since(start).Seconds())
 
 	return nil, nil
 }

--- a/token/services/ttx/collectendorsements.go
+++ b/token/services/ttx/collectendorsements.go
@@ -85,6 +85,7 @@ func NewCollectEndorsementsView(tx *Transaction, opts ...EndorsementsOpt) *Colle
 // the token transaction valid.
 func (c *CollectEndorsementsView) Call(context view.Context) (interface{}, error) {
 	metrics := GetMetrics(context)
+	start := time.Now()
 
 	externalWallets := make(map[string]ExternalWalletSigner)
 
@@ -148,6 +149,7 @@ func (c *CollectEndorsementsView) Call(context view.Context) (interface{}, error
 		"namespace", c.tx.Namespace(),
 	}
 	metrics.EndorsedTransactions.With(labels...).Add(1)
+	metrics.EndorsementDuration.With(labels...).Observe(time.Since(start).Seconds())
 
 	return nil, nil
 }

--- a/token/services/ttx/metrics.go
+++ b/token/services/ttx/metrics.go
@@ -13,6 +13,8 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 )
 
+var defaultDurationBuckets = []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30}
+
 var (
 	spKey = reflect.TypeOf((*Metrics)(nil))
 
@@ -31,12 +33,33 @@ var (
 		Help:       "The number of accepted transactions.",
 		LabelNames: []string{"network", "channel", "namespace"},
 	}
+	endorsementDuration = metrics.HistogramOpts{
+		Name:       "endorsement_duration_seconds",
+		Help:       "Duration of the full endorsement collection phase including signatures, audit, and chaincode approval.",
+		LabelNames: []string{"network", "channel", "namespace"},
+		Buckets:    defaultDurationBuckets,
+	}
+	auditApprovalDuration = metrics.HistogramOpts{
+		Name:       "audit_approval_duration_seconds",
+		Help:       "Duration of the auditor approval phase including validation, append, and signing.",
+		LabelNames: []string{"network", "channel", "namespace"},
+		Buckets:    defaultDurationBuckets,
+	}
+	orderingDuration = metrics.HistogramOpts{
+		Name:       "ordering_duration_seconds",
+		Help:       "Duration of the transaction broadcast to the ordering service.",
+		LabelNames: []string{"network", "channel", "namespace"},
+		Buckets:    defaultDurationBuckets,
+	}
 )
 
 type Metrics struct {
 	EndorsedTransactions      metrics.Counter
 	AuditApprovedTransactions metrics.Counter
 	AcceptedTransactions      metrics.Counter
+	EndorsementDuration       metrics.Histogram
+	AuditApprovalDuration     metrics.Histogram
+	OrderingDuration          metrics.Histogram
 }
 
 func NewMetrics(p metrics.Provider) *Metrics {
@@ -44,6 +67,9 @@ func NewMetrics(p metrics.Provider) *Metrics {
 		EndorsedTransactions:      p.NewCounter(endorsedTransactions),
 		AuditApprovedTransactions: p.NewCounter(auditApprovedTransactions),
 		AcceptedTransactions:      p.NewCounter(acceptedTransactions),
+		EndorsementDuration:       p.NewHistogram(endorsementDuration),
+		AuditApprovalDuration:     p.NewHistogram(auditApprovalDuration),
+		OrderingDuration:          p.NewHistogram(orderingDuration),
 	}
 }
 

--- a/token/services/ttx/ordering.go
+++ b/token/services/ttx/ordering.go
@@ -34,6 +34,7 @@ func NewOrderingViewWithOpts(opts ...TxOption) *orderingView {
 // The view does the following:
 // 1. It broadcasts the token transaction to the proper backend.
 func (o *orderingView) Call(context view.Context) (interface{}, error) {
+	start := time.Now()
 	// Compile options
 	options, err := CompileOpts(o.opts...)
 	if err != nil {
@@ -53,6 +54,13 @@ func (o *orderingView) Call(context view.Context) (interface{}, error) {
 			logger.WarnfContext(context.Context(), "failed to cache token request [%s], this might cause delay, investigate when possible: [%s]", options.Transaction.TokenRequest.Anchor, err)
 		}
 	}
+
+	labels := []string{
+		"network", options.Transaction.Network(),
+		"channel", options.Transaction.Channel(),
+		"namespace", options.Transaction.Namespace(),
+	}
+	GetMetrics(context).OrderingDuration.With(labels...).Observe(time.Since(start).Seconds())
 
 	return nil, nil
 }


### PR DESCRIPTION
We could always see *how many* transactions passed through each phase ,  but never *how long* they took. I've wanted to fix this for a while, especially after adding similar histograms to the finality queue in #1449 and #1451. The ttx layer felt like the obvious next step.

This PR adds three Prometheus histograms to track latency across the three core phases of every token transaction:

- `endorsement_duration_seconds`,  time spent collecting endorsements
- `audit_approval_duration_seconds`, time spent in auditor validation and signing
- `ordering_duration_seconds`, time spent broadcasting to the ordering service

**What I changed:**
- `metrics.go` ,  defined the 3 histograms with a shared bucket slice and added them to the `Metrics` struct
- `collectendorsements.go` ,  wrapped `Call()` with a `time.Now()` / `.Observe()` on the success path
- `auditor.go` ,  same pattern in `AuditApproveView.Call()`
- `ordering.go` ,  same pattern in `orderingView.Call()`

A couple of intentional choices: durations are only observed on success (same as the finality queue pattern), and I reused the same `{network, channel, namespace}` label set as the existing counters so Grafana joins just work.

Operators can now actually alert on p99 endorsement time, spot audit bottlenecks, and see whether a slow transaction is stuck at signatures, the auditor, or the network, all previously invisible.