### PR TITLE
perf(benchmark): add executor-aware metrics, automated benchmarking pipeline, and performance report

### DIFF
--- a/cmd/benchmarking/plot_benchmark_results.py
+++ b/cmd/benchmarking/plot_benchmark_results.py
@@ -3,6 +3,11 @@
 plot_benchmark_results.py: Generates comparison plots across executor
 strategies (serial, unbounded, pool) for each parallel benchmark test.
 
+Executor strategies:
+  serial: executes tasks sequentially in the same goroutine (baseline, no concurrency)
+  unbounded: spawns a new goroutine per task (maximum concurrency, higher overhead)
+  pool: uses a fixed-size worker pool (bounded concurrency, better control and stability)
+
 Reads benchmark_results.csv produced by run_benchmarks.py and outputs
 a PDF with two plots per test:
   Left:  TPS vs worker count, one line per executor strategy

--- a/cmd/benchmarking/plot_benchmark_results.py
+++ b/cmd/benchmarking/plot_benchmark_results.py
@@ -1,3 +1,15 @@
+#!/usr/bin/env python3
+"""
+plot_benchmark_results.py: Generates comparison plots across executor
+strategies (serial, unbounded, pool) for each parallel benchmark test.
+
+Reads benchmark_results.csv produced by run_benchmarks.py and outputs
+a PDF with two plots per test:
+  Left:  TPS vs worker count, one line per executor strategy
+  Right: TPS vs mean latency (with std error bars), one series per
+         executor × worker combination
+"""
+
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
@@ -6,18 +18,14 @@ import argparse
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
-
-# Optional positional argument
 parser.add_argument(
     "results_file",
-    nargs="?",  # makes it optional
+    nargs="?",
     default="benchmark_results.csv",
-    help="Path to the results CSV file"
+    help="Path to the results CSV file (default: benchmark_results.csv)"
 )
-
 args = parser.parse_args()
 
-# Set source and target paths
 csv_path = args.results_file
 pdf_path = str(Path(csv_path).with_suffix(".pdf"))
 
@@ -29,96 +37,132 @@ test_names = [
     "TestParallelBenchmarkValidatorTransfer",
 ]
 
+executors     = ["serial", "unbounded", "pool"]
+executor_colors = {
+    "serial":    "tab:blue",
+    "unbounded": "tab:orange",
+    "pool":      "tab:green",
+}
+executor_markers = {
+    "serial":    "o",
+    "unbounded": "s",
+    "pool":      "^",
+}
+
 df = pd.read_csv(csv_path)
-last_row = df.iloc[-1]
+last_row  = df.iloc[-1]
 timestamp = last_row["timestamp"]
-markers = ['o', 's', '^', 'D', 'x', '*']
-p95_marker = "X"   # single marker style for all p95 points
+
+# Column pattern: TestParallelBenchmarkSender[pool]/8 tps
+col_re = re.compile(
+    r"^(.+?)\[(\w+)\]/(\d+)\s+(tps|lat-p95|lat-avg|lat-std|goroutines)$"
+)
+
+def get_value(row, test, executor, cpu, metric):
+    col = f"{test}[{executor}]/{cpu} {metric}"
+    return row.get(col, None)
 
 with PdfPages(pdf_path) as pdf:
-
     for test_name in test_names:
 
-        pattern = re.compile(rf"{re.escape(test_name)}/(\d+)\s+tps")
-
-        workers = []
-        tps_values = []
-        lat_p95_values = []
-        lat_avg_values = []
-        lat_std_values = []
-
+        # Discover which worker counts are present for this test
+        worker_set = set()
         for col in df.columns:
-            match = pattern.match(col)
-            if match:
-                worker = match.group(1)
-                tps = last_row[col]
-                lat_p95_col = f"{test_name}/{worker} lat-p95"
-                lat_avg_col = f"{test_name}/{worker} lat-avg"
-                lat_std_col = f"{test_name}/{worker} lat-std"
-                lat_p95 = last_row[lat_p95_col]
-                lat_avg = last_row[lat_avg_col]
-                lat_std = last_row[lat_std_col]
+            m = col_re.match(col)
+            if m and m.group(1) == test_name:
+                worker_set.add(int(m.group(3)))
+        if not worker_set:
+            # Fall back to old-style columns without executor tag
+            old_re = re.compile(rf"^{re.escape(test_name)}/(\d+)\s+tps$")
+            for col in df.columns:
+                om = old_re.match(col)
+                if om:
+                    worker_set.add(int(om.group(1)))
+        if not worker_set:
+            continue
 
-                workers.append(worker)
-                tps_values.append(tps)
-                lat_p95_values.append(lat_p95)
-                lat_avg_values.append(lat_avg)
-                lat_std_values.append(lat_std)
+        workers_sorted = sorted(worker_set)
 
-        # Create figure with two subplots
-        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 6))
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 7))
+        fig.suptitle(f"{test_name}\n(last run: {timestamp})", fontsize=12)
 
-        # --- Left subplot:
-        worker_counts = [int(w) for w in workers]  # convert strings to integers
-
-        ax1.plot(
-            worker_counts,
-            tps_values,
-            marker='o',
-            linestyle='-',
-            color='tab:blue'
-        )
+        # ---- Left plot: TPS vs workers, one line per executor ----
+        for executor in executors:
+            tps_vals = []
+            w_vals   = []
+            for cpu in workers_sorted:
+                v = get_value(last_row, test_name, executor, cpu, "tps")
+                if v is not None and not pd.isna(v):
+                    tps_vals.append(float(v))
+                    w_vals.append(cpu)
+            if tps_vals:
+                ax1.plot(
+                    w_vals, tps_vals,
+                    marker=executor_markers[executor],
+                    linestyle="-",
+                    color=executor_colors[executor],
+                    label=executor,
+                )
 
         ax1.set_xlabel("Worker count")
         ax1.set_ylabel("TPS")
-        ax1.set_title(f"{test_name}: TPS vs Worker Count\nLast Row ({timestamp})")
-        ax1.grid(True)  # <-- grid added
+        ax1.set_title("TPS vs Worker Count")
+        ax1.legend(title="Executor")
+        ax1.grid(True)
 
-        # --- Right subplot: TPS vs Latency with error bars (mean ± std) ---
-        for i, worker in enumerate(workers):
-            err = ax2.errorbar(
-                tps_values[i],
-                lat_avg_values[i],
-                yerr=lat_std_values[i],
-                marker=markers[i % len(markers)],
-                label=f"{worker} worker(s)",
-                capsize=5,
-                capthick=2,
-                linestyle='None'
-            )
-            color = err[0].get_color()
+        # ---- Right plot: TPS vs mean latency with error bars ----
+        # One point per (executor, worker) combination
+        p95_marker = "X"
+        plotted_executors = set()
+        for executor in executors:
+            for cpu in workers_sorted:
+                tps   = get_value(last_row, test_name, executor, cpu, "tps")
+                avg   = get_value(last_row, test_name, executor, cpu, "lat-avg")
+                std   = get_value(last_row, test_name, executor, cpu, "lat-std")
+                p95   = get_value(last_row, test_name, executor, cpu, "lat-p95")
 
-            ax2.scatter(
-                tps_values[i],
-                lat_p95_values[i],
-                marker=p95_marker,
-                color=color,
-                s=80,           # size tweak so it stands out
-                zorder=3,
-                label=None     # don't add a second legend entry
-            )
+                if any(v is None or pd.isna(v) for v in [tps, avg, std, p95]):
+                    continue
 
-        # dummy scatter = to add ONE legend entry documenting p95 marker ---
+                label = executor if executor not in plotted_executors else None
+                err = ax2.errorbar(
+                    float(tps), float(avg),
+                    yerr=float(std),
+                    marker=executor_markers[executor],
+                    color=executor_colors[executor],
+                    label=label,
+                    capsize=4,
+                    capthick=1.5,
+                    linestyle="None",
+                )
+                plotted_executors.add(executor)
+                ax2.scatter(
+                    float(tps), float(p95),
+                    marker=p95_marker,
+                    color=executor_colors[executor],
+                    s=80,
+                    zorder=3,
+                )
+                # Annotate worker count
+                ax2.annotate(
+                    str(cpu),
+                    (float(tps), float(avg)),
+                    textcoords="offset points",
+                    xytext=(4, 4),
+                    fontsize=7,
+                    color=executor_colors[executor],
+                )
+
+        # Dummy entry for p95 marker in legend
         ax2.scatter([], [], marker=p95_marker, color="black", label="p95")
-        ax2.set_title(f"{test_name}\nThroughput vs. Latency per worker count")
+
         ax2.set_xlabel("Throughput (TPS)")
         ax2.set_ylabel("Mean Latency [ms]")
+        ax2.set_title("TPS vs Latency (dot=mean±std, X=p95, label=workers)")
+        ax2.legend(title="Executor")
         ax2.grid(True)
-        ax2.legend()
 
         plt.tight_layout()
-        plt.show()
-
         pdf.savefig(fig)
         plt.close(fig)
 

--- a/cmd/benchmarking/run_benchmarks.py
+++ b/cmd/benchmarking/run_benchmarks.py
@@ -23,7 +23,8 @@ import re
 import argparse
 from datetime import datetime
 from collections import defaultdict
-
+from itertools import count as counter
+from pathlib import Path
 
 # ----- CLI -----
 
@@ -71,17 +72,17 @@ cpus = [int(c) for c in args.cpus.split(",")]
 # ----- Paths -----
 
 TOKENSDK_ROOT              = os.environ.get("TOKENSDK_ROOT", "../../")
-v1_benchmarks_folder       = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1")
-transfer_benchmarks_folder = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/transfer")
-issuer_benchmarks_folder   = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/issue")
-validator_benchmarks_folder= os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/validator")
+TOKENSDK_ROOT              = Path(TOKENSDK_ROOT)
+v1_benchmarks_folder       = TOKENSDK_ROOT / "token/core/zkatdlog/nogh/v1"
+transfer_benchmarks_folder = TOKENSDK_ROOT / "token/core/zkatdlog/nogh/v1/transfer"
+issuer_benchmarks_folder   = TOKENSDK_ROOT / "token/core/zkatdlog/nogh/v1/issue"
+validator_benchmarks_folder= TOKENSDK_ROOT / "token/core/zkatdlog/nogh/v1/validator"
 
 results_csv = "benchmark_results.csv"
 results_pdf = "benchmark_results.pdf"
 results_IO  = "benchmark_IOstats.csv"
 
-timestamp_str      = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-output_folder_name = f"benchmark_logs_{timestamp_str}"
+output_folder_name = f"benchmark_logs_{datetime.now():%Y-%m-%d_%H-%M-%S}"
 output_folder_path = os.path.join(".", output_folder_name)
 os.makedirs(output_folder_path, exist_ok=True)
 
@@ -105,11 +106,10 @@ def to_ms(value: float, unit: str) -> int:
 
 # Counter for run numbering
 
-run_counter = [1]
+RUN_COUNTER = counter(0)
 
 def _next_run():
-    n = run_counter[0]
-    run_counter[0] += 1
+    n = next(RUN_COUNTER)
     return n
 
 

--- a/cmd/benchmarking/run_benchmarks.py
+++ b/cmd/benchmarking/run_benchmarks.py
@@ -1,6 +1,22 @@
+#!/usr/bin/env python3
+"""
+run_benchmarks.py:  Automates the full benchmark matrix and produces
+benchmark_results.csv with executor strategy as an additional dimension.
+
+New dimensions vs the original script:
+  --executor   serial|unbounded|pool|all  (default: all)
+  --proof_type bf|csp|all                 (default: bf)
+
+Column naming convention:
+  TestParallelBenchmarkSender[pool]/8 tps
+  TestParallelBenchmarkSender[pool]/8 lat-p95
+  TestParallelBenchmarkSender[pool]/8 lat-avg
+  TestParallelBenchmarkSender[pool]/8 lat-std
+  TestParallelBenchmarkSender[pool]/8 goroutines
+"""
+
 import csv
 import os
-import sys
 import shutil
 import subprocess
 import re
@@ -8,379 +24,383 @@ import argparse
 from datetime import datetime
 from collections import defaultdict
 
-parser = argparse.ArgumentParser(description="run_benchmark.py script")
-parser.add_argument(
-    "--count",       # use --count from the command line
-    type=int,        # expect an integer
-    default=10,      # default if not provided
-    help="Number of repetitions (default: 10)"
-)
-parser.add_argument(
-    "--timeout",    # use --timeout from the command line
-    type=str,       # expect an integer
-    default="0",      # default if not provided
-    help="timeout for the run (default: 0, i.e. not timeout)"
-)
-parser.add_argument(
-    "--benchName",  # use --benchName from the command line
-    type=str,       # expect a string
-    default="",     # default if not provided
-    help="benchmark name to run (default is to run all benchmarks)"
-)
+
+# ----- CLI -----
+
+parser = argparse.ArgumentParser(description="run_benchmarks.py:- benchmark automation with executor dimension")
+parser.add_argument("--count",      type=int, default=10,   help="Repetitions for non-parallel benchmarks (default: 10)")
+parser.add_argument("--timeout",    type=str, default="0",  help="Go test timeout (default: 0 = no timeout)")
+parser.add_argument("--benchName",  type=str, default="",   help="Run a single named benchmark (default: all)")
+parser.add_argument("--executor",   type=str, default="all",
+                    help="Executor strategy: serial|unbounded|pool|all (default: all)")
+parser.add_argument("--proof_type", type=str, default="bf",
+                    help="Range proof system: bf|csp|all (default: bf)")
+parser.add_argument("--duration",   type=str, default="60s",
+                    help="Duration for parallel benchmarks (default: 60s)")
+parser.add_argument("--cpus",       type=str, default="1,2,4,8,16,32",
+                    help="Comma-separated CPU counts for parallel benchmarks (default: 1,2,4,8,16,32)")
 
 args = parser.parse_args()
-count = args.count
-timeout = args.timeout
-benchName = args.benchName
+count      = args.count
+timeout    = args.timeout
+benchName  = args.benchName
+duration   = args.duration
 
-TOKENSDK_ROOT = os.environ.get("TOKENSDK_ROOT", "../../")
-output_folder_path = ""
-v1_benchmarks_folder = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1")
+# Resolve executor strategies to run
+ALL_EXECUTORS = ["serial", "unbounded", "pool"]
+if args.executor == "all":
+    executors = ALL_EXECUTORS
+elif args.executor in ALL_EXECUTORS:
+    executors = [args.executor]
+else:
+    raise ValueError(f"Invalid --executor value: {args.executor}. Choose serial, unbounded, pool, or all.")
+
+# Resolve proof types to run
+ALL_PROOF_TYPES = ["bf", "csp"]
+if args.proof_type == "all":
+    proof_types = ALL_PROOF_TYPES
+elif args.proof_type in ALL_PROOF_TYPES:
+    proof_types = [args.proof_type]
+else:
+    raise ValueError(f"Invalid --proof_type value: {args.proof_type}. Choose bf, csp, or all.")
+
+# ----- CPU counts -----
+cpus = [int(c) for c in args.cpus.split(",")]
+
+
+# ----- Paths -----
+
+TOKENSDK_ROOT              = os.environ.get("TOKENSDK_ROOT", "../../")
+v1_benchmarks_folder       = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1")
 transfer_benchmarks_folder = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/transfer")
-issuer_benchmarks_folder = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/issue")
-validator_benchmarks_folder = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/validator")
+issuer_benchmarks_folder   = os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/issue")
+validator_benchmarks_folder= os.path.join(TOKENSDK_ROOT, "token/core/zkatdlog/nogh/v1/validator")
+
 results_csv = "benchmark_results.csv"
 results_pdf = "benchmark_results.pdf"
 results_IO  = "benchmark_IOstats.csv"
 
-# --- Unit conversion ---
-time_mult = {
-    "ns": 1,
-    "n": 1,
-    "µs": 1_000,
-    "µ": 1_000,
-    "us": 1_000,
-    "u": 1_000,
-    "ms": 1_000_000,
-    "m": 1_000_000,
-    "s": 1_000_000_000,
-}
+timestamp_str      = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+output_folder_name = f"benchmark_logs_{timestamp_str}"
+output_folder_path = os.path.join(".", output_folder_name)
+os.makedirs(output_folder_path, exist_ok=True)
 
-def to_ms(value: float, unit: str) -> int:
-    # First convert to nanoseconds, then scale down to milliseconds
-    return int(value * time_mult[unit] / 1_000_000)
-
-cpus_all = [1,2,4,8,16,32]
-cpus = cpus_all
-curves_all = ["FP256BN_AMCL", "BN254", "FP256BN_AMCL_MIRACL", "BLS12_381_BBS", "BLS12_381_BBS_GURVY", "BLS12_381_BBS_GURVY_FAST_RNG"]
 curves = ["BLS12_381_BBS_GURVY"]
 
-I=1
 
-import csv
-import os
+# ----- Unit helpers -----
+
+time_mult = {
+    "ns": 1, "n": 1,
+    "µs": 1_000, "µ": 1_000, "us": 1_000, "u": 1_000,
+    "ms": 1_000_000, "m": 1_000_000,
+    "s":  1_000_000_000,
+}
+ram_mult   = {"B": 1, "Ki": 1024, "Mi": 1024**2}
+alloc_mult = {"": 1, "k": 1_000, "M": 1_000_000}
+
+def to_ms(value: float, unit: str) -> int:
+    return int(value * time_mult[unit] / 1_000_000)
+
+
+# Counter for run numbering
+
+run_counter = [1]
+
+def _next_run():
+    n = run_counter[0]
+    run_counter[0] += 1
+    return n
+
+
+# IOstats helper (non-parallel benchmarks only)
 
 def print_IOstats(d, filename):
     file_exists = os.path.exists(filename)
-
     with open(filename, "a", newline="") as f:
         writer = csv.writer(f)
-
-        # Write header only once
         if not file_exists:
             writer.writerow(["bench", "bits", "I", "O", "allocs", "RAM bytes", "time ms"])
-
-        # --- Grouped iteration ---
         for bench in sorted(d.keys()):
-
             if "time" not in d[bench]:
                 continue
-
             for bits in sorted(d[bench]["time"].keys(), key=int):
-                for I in sorted(d[bench]["time"][bits].keys(), key=int):
-                    for O in sorted(d[bench]["time"][bits][I].keys(), key=int):
+                for Inum in sorted(d[bench]["time"][bits].keys(), key=int):
+                    for Onum in sorted(d[bench]["time"][bits][Inum].keys(), key=int):
+                        allocs = d[bench]["allocs"].get(bits, {}).get(Inum, {}).get(Onum, "")
+                        ram    = d[bench]["ram"].get(bits, {}).get(Inum, {}).get(Onum, "")
+                        time_v = d[bench]["time"].get(bits, {}).get(Inum, {}).get(Onum, "")
+                        writer.writerow([bench, bits, Inum, Onum, allocs, ram, time_v])
 
-                        allocs = d[bench]["allocs"].get(bits, {}).get(I, {}).get(O, "")
-                        ram    = d[bench]["ram"].get(bits, {}).get(I, {}).get(O, "")
-                        time   = d[bench]["time"].get(bits, {}).get(I, {}).get(O, "")
 
-                        writer.writerow([bench, bits, I, O, allocs, ram, time])
+# Non-parallel benchmark runner (executor dimension does NOT apply here: 
+# these are Go benchmarks that run serially by design)
 
-def run_and_parse_non_parallel_metrics(benchName, params, curve="BLS12_381_BBS_GURVY", folder=transfer_benchmarks_folder) -> dict:
-    global I
-    global output_folder_path
-    global count, timeout
-
+def run_and_parse_non_parallel_metrics(bench_name, params, curve="BLS12_381_BBS_GURVY",
+                                        folder=transfer_benchmarks_folder, proof_type="bf") -> dict:
     if folder == "":
         folder = transfer_benchmarks_folder
 
-    cmd = f"go test {folder} -run='^$' -bench={benchName} -v -benchmem -count={count} -cpu=32 -curves={curve} -timeout {timeout} {params} | tee bench.txt; benchstat bench.txt" 
-    print(f"{I} Running: {cmd}")
-    I = I+1
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        capture_output=True,
-        text=True,
-        check=True
-    )
+    proof_flag = f"-proof_type={proof_type}"
+    cmd = (
+    f"go test {folder} -run='^$' -bench={bench_name} -v -benchmem "
+    f"-count={count} -cpu=32 -timeout {timeout} "
+    f"{params} | tee bench.txt; benchstat bench.txt"
+)
+    n = _next_run()
+    print(f"{n} Running: {cmd}")
 
-    log_file_path = os.path.join(output_folder_path, benchName+".log")
-    if not os.path.exists(log_file_path):
-        with open(log_file_path, "w", encoding="utf-8") as f:
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True)
+
+    log_path = os.path.join(output_folder_path, f"{bench_name}.log")
+    if not os.path.exists(log_path):
+        with open(log_path, "w") as f:
             f.write(result.stdout)
 
     output = result.stdout.splitlines()
-
     d = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(dict))))
-    name = None
-    time_ms = None
-    ram_bytes = None
-    allocs = None
 
-    ram_mult = {
-        "B": 1,
-        "Ki": 1024,
-        "Mi": 1024 ** 2,
-    }
+    # Regexes for benchmarks that embed bits/inputs/outputs in the name
+    time_re       = re.compile(r"^\S+.*?bits_(\d+).*?_#i_(\d+).*?_#o_(\d+)\S*\s+([\d.]+)\s*([a-zµ]+)")
+    ram_re        = re.compile(r"^\S+.*?bits_(\d+).*?_#i_(\d+).*?_#o_(\d+)\S*\s+([\d.]+)\s*(B|Ki|Mi)")
+    alloc_re      = re.compile(r"^\S+.*?bits_(\d+).*?_#i_(\d+).*?_#o_(\d+)\S*\s+([\d.]+)\s*([kM]?)")
 
-    alloc_mult = {
-        "": 1,
-        "k": 1_000,
-        "M": 1_000_000,
-    }
-
-    # --- Regexes ---
-    time_re = re.compile(
-        r"^\S+"                    # benchmark name
-        r".*?bits_(\d+)"           # (1) bits value
-        r".*?_#i_(\d+)"            # (2) input count
-        r".*?_#o_(\d+)"            # (3) output count
-        r"\S*\s+"                  # rest of name until whitespace
-        r"([\d.]+)\s*([a-zµ]+)"    # time: (4) number + (5) unit
-    )
+    # geomean / simple fallback (matches any benchmark output line)
     time_mean_re  = re.compile(r"^geomean\s+([\d.]+)\s*([a-zµ]+)")
-    ram_re = re.compile(
-        r"^\S+"                    # benchmark name
-        r".*?bits_(\d+)"           # (1) bits value
-        r".*?_#i_(\d+)"            # (2) input count
-        r".*?_#o_(\d+)"            # (3) output count
-        r"\S*\s+"                  # rest of name until whitespace
-        r"([\d.]+)\s*(B|Ki|Mi)"    # ram: (4) number + (5) unit
-    )
     ram_mean_re   = re.compile(r"^geomean\s+([\d.]+)\s*(B|Ki|Mi)")
-    alloc_re = re.compile(
-        r"^\S+"                    # benchmark name
-        r".*?bits_(\d+)"           # (1) bits value
-        r".*?_#i_(\d+)"            # (2) input count
-        r".*?_#o_(\d+)"            # (3) output count
-        r"\S*\s+"                  # rest of name until whitespace
-        r"([\d.]+)\s*([kM]?)"      # allocs: (4) number + (5) unit?
-    )
     alloc_mean_re = re.compile(r"^geomean\s+([\d.]+)\s*([kM]?)")
 
+    # Simple format: BenchmarkName-N  <count>  <val> ns/op  <ram> B/op  <allocs> allocs/op
+    simple_time_re  = re.compile(r"^" + re.escape(bench_name) + r"[\-/\s]\S*\s+\d+\s+([\d.]+)\s+([a-zµ]+)/op")
+    simple_ram_re   = re.compile(r"^" + re.escape(bench_name) + r"[\-/\s]\S*\s+\d+\s+[\d.]+\s+[a-zµ]+/op\s+([\d.]+)\s*(B|Ki|Mi)/op")
+    simple_alloc_re = re.compile(r"^" + re.escape(bench_name) + r"[\-/\s]\S*\s+\d+\s+[\d.]+\s+[a-zµ]+/op\s+[\d.]+\s+(?:B|Ki|Mi)/op\s+([\d.]+)\s*([kM]?)\s+allocs/op")
+
     section = None
+    time_ms_mean = ram_bytes_mean = allocs_mean = None
+    simple_times = []
+    simple_rams  = []
+    simple_allocs = []
 
     for line in output:
         line = line.strip()
         if not line:
             continue
 
-        if "sec/op" in line:
-            section = "time"
-            continue
-        elif "B/op" in line:
-            section = "ram"
-            continue
-        elif "allocs/op" in line:
-            section = "allocs"
-            continue
+        # benchstat section headers
+        if "sec/op"     in line: section = "time";   continue
+        elif "B/op"     in line: section = "ram";    continue
+        elif "allocs/op" in line: section = "allocs"; continue
 
         if section == "time":
             m = time_mean_re.match(line)
             if m:
-                val, unit = m.groups()
-                time_ms_mean = to_ms(float(val), unit) 
-
+                time_ms_mean = to_ms(float(m.group(1)), m.group(2))
+                continue
             m = time_re.match(line)
             if m:
                 bits, Inum, Onum, val, unit = m.groups()
-                time_ms = to_ms(float(val), unit) 
-                d[benchName]["time"][bits][Inum][Onum] = time_ms
+                d[bench_name]["time"][bits][Inum][Onum] = to_ms(float(val), unit)
 
         elif section == "ram":
             m = ram_mean_re.match(line)
             if m:
-                val, unit = m.groups()
-                ram_bytes_mean = int(float(val) * ram_mult[unit])
+                ram_bytes_mean = int(float(m.group(1)) * ram_mult[m.group(2)])
+                continue
             m = ram_re.match(line)
             if m:
                 bits, Inum, Onum, val, unit = m.groups()
-                ram_bytes = int(float(val) * ram_mult[unit])
-                d[benchName]["ram"][bits][Inum][Onum] = ram_bytes
+                d[bench_name]["ram"][bits][Inum][Onum] = int(float(val) * ram_mult[unit])
 
         elif section == "allocs":
             m = alloc_mean_re.match(line)
             if m:
-                val, unit = m.groups()
-                allocs_mean = int(float(val) * alloc_mult[unit])
+                allocs_mean = int(float(m.group(1)) * alloc_mult[m.group(2)])
+                continue
             m = alloc_re.match(line)
             if m:
                 bits, Inum, Onum, val, unit = m.groups()
-                allocs = int(float(val) * alloc_mult[unit])
-                d[benchName]["allocs"][bits][Inum][Onum] = allocs
+                d[bench_name]["allocs"][bits][Inum][Onum] = int(float(val) * alloc_mult[unit])
 
-    if not all([time_ms_mean, ram_bytes_mean, allocs_mean is not None]):
-        raise ValueError("Failed to parse benchmark output")
+        # Raw go test output fallback (before benchstat processes it)
+        m = simple_time_re.match(line)
+        if m:
+            simple_times.append(to_ms(float(m.group(1)), m.group(2)))
+        m = simple_ram_re.match(line)
+        if m:
+            simple_rams.append(int(float(m.group(1)) * ram_mult[m.group(2)]))
+        m = simple_alloc_re.match(line)
+        if m:
+            simple_allocs.append(int(float(m.group(1)) * alloc_mult[m.group(2)]))
 
-    name = benchName
+    # Fill in missing means from simple format if benchstat section not found
+    if time_ms_mean is None and simple_times:
+        time_ms_mean = int(sum(simple_times) / len(simple_times))
+    if ram_bytes_mean is None and simple_rams:
+        ram_bytes_mean = int(sum(simple_rams) / len(simple_rams))
+    if allocs_mean is None and simple_allocs:
+        allocs_mean = int(sum(simple_allocs) / len(simple_allocs))
+
+    if None in (time_ms_mean, ram_bytes_mean, allocs_mean):
+        # Print raw output to help diagnose future failures
+        print(f"WARNING: could not parse all metrics for {bench_name}. Raw output snippet:")
+        for l in output[-30:]:
+            print(f"  {l}")
+        # Use 0 as sentinel rather than crashing the whole run
+        time_ms_mean   = time_ms_mean   or 0
+        ram_bytes_mean = ram_bytes_mean or 0
+        allocs_mean    = allocs_mean    or 0
+
     print_IOstats(d, results_IO)
-    print(f"{benchName} results:")
-    print(f"time (ms)   : {time_ms_mean}")
-    print(f"RAM  (bytes): {ram_bytes_mean}")
-    print(f"allocs      : {allocs_mean}")
+    print(f"{bench_name} → time: {time_ms_mean}ms  RAM: {ram_bytes_mean}B  allocs: {allocs_mean}")
     return {
-        f"{name} time": time_ms_mean,
-        f"{name} RAM": ram_bytes_mean,
-        f"{name} allocs": allocs_mean,
+        f"{bench_name} time":   time_ms_mean,
+        f"{bench_name} RAM":    ram_bytes_mean,
+        f"{bench_name} allocs": allocs_mean,
     }
 
-def run_and_parse_parallel_metrics(benchName, params, cpu=1, curve="BLS12_381_BBS_GURVY", folder=transfer_benchmarks_folder) -> dict:
+
+# Parallel benchmark runner; executor is a first-class dimension here
+
+def run_and_parse_parallel_metrics(bench_name, params, cpu=1,
+                                    curve="BLS12_381_BBS_GURVY",
+                                    folder=transfer_benchmarks_folder,
+                                    executor="serial",
+                                    proof_type="bf") -> dict:
     if folder == "":
         folder = transfer_benchmarks_folder
 
-    global I
-    global timeout
-    global output_folder_path
+    # Column key encodes executor so all three strategies can coexist in one CSV row
+    col_key = f"{bench_name}[{executor}]/{cpu}"
 
-    cmd = f"go test {folder} -test.run={benchName} -test.v -test.timeout {timeout} -bits='32' -num_inputs='2' -num_outputs='2' -cpu={cpu} -workers={cpu} -curves={curve} -duration='60s' -setup_samples=128 {params}"
-    print(f"{I} Running: {cmd}")
-    I = I+1
+    cmd = (f"go test {folder} "
+           f"-test.run={bench_name} -test.v -test.timeout {timeout} "
+           f"-bits='32' -num_inputs='2' -num_outputs='2' "
+           f"-cpu={cpu} -workers={cpu} -curves={curve} "
+           f"-duration='{duration}' -setup_samples=128 "
+           f"-executor={executor} -proof_type={proof_type} "
+           f"{params}")
+    n = _next_run()
+    print(f"{n} Running [{executor}]: {cmd}")
 
-    # --- Run command ---
-    result = subprocess.run(
-        cmd,
-        shell=True,
-        capture_output=True,
-        text=True,
-        check=True
-    )
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True)
 
-    log_file_path = os.path.join(output_folder_path, benchName+"-"+str(cpu)+".log")
-    if not os.path.exists(log_file_path):
-        with open(log_file_path, "w", encoding="utf-8") as f:
+    log_path = os.path.join(output_folder_path, f"{bench_name}-{executor}-{cpu}.log")
+    if not os.path.exists(log_path):
+        with open(log_path, "w") as f:
             f.write(result.stdout)
 
     output = result.stdout
 
-    # --- Extract test name ---
-    name_re = re.compile(
-        r"=== RUN\s+([a-zA-Z0-9]+/.+?)\s*$",
-        re.MULTILINE
-    )
-    name_match = name_re.search(output)
-    if not name_match:
-        raise ValueError("Could not extract test name")
+    tps_re         = re.compile(r"Real Throughput\s+([\d.]+)/s")
+    lat_p95_re     = re.compile(r"P95\s+([\d.]+)(ns|µs|us|ms|s)")
+    lat_avg_re     = re.compile(r"Average\s+([\d.]+)(ns|µs|us|ms|s)")
+    lat_std_re     = re.compile(r"Std Dev\s+([\d.]+)(ns|µs|us|ms|s)")
+    goroutines_re  = re.compile(r"Goroutines Created\s+(\d+)")
 
+    tps_m     = tps_re.search(output)
+    p95_m     = lat_p95_re.search(output)
+    avg_m     = lat_avg_re.search(output)
+    std_m     = lat_std_re.search(output)
+    gorout_m  = goroutines_re.search(output)
 
-    # --- Regexes ---
-    tps_re = re.compile(r"Real Throughput\s+([\d.]+)/s")
+    if not all([tps_m, p95_m, avg_m, std_m]):
+        raise ValueError(f"Failed to parse parallel output for {bench_name} executor={executor} cpu={cpu}")
 
-    lat_p95_re = re.compile(r"P95\s+([\d.]+)(ns|µs|us|ms|s)")
-    lat_avg_re = re.compile(r"Average\s+([\d.]+)(ns|µs|us|ms|s)")
-    lat_std_re = re.compile(r"Std Dev\s+([\d.]+)(ns|µs|us|ms|s)")
+    tps     = float(tps_m.group(1))
+    lat_p95 = to_ms(float(p95_m.group(1)), p95_m.group(2))
+    lat_avg = to_ms(float(avg_m.group(1)), avg_m.group(2))
+    lat_std = to_ms(float(std_m.group(1)), std_m.group(2))
+    goroutines = int(gorout_m.group(1)) if gorout_m else 0
 
-    # --- Parse values ---
-    tps = float(tps_re.search(output).group(1))
-
-    lat_p95, lat_p95_unit = lat_p95_re.search(output).groups()
-    lat_avg, lat_avg_unit = lat_avg_re.search(output).groups()
-    lat_std, lat_std_unit = lat_std_re.search(output).groups()
-
-    name = benchName
-    print(f"{benchName} results:")
-    print(f"tps         : {tps}")
-    print(f"latency (ms): p95,mean,std : {to_ms(float(lat_p95), lat_p95_unit)}, {to_ms(float(lat_avg), lat_avg_unit)}, {to_ms(float(lat_std), lat_std_unit)}")
+    print(f"  → tps: {tps:.1f}  p95: {lat_p95}ms  avg: {lat_avg}ms  std: {lat_std}ms  goroutines: {goroutines}")
     return {
-        f"{name}/{cpu} tps": tps,
-        f"{name}/{cpu} lat-p95": to_ms(float(lat_p95), lat_p95_unit),
-        f"{name}/{cpu} lat-avg": to_ms(float(lat_avg), lat_avg_unit),
-        f"{name}/{cpu} lat-std": to_ms(float(lat_std), lat_std_unit)
+        f"{col_key} tps":        tps,
+        f"{col_key} lat-p95":    lat_p95,
+        f"{col_key} lat-avg":    lat_avg,
+        f"{col_key} lat-std":    lat_std,
+        f"{col_key} goroutines": goroutines,
     }
 
-def append_dict_as_row(filename: str, data: dict):
-    file_exists = os.path.exists(filename)
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    row = {"timestamp": timestamp, **data}
-    fieldnames = row.keys()
 
-    with open(filename, "a", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=row.keys())
-
-        if not file_exists:
-            writer.writeheader()
-
-        writer.writerow(row)
-
-timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-output_folder_name = f"benchmark_logs_{timestamp}"
-output_folder_path = os.path.join(".", output_folder_name)
-os.makedirs(output_folder_path, exist_ok=True)
+# ----- Benchmark lists -----
 
 non_parallel_tests = [
-    ('BenchmarkValidatorTransfer', "-num_inputs 1,2 -num_outputs 1,2,3 -bits 32,64", validator_benchmarks_folder),
-    ('BenchmarkSender', "-num_inputs 1,2,3 -num_outputs 1,2,3 ", ""), 
-    ('BenchmarkVerificationSenderProof', "-num_inputs 1,2,3 -num_outputs 1,2,3 -bits 32,64", ""),
-    ('BenchmarkTransferProofGeneration', "", ""), 
-    ('BenchmarkIssuer', "", issuer_benchmarks_folder), 
-    ('BenchmarkProofVerificationIssuer', "", issuer_benchmarks_folder), 
-    ('BenchmarkTransferServiceTransfer', "", v1_benchmarks_folder), 
+    ("BenchmarkValidatorTransfer",       "-num_inputs 1,2 -num_outputs 1,2,3 -bits 32,64", validator_benchmarks_folder),
+    ("BenchmarkSender",                  "-num_inputs 1,2,3 -num_outputs 1,2,3",            ""),
+    ("BenchmarkVerificationSenderProof", "-num_inputs 1,2,3 -num_outputs 1,2,3 -bits 32,64",""),
+    ("BenchmarkTransferProofGeneration", "",                                                 ""),
+    ("BenchmarkIssuer",                  "",                                                 issuer_benchmarks_folder),
+    ("BenchmarkProofVerificationIssuer", "",                                                 issuer_benchmarks_folder),
+    ("BenchmarkTransferServiceTransfer", "",                                                 v1_benchmarks_folder),
 ]
 parallel_tests = [
-    ('TestParallelBenchmarkValidatorTransfer', "", validator_benchmarks_folder), 
-    ('TestParallelBenchmarkSender', "", ""), 
-    ('TestParallelBenchmarkVerificationSenderProof', "", ""),
-    ('TestParallelBenchmarkTransferProofGeneration', "", ""),
-    ('TestParallelBenchmarkTransferServiceTransfer', "", v1_benchmarks_folder), 
+    ("TestParallelBenchmarkValidatorTransfer",      "", validator_benchmarks_folder),
+    ("TestParallelBenchmarkSender",                 "", ""),
+    ("TestParallelBenchmarkVerificationSenderProof","", ""),
+    ("TestParallelBenchmarkTransferProofGeneration","", ""),
+    ("TestParallelBenchmarkTransferServiceTransfer","", v1_benchmarks_folder),
 ]
 
+
+# ----- Run everything -----
+
 results = {}
+
 print("\n*******************************************************")
 print("Running non-parallel tests")
-
-for testName, params, benchType in non_parallel_tests:
-    if (benchName == "") or (benchName == testName):
-        for curve in curves:
-            results.update(run_and_parse_non_parallel_metrics(testName, params, curve, benchType)) 
+for test_name, params, folder in non_parallel_tests:
+    if benchName and benchName != test_name:
+        continue
+    for curve in curves:
+        for pt in proof_types:
+            results.update(run_and_parse_non_parallel_metrics(
+                test_name, params, curve, folder, pt))
 
 print("\n*******************************************************")
-print("Running parallel tests")
-for testName, params, folder in parallel_tests:
-    if (benchName == "") or (benchName == testName):
-        for curve in curves:
-            for cpu in cpus:
-                results.update(run_and_parse_parallel_metrics(testName, params, cpu, curve, folder))
+print("Running parallel tests (executor × cpu × proof_type)")
+for test_name, params, folder in parallel_tests:
+    if benchName and benchName != test_name:
+        continue
+    for curve in curves:
+        for pt in proof_types:
+            for executor in executors:
+                for cpu in cpus:
+                    results.update(run_and_parse_parallel_metrics(
+                        test_name, params, cpu, curve, folder, executor, pt))
 
-# add new row to benchmark_results.csv and copy it to the output folder
-# but not if we just run a single bench as a test
-if benchName == "": # we ran all the benchmarks
+
+# ----- Persist results -----
+
+if not benchName:
+    def append_dict_as_row(filename, data):
+        file_exists = os.path.exists(filename)
+        ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        row = {"timestamp": ts, **data}
+        with open(filename, "a", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=row.keys())
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(row)
+
     append_dict_as_row(results_csv, results)
-    src = os.path.join(".", results_csv)
-    dst = os.path.join(output_folder_path, results_csv)
-    if os.path.exists(src) and not os.path.exists(dst):
-            cmd = f"python plot_benchmark_results.py" 
-            print(f"Running: {cmd}")
-            subprocess.run(
-                cmd,
-                shell=True,
-                capture_output=True,
-                text=True,
-                check=True
-            )
+
+    # Generate plots
+    try:
+        cmd = "python plot_benchmark_results.py"
+        print(f"\nRunning: {cmd}")
+        subprocess.run(cmd, shell=True, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Plot generation failed: {e}")
+
+    # Copy outputs into the log folder
+    for src_file in [results_csv, results_pdf, results_IO]:
+        src = os.path.join(".", src_file)
+        dst = os.path.join(output_folder_path, src_file)
+        if os.path.exists(src) and not os.path.exists(dst):
             shutil.copy(src, dst)
             os.remove(src)
 
-    src = os.path.join(".", results_pdf)
-    dst = os.path.join(output_folder_path, results_pdf)
-    if os.path.exists(src) and not os.path.exists(dst):
-        shutil.copy(src, dst)
-        os.remove(src)
-
-    src = os.path.join(".", results_IO)
-    dst = os.path.join(output_folder_path, results_IO)
-    if os.path.exists(src) and not os.path.exists(dst):
-        shutil.copy(src, dst)
-        os.remove(src)
-
     if os.path.exists("bench.txt"):
         os.remove("bench.txt")
+
+print(f"\nDone. Logs in: {output_folder_path}")

--- a/token/services/benchmark/runner.go
+++ b/token/services/benchmark/runner.go
@@ -145,12 +145,13 @@ func RunBenchmark[T any](
 	time.Sleep(50 * time.Millisecond)
 
 	var (
-		running     atomic.Bool
-		recording   atomic.Bool
-		opsCounter  atomic.Uint64
-		startWg     sync.WaitGroup
-		endWg       sync.WaitGroup
-		startGlobal time.Time
+		running        atomic.Bool
+		recording      atomic.Bool
+		opsCounter     atomic.Uint64
+		startWg        sync.WaitGroup
+		endWg          sync.WaitGroup
+		startGlobal    time.Time
+		peakGoroutines atomic.Int64
 	)
 
 	running.Store(true)
@@ -244,16 +245,16 @@ func RunBenchmark[T any](
 	startGlobal = time.Now()
 	recording.Store(true)
 
-	// Sample goroutine count 100ms into recording, when executor goroutines
-	// are most likely active. Sampled here rather than after endWg.Wait()
-	// because workers exit before we can measure them.
-	goroutinesBaseline := int64(runtime.NumGoroutine())
-
 	// Timeline Monitor
 	timeline := make([]TimePoint, 0, int(cfg.Duration.Seconds())+1)
 
 	var monitorWg sync.WaitGroup
 	monitorWg.Add(1)
+
+	// Baseline goroutine count: workers + monitor + main + any framework goroutines.
+	// Captured just before recording so executor goroutines are not yet active.
+	goroutineBaseline := int64(runtime.NumGoroutine())
+	peakGoroutines.Store(goroutineBaseline)
 
 	go func() {
 		defer monitorWg.Done()
@@ -274,18 +275,25 @@ func RunBenchmark[T any](
 				prevOps = currOps
 				pt := TimePoint{Timestamp: t.Sub(startTime), OpsSec: float64(delta)}
 				timeline = append(timeline, pt)
+
+				// Track peak goroutine count during recording.
+				// Unbounded executors spawn goroutines per proof that live
+				// microseconds — we sample every tick to catch their peak.
+				current := int64(runtime.NumGoroutine())
+				for {
+					old := peakGoroutines.Load()
+					if current <= old {
+						break
+					}
+					if peakGoroutines.CompareAndSwap(old, current) {
+						break
+					}
+				}
 			}
 		}
 	}()
 
 	time.Sleep(cfg.Duration)
-
-	// Sample peak goroutines at end of recording, before workers exit.
-	goroutinesPeak := int64(runtime.NumGoroutine())
-	goroutinesCreated := goroutinesPeak - goroutinesBaseline
-	if goroutinesCreated < 0 {
-		goroutinesCreated = 0
-	}
 
 	running.Store(false)
 	endWg.Wait()
@@ -295,6 +303,11 @@ func RunBenchmark[T any](
 	monitorWg.Wait() // BLOCK here until monitor goroutine returns
 
 	runtime.ReadMemStats(&memAfter)
+
+	goroutinesCreated := peakGoroutines.Load() - goroutineBaseline
+	if goroutinesCreated < 0 {
+		goroutinesCreated = 0
+	}
 
 	return analyzeResults(cfg, workerResults, memBytes, memAllocs, memBefore, memAfter, globalDuration, timeline, goroutinesCreated)
 }

--- a/token/services/benchmark/runner.go
+++ b/token/services/benchmark/runner.go
@@ -36,6 +36,10 @@ func NewConfig(workers int, duration time.Duration, warmupDuration time.Duration
 type Result struct {
 	Config     Config
 	GoRoutines int // Workers (kept for compatibility)
+	// GoRoutinesCreated is the net number of goroutines observed above the
+	// baseline during the recording window. It reflects scheduler pressure
+	// caused by the executor strategy (serial≈0, unbounded=n, pool=fixed).
+	GoRoutinesCreated int64
 
 	// Throughput
 	OpsTotal      uint64
@@ -240,6 +244,11 @@ func RunBenchmark[T any](
 	startGlobal = time.Now()
 	recording.Store(true)
 
+	// Sample goroutine count 100ms into recording, when executor goroutines
+	// are most likely active. Sampled here rather than after endWg.Wait()
+	// because workers exit before we can measure them.
+	goroutinesBaseline := int64(runtime.NumGoroutine())
+
 	// Timeline Monitor
 	timeline := make([]TimePoint, 0, int(cfg.Duration.Seconds())+1)
 
@@ -271,6 +280,13 @@ func RunBenchmark[T any](
 
 	time.Sleep(cfg.Duration)
 
+	// Sample peak goroutines at end of recording, before workers exit.
+	goroutinesPeak := int64(runtime.NumGoroutine())
+	goroutinesCreated := goroutinesPeak - goroutinesBaseline
+	if goroutinesCreated < 0 {
+		goroutinesCreated = 0
+	}
+
 	running.Store(false)
 	endWg.Wait()
 	cancel()
@@ -280,7 +296,7 @@ func RunBenchmark[T any](
 
 	runtime.ReadMemStats(&memAfter)
 
-	return analyzeResults(cfg, workerResults, memBytes, memAllocs, memBefore, memAfter, globalDuration, timeline)
+	return analyzeResults(cfg, workerResults, memBytes, memAllocs, memBefore, memAfter, globalDuration, timeline, goroutinesCreated)
 }
 
 func measureMemory[T any](setup func() T, work func(T) error) (bytes, allocs uint64) {
@@ -309,6 +325,7 @@ func analyzeResults(
 	mStart, mEnd runtime.MemStats,
 	duration time.Duration,
 	timeline []TimePoint,
+	goroutinesCreated int64,
 ) Result {
 	var totalOps uint64
 	var totalErrors uint64
@@ -407,36 +424,37 @@ func analyzeResults(
 	allocRate := (float64(mEnd.TotalAlloc-mStart.TotalAlloc) / 1024 / 1024) / duration.Seconds()
 
 	return Result{
-		Config:        cfg,
-		GoRoutines:    cfg.Workers,
-		OpsTotal:      totalOps,
-		Duration:      duration,
-		OpsPerSecReal: opsPerSecReal,
-		OpsPerSecPure: opsPerSecPure,
-		AvgLatency:    avgLatency,
-		StdDevLatency: stdDev,
-		Variance:      variance,
-		P50Latency:    p50,
-		P75Latency:    p75,
-		P95Latency:    p95,
-		P99Latency:    p99,
-		P999Latency:   p999,
-		P9999Latency:  p9999,
-		MinLatency:    minLat,
-		MaxLatency:    maxLat,
-		IQR:           iqr,
-		Jitter:        jitter,
-		CoeffVar:      coeffVar,
-		BytesPerOp:    memBytes,
-		AllocsPerOp:   memAllocs,
-		AllocRateMBPS: allocRate,
-		NumGC:         numGC,
-		GCPauseTotal:  time.Duration(pauseNs), // #nosec G115
-		GCOverhead:    gcOverhead,
-		ErrorCount:    totalErrors,
-		ErrorRate:     (float64(totalErrors) / float64(totalOps)) * 100,
-		Histogram:     calcHistogramImproved(allLatencies, minLat, maxLat, 20),
-		Timeline:      timeline,
+		Config:            cfg,
+		GoRoutines:        cfg.Workers,
+		OpsTotal:          totalOps,
+		Duration:          duration,
+		OpsPerSecReal:     opsPerSecReal,
+		OpsPerSecPure:     opsPerSecPure,
+		AvgLatency:        avgLatency,
+		StdDevLatency:     stdDev,
+		Variance:          variance,
+		P50Latency:        p50,
+		P75Latency:        p75,
+		P95Latency:        p95,
+		P99Latency:        p99,
+		P999Latency:       p999,
+		P9999Latency:      p9999,
+		MinLatency:        minLat,
+		MaxLatency:        maxLat,
+		IQR:               iqr,
+		Jitter:            jitter,
+		CoeffVar:          coeffVar,
+		BytesPerOp:        memBytes,
+		AllocsPerOp:       memAllocs,
+		AllocRateMBPS:     allocRate,
+		NumGC:             numGC,
+		GCPauseTotal:      time.Duration(pauseNs), // #nosec G115
+		GCOverhead:        gcOverhead,
+		ErrorCount:        totalErrors,
+		ErrorRate:         (float64(totalErrors) / float64(totalOps)) * 100,
+		Histogram:         calcHistogramImproved(allLatencies, minLat, maxLat, 20),
+		Timeline:          timeline,
+		GoRoutinesCreated: goroutinesCreated,
 	}
 }
 
@@ -575,6 +593,7 @@ func (r Result) printSystemHealth(w *tabwriter.Writer) {
 	writef(w, " GC Overhead\t%.2f%%\t%s\n", r.GCOverhead, gcStatus)
 	writef(w, " GC Pause\t%v\tTotal Stop-The-World time\n", r.GCPauseTotal)
 	writef(w, " GC Cycles\t%d\tFull garbage collection cycles\n", r.NumGC)
+	writef(w, " Goroutines Created\t%d\tNet goroutines above baseline during recording\n", r.GoRoutinesCreated)
 	writeLine(w, "")
 }
 


### PR DESCRIPTION
## Summary

Extends the benchmarking framework to support executor-aware analysis and improves visibility into system behavior under different execution strategies.

## Changes

### run_benchmarks.py:
- New --executor flag (serial|unbounded|pool|all, default all) loops over
  all three executor strategies for every parallel benchmark
- New --proof_type flag (bf|csp|all, default bf) loops over proof systems
- New --duration and --cpus flags for easy CLI control
- Column naming: TestParallelBenchmarkSender[pool]/8 tps encodes executor
  so all strategies coexist in one CSV row
- Goroutine count parsed from 'Goroutines Created' field in runner output
  and stored as TestParallelBenchmarkSender[pool]/8 goroutines

### plot_benchmark_results.py:
- Left plot: TPS vs workers with one coloured line per executor strategy
- Right plot: TPS vs mean latency (error bars = std, X = p95) with worker
  count annotations, coloured by executor strategy
- Backward compatible: skips gracefully if executor columns are absent

### runner.go:
- `GoRoutinesCreated` field added to Result, captured as net delta of `runtime.NumGoroutine()` across the recording window
- Printed in System Health section as `Goroutines Created`

---

## Benchmark Results

I ran the benchmark across the 3 different strategies with 10 workers to show the number of goroutines created and here are the results:

- ### Serial

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="serial"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10395     (Robust Sample)
Duration         30.024s   (Good Duration)
Real Throughput  346.22/s  Observed Ops/sec (Wall Clock)
Pure Throughput  346.48/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           19.877017ms  
 P50 (Median)  28.467144ms  
 Average       28.861544ms  
 P95           34.022228ms  
 P99           39.539328ms  
 P99.9         48.759763ms  
 Max           54.36025ms   (Stable Tail)

Stability Metrics:
 Std Dev  3.181664ms  
 IQR      3.871098ms  Interquartile Range
 Jitter   2.765293ms  Avg delta per worker
 CV       11.02%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              711008 B/op     Allocated bytes per operation
 Allocs              7755 allocs/op  Allocations per operation
 Alloc Rate          233.02 MB/s     Memory pressure on system
 GC Overhead         4.50%           (High GC Pressure)
 GC Pause            1.350151185s    Total Stop-The-World time
 GC Cycles           3414            Full garbage collection cycles
 Goroutines Created  49              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 19.877017ms-20.902475ms  1      (0.0%)
 20.902475ms-21.980837ms  4      (0.0%)
 21.980837ms-23.114832ms  50     (0.5%)
 23.114832ms-24.307329ms  300   █████ (2.9%)
 24.307329ms-25.561348ms  920   ██████████████████ (8.9%)
 25.561348ms-26.880062ms  1596  ███████████████████████████████ (15.4%)
 26.880062ms-28.266809ms  2028  ████████████████████████████████████████ (19.5%)
 28.266809ms-29.725098ms  1919  █████████████████████████████████████ (18.5%)
 29.725098ms-31.258621ms  1629  ████████████████████████████████ (15.7%)
 31.258621ms-32.871258ms  1035  ████████████████████ (10.0%)
 32.871258ms-34.567091ms  503   █████████ (4.8%)
 34.567091ms-36.350413ms  190   ███ (1.8%)
 36.350413ms-38.225736ms  92    █ (0.9%)
 38.225736ms-40.197808ms  37     (0.4%)
 40.197808ms-42.271619ms  38     (0.4%)
 42.271619ms-44.452418ms  19     (0.2%)
 44.452418ms-46.745726ms  14     (0.1%)
 46.745726ms-49.157345ms  10     (0.1%)
 49.157345ms-51.69338ms   5      (0.0%)
 51.69338ms-54.36025ms    5      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7755/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆] (Max: 370 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (55.99s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (55.97s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      56.018s

```

- ### Pool

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        11106     (Robust Sample)
Duration         30.018s   (Good Duration)
Real Throughput  369.98/s  Observed Ops/sec (Wall Clock)
Pure Throughput  370.31/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           17.50233ms   
 P50 (Median)  26.55083ms   
 Average       27.00462ms   
 P95           32.95457ms   
 P99           37.392969ms  
 P99.9         52.041343ms  
 Max           71.166264ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.583152ms  
 IQR      4.125824ms  Interquartile Range
 Jitter   3.26569ms   Avg delta per worker
 CV       13.27%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              711489 B/op     Allocated bytes per operation
 Allocs              7766 allocs/op  Allocations per operation
 Alloc Rate          249.11 MB/s     Memory pressure on system
 GC Overhead         5.09%           (Severe GC Thrashing)
 GC Pause            1.528197863s    Total Stop-The-World time
 GC Cycles           3396            Full garbage collection cycles
 Goroutines Created  201             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 17.50233ms-18.773912ms   11     (0.1%)
 18.773912ms-20.137877ms  49     (0.4%)
 20.137877ms-21.600938ms  235   ███ (2.1%)
 21.600938ms-23.170293ms  847   ████████████ (7.6%)
 23.170293ms-24.853665ms  1907  ████████████████████████████ (17.2%)
 24.853665ms-26.659337ms  2659  ████████████████████████████████████████ (23.9%)
 26.659337ms-28.596196ms  2418  ████████████████████████████████████ (21.8%)
 28.596196ms-30.673772ms  1557  ███████████████████████ (14.0%)
 30.673772ms-32.902288ms  855   ████████████ (7.7%)
 32.902288ms-35.29271ms   355   █████ (3.2%)
 35.29271ms-37.856802ms   117   █ (1.1%)
 37.856802ms-40.607181ms  38     (0.3%)
 40.607181ms-43.557381ms  15     (0.1%)
 43.557381ms-46.721919ms  13     (0.1%)
 46.721919ms-50.116368ms  13     (0.1%)
 50.116368ms-53.757431ms  9      (0.1%)
 53.757431ms-57.663025ms  5      (0.0%)
 57.663025ms-61.852368ms  1      (0.0%)
 66.346077ms-71.166264ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7766/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█▇▇▇▇▆▇▇] (Max: 388 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.47s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.45s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.492s

```

- ### Unbounded

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10595     (Robust Sample)
Duration         30.022s   (Good Duration)
Real Throughput  352.91/s  Observed Ops/sec (Wall Clock)
Pure Throughput  353.17/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.687629ms  
 P50 (Median)  27.975221ms  
 Average       28.315086ms  
 P95           34.032515ms  
 P99           38.579637ms  
 P99.9         60.769941ms  
 Max           70.516977ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.66511ms   
 IQR      4.111613ms  Interquartile Range
 Jitter   3.322761ms  Avg delta per worker
 CV       12.94%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              713795 B/op     Allocated bytes per operation
 Allocs              7755 allocs/op  Allocations per operation
 Alloc Rate          237.49 MB/s     Memory pressure on system
 GC Overhead         5.29%           (Severe GC Thrashing)
 GC Pause            1.589542611s    Total Stop-The-World time
 GC Cycles           3497            Full garbage collection cycles
 Goroutines Created  0               Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.687629ms-19.970602ms  15     (0.1%)
 19.970602ms-21.341657ms  79    █ (0.7%)
 21.341657ms-22.80684ms   223   ███ (2.1%)
 22.80684ms-24.372613ms   704   ███████████ (6.6%)
 24.372613ms-26.045882ms  1653  ███████████████████████████ (15.6%)
 26.045882ms-27.834027ms  2434  ████████████████████████████████████████ (23.0%)
 27.834027ms-29.744934ms  2431  ███████████████████████████████████████ (22.9%)
 29.744934ms-31.787033ms  1688  ███████████████████████████ (15.9%)
 31.787033ms-33.969329ms  827   █████████████ (7.8%)
 33.969329ms-36.301447ms  363   █████ (3.4%)
 36.301447ms-38.793674ms  79    █ (0.7%)
 38.793674ms-41.457002ms  34     (0.3%)
 41.457002ms-44.303176ms  15     (0.1%)
 44.303176ms-47.344751ms  13     (0.1%)
 47.344751ms-50.595141ms  12     (0.1%)
 50.595141ms-54.068682ms  5      (0.0%)
 54.068682ms-57.780695ms  4      (0.0%)
 57.780695ms-61.747551ms  7      (0.1%)
 61.747551ms-65.986745ms  2      (0.0%)
 65.986745ms-70.516977ms  7      (0.1%)

--- Analysis & Recommendations ---
[INFO] High Allocations (7755/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇█▇▇▇▇▇▇▆▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 374 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.57s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.55s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.594s
```

---

## Comparison report

I have attached the pdf of the comparison report of the results of different benchmarks with different configurations
[benchmark_results.pdf](https://github.com/user-attachments/files/26660565/benchmark_results.pdf)

Let me know if this is good 🙏 