### PR TITLE
test(certifier): add unit tests for driver holder registration

### DIFF
--- a/token/services/certifier/driver_test.go
+++ b/token/services/certifier/driver_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package certifier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/certifier/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/test-go/testify/require"
+)
+
+// mockDriver implements driver.Driver for testing
+type mockDriver struct{}
+
+func (m *mockDriver) NewCertificationClient(_ context.Context, _ *token.ManagementService) (driver.CertificationClient, error) {
+	return nil, nil
+}
+
+func (m *mockDriver) NewCertificationService(_ *token.ManagementService, _ string) (driver.CertificationService, error) {
+	return nil, nil
+}
+
+func TestHolder_Register_And_Get(t *testing.T) {
+	d := &mockDriver{}
+	key := "test-driver-register"
+
+	holder.Register(key, d)
+
+	got, ok := holder.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, d, got)
+}
+
+func TestHolder_Get_NonExistent(t *testing.T) {
+	_, ok := holder.Get("non-existent-driver")
+	assert.False(t, ok)
+}
+
+func TestHolder_Register_NilDriver_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		holder.Register("nil-driver", nil)
+	})
+}
+
+func TestHolder_Register_Duplicate_Panics(t *testing.T) {
+	d := &mockDriver{}
+	key := "test-driver-duplicate"
+
+	holder.Register(key, d)
+
+	assert.Panics(t, func() {
+		holder.Register(key, d)
+	})
+}


### PR DESCRIPTION
Part of #1437
Adds unit tests for `token/services/certifier/driver.go`, which had no test coverage.
## What's covered

- `TestHolder_Register_And_Get`: register a driver and retrieve it successfully
- `TestHolder_Get_NonExistent` :  getting an unregistered key returns false
- `TestHolder_Register_NilDriver_Panics` : registering nil panics
- `TestHolder_Register_Duplicate_Panics`: egistering same key twice panics

All tests pass locally: