### PR TITLE
fix(ttx): check for nil wallet in ExchangeRecipientIdentitiesView

### DIFF
--- a/token/services/ttx/recipients.go
+++ b/token/services/ttx/recipients.go
@@ -504,7 +504,11 @@ func (f *ExchangeRecipientIdentitiesView) Call(context view.Context) (interface{
 			return nil, err
 		}
 
-		me, err := ts.WalletManager().OwnerWallet(context.Context(), f.Wallet).GetRecipientIdentity(context.Context())
+		meWallet := ts.WalletManager().OwnerWallet(context.Context(), f.Wallet)
+		if meWallet == nil {
+			return nil, errors.Errorf("wallet [%s:%s] not found", f.Wallet, f.TMSID)
+		}
+		me, err := meWallet.GetRecipientIdentity(context.Context())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION

## Summary

In `ExchangeRecipientIdentitiesView.Call()`, when both parties are on the same node (`f.Other` is a local wallet), the code looked up the local wallet for `f.Wallet` and immediately chained `.GetRecipientIdentity()` with no nil check.

If `f.Wallet` is not registered on the node due to misconfiguration, wrong namespace, or wallet not yet set up, this causes a runtime panic instead of returning a clean error. The `else` branch (remote recipient path) already performed the correct nil check for the same wallet lookup the `if` branch (local path) was inconsistent.

## Change

Split the single-line chain into a two-step nil-checked call, matching the existing pattern in the `else` branch:

```go
// Before panics if f.Wallet is not found
me, err := ts.WalletManager().OwnerWallet(context.Context(), f.Wallet).GetRecipientIdentity(context.Context())

// After returns a descriptive error instead of panicking
meWallet := ts.WalletManager().OwnerWallet(context.Context(), f.Wallet)
if meWallet == nil {
    return nil, errors.Errorf("wallet [%s:%s] not found", f.Wallet, f.TMSID)
}
me, err := meWallet.GetRecipientIdentity(context.Context())
```

The error message format matches the existing error returned for the same case in the `else` branch (line 521).

## Test Plan

- `go build ./token/services/ttx/...`  compiles cleanly
- `go vet ./token/services/ttx/...`  no issues
- `go test ./token/services/ttx/...`  all existing tests pass

---

## Suggestion: Should `WalletManager.OwnerWallet()` return `(*OwnerWallet, error)`?

While fixing the nil dereference here, I noticed that the lower-level `driver.WalletService.OwnerWallet()` already returns `(OwnerWallet, error)`, but `WalletManager.OwnerWallet()` swallows the error and returns `nil` for both "not found" and real storage failures.

9 call sites currently do:

```go
w := wm.OwnerWallet(ctx, id)
if w == nil {
    return errors.Errorf("wallet not found") // original error is lost
}
```