### PR TITLE
perf(csp): thread ExecutorProvider through csp.RangeCorrectnessProver and csp.RangeCorrectnessVerifier

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
-	rp "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 )
 
 // IPA contains the proof for the inner product argument.
@@ -113,7 +113,7 @@ type ipaProver struct {
 	Curve *mathlib.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewIPAProver returns a new ipaProver instance.
@@ -127,10 +127,10 @@ func NewIPAProver(
 	Commitment *mathlib.G1,
 	rounds uint64,
 	c *mathlib.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *ipaProver {
 	if provider == nil {
-		provider = rp.DefaultProvider
+		provider = executor.DefaultProvider
 	}
 
 	return &ipaProver{
@@ -254,7 +254,7 @@ type ipaVerifier struct {
 	Curve *mathlib.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewIPAVerifier returns an ipaVerifier instance.
@@ -267,10 +267,10 @@ func NewIPAVerifier(
 	Commitment *mathlib.G1,
 	rounds uint64,
 	c *mathlib.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *ipaVerifier {
 	if provider == nil {
-		provider = rp.DefaultProvider
+		provider = executor.DefaultProvider
 	}
 
 	return &ipaVerifier{
@@ -406,7 +406,7 @@ func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Cu
 
 // reduceGenerators reduces the number of generators passed in the parameters by 1/2,
 // as a function of the old generators,  x and 1/x
-func reduceGenerators(leftGen, rightGen []*mathlib.G1, x, xInv *mathlib.Zr, provider rp.ExecutorProvider) ([]*mathlib.G1, []*mathlib.G1) {
+func reduceGenerators(leftGen, rightGen []*mathlib.G1, x, xInv *mathlib.Zr, provider executor.ExecutorProvider) ([]*mathlib.G1, []*mathlib.G1) {
 	l := len(leftGen) / 2
 	// Use the Executor abstraction so that the execution strategy can be
 	// swapped without changing this function. SerialExecutor runs each task

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rangecorrectness.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rangecorrectness.go
@@ -10,7 +10,7 @@ import (
 	math "github.com/IBM/mathlib"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
-	rp "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 )
 
 // RangeCorrectness contains a set of range proofs for multiple commitments.
@@ -87,7 +87,7 @@ type RangeCorrectnessProver struct {
 	Curve *math.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeCorrectnessProver returns a new RangeCorrectnessProver.
@@ -101,10 +101,10 @@ func NewRangeCorrectnessProver(
 	P, Q *math.G1,
 	bitLength, rounds uint64,
 	c *math.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *RangeCorrectnessProver {
 	if provider == nil {
-		provider = rp.DefaultProvider
+		provider = executor.DefaultProvider
 	}
 
 	return &RangeCorrectnessProver{
@@ -188,7 +188,7 @@ type RangeCorrectnessVerifier struct {
 	Curve *math.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeCorrectnessVerifier returns a new RangeCorrectnessVerifier.
@@ -199,10 +199,10 @@ func NewRangeCorrectnessVerifier(
 	P, Q *math.G1,
 	bitLength, rounds uint64,
 	curve *math.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *RangeCorrectnessVerifier {
 	if provider == nil {
-		provider = rp.DefaultProvider
+		provider = executor.DefaultProvider
 	}
 
 	return &RangeCorrectnessVerifier{

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
 	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
-	rp "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 )
 
 // RangeProofData contains the elements of a Bulletproof-style range proof.
@@ -202,7 +202,7 @@ type rangeProver struct {
 	Curve *math.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeProver returns a rangeProver based on  the passed arguments
@@ -216,7 +216,7 @@ func NewRangeProver(
 	P, Q *math.G1,
 	numberOfRounds, bitLength uint64,
 	curve *math.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *rangeProver {
 	return &rangeProver{
 		Commitment:           com,
@@ -451,7 +451,7 @@ type rangeVerifier struct {
 	Curve *math.Curve
 	// Provider creates a fresh Executor for each Prove call.
 	// If nil, DefaultProvider (SerialProvider) is used.
-	Provider rp.ExecutorProvider
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeVerifier returns a rangeVerifier based on the passed arguments
@@ -463,7 +463,7 @@ func NewRangeVerifier(
 	P, Q *math.G1,
 	numberOfRounds, bitLength uint64,
 	curve *math.Curve,
-	provider rp.ExecutorProvider,
+	provider executor.ExecutorProvider,
 ) *rangeVerifier {
 	return &rangeVerifier{
 		Commitment:           com,

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rangecorrectness.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rangecorrectness.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 )
 
 // RangeCorrectness contains a set of range proofs for multiple commitments.
@@ -80,9 +81,14 @@ type RangeCorrectnessProver struct {
 	// Curve is the mathematical curve.
 	Curve            *math.Curve
 	TranscriptHeader []byte
+	// Provider creates a fresh Executor for each Prove call.
+	// If nil, executor.DefaultProvider (SerialProvider) is used.
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeCorrectnessProver returns a new RangeCorrectnessProver instance.
+// provider controls how independent range proofs are executed; pass nil
+// to use SerialProvider, which preserves the previous serial behaviour.
 func NewRangeCorrectnessProver(
 	coms []*math.G1,
 	values []uint64,
@@ -90,7 +96,12 @@ func NewRangeCorrectnessProver(
 	pedersenParameters, leftGenerators, rightGenerators []*math.G1,
 	bitLength uint64,
 	c *math.Curve,
+	provider executor.ExecutorProvider,
 ) *RangeCorrectnessProver {
+	if provider == nil {
+		provider = executor.DefaultProvider
+	}
+
 	return &RangeCorrectnessProver{
 		Commitments:        coms,
 		Values:             values,
@@ -100,32 +111,49 @@ func NewRangeCorrectnessProver(
 		RightGenerators:    rightGenerators,
 		BitLength:          bitLength,
 		Curve:              c,
+		Provider:           provider,
 	}
 }
 
-// Prove generates a set of range proofs.
+// Prove generates a set of range proofs, one per commitment.
+// Independent proofs are executed using the Provider's Executor strategy.
 func (p *RangeCorrectnessProver) Prove() (*RangeCorrectness, error) {
 	if len(p.TranscriptHeader) == 0 {
 		return nil, errors.New("transcript header is empty")
 	}
-	rc := &RangeCorrectness{}
-	rc.Proofs = make([]*RangeProof, len(p.Commitments))
-	for i := range len(p.Commitments) {
-		bp := NewRangeProver(
-			p.Commitments[i],
-			math2.NewCachedZrFromInt(p.Curve, p.Values[i]),
-			p.BlindingFactors[i],
-			p.PedersenParameters,
-			p.LeftGenerators,
-			p.RightGenerators,
-			p.BitLength,
-			p.Curve,
-		).WithTranscriptHeader(p.TranscriptHeader)
-		proof, err := bp.Prove()
+
+	n := len(p.Commitments)
+	rc := &RangeCorrectness{
+		Proofs: make([]*RangeProof, n),
+	}
+	errs := make([]error, n)
+
+	// A fresh Executor is obtained per Prove call so that concurrent callers
+	// on the same RangeCorrectnessProver never share an Executor instance.
+	exec := p.Provider.New()
+
+	for i := range n {
+		exec.Submit(func() {
+			bp := NewRangeProver(
+				p.Commitments[i],
+				math2.NewCachedZrFromInt(p.Curve, p.Values[i]),
+				p.BlindingFactors[i],
+				p.PedersenParameters,
+				p.LeftGenerators,
+				p.RightGenerators,
+				p.BitLength,
+				p.Curve,
+			).WithTranscriptHeader(p.TranscriptHeader)
+			rc.Proofs[i], errs[i] = bp.Prove()
+		})
+	}
+
+	exec.Wait()
+
+	for _, err := range errs {
 		if err != nil {
 			return nil, err
 		}
-		rc.Proofs[i] = proof
 	}
 
 	return rc, nil
@@ -150,27 +178,38 @@ type RangeCorrectnessVerifier struct {
 	// BitLength is the maximum bit length of the values.
 	BitLength uint64
 	// Curve is the mathematical curve.
-	Curve *math.Curve
-
+	Curve            *math.Curve
 	TranscriptHeader []byte
+	// Provider creates a fresh Executor for each Verify call.
+	// If nil, executor.DefaultProvider (SerialProvider) is used.
+	Provider executor.ExecutorProvider
 }
 
 // NewRangeCorrectnessVerifier returns a new RangeCorrectnessVerifier instance.
+// provider controls how independent range proofs are verified; pass nil
+// to use SerialProvider, which preserves the previous serial behaviour.
 func NewRangeCorrectnessVerifier(
 	pedersenParameters, leftGenerators, rightGenerators []*math.G1,
 	bitLength uint64,
 	curve *math.Curve,
+	provider executor.ExecutorProvider,
 ) *RangeCorrectnessVerifier {
+	if provider == nil {
+		provider = executor.DefaultProvider
+	}
+
 	return &RangeCorrectnessVerifier{
 		PedersenParameters: pedersenParameters,
 		LeftGenerators:     leftGenerators,
 		RightGenerators:    rightGenerators,
 		BitLength:          bitLength,
 		Curve:              curve,
+		Provider:           provider,
 	}
 }
 
 // Verify checks if the provided set of range proofs is valid.
+// Independent proofs are verified using the Provider's Executor strategy.
 func (v *RangeCorrectnessVerifier) Verify(rc *RangeCorrectness) error {
 	if len(rc.Proofs) != len(v.Commitments) {
 		return errors.New("invalid range proof")
@@ -178,19 +217,38 @@ func (v *RangeCorrectnessVerifier) Verify(rc *RangeCorrectness) error {
 	if len(v.TranscriptHeader) == 0 {
 		return errors.New("transcript header is empty")
 	}
-	for i := range len(rc.Proofs) {
-		if rc.Proofs[i] == nil {
-			return errors.Errorf("invalid range proof: nil proof at index %d", i)
-		}
-		bv := NewRangeVerifier(
-			v.PedersenParameters,
-			v.LeftGenerators,
-			v.RightGenerators,
-			v.Commitments[i],
-			v.BitLength,
-			v.Curve,
-		).WithTranscriptHeader(v.TranscriptHeader)
-		err := bv.Verify(rc.Proofs[i])
+
+	n := len(rc.Proofs)
+	errs := make([]error, n)
+
+	// A fresh Executor is obtained per Verify call so that concurrent callers
+	// on the same RangeCorrectnessVerifier never share an Executor instance.
+	exec := v.Provider.New()
+
+	for i := range n {
+		exec.Submit(func() {
+			if rc.Proofs[i] == nil {
+				errs[i] = errors.Errorf("invalid range proof: nil proof at index %d", i)
+
+				return
+			}
+
+			bv := NewRangeVerifier(
+				v.PedersenParameters,
+				v.LeftGenerators,
+				v.RightGenerators,
+				v.Commitments[i],
+				v.BitLength,
+				v.Curve,
+			).WithTranscriptHeader(v.TranscriptHeader)
+
+			errs[i] = bv.Verify(rc.Proofs[i])
+		})
+	}
+
+	exec.Wait()
+
+	for i, err := range errs {
 		if err != nil {
 			return errors.Wrapf(err, "invalid range proof at index %d", i)
 		}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rangecorrectness_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rangecorrectness_test.go
@@ -63,6 +63,7 @@ func TestCSPRangeCorrectnessProveVerify(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -77,6 +78,7 @@ func TestCSPRangeCorrectnessProveVerify(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = commitments
 
@@ -125,6 +127,7 @@ func TestCSPRangeCorrectnessSingleCommitment(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -137,6 +140,7 @@ func TestCSPRangeCorrectnessSingleCommitment(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = []*math.G1{commitment}
 
@@ -177,6 +181,7 @@ func TestCSPRangeCorrectnessEmptyCommitments(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -189,6 +194,7 @@ func TestCSPRangeCorrectnessEmptyCommitments(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			verifier.Commitments = []*math.G1{}
@@ -243,6 +249,7 @@ func TestCSPRangeCorrectnessMismatchedProofCount(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = commitments
 
@@ -290,6 +297,7 @@ func TestCSPRangeCorrectnessNilProof(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = []*math.G1{commitment}
 
@@ -346,6 +354,7 @@ func TestCSPRangeCorrectnessSerializationRoundTrip(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -373,6 +382,7 @@ func TestCSPRangeCorrectnessSerializationRoundTrip(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			verifier.Commitments = commitments
@@ -495,6 +505,7 @@ func TestCSPRangeCorrectnessLargeSet(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -507,6 +518,7 @@ func TestCSPRangeCorrectnessLargeSet(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = commitments
 
@@ -560,6 +572,7 @@ func TestCSPRangeCorrectnessBoundaryValues(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -571,6 +584,7 @@ func TestCSPRangeCorrectnessBoundaryValues(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = commitments
 
@@ -619,6 +633,7 @@ func TestCSPRangeCorrectnessWrongCommitment(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 
 			rc, err := prover.Prove()
@@ -633,6 +648,7 @@ func TestCSPRangeCorrectnessWrongCommitment(t *testing.T) {
 				rightGens,
 				n,
 				curve,
+				nil,
 			).WithTranscriptHeader([]byte("a_transcript_header"))
 			verifier.Commitments = []*math.G1{wrongCommitment}
 

--- a/token/core/zkatdlog/nogh/v1/issue/cspissue.go
+++ b/token/core/zkatdlog/nogh/v1/issue/cspissue.go
@@ -93,6 +93,7 @@ func NewCSPBasedProver(tw []*token.Metadata, tokens []*math.G1, pp *v1.PublicPar
 		pp.CSPRangeProofParams.RightGenerators,
 		pp.CSPRangeProofParams.BitLength,
 		math.Curves[pp.Curve],
+		nil,
 	).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 
 	return p, nil
@@ -143,6 +144,7 @@ func NewCSPVerifier(tokens []*math.G1, pp *v1.PublicParams) *CSPVerifier {
 		pp.CSPRangeProofParams.RightGenerators,
 		pp.CSPRangeProofParams.BitLength,
 		math.Curves[pp.Curve],
+		nil,
 	).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 
 	return v

--- a/token/core/zkatdlog/nogh/v1/transfer/csptransfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/csptransfer.go
@@ -121,6 +121,7 @@ func NewCSPBasedProver(inputWitness, outputWitness []*token.Metadata, inputs, ou
 			pp.CSPRangeProofParams.RightGenerators,
 			pp.CSPRangeProofParams.BitLength,
 			math.Curves[pp.Curve],
+			nil,
 		).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 	}
 
@@ -175,6 +176,7 @@ func NewCSPVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams) *CSPVerifie
 			pp.CSPRangeProofParams.RightGenerators,
 			pp.CSPRangeProofParams.BitLength,
 			math.Curves[pp.Curve],
+			nil,
 		).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 	}
 


### PR DESCRIPTION
## Summary 

Extends the Executor abstraction from the bulletproof package (PR #1497) to the CSP-based range proof system in the csp package, as requested by @adecaro .

---
## Changes 

### Modified `rangecorrectness.go`

`RangeCorrectnessProver` and `RangeCorrectnessVerifier` now hold an `ExecutorProvider` field. Their constructors accept `provider ExecutorProvider` as a final parameter; `nil` maps to `DefaultProvider`. `Prove()` and `Verify()` call `provider.New()` to get a fresh `Executor` per call, so concurrent callers never share an `Executor` instance.

## Testing

```
go test -race ./token/core/zkatdlog/...
```
passes with  zero failures, zero races

---

Let me know if this looks good 🙏 