### PR TITLE
fix: sherdlock selector leaks token lock on bad quantity

### DIFF
--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -205,19 +205,17 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 			s.logger.DebugfContext(ctx, "Got the lock on token [%v]", t)
 			q, err := token2.ToQuantity(t.Quantity, s.precision)
 			if err != nil {
-				if unlockErr := s.locker.UnlockAll(ctx); unlockErr != nil {
-					s.logger.Errorf("failed to unlock tokens after quantity parse error: %s", unlockErr)
-				}
-				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found", t.Id)
+				err2 := s.locker.UnlockAll(ctx)
+
+				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found - unlock: %v", t.Id, err2)
 			}
 			s.logger.DebugfContext(ctx, "Found token [%s] to add: [%s:%s].", t.Id, q.Decimal(), t.Type)
 			immediateRetries = 0
 			sum, err = sum.Add(q)
 			if err != nil {
-				if unlockErr := s.locker.UnlockAll(ctx); unlockErr != nil {
-					s.logger.Errorf("failed to unlock tokens after quantity add error: %s", unlockErr)
-				}
-				return nil, nil, immediateRetries, errors.Wrap(err, "failed to add quantity")
+				err2 := s.locker.UnlockAll(ctx)
+
+				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to add quantity - unlock: %v", err2)
 			}
 			selected.Add(&t.Id)
 			if sum.Cmp(quantity) >= 0 {

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -124,6 +124,11 @@ func NewSelector(logger logging.Logger, tokenDB tokenFetcher, lockDB tokenLocker
 func (s *selector) Select(ctx context.Context, owner token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	start := time.Now()
 	ids, quantity, immediateRetries, err := s.selectInternal(ctx, owner, q, tokenType)
+	if err != nil {
+		if err2 := s.locker.UnlockAll(ctx); err2 != nil {
+			s.logger.Warnf("failed to unlock tokens after selection error: %v", err2)
+		}
+	}
 	s.metrics.SelectionDuration.Observe(time.Since(start).Seconds())
 	s.metrics.ImmediateRetries.Observe(float64(immediateRetries))
 	if err == nil {
@@ -142,6 +147,11 @@ func (s *selector) Select(ctx context.Context, owner token.OwnerFilter, q string
 // selectWithoutMetrics is used by stubbornSelector to avoid double-counting metrics.
 func (s *selector) selectWithoutMetrics(ctx context.Context, owner token.OwnerFilter, q string, tokenType token2.Type) ([]*token2.ID, token2.Quantity, error) {
 	ids, quantity, _, err := s.selectInternal(ctx, owner, q, tokenType)
+	if err != nil {
+		if err2 := s.locker.UnlockAll(ctx); err2 != nil {
+			s.logger.Warnf("failed to unlock tokens after selection error: %v", err2)
+		}
+	}
 
 	return ids, quantity, err
 }
@@ -157,15 +167,9 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 	sum, selected, tokensLockedByOthersExist, immediateRetries := token2.NewZeroQuantity(s.precision), collections.NewSet[*token2.ID](), true, 0
 	for {
 		if t, err := s.cache.Next(); err != nil {
-			err2 := s.locker.UnlockAll(ctx)
-
-			return nil, nil, immediateRetries, errors.Wrapf(err, "failed to get tokens for [%s:%s] - unlock: %v", owner.ID(), tokenType, err2)
+			return nil, nil, immediateRetries, errors.Wrapf(err, "failed to get tokens for [%s:%s]", owner.ID(), tokenType)
 		} else if t == nil {
 			if !tokensLockedByOthersExist {
-				if err2 := s.locker.UnlockAll(ctx); err2 != nil {
-					s.logger.Warnf("failed to unlock tokens on insufficient funds: %v", err2)
-				}
-
 				return nil, nil, immediateRetries, errors.Wrapf(
 					token.SelectorInsufficientFunds,
 					"insufficient funds, only [%s] tokens of type [%s] are available, but [%s] were requested and no other process has any tokens locked",
@@ -177,9 +181,6 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 
 			if immediateRetries > maxImmediateRetries {
 				s.logger.Warnf("Exceeded max number of immediate retries. Unlock tokens and abort...")
-				if err := s.locker.UnlockAll(ctx); err != nil {
-					return nil, nil, immediateRetries, errors.Wrapf(err, "exceeded number of retries: %d and unlock failed", maxImmediateRetries)
-				}
 
 				// When we loop over the tokens, we check whether a token is already locked.
 				// Every time our token cache finishes, but we noted that one of the tokens we saw was used by someone,
@@ -191,9 +192,7 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 
 			s.logger.DebugfContext(ctx, "Fetch all non-deleted tokens from the DB and refresh the token cache.")
 			if s.cache, err = s.fetcher.UnspentTokensIteratorBy(ctx, owner.ID(), tokenType); err != nil {
-				err2 := s.locker.UnlockAll(ctx)
-
-				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reload tokens for retry %d [%s:%s] - unlock: %v", immediateRetries, owner.ID(), tokenType, err2)
+				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to reload tokens for retry %d [%s:%s]", immediateRetries, owner.ID(), tokenType)
 			}
 
 			immediateRetries++
@@ -205,17 +204,13 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 			s.logger.DebugfContext(ctx, "Got the lock on token [%v]", t)
 			q, err := token2.ToQuantity(t.Quantity, s.precision)
 			if err != nil {
-				err2 := s.locker.UnlockAll(ctx)
-
-				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found - unlock: %v", t.Id, err2)
+				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found", t.Id)
 			}
 			s.logger.DebugfContext(ctx, "Found token [%s] to add: [%s:%s].", t.Id, q.Decimal(), t.Type)
 			immediateRetries = 0
 			sum, err = sum.Add(q)
 			if err != nil {
-				err2 := s.locker.UnlockAll(ctx)
-
-				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to add quantity - unlock: %v", err2)
+				return nil, nil, immediateRetries, errors.Wrapf(err, "failed to add quantity")
 			}
 			selected.Add(&t.Id)
 			if sum.Cmp(quantity) >= 0 {

--- a/token/services/selector/sherdlock/selector.go
+++ b/token/services/selector/sherdlock/selector.go
@@ -205,12 +205,18 @@ func (s *selector) selectInternal(ctx context.Context, owner token.OwnerFilter, 
 			s.logger.DebugfContext(ctx, "Got the lock on token [%v]", t)
 			q, err := token2.ToQuantity(t.Quantity, s.precision)
 			if err != nil {
+				if unlockErr := s.locker.UnlockAll(ctx); unlockErr != nil {
+					s.logger.Errorf("failed to unlock tokens after quantity parse error: %s", unlockErr)
+				}
 				return nil, nil, immediateRetries, errors.Wrapf(err, "invalid token [%s] found", t.Id)
 			}
 			s.logger.DebugfContext(ctx, "Found token [%s] to add: [%s:%s].", t.Id, q.Decimal(), t.Type)
 			immediateRetries = 0
 			sum, err = sum.Add(q)
 			if err != nil {
+				if unlockErr := s.locker.UnlockAll(ctx); unlockErr != nil {
+					s.logger.Errorf("failed to unlock tokens after quantity add error: %s", unlockErr)
+				}
 				return nil, nil, immediateRetries, errors.Wrap(err, "failed to add quantity")
 			}
 			selected.Add(&t.Id)

--- a/token/services/selector/sherdlock/selector_shutdown_test.go
+++ b/token/services/selector/sherdlock/selector_shutdown_test.go
@@ -67,6 +67,42 @@ func TestStubbornSelector_ContextCancellation(t *testing.T) {
 	})
 }
 
+// TestSelector_UnlockAllOnQuantityParseError verifies that when TryLock succeeds
+// but ToQuantity fails (e.g. after a precision change), UnlockAll is called and
+// the unlock error is surfaced alongside the original error.
+func TestSelector_UnlockAllOnQuantityParseError(t *testing.T) {
+	t.Run("unlocks all tokens when ToQuantity fails after TryLock", func(t *testing.T) {
+		unlockAllCalled := false
+
+		mockFetcher := &mockTokenFetcher{
+			unspentTokensIteratorByFunc: func(_ context.Context, _ string, _ token2.Type) (iterator[*token2.UnspentTokenInWallet], error) {
+				// quantity "not-a-number" will fail token2.ToQuantity for any precision
+				tok := &token2.UnspentTokenInWallet{
+					Id:       token2.ID{TxId: "tx1", Index: 0},
+					Type:     "USD",
+					Quantity: "not-a-number",
+				}
+
+				return collections.NewSliceIterator([]*token2.UnspentTokenInWallet{tok}), nil
+			},
+		}
+
+		// TryLock always succeeds so the code enters the else-branch that used to leak.
+		mockLck := &cancelTestLocker{
+			tryLockResult:   true,
+			unlockAllCalled: &unlockAllCalled,
+		}
+
+		m := NewMetrics(&disabled.Provider{})
+		sel := NewSelector(logger, mockFetcher, mockLck, 64, m)
+
+		_, _, err := sel.Select(context.Background(), &ownerFilter{id: "wallet1"}, "100", "USD")
+
+		require.Error(t, err)
+		assert.True(t, unlockAllCalled, "UnlockAll must be called when ToQuantity fails after TryLock")
+	})
+}
+
 // cancelTestLocker is a locker where TryLock always returns false (simulating all
 // tokens locked by others) and records whether UnlockAll was called.
 type cancelTestLocker struct {


### PR DESCRIPTION
Found a spot in the sherdlock selector where we lock a token but then hit a parse error and just... return. Never unlock. The token sits locked in `tokenlockdb` until the lease cleanup goroutine gets around to it (or forever if cleanup is off).

Two lines in `selectInternal`; after `TryLock` succeeds, if `ToQuantity` fails or `sum.Add` fails, we were bailing without calling `UnlockAll`. Every other error path in the same loop does the unlock correctly, these two just got missed.

Added the `UnlockAll` call before each of those returns. That's it.