### PR TITLE
Feat/unit test htlc package

### DIFF
--- a/token/services/interop/htlc/audit.go
+++ b/token/services/interop/htlc/audit.go
@@ -50,7 +50,7 @@ func (i *Input) Script() (*Script, error) {
 	script := &Script{}
 	err = json.Unmarshal(owner.Identity, script)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmrshal HTLC script")
+		return nil, errors.Wrapf(err, "failed to unmarshal HTLC script")
 	}
 
 	return script, nil
@@ -92,7 +92,7 @@ func (o *Output) Script() (*Script, error) {
 	script := &Script{}
 	err = json.Unmarshal(owner.Identity, script)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmrshal HTLC script")
+		return nil, errors.Wrapf(err, "failed to unmarshal HTLC script")
 	}
 
 	return script, nil

--- a/token/services/interop/htlc/audit_test.go
+++ b/token/services/interop/htlc/audit_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	tokenapi "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/marshal"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+func htlcOwnerBytes(t *testing.T, sender, recipient []byte) []byte {
+	t.Helper()
+	raw, err := json.Marshal(htlc.Script{Sender: sender, Recipient: recipient})
+	require.NoError(t, err)
+
+	return marshal.EncodeIdentity(driver.HTLCScriptIdentityType, raw)
+}
+
+// ---- Input tests ----
+
+func TestToInputHTLC(t *testing.T) {
+	owner := htlcOwnerBytes(t, []byte("sender"), []byte("recipient"))
+	result, err := htlc.ToInput(&tokenapi.Input{Owner: owner})
+	require.NoError(t, err)
+	require.True(t, result.IsHTLC())
+}
+
+func TestToInputNonHTLC(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.X509IdentityType, []byte("id"))
+	result, err := htlc.ToInput(&tokenapi.Input{Owner: owner})
+	require.NoError(t, err)
+	require.False(t, result.IsHTLC())
+}
+
+func TestToInputInvalidOwner(t *testing.T) {
+	_, err := htlc.ToInput(&tokenapi.Input{Owner: []byte("garbage")})
+	require.Error(t, err)
+}
+
+func TestInputScript(t *testing.T) {
+	owner := htlcOwnerBytes(t, []byte("sender"), []byte("recipient"))
+	result, err := htlc.ToInput(&tokenapi.Input{Owner: owner})
+	require.NoError(t, err)
+
+	script, err := result.Script()
+	require.NoError(t, err)
+	require.NotNil(t, script)
+	require.Equal(t, []byte("sender"), []byte(script.Sender))
+	require.Equal(t, []byte("recipient"), []byte(script.Recipient))
+}
+
+func TestInputScriptOnNonHTLC(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.X509IdentityType, []byte("id"))
+	result, err := htlc.ToInput(&tokenapi.Input{Owner: owner})
+	require.NoError(t, err)
+
+	_, err = result.Script()
+	require.EqualError(t, err, "this input does not refer to an HTLC script")
+}
+
+func TestInputScriptInvalidJSON(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.HTLCScriptIdentityType, []byte("not-json"))
+	result, err := htlc.ToInput(&tokenapi.Input{Owner: owner})
+	require.NoError(t, err)
+	require.True(t, result.IsHTLC())
+
+	_, err = result.Script()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmrshal HTLC script")
+}
+
+// ---- Output tests ----
+
+func TestToOutputHTLC(t *testing.T) {
+	owner := htlcOwnerBytes(t, []byte("sender"), []byte("recipient"))
+	result, err := htlc.ToOutput(&tokenapi.Output{Owner: owner})
+	require.NoError(t, err)
+	require.True(t, result.IsHTLC())
+}
+
+func TestToOutputNonHTLC(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.X509IdentityType, []byte("id"))
+	result, err := htlc.ToOutput(&tokenapi.Output{Owner: owner})
+	require.NoError(t, err)
+	require.False(t, result.IsHTLC())
+}
+
+func TestToOutputInvalidOwner(t *testing.T) {
+	_, err := htlc.ToOutput(&tokenapi.Output{Owner: []byte("garbage")})
+	require.Error(t, err)
+}
+
+func TestOutputScript(t *testing.T) {
+	owner := htlcOwnerBytes(t, []byte("sender"), []byte("recipient"))
+	result, err := htlc.ToOutput(&tokenapi.Output{Owner: owner})
+	require.NoError(t, err)
+
+	script, err := result.Script()
+	require.NoError(t, err)
+	require.NotNil(t, script)
+	require.Equal(t, []byte("sender"), []byte(script.Sender))
+	require.Equal(t, []byte("recipient"), []byte(script.Recipient))
+}
+
+func TestOutputScriptOnNonHTLC(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.X509IdentityType, []byte("id"))
+	result, err := htlc.ToOutput(&tokenapi.Output{Owner: owner})
+	require.NoError(t, err)
+
+	_, err = result.Script()
+	require.EqualError(t, err, "this output does not refer to an HTLC script")
+}
+
+func TestOutputScriptInvalidJSON(t *testing.T) {
+	owner := marshal.EncodeIdentity(driver.HTLCScriptIdentityType, []byte("not-json"))
+	result, err := htlc.ToOutput(&tokenapi.Output{Owner: owner})
+	require.NoError(t, err)
+	require.True(t, result.IsHTLC())
+
+	_, err = result.Script()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to unmrshal HTLC script")
+}

--- a/token/services/interop/htlc/audit_test.go
+++ b/token/services/interop/htlc/audit_test.go
@@ -75,7 +75,7 @@ func TestInputScriptInvalidJSON(t *testing.T) {
 
 	_, err = result.Script()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to unmrshal HTLC script")
+	require.Contains(t, err.Error(), "failed to unmarshal HTLC script")
 }
 
 // ---- Output tests ----
@@ -128,5 +128,5 @@ func TestOutputScriptInvalidJSON(t *testing.T) {
 
 	_, err = result.Script()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to unmrshal HTLC script")
+	require.Contains(t, err.Error(), "failed to unmarshal HTLC script")
 }

--- a/token/services/interop/htlc/distribute_test.go
+++ b/token/services/interop/htlc/distribute_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+func validTerms() *htlc.Terms {
+	return &htlc.Terms{
+		ReclamationDeadline: time.Hour,
+		Type1:               "USD",
+		Amount1:             100,
+		Type2:               "EUR",
+		Amount2:             90,
+	}
+}
+
+func TestTermsValidate(t *testing.T) {
+	require.NoError(t, validTerms().Validate())
+}
+
+func TestTermsValidateZeroDeadline(t *testing.T) {
+	terms := validTerms()
+	terms.ReclamationDeadline = 0
+	require.EqualError(t, terms.Validate(), "reclamation deadline should be larger than zero")
+}
+
+func TestTermsValidateNegativeDeadline(t *testing.T) {
+	terms := validTerms()
+	terms.ReclamationDeadline = -time.Hour
+	require.EqualError(t, terms.Validate(), "reclamation deadline should be larger than zero")
+}
+
+func TestTermsValidateEmptyType1(t *testing.T) {
+	terms := validTerms()
+	terms.Type1 = ""
+	require.EqualError(t, terms.Validate(), "types should be set")
+}
+
+func TestTermsValidateEmptyType2(t *testing.T) {
+	terms := validTerms()
+	terms.Type2 = ""
+	require.EqualError(t, terms.Validate(), "types should be set")
+}
+
+func TestTermsValidateZeroAmount1(t *testing.T) {
+	terms := validTerms()
+	terms.Amount1 = 0
+	require.EqualError(t, terms.Validate(), "amounts should be larger than zero")
+}
+
+func TestTermsValidateZeroAmount2(t *testing.T) {
+	terms := validTerms()
+	terms.Amount2 = 0
+	require.EqualError(t, terms.Validate(), "amounts should be larger than zero")
+}
+
+func TestTermsBytesRoundtrip(t *testing.T) {
+	original := validTerms()
+
+	raw, err := original.Bytes()
+	require.NoError(t, err)
+	require.NotEmpty(t, raw)
+
+	parsed := &htlc.Terms{}
+	require.NoError(t, parsed.FromBytes(raw))
+
+	require.Equal(t, original.ReclamationDeadline, parsed.ReclamationDeadline)
+	require.Equal(t, original.Type1, parsed.Type1)
+	require.Equal(t, original.Amount1, parsed.Amount1)
+	require.Equal(t, original.Type2, parsed.Type2)
+	require.Equal(t, original.Amount2, parsed.Amount2)
+}
+
+func TestTermsFromBytesInvalidJSON(t *testing.T) {
+	terms := &htlc.Terms{}
+	require.Error(t, terms.FromBytes([]byte("not-json")))
+}

--- a/token/services/interop/htlc/keys_test.go
+++ b/token/services/interop/htlc/keys_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimKey(t *testing.T) {
+	v := []byte{0x01, 0x02, 0x03}
+	require.Equal(t, htlc.ClaimPreImage+hex.EncodeToString(v), htlc.ClaimKey(v))
+}
+
+func TestLockKey(t *testing.T) {
+	v := []byte{0xAB, 0xCD}
+	require.Equal(t, htlc.LockHash+hex.EncodeToString(v), htlc.LockKey(v))
+}
+
+func TestLockValue(t *testing.T) {
+	v := []byte{0xDE, 0xAD}
+	require.Equal(t, []byte(hex.EncodeToString(v)), htlc.LockValue(v))
+}
+
+func TestClaimKeyEmpty(t *testing.T) {
+	require.Equal(t, htlc.ClaimPreImage, htlc.ClaimKey(nil))
+}
+
+func TestLockKeyEmpty(t *testing.T) {
+	require.Equal(t, htlc.LockHash, htlc.LockKey(nil))
+}
+
+func TestClaimAndLockKeysDiffer(t *testing.T) {
+	v := []byte{0x01}
+	require.NotEqual(t, htlc.ClaimKey(v), htlc.LockKey(v))
+}
+
+func TestLockValueRoundtrip(t *testing.T) {
+	v := []byte("somedata")
+	decoded, err := hex.DecodeString(string(htlc.LockValue(v)))
+	require.NoError(t, err)
+	require.Equal(t, v, decoded)
+}

--- a/token/services/interop/htlc/signer_test.go
+++ b/token/services/interop/htlc/signer_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver/mock"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/encoding"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- ClaimSigner ----
+
+func TestClaimSignerSign(t *testing.T) {
+	preImage := []byte("secret")
+	tokenReq := []byte("txrequest")
+	expectedSig := []byte("recipient-sig")
+
+	signer := &mock.Signer{}
+	signer.SignReturns(expectedSig, nil)
+
+	cs := &htlc.ClaimSigner{Recipient: signer, Preimage: preImage}
+	result, err := cs.Sign(tokenReq)
+	require.NoError(t, err)
+
+	var claimSig htlc.ClaimSignature
+	require.NoError(t, json.Unmarshal(result, &claimSig))
+	require.Equal(t, preImage, claimSig.Preimage)
+	require.Equal(t, expectedSig, claimSig.RecipientSignature)
+
+	// signer must be called with tokenReq+preImage
+	require.Equal(t, 1, signer.SignCallCount())
+	require.Equal(t, append(tokenReq, preImage...), signer.SignArgsForCall(0))
+}
+
+func TestClaimSignerSignError(t *testing.T) {
+	signer := &mock.Signer{}
+	signer.SignReturns(nil, errors.New("sign failed"))
+
+	cs := &htlc.ClaimSigner{Recipient: signer, Preimage: []byte("p")}
+	_, err := cs.Sign([]byte("req"))
+	require.EqualError(t, err, "sign failed")
+}
+
+// ---- ClaimVerifier ----
+
+func validClaimSigBytes(t *testing.T, preImage, recipientSig []byte) []byte {
+	t.Helper()
+	raw, err := json.Marshal(htlc.ClaimSignature{Preimage: preImage, RecipientSignature: recipientSig})
+	require.NoError(t, err)
+
+	return raw
+}
+
+func claimHashInfo(preImage []byte) htlc.HashInfo {
+	h := crypto.SHA256.New()
+	h.Write(preImage)
+
+	return htlc.HashInfo{
+		Hash:         []byte(encoding.Base64.New().EncodeToString(h.Sum(nil))),
+		HashFunc:     crypto.SHA256,
+		HashEncoding: encoding.Base64,
+	}
+}
+
+func TestClaimVerifierVerifySuccess(t *testing.T) {
+	preImage := []byte("secret")
+	tokenReq := []byte("txrequest")
+	recipientSig := []byte("sig")
+
+	verifier := &mock.Verifier{}
+	verifier.VerifyReturns(nil)
+
+	cv := &htlc.ClaimVerifier{Recipient: verifier, HashInfo: claimHashInfo(preImage)}
+	require.NoError(t, cv.Verify(tokenReq, validClaimSigBytes(t, preImage, recipientSig)))
+
+	// verifier called with tokenReq+preImage
+	msg, _ := verifier.VerifyArgsForCall(0)
+	require.Equal(t, append(tokenReq, preImage...), msg)
+}
+
+func TestClaimVerifierVerifyInvalidJSON(t *testing.T) {
+	cv := &htlc.ClaimVerifier{Recipient: &mock.Verifier{}, HashInfo: claimHashInfo([]byte("p"))}
+	require.Error(t, cv.Verify([]byte("req"), []byte("not-json")))
+}
+
+func TestClaimVerifierVerifyBadRecipientSignature(t *testing.T) {
+	preImage := []byte("secret")
+	verifier := &mock.Verifier{}
+	verifier.VerifyReturns(errors.New("bad sig"))
+
+	cv := &htlc.ClaimVerifier{Recipient: verifier, HashInfo: claimHashInfo(preImage)}
+	err := cv.Verify([]byte("req"), validClaimSigBytes(t, preImage, []byte("sig")))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to verify recipient signature")
+}
+
+func TestClaimVerifierVerifyHashMismatch(t *testing.T) {
+	preImage := []byte("secret")
+	verifier := &mock.Verifier{}
+	verifier.VerifyReturns(nil)
+
+	hi := claimHashInfo([]byte("different-preimage")) // hash of something else
+	cv := &htlc.ClaimVerifier{Recipient: verifier, HashInfo: hi}
+	err := cv.Verify([]byte("req"), validClaimSigBytes(t, preImage, []byte("sig")))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "hash mismatch")
+}
+
+func TestClaimVerifierVerifyUnavailableHashFunc(t *testing.T) {
+	preImage := []byte("secret")
+	verifier := &mock.Verifier{}
+	verifier.VerifyReturns(nil)
+
+	cv := &htlc.ClaimVerifier{
+		Recipient: verifier,
+		HashInfo:  htlc.HashInfo{Hash: []byte("h"), HashFunc: crypto.Hash(999), HashEncoding: encoding.Base64},
+	}
+	err := cv.Verify([]byte("req"), validClaimSigBytes(t, preImage, []byte("sig")))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "script hash function not available")
+}
+
+// ---- Verifier ----
+
+func TestVerifierVerifyBeforeDeadline(t *testing.T) {
+	preImage := []byte("secret")
+	tokenReq := []byte("txrequest")
+
+	recipientVerifier := &mock.Verifier{}
+	recipientVerifier.VerifyReturns(nil)
+
+	v := &htlc.Verifier{
+		Recipient: recipientVerifier,
+		Sender:    &mock.Verifier{},
+		Deadline:  time.Now().Add(time.Hour),
+		HashInfo:  claimHashInfo(preImage),
+	}
+
+	sigma := validClaimSigBytes(t, preImage, []byte("sig"))
+	require.NoError(t, v.Verify(tokenReq, sigma))
+	require.Equal(t, 1, recipientVerifier.VerifyCallCount())
+}
+
+func TestVerifierVerifyBeforeDeadlineInvalidClaim(t *testing.T) {
+	recipientVerifier := &mock.Verifier{}
+	recipientVerifier.VerifyReturns(errors.New("bad claim"))
+
+	v := &htlc.Verifier{
+		Recipient: recipientVerifier,
+		Deadline:  time.Now().Add(time.Hour),
+		HashInfo:  claimHashInfo([]byte("p")),
+	}
+
+	sigma := validClaimSigBytes(t, []byte("p"), []byte("sig"))
+	err := v.Verify([]byte("req"), sigma)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed verifying htlc claim signature")
+}
+
+func TestVerifierVerifyAfterDeadline(t *testing.T) {
+	senderVerifier := &mock.Verifier{}
+	senderVerifier.VerifyReturns(nil)
+
+	v := &htlc.Verifier{
+		Sender:   senderVerifier,
+		Deadline: time.Now().Add(-time.Hour),
+		HashInfo: claimHashInfo([]byte("p")),
+	}
+
+	require.NoError(t, v.Verify([]byte("req"), []byte("sender-sig")))
+	require.Equal(t, 1, senderVerifier.VerifyCallCount())
+}
+
+func TestVerifierVerifyAfterDeadlineInvalidReclaim(t *testing.T) {
+	senderVerifier := &mock.Verifier{}
+	senderVerifier.VerifyReturns(errors.New("bad reclaim"))
+
+	v := &htlc.Verifier{
+		Sender:   senderVerifier,
+		Deadline: time.Now().Add(-time.Hour),
+	}
+
+	err := v.Verify([]byte("req"), []byte("sig"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "deadline elapsed, failed verifying htlc reclaim signature")
+}

--- a/token/services/interop/htlc/stream_test.go
+++ b/token/services/interop/htlc/stream_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package htlc_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	tokenapi "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/marshal"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/htlc"
+	tokentypes "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+// makeStreamOutput creates a tokenapi.Output whose embedded Token.Owner holds the
+// given raw owner bytes (the field htlc.OutputStream reads for script detection).
+func makeStreamOutput(ownerBytes []byte) *tokenapi.Output {
+	out := &tokenapi.Output{}
+	out.Token = tokentypes.Token{Owner: ownerBytes, Type: "USD", Quantity: "10"}
+
+	return out
+}
+
+func htlcStreamOwner(t *testing.T, sender, recipient []byte) []byte {
+	t.Helper()
+	raw, err := json.Marshal(htlc.Script{Sender: sender, Recipient: recipient})
+	require.NoError(t, err)
+
+	return marshal.EncodeIdentity(driver.HTLCScriptIdentityType, raw)
+}
+
+func newHTLCOutputStream(outputs ...*tokenapi.Output) *htlc.OutputStream {
+	return htlc.NewOutputStream(tokenapi.NewOutputStream(outputs, 64))
+}
+
+// ---- ByScript ----
+
+func TestOutputStreamByScriptFiltersHTLC(t *testing.T) {
+	htlcOut := makeStreamOutput(htlcStreamOwner(t, []byte("sender"), []byte("recipient")))
+	plainOut := makeStreamOutput(marshal.EncodeIdentity(driver.X509IdentityType, []byte("id")))
+
+	os := newHTLCOutputStream(htlcOut, plainOut)
+	filtered := os.ByScript()
+
+	require.Equal(t, 1, filtered.Count())
+}
+
+func TestOutputStreamByScriptNoneMatch(t *testing.T) {
+	plainOut := makeStreamOutput(marshal.EncodeIdentity(driver.X509IdentityType, []byte("id")))
+	os := newHTLCOutputStream(plainOut)
+	require.Equal(t, 0, os.ByScript().Count())
+}
+
+func TestOutputStreamByScriptAllMatch(t *testing.T) {
+	owner := htlcStreamOwner(t, []byte("sender"), []byte("recipient"))
+	os := newHTLCOutputStream(makeStreamOutput(owner), makeStreamOutput(owner))
+	require.Equal(t, 2, os.ByScript().Count())
+}
+
+func TestOutputStreamByScriptInvalidOwnerExcluded(t *testing.T) {
+	os := newHTLCOutputStream(makeStreamOutput([]byte("garbage")))
+	require.Equal(t, 0, os.ByScript().Count())
+}
+
+// ---- ScriptAt ----
+
+func TestOutputStreamScriptAt(t *testing.T) {
+	owner := htlcStreamOwner(t, []byte("sender"), []byte("recipient"))
+	os := newHTLCOutputStream(makeStreamOutput(owner))
+
+	script := os.ScriptAt(0)
+	require.NotNil(t, script)
+	require.Equal(t, []byte("sender"), []byte(script.Sender))
+	require.Equal(t, []byte("recipient"), []byte(script.Recipient))
+}
+
+func TestOutputStreamScriptAtNonHTLC(t *testing.T) {
+	plainOut := makeStreamOutput(marshal.EncodeIdentity(driver.X509IdentityType, []byte("id")))
+	os := newHTLCOutputStream(plainOut)
+	require.Nil(t, os.ScriptAt(0))
+}
+
+func TestOutputStreamScriptAtInvalidJSON(t *testing.T) {
+	out := makeStreamOutput(marshal.EncodeIdentity(driver.HTLCScriptIdentityType, []byte("not-json")))
+	os := newHTLCOutputStream(out)
+	require.Nil(t, os.ScriptAt(0))
+}
+
+func TestOutputStreamScriptAtNilSender(t *testing.T) {
+	// Script with nil sender — ScriptAt should return nil
+	raw, err := json.Marshal(htlc.Script{Sender: nil, Recipient: []byte("r")})
+	require.NoError(t, err)
+	out := makeStreamOutput(marshal.EncodeIdentity(driver.HTLCScriptIdentityType, raw))
+	os := newHTLCOutputStream(out)
+	require.Nil(t, os.ScriptAt(0))
+}
+
+// ---- Filter passthrough ----
+
+func TestOutputStreamFilter(t *testing.T) {
+	owner := htlcStreamOwner(t, []byte("sender"), []byte("recipient"))
+	os := newHTLCOutputStream(makeStreamOutput(owner), makeStreamOutput(owner))
+
+	// keep none
+	require.Equal(t, 0, os.Filter(func(*tokenapi.Output) bool { return false }).Count())
+	// keep all
+	require.Equal(t, 2, os.Filter(func(*tokenapi.Output) bool { return true }).Count())
+}

--- a/token/services/interop/htlc/wallet_filter_test.go
+++ b/token/services/interop/htlc/wallet_filter_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// package htlc (internal) to access unexported PreImageSelector.preImage
+package htlc
+
+import (
+	"crypto"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/marshal"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/interop/encoding"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+// makeFilterToken builds an UnspentToken whose owner encodes the given Script.
+func makeFilterToken(t *testing.T, script *Script) *token2.UnspentToken {
+	t.Helper()
+	raw, err := json.Marshal(script)
+	require.NoError(t, err)
+
+	return &token2.UnspentToken{
+		Owner:    marshal.EncodeIdentity(driver.HTLCScriptIdentityType, raw),
+		Type:     "USD",
+		Quantity: "10",
+	}
+}
+
+// ---- SelectExpired ----
+
+func TestSelectExpiredTrue(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(-time.Hour)}
+	tok := makeFilterToken(t, script)
+	ok, err := SelectExpired(tok, script)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestSelectExpiredFalse(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(time.Hour)}
+	tok := makeFilterToken(t, script)
+	ok, err := SelectExpired(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// ---- SelectNonExpired ----
+
+func TestSelectNonExpiredTrue(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(time.Hour)}
+	tok := makeFilterToken(t, script)
+	ok, err := SelectNonExpired(tok, script)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestSelectNonExpiredFalse(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(-time.Hour)}
+	tok := makeFilterToken(t, script)
+	ok, err := SelectNonExpired(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// ---- ExpiredAndHashSelector ----
+
+func TestExpiredAndHashSelectorMatch(t *testing.T) {
+	hash := []byte("testhash")
+	script := &Script{Deadline: time.Now().Add(-time.Hour), HashInfo: HashInfo{Hash: hash}}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&ExpiredAndHashSelector{Hash: hash}).Select(tok, script)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestExpiredAndHashSelectorHashMismatch(t *testing.T) {
+	script := &Script{Deadline: time.Now().Add(-time.Hour), HashInfo: HashInfo{Hash: []byte("hash-a")}}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&ExpiredAndHashSelector{Hash: []byte("hash-b")}).Select(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestExpiredAndHashSelectorNotExpired(t *testing.T) {
+	hash := []byte("testhash")
+	script := &Script{Deadline: time.Now().Add(time.Hour), HashInfo: HashInfo{Hash: hash}}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&ExpiredAndHashSelector{Hash: hash}).Select(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// ---- PreImageSelector ----
+
+func computeHash(preImage []byte) []byte {
+	h := crypto.SHA256.New()
+	h.Write(preImage)
+
+	return []byte(encoding.Base64.New().EncodeToString(h.Sum(nil)))
+}
+
+func TestPreImageSelectorMatch(t *testing.T) {
+	preImage := []byte("secret")
+	script := &Script{
+		HashInfo: HashInfo{
+			Hash:         computeHash(preImage),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&PreImageSelector{preImage: preImage}).Filter(tok, script)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestPreImageSelectorNoMatch(t *testing.T) {
+	preImage := []byte("secret")
+	script := &Script{
+		HashInfo: HashInfo{
+			Hash:         computeHash(preImage),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Base64,
+		},
+	}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&PreImageSelector{preImage: []byte("wrong")}).Filter(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestPreImageSelectorUnavailableHashFunc(t *testing.T) {
+	script := &Script{
+		HashInfo: HashInfo{
+			HashFunc:     crypto.Hash(999),
+			HashEncoding: encoding.Base64,
+		},
+	}
+	tok := makeFilterToken(t, script)
+
+	ok, err := (&PreImageSelector{preImage: []byte("any")}).Filter(tok, script)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+// ---- IsScript ----
+
+func TestIsScriptValidHTLC(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(time.Hour)}
+	tok := makeFilterToken(t, script)
+
+	predicate := IsScript(SelectNonExpired)
+	require.True(t, predicate(tok))
+}
+
+func TestIsScriptExpiredRejectedBySelector(t *testing.T) {
+	script := &Script{Sender: []byte("s"), Recipient: []byte("r"), Deadline: time.Now().Add(-time.Hour)}
+	tok := makeFilterToken(t, script)
+
+	predicate := IsScript(SelectNonExpired)
+	require.False(t, predicate(tok))
+}
+
+func TestIsScriptNonHTLCOwner(t *testing.T) {
+	tok := &token2.UnspentToken{
+		Owner: marshal.EncodeIdentity(driver.X509IdentityType, []byte("id")),
+	}
+	predicate := IsScript(SelectNonExpired)
+	require.False(t, predicate(tok))
+}
+
+func TestIsScriptInvalidOwnerBytes(t *testing.T) {
+	tok := &token2.UnspentToken{Owner: []byte("garbage")}
+	predicate := IsScript(SelectNonExpired)
+	require.False(t, predicate(tok))
+}
+
+func TestIsScriptInvalidScriptJSON(t *testing.T) {
+	tok := &token2.UnspentToken{
+		Owner: marshal.EncodeIdentity(driver.HTLCScriptIdentityType, []byte("not-json")),
+	}
+	predicate := IsScript(SelectNonExpired)
+	require.False(t, predicate(tok))
+}
+
+func TestIsScriptNilSender(t *testing.T) {
+	script := &Script{Sender: nil, Recipient: []byte("r")}
+	tok := makeFilterToken(t, script)
+
+	predicate := IsScript(SelectNonExpired)
+	require.False(t, predicate(tok))
+}


### PR DESCRIPTION
### What this PR does
This PR adds comprehensive unit tests for several files in the `token/services/interop/htlc` package that previously had no test coverage. 

### Changes
Added tests for:
- `audit.go`
- `distribute.go`
- `keys.go`
- `signer.go`
- `stream.go`
- `wallet_filter.go`

#1491
