### PR TITLE
perf(benchmark): add -executor flag to select execution strategy in parallel benchmark tests

### DIFF
--- a/docs/drivers/benchmark/core/dlognogh/dlognogh.md
+++ b/docs/drivers/benchmark/core/dlognogh/dlognogh.md
@@ -18,6 +18,16 @@ The proof system is selected via the `-proof_type` flag:
 
 **Performance Impact**: CSP proofs offer improved verification performance through optimized Lagrange interpolation, particularly beneficial for high-throughput scenarios. Benchmark results will vary based on the selected proof system.
 
+## Executor Strategies
+
+The driver supports three execution strategies for independent range proof generation and verification, controlled via the `-executor` flag:
+
+- `serial` (default) — Tasks run inline on the calling goroutine. Zero scheduling overhead. Best for latency-sensitive single-proof workloads.
+- `unbounded` — One goroutine per range proof. Maximum parallelism but unbounded goroutine creation. Best for small numbers of coarse-grained independent proofs.
+- `pool` — Bounded pool of `runtime.NumCPU()` goroutines. Balances throughput and stability. Best for high-concurrency scenarios with multiple output tokens.
+
+The executor strategy adds a new dimension to benchmarking: a given workload can be measured with all three strategies to find the optimal configuration for a specific deployment's latency/throughput tradeoff.
+
 ## Benchmark Packages
 
 Packages with benchmark tests:
@@ -56,6 +66,7 @@ The benchmark accepts the following tunable parameters:
 - NumInputs: number of input tokens provided to the sender (1, 2, ...).
 - NumOutputs: number of outputs produced by the transfer (1, 2, ...).
 - ProofType: the range proof system to use (`bulletproof` or `csp`).
+- Executor: the execution strategy for independent range proofs (`serial`, `unbounded`, or `pool`).
 
 These parameters can be configured from the command line using the following flags:
 
@@ -70,6 +81,8 @@ These parameters can be configured from the command line using the following fla
         a comma-separate list of number of outputs (1,2,3,...)
   -proof_type string
         range proof system: bulletproof (default) or csp
+  -executor string
+        execution strategy for range proofs: serial (default), unbounded, or pool
 ```
 
 ### Default parameter set used in the benchmark
@@ -80,6 +93,7 @@ If no flag is used, the test file currently uses the following parameter slices 
 - curves: [BN254, BLS12_381_BBS_GURVY, BLS12_381_BBS_GURVY_FAST_RNG]
 - inputs: [1, 2, 3]
 - outputs: [1, 2, 3]
+- executor: serial
 
 This produces 2 (bits) * 3 (curves) * 3 (inputs) * 3 (outputs) = 54 sub-benchmarks. 
 Each sub-benchmark runs the standard `b.N` iterations and reports time and allocation statistics.
@@ -107,11 +121,10 @@ Note: `-count` controls how many times the test binary is executed (useful to re
 You can also change the parameters:
 
 ```shell
-go test ./token/core/zkatdlog/nogh/v1/transfer -test.bench=BenchmarkSender -test.benchmem -test.count=10 -test.cpu=1 -test.timeout 0 -test.run=^$ -bits="32" -curves="BN254" -num_inputs="2" -num_outputs="2"  | tee bench.txt
+go test ./token/core/zkatdlog/nogh/v1/transfer -test.bench=BenchmarkSender -test.benchmem -test.count=10 -test.cpu=1 -test.timeout 0 -test.run=^$ -bits="32" -curves="BN254" -num_inputs="2" -num_outputs="2" -proof_type="csp" -executor="pool" | tee bench.txt
 ```
 
 > Notice that in this the above case, the `go test` options must be prefixed with `test.` otherwise the tool will fail.
- 
 
 
 ### Notes and best practices
@@ -120,6 +133,7 @@ go test ./token/core/zkatdlog/nogh/v1/transfer -test.bench=BenchmarkSender -test
   For CI or quick local runs, reduce the parameter lists to a small subset (for example: one bit size, one curve, and 1-2 input/output sizes).
 - The benchmark creates `b.N` independent sender environments (via `NewBenchmarkSenderEnv`) and runs `GenerateZKTransfer` for each environment in the inner loop — so memory and setup cost scale with `b.N` during setup.
 - If you need to measure only the transfer-generation time and omit setup, consider modifying the benchmark to move expensive one-time setup out of the measured region and call `b.ResetTimer()` appropriately (the current benchmark already calls `b.ResetTimer()` before the inner loop).
+- When comparing executor strategies, run each strategy in isolation with the same duration and worker count to get a fair comparison. The `pool` executor generally reduces tail latency at the cost of slightly higher GC overhead compared to `serial`.
 
 ### Collecting and interpreting results
 
@@ -143,7 +157,7 @@ This allows the analyst to understand if shared data structures are actual bottl
 It uses a custom-made runner whose documentation can be found [here](../../../../../token/services/benchmark/runner.md).
 
 ```shell
-go test ./token/core/zkatdlog/nogh/v1/transfer -test.run=TestParallelBenchmarkSender -test.v -test.timeout 0 -bits="32" -curves="BN254" -num_inputs="2" -num_outputs="2" -workers="NumCPU" -duration="10s" -setup_samples=128 | tee bench.txt
+go test ./token/core/zkatdlog/nogh/v1/transfer -test.run=TestParallelBenchmarkSender -test.v -test.timeout 0 -bits="32" -curves="BN254" -num_inputs="2" -num_outputs="2" -workers="NumCPU" -duration="10s" -setup_samples=128 -executor="pool" | tee bench.txt
 ```
 
 The test supports the following flags:
@@ -160,6 +174,10 @@ The test supports the following flags:
         a comma-separate list of number of outputs (1,2,3,...)
   -workers string
         a comma-separate list of workers (1,2,3,...,NumCPU), where NumCPU is converted to the number of available CPUs
+  -proof_type string
+        range proof system: bulletproof (default) or csp
+  -executor string
+        execution strategy for range proofs: serial (default), unbounded, or pool
   -profile bool
         write pprof profiles to file
   -setup_samples uint
@@ -174,70 +192,67 @@ The test supports the following flags:
 Metric           Value     Description
 ------           -----     -----------
 Workers          10        
-Total Ops        1230      (Low Sample Size)
-Duration         10.068s   (Good Duration)
-Real Throughput  122.17/s  Observed Ops/sec (Wall Clock)
-Pure Throughput  123.04/s  Theoretical Max (Low Overhead)
+Total Ops        2415      (Low Sample Size)
+Duration         10.029s   (Good Duration)
+Real Throughput  240.80/s  Observed Ops/sec (Wall Clock)
+Pure Throughput  241.47/s  Theoretical Max (Low Overhead)
 
 Latency Distribution:
- Min           59.895916ms   
- P50 (Median)  77.717333ms   
- Average       81.27214ms    
- P95           112.28194ms   
- P99           137.126207ms  
- P99.9         189.117473ms  
- Max           215.981417ms  (Stable Tail)
+ Min           31.760236ms  
+ P50 (Median)  41.257005ms  
+ Average       41.41284ms   
+ P95           45.007531ms  
+ P99           46.786355ms  
+ P99.9         48.476513ms  
+ Max           49.139729ms  (Stable Tail)
 
 Stability Metrics:
- Std Dev  16.96192ms   
- IQR      19.050834ms  Interquartile Range
- Jitter   15.937043ms  Avg delta per worker
- CV       20.87%       Unstable (>20%) - Result is Noisy
+ Std Dev  2.026146ms  
+ IQR      2.616459ms  Interquartile Range
+ Jitter   1.960907ms  Avg delta per worker
+ CV       4.89%       Excellent Stability (<5%)
 
 System Health & Reliability:
  Error Rate   0.0000%          (100% Success) (0 errors)
- Memory       1159374 B/op     Allocated bytes per operation
- Allocs       17213 allocs/op  Allocations per operation
- Alloc Rate   133.20 MB/s      Memory pressure on system
- GC Overhead  1.27%            (High GC Pressure)
- GC Pause     127.435871ms     Total Stop-The-World time
- GC Cycles    264              Full garbage collection cycles
+ Memory       1787240 B/op     Allocated bytes per operation
+ Allocs       19166 allocs/op  Allocations per operation
+ Alloc Rate   397.47 MB/s      Memory pressure on system
+ GC Overhead  7.00%            (Severe GC Thrashing)
+ GC Pause     702.07326ms      Total Stop-The-World time
+ GC Cycles    2160             Full garbage collection cycles
 
 Latency Heatmap (Dynamic Range):
-Range                       Freq  Distribution Graph
- 59.895916ms-63.862831ms    98    ██████████████████████ (8.0%)
- 63.862831ms-68.092476ms    163   ████████████████████████████████████ (13.3%)
- 68.092476ms-72.602251ms    170   ██████████████████████████████████████ (13.8%)
- 72.602251ms-77.410709ms    172   ██████████████████████████████████████ (14.0%)
- 77.410709ms-82.537631ms    177   ████████████████████████████████████████ (14.4%)
- 82.537631ms-88.004111ms    128   ████████████████████████████ (10.4%)
- 88.004111ms-93.832637ms    119   ██████████████████████████ (9.7%)
- 93.832637ms-100.047186ms   73    ████████████████ (5.9%)
- 100.047186ms-106.673326ms  40    █████████ (3.3%)
- 106.673326ms-113.738317ms  32    ███████ (2.6%)
- 113.738317ms-121.271222ms  20    ████ (1.6%)
- 121.271222ms-129.303034ms  14    ███ (1.1%)
- 129.303034ms-137.866793ms  12    ██ (1.0%)
- 137.866793ms-146.997731ms  3      (0.2%)
- 146.997731ms-156.733413ms  4      (0.3%)
- 167.11389ms-178.181868ms   2      (0.2%)
- 178.181868ms-189.98288ms   1      (0.1%)
- 189.98288ms-202.565475ms   1      (0.1%)
- 202.565475ms-215.981417ms  1      (0.1%)
+Range                     Freq  Distribution Graph
+ 31.760236ms-32.460946ms  2      (0.1%)
+ 33.177115ms-33.909085ms  1      (0.0%)
+ 35.421828ms-36.203322ms  2      (0.1%)
+ 36.203322ms-37.002058ms  12    █ (0.5%)
+ 37.002058ms-37.818416ms  54    ████ (2.2%)
+ 37.818416ms-38.652784ms  103   ████████ (4.3%)
+ 38.652784ms-39.505561ms  230   ████████████████████ (9.5%)
+ 39.505561ms-40.377152ms  349   ██████████████████████████████ (14.5%)
+ 40.377152ms-41.267973ms  460   ████████████████████████████████████████ (19.0%)
+ 41.267973ms-42.178447ms  421   ████████████████████████████████████ (17.4%)
+ 42.178447ms-43.109009ms  311   ███████████████████████████ (12.9%)
+ 43.109009ms-44.060101ms  232   ████████████████████ (9.6%)
+ 44.060101ms-45.032177ms  119   ██████████ (4.9%)
+ 45.032177ms-46.025699ms  81    ███████ (3.4%)
+ 46.025699ms-47.041141ms  19    █ (0.8%)
+ 47.041141ms-48.078986ms  15    █ (0.6%)
+ 48.078986ms-49.139729ms  4      (0.2%)
 
 --- Analysis & Recommendations ---
-[WARN] Low sample size (1230). Results may not be statistically significant. Run for longer.
-[FAIL] High Variance (CV 20.87%). System noise is affecting results. Isolate the machine or increase duration.
-[INFO] High Allocations (17213/op). This will trigger frequent GC cycles and increase Max Latency.
+[WARN] Low sample size (2415). Results may not be statistically significant. Run for longer.
+[INFO] High Allocations (19166/op). This will trigger frequent GC cycles and increase Max Latency.
 ----------------------------------
 
 --- Throughput Timeline ---
-Timeline: [▇▇▇█▇▇▇▇▆▇] (Max: 131 ops/s)
+Timeline: [▇█▇▇▇▇▇▇▇] (Max: 247 ops/s)
 
---- PASS: TestParallelBenchmarkSender (13.97s)
-    --- PASS: TestParallelBenchmarkSender/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_10_workers (13.96s)
+--- PASS: TestParallelBenchmarkSender (13.29s)
+    --- PASS: TestParallelBenchmarkSender/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_10_workers (13.28s)
 PASS
-ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/transfer       14.566s
+ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/transfer       13.320s
 ```
 
 ### Running selected benchmarks with run_benchmarks.py
@@ -282,4 +297,3 @@ python run_benchmarks.py --benchName BenchmarkSender --timeout 4s --count 5
 ```shell
 python run_benchmarks.py --benchName BenchmarkSender --timeout 4s --count 5
 ```
-

--- a/token/core/zkatdlog/nogh/v1/benchmark/flags.go
+++ b/token/core/zkatdlog/nogh/v1/benchmark/flags.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 )
 
 var (
-	proofType = flag.String("proof_type", "1", "1 or bulletproof or bf, 2 or csp")
+	proofType    = flag.String("proof_type", "1", "1 or bulletproof or bf, 2 or csp")
+	executorFlag = flag.String("executor", "serial", "execution strategy for range proofs: serial, unbounded, pool")
 )
 
 // ProofType returns the proof type flag value (0 = RangeProof, 1 = CSPRangeProof).
@@ -36,4 +38,26 @@ func ProofType() rp.ProofType {
 		return rp.CSPRangeProofType
 	}
 	panic(fmt.Errorf("invalid proof_type: %s", str))
+}
+
+// ExecutorProvider returns the ExecutorProvider selected via the -executor flag.
+// Supported values:
+//   - "serial" (default): tasks run inline, zero overhead
+//   - "unbounded": one goroutine per task
+//   - "pool": bounded pool of runtime.NumCPU() goroutines
+func ExecutorProvider() executor.ExecutorProvider {
+	str := *executorFlag
+	if len(str) == 0 {
+		return executor.SerialProvider{}
+	}
+
+	switch strings.ToLower(str) {
+	case "serial":
+		return executor.SerialProvider{}
+	case "unbounded":
+		return executor.UnboundedProvider{}
+	case "pool":
+		return executor.WorkerPoolProvider{}
+	}
+	panic(fmt.Errorf("invalid executor: %s (want serial, unbounded, or pool)", str))
 }

--- a/token/core/zkatdlog/nogh/v1/benchmark/setup.go
+++ b/token/core/zkatdlog/nogh/v1/benchmark/setup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/common/crypto/math"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity"
@@ -52,6 +53,9 @@ type SetupParams struct {
 	CurveIDs           []math.CurveID
 	OwnerIdentityType  identity.Type
 	ProofType          rp.ProofType // RangeProofType or CSPRangeProofType
+	// ExecutorProvider controls how independent range proofs are executed.
+	// If nil, rp.SerialProvider{} is used (serial execution, zero overhead).
+	ExecutorProvider executor.ExecutorProvider
 }
 
 // SetupConfiguration holds the prepared public parameters and related
@@ -68,6 +72,8 @@ type SetupConfiguration struct {
 	IssuerSigner  *Signer
 	Bits          uint64
 	CurveID       math.CurveID
+	// ExecutorProvider is the execution strategy for range proofs in this configuration.
+	ExecutorProvider executor.ExecutorProvider
 }
 
 // SetupConfigurations contains a set of named benchmark configurations.
@@ -168,13 +174,21 @@ func NewSetupConfigurationsWithParams(params SetupParams) (*SetupConfigurations,
 				return nil, err
 			}
 			pp.AddAuditor(auditorID)
+
+			provider := params.ExecutorProvider
+			if provider == nil {
+				provider = executor.SerialProvider{}
+			}
+			pp.ExecutorProvider = provider
+
 			configurations[key(bit, curveID)] = &SetupConfiguration{
-				Bits:          bit,
-				CurveID:       curveID,
-				PP:            pp,
-				OwnerIdentity: oID,
-				AuditorSigner: auditorSigner,
-				IssuerSigner:  issuerSigner,
+				Bits:             bit,
+				CurveID:          curveID,
+				PP:               pp,
+				OwnerIdentity:    oID,
+				AuditorSigner:    auditorSigner,
+				IssuerSigner:     issuerSigner,
+				ExecutorProvider: provider,
 			}
 		}
 	}

--- a/token/core/zkatdlog/nogh/v1/issue/bfissue.go
+++ b/token/core/zkatdlog/nogh/v1/issue/bfissue.go
@@ -96,7 +96,7 @@ func NewBulletProofProver(tw []*token.Metadata, tokens []*math.G1, pp *v1.Public
 		pp.RangeProofParams.BitLength,
 		pp.RangeProofParams.NumberOfRounds,
 		math.Curves[pp.Curve],
-		nil,
+		pp.ExecutorProvider,
 	)
 
 	return p, nil

--- a/token/core/zkatdlog/nogh/v1/issue/cspissue.go
+++ b/token/core/zkatdlog/nogh/v1/issue/cspissue.go
@@ -93,7 +93,7 @@ func NewCSPBasedProver(tw []*token.Metadata, tokens []*math.G1, pp *v1.PublicPar
 		pp.CSPRangeProofParams.RightGenerators,
 		pp.CSPRangeProofParams.BitLength,
 		math.Curves[pp.Curve],
-		nil,
+		pp.ExecutorProvider,
 	).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 
 	return p, nil
@@ -144,7 +144,7 @@ func NewCSPVerifier(tokens []*math.G1, pp *v1.PublicParams) *CSPVerifier {
 		pp.CSPRangeProofParams.RightGenerators,
 		pp.CSPRangeProofParams.BitLength,
 		math.Curves[pp.Curve],
-		nil,
+		pp.ExecutorProvider,
 	).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 
 	return v

--- a/token/core/zkatdlog/nogh/v1/issue/verifier.go
+++ b/token/core/zkatdlog/nogh/v1/issue/verifier.go
@@ -25,7 +25,7 @@ type BulletProofVerifier struct {
 func NewBulletProofVerifier(tokens []*math.G1, pp *v1.PublicParams) *BulletProofVerifier {
 	v := &BulletProofVerifier{}
 	v.SameType = NewSameTypeVerifier(tokens, pp.PedersenGenerators, math.Curves[pp.Curve])
-	v.RangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], nil)
+	v.RangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], pp.ExecutorProvider)
 
 	return v
 }

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/csp"
+	executor "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/executor"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
 	pp2 "github.com/hyperledger-labs/fabric-token-sdk/token/driver/protos-go/pp"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/protos"
@@ -265,6 +266,9 @@ type PublicParams struct {
 	// ExtraData contains any extra custom data
 	ExtraData           driver.Extras
 	CSPRangeProofParams *CSPRangeProofParams
+	// ExecutorProvider is a runtime-only field (not serialized) that controls
+	// how independent range proofs are executed. If nil, SerialProvider is used.
+	ExecutorProvider executor.ExecutorProvider `json:"-"`
 }
 
 // NewPublicParamsFromBytes unmarshal the given serialized version of the public parameters

--- a/token/core/zkatdlog/nogh/v1/transfer/bftransfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/bftransfer.go
@@ -75,7 +75,7 @@ func NewBulletProofVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams) *Bu
 	// if so, skip range proof as well-formedness proof is sufficient.
 	var rangeCorrectness *bulletproof.RangeCorrectnessVerifier
 	if len(inputs) != 1 || len(outputs) != 1 {
-		rangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], nil)
+		rangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], pp.ExecutorProvider)
 	}
 
 	return &BulletProofVerifier{
@@ -186,7 +186,7 @@ func NewBulletProofProver(inputWitness, outputWitness []*token.Metadata, inputs,
 			pp.RangeProofParams.BitLength,
 			pp.RangeProofParams.NumberOfRounds,
 			math.Curves[pp.Curve],
-			nil,
+			pp.ExecutorProvider,
 		)
 	}
 

--- a/token/core/zkatdlog/nogh/v1/transfer/csptransfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/csptransfer.go
@@ -121,7 +121,7 @@ func NewCSPBasedProver(inputWitness, outputWitness []*token.Metadata, inputs, ou
 			pp.CSPRangeProofParams.RightGenerators,
 			pp.CSPRangeProofParams.BitLength,
 			math.Curves[pp.Curve],
-			nil,
+			pp.ExecutorProvider,
 		).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 	}
 
@@ -176,7 +176,7 @@ func NewCSPVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams) *CSPVerifie
 			pp.CSPRangeProofParams.RightGenerators,
 			pp.CSPRangeProofParams.BitLength,
 			math.Curves[pp.Curve],
-			nil,
+			pp.ExecutorProvider,
 		).WithTranscriptHeader(pp.CSPRangeProofParams.RPTranscriptHeader)
 	}
 

--- a/token/core/zkatdlog/nogh/v1/transfer_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer_test.go
@@ -110,12 +110,14 @@ func TestParallelBenchmarkTransferServiceTransfer(t *testing.T) {
 	bits, curves, cases, err := benchmark2.GenerateCasesWithDefaults()
 	require.NoError(t, err)
 	proofType := benchmark.ProofType()
+	executorProvider := benchmark.ExecutorProvider()
 	configurations, err := benchmark.NewSetupConfigurationsWithParams(benchmark.SetupParams{
 		IdemixTestdataPath: "./testdata",
 		Bits:               bits,
 		CurveIDs:           curves,
 		OwnerIdentityType:  idemixnym.IdentityType,
 		ProofType:          proofType,
+		ExecutorProvider:   executorProvider,
 	})
 	require.NoError(t, err)
 

--- a/token/core/zkatdlog/nogh/v1/validator/validator_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_test.go
@@ -131,12 +131,14 @@ func TestParallelBenchmarkValidatorTransfer(t *testing.T) {
 	bits, curves, cases, err := benchmark2.GenerateCasesWithDefaults()
 	require.NoError(t, err)
 	proofType := benchmark.ProofType()
+	executorProvider := benchmark.ExecutorProvider()
 	configurations, err := benchmark.NewSetupConfigurationsWithParams(benchmark.SetupParams{
 		IdemixTestdataPath: "./../testdata",
 		Bits:               bits,
 		CurveIDs:           curves,
 		OwnerIdentityType:  idemixnym.IdentityType,
 		ProofType:          proofType,
+		ExecutorProvider:   executorProvider,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Adds an `-executor` CLI flag that threads the selected `ExecutorProvider` through the parallel benchmark tests all the way down to the `NewRangeCorrectnessProver` and `NewRangeCorrectnessVerifier` call sites.
This enables the full battery of benchmark tests to be run with all three execution strategies as a new dimension.

---

## Usage

```bash
# Serial (default)
go test ./token/core/zkatdlog/nogh/v1/validator \
    -test.run=TestParallelBenchmarkValidatorTransfer \
    -test.v -test.timeout 0 \
    -bits="32" -curves="BLS12_381_BBS_GURVY" \
    -num_inputs="2" -num_outputs="2" \
    -workers="NumCPU" -duration="1m" -setup_samples=128 \
    -executor="serial"

# Unbounded goroutines
    -executor="unbounded"

# Bounded worker pool
    -executor="pool"
```

---


## Design rationale

Storing `ExecutorProvider` on `PublicParams` as a runtime-only field (rather than adding it as a parameter to every prover/verifier constructor) means zero changes to the production API surface. All existing call sites that pass `nil` continue to work identically. The benchmark infrastructure is the only path that sets a non-nil value.

---

## Testing

I ran the `TestParallelBenchmarkValidatorTransfer` test with the new executor flag for the three different strategies with 10 workers and these are the benchmark results:

- ### Serial

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor=
"serial"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10023     (Robust Sample)
Duration         30.02s    (Good Duration)
Real Throughput  333.87/s  Observed Ops/sec (Wall Clock)
Pure Throughput  334.15/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           21.997419ms  
 P50 (Median)  29.496824ms  
 Average       29.926621ms  
 P95           34.642018ms  
 P99           39.609869ms  
 P99.9         58.172119ms  
 Max           77.859567ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.212995ms  
 IQR      3.249671ms  Interquartile Range
 Jitter   2.443266ms  Avg delta per worker
 CV       10.74%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate   0.0000%         (100% Success) (0 errors)
 Memory       710715 B/op     Allocated bytes per operation
 Allocs       7749 allocs/op  Allocations per operation
 Alloc Rate   224.68 MB/s     Memory pressure on system
 GC Overhead  4.18%           (High GC Pressure)
 GC Pause     1.254142853s    Total Stop-The-World time
 GC Cycles    3340            Full garbage collection cycles

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 21.997419ms-23.432506ms  10     (0.1%)
 23.432506ms-24.961216ms  83    █ (0.8%)
 24.961216ms-26.589658ms  714   █████████ (7.1%)
 26.589658ms-28.324338ms  2210  ████████████████████████████ (22.0%)
 28.324338ms-30.172187ms  3082  ████████████████████████████████████████ (30.7%)
 30.172187ms-32.140587ms  2226  ████████████████████████████ (22.2%)
 32.140587ms-34.237403ms  1084  ██████████████ (10.8%)
 34.237403ms-36.471013ms  394   █████ (3.9%)
 36.471013ms-38.850341ms  104   █ (1.0%)
 38.850341ms-41.384894ms  36     (0.4%)
 41.384894ms-44.084799ms  17     (0.2%)
 44.084799ms-46.960842ms  15     (0.1%)
 46.960842ms-50.024515ms  15     (0.1%)
 50.024515ms-53.288059ms  7      (0.1%)
 53.288059ms-56.764513ms  11     (0.1%)
 56.764513ms-60.467767ms  6      (0.1%)
 60.467767ms-64.412617ms  3      (0.0%)
 64.412617ms-68.614824ms  3      (0.0%)
 68.614824ms-73.091179ms  1      (0.0%)
 73.091179ms-77.859567ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7749/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▆▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 352 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (56.35s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (56.33s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      56.381s
```

- ### Worker pool

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10645     (Robust Sample)
Duration         30.01s    (Good Duration)
Real Throughput  354.72/s  Observed Ops/sec (Wall Clock)
Pure Throughput  354.89/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.605479ms  
 P50 (Median)  28.045936ms  
 Average       28.17769ms   
 P95           33.293479ms  
 P99           36.101745ms  
 P99.9         42.270897ms  
 Max           51.201573ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.040898ms  
 IQR      3.890853ms  Interquartile Range
 Jitter   3.137883ms  Avg delta per worker
 CV       10.79%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate   0.0000%         (100% Success) (0 errors)
 Memory       711379 B/op     Allocated bytes per operation
 Allocs       7766 allocs/op  Allocations per operation
 Alloc Rate   238.54 MB/s     Memory pressure on system
 GC Overhead  4.40%           (High GC Pressure)
 GC Pause     1.320454615s    Total Stop-The-World time
 GC Cycles    2937            Full garbage collection cycles

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.605479ms-19.571448ms  11     (0.1%)
 19.571448ms-20.58757ms   22     (0.2%)
 20.58757ms-21.656447ms   75    █ (0.7%)
 21.656447ms-22.780819ms  193   ███ (1.8%)
 22.780819ms-23.963567ms  475   █████████ (4.5%)
 23.963567ms-25.207721ms  879   ████████████████ (8.3%)
 25.207721ms-26.51647ms   1478  ████████████████████████████ (13.9%)
 26.51647ms-27.893167ms   1971  ██████████████████████████████████████ (18.5%)
 27.893167ms-29.34134ms   2070  ████████████████████████████████████████ (19.4%)
 29.34134ms-30.864701ms   1626  ███████████████████████████████ (15.3%)
 30.864701ms-32.467152ms  1013  ███████████████████ (9.5%)
 32.467152ms-34.1528ms    504   █████████ (4.7%)
 34.1528ms-35.925965ms    208   ████ (2.0%)
 35.925965ms-37.79119ms   72    █ (0.7%)
 37.79119ms-39.753254ms   27     (0.3%)
 39.753254ms-41.817186ms  9      (0.1%)
 41.817186ms-43.988275ms  5      (0.0%)
 43.988275ms-46.272083ms  3      (0.0%)
 46.272083ms-48.674464ms  2      (0.0%)
 48.674464ms-51.201573ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7766/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 374 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.70s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.68s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.732s
```

- ### Unbounded

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10226     (Robust Sample)
Duration         30.025s   (Good Duration)
Real Throughput  340.58/s  Observed Ops/sec (Wall Clock)
Pure Throughput  340.83/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           16.902032ms  
 P50 (Median)  29.071152ms  
 Average       29.339788ms  
 P95           34.953354ms  
 P99           38.987437ms  
 P99.9         56.443017ms  
 Max           71.241048ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.592403ms  
 IQR      4.223412ms  Interquartile Range
 Jitter   3.267278ms  Avg delta per worker
 CV       12.24%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate   0.0000%         (100% Success) (0 errors)
 Memory       711265 B/op     Allocated bytes per operation
 Allocs       7756 allocs/op  Allocations per operation
 Alloc Rate   228.92 MB/s     Memory pressure on system
 GC Overhead  4.49%           (High GC Pressure)
 GC Pause     1.34883063s     Total Stop-The-World time
 GC Cycles    2961            Full garbage collection cycles

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 16.902032ms-18.162619ms  1      (0.0%)
 18.162619ms-19.517224ms  1      (0.0%)
 19.517224ms-20.972858ms  21     (0.2%)
 20.972858ms-22.537056ms  106   █ (1.0%)
 22.537056ms-24.217915ms  360   █████ (3.5%)
 24.217915ms-26.024136ms  1091  ████████████████ (10.7%)
 26.024136ms-27.965069ms  2074  ██████████████████████████████ (20.3%)
 27.965069ms-30.05076ms   2701  ████████████████████████████████████████ (26.4%)
 30.05076ms-32.292007ms   2175  ████████████████████████████████ (21.3%)
 32.292007ms-34.70041ms   1109  ████████████████ (10.8%)
 34.70041ms-37.288436ms   401   █████ (3.9%)
 37.288436ms-40.069483ms  107   █ (1.0%)
 40.069483ms-43.057946ms  38     (0.4%)
 43.057946ms-46.269295ms  9      (0.1%)
 46.269295ms-49.720152ms  4      (0.0%)
 49.720152ms-53.428382ms  8      (0.1%)
 53.428382ms-57.413178ms  11     (0.1%)
 57.413178ms-61.695169ms  3      (0.0%)
 61.695169ms-66.296519ms  5      (0.0%)
 66.296519ms-71.241048ms  1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7756/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇▇▇█▇▇▆▇▇▇▇▇▇▆▇▇▇▇▇▇▇▇] (Max: 368 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (45.04s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (45.02s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      45.063s
```



Let me know if this is good 🙏