### PR TITLE
refactor(finality): simplify DeliveryScanQueryByID per #1426 review

### DIFF
--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -8,8 +8,10 @@ package finality
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
-	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	fscerrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	vault2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
@@ -17,6 +19,7 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/committer"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/fabricutils"
+	fscFinality "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/rwset"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/vault"
 	driver3 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/driver"
@@ -56,6 +59,35 @@ func (e *listenerEntry) OnStatus(ctx context.Context, info TxInfo) {
 
 func (e *listenerEntry) Equals(other events.ListenerEntry[TxInfo]) bool {
 	return other != nil && other.(*listenerEntry).listener == e.listener
+}
+
+// normalizedLedger wraps the FSC ledger and translates its string-based "not found"
+// errors into the typed ErrTxNotFound sentinel so that DeliveryScanQueryByID can
+// use errors.Is instead of fragile substring matching.
+//
+// This adapter lives in the wiring layer so that deliveryqs.go stays free of
+// FSC error-format knowledge. Once FSC's Ledger.GetTransactionByID returns a
+// typed TxNotFound error, this wrapper can be removed.
+type normalizedLedger struct {
+	inner txLedger
+}
+
+func newNormalizedLedger(l txLedger) *normalizedLedger {
+	return &normalizedLedger{inner: l}
+}
+
+func (l *normalizedLedger) GetTransactionByID(txID string) (*fabric.ProcessedTransaction, error) {
+	pt, err := l.inner.GetTransactionByID(txID)
+	if err == nil {
+		return pt, nil
+	}
+	if fscerrors.HasCause(err, fscFinality.TxNotFound) ||
+		strings.Contains(err.Error(), fmt.Sprintf("TXID [%s] not available", txID)) ||
+		strings.Contains(err.Error(), fmt.Sprintf("no such transaction ID [%s]", txID)) {
+		return nil, fmt.Errorf("%w: %w", ErrTxNotFound, err)
+	}
+
+	return nil, err
 }
 
 type TxInfo struct {
@@ -116,7 +148,7 @@ func (p *deliveryBasedFLMProvider) NewManager(network, channel string) (Listener
 		},
 		&DeliveryScanQueryByID{
 			Delivery: ch.Delivery(),
-			Ledger:   ch.Ledger(),
+			Ledger:   newNormalizedLedger(ch.Ledger()),
 			Mapper:   mapper,
 		},
 		p.tracerProvider.Tracer("finality_listener_manager", tracing.WithMetricsOpts(tracing.MetricsOpts{})),
@@ -145,7 +177,7 @@ type endorserTxInfoMapper struct {
 func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *common.BlockMetadata, blockNum driver2.BlockNum, txNum driver2.TxNum) (map[driver2.Namespace]TxInfo, error) {
 	_, payl, chdr, err := fabricutils.UnmarshalTx(tx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
+		return nil, fscerrors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
 	}
 	if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
 		logger.DebugfContext(ctx, "Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
@@ -154,11 +186,11 @@ func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *
 	}
 	rwSet, err := rwset.NewEndorserTransactionReader(m.network).Read(payl, chdr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed extracting rwset")
+		return nil, fscerrors.Wrapf(err, "failed extracting rwset")
 	}
 
 	if len(block.Metadata) < int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
-		return nil, errors.Errorf("block metadata lacks transaction filter")
+		return nil, fscerrors.Errorf("block metadata lacks transaction filter")
 	}
 	code, message := committer.MapValidationCode(int32(committer.ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[txNum]))
 
@@ -186,7 +218,7 @@ func (m *endorserTxInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) (
 func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string, code driver3.ValidationCode, message string) (map[driver2.Namespace]TxInfo, error) {
 	key, err := m.keyTranslator.CreateTokenRequestKey(txID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't create for token request [%s]", txID)
+		return nil, fscerrors.Wrapf(err, "can't create for token request [%s]", txID)
 	}
 	txInfos := make(map[driver2.Namespace]TxInfo, len(rwSet.Writes))
 	logger.Debugf("TX [%s] has %d namespaces", txID, len(rwSet.Writes))

--- a/token/services/network/fabric/finality/deliveryflm.go
+++ b/token/services/network/fabric/finality/deliveryflm.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"strings"
 
-	fscerrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	vault2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/core/generic/vault"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
@@ -81,7 +81,7 @@ func (l *normalizedLedger) GetTransactionByID(txID string) (*fabric.ProcessedTra
 	if err == nil {
 		return pt, nil
 	}
-	if fscerrors.HasCause(err, fscFinality.TxNotFound) ||
+	if errors.HasCause(err, fscFinality.TxNotFound) ||
 		strings.Contains(err.Error(), fmt.Sprintf("TXID [%s] not available", txID)) ||
 		strings.Contains(err.Error(), fmt.Sprintf("no such transaction ID [%s]", txID)) {
 		return nil, fmt.Errorf("%w: %w", ErrTxNotFound, err)
@@ -177,7 +177,7 @@ type endorserTxInfoMapper struct {
 func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *common.BlockMetadata, blockNum driver2.BlockNum, txNum driver2.TxNum) (map[driver2.Namespace]TxInfo, error) {
 	_, payl, chdr, err := fabricutils.UnmarshalTx(tx)
 	if err != nil {
-		return nil, fscerrors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
+		return nil, errors.Wrapf(err, "failed unmarshaling tx [%d:%d]", blockNum, txNum)
 	}
 	if common.HeaderType(chdr.Type) != common.HeaderType_ENDORSER_TRANSACTION {
 		logger.DebugfContext(ctx, "Type of TX [%d:%d] is [%d]. Skipping...", blockNum, txNum, chdr.Type)
@@ -186,11 +186,11 @@ func (m *endorserTxInfoMapper) MapTxData(ctx context.Context, tx []byte, block *
 	}
 	rwSet, err := rwset.NewEndorserTransactionReader(m.network).Read(payl, chdr)
 	if err != nil {
-		return nil, fscerrors.Wrapf(err, "failed extracting rwset")
+		return nil, errors.Wrapf(err, "failed extracting rwset")
 	}
 
 	if len(block.Metadata) < int(common.BlockMetadataIndex_TRANSACTIONS_FILTER) {
-		return nil, fscerrors.Errorf("block metadata lacks transaction filter")
+		return nil, errors.Errorf("block metadata lacks transaction filter")
 	}
 	code, message := committer.MapValidationCode(int32(committer.ValidationFlags(block.Metadata[common.BlockMetadataIndex_TRANSACTIONS_FILTER])[txNum]))
 
@@ -218,7 +218,7 @@ func (m *endorserTxInfoMapper) MapProcessedTx(tx *fabric.ProcessedTransaction) (
 func (m *endorserTxInfoMapper) mapTxInfo(rwSet vault2.ReadWriteSet, txID string, code driver3.ValidationCode, message string) (map[driver2.Namespace]TxInfo, error) {
 	key, err := m.keyTranslator.CreateTokenRequestKey(txID)
 	if err != nil {
-		return nil, fscerrors.Wrapf(err, "can't create for token request [%s]", txID)
+		return nil, errors.Wrapf(err, "can't create for token request [%s]", txID)
 	}
 	txInfos := make(map[driver2.Namespace]TxInfo, len(rwSet.Writes))
 	logger.Debugf("TX [%s] has %d namespaces", txID, len(rwSet.Writes))

--- a/token/services/network/fabric/finality/deliveryqs.go
+++ b/token/services/network/fabric/finality/deliveryqs.go
@@ -8,21 +8,24 @@ package finality
 
 import (
 	"context"
-	"fmt"
-	"strings"
+	"errors"
 
-	errors2 "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
 	events2 "github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/finality"
 )
 
 const (
 	NumberPastBlocks = 10
 	FirstBlock       = 1
 )
+
+// ErrTxNotFound is the sentinel returned by txLedger when a transaction does not
+// exist on the ledger. The wiring layer (deliveryflm.go) translates FSC's
+// string-based "not found" errors into this typed error so that callers can use
+// errors.Is instead of fragile substring matching.
+var ErrTxNotFound = errors.New("transaction not found")
 
 type txLedger interface {
 	GetTransactionByID(txID string) (*fabric.ProcessedTransaction, error)
@@ -32,10 +35,16 @@ type blockScanner interface {
 	ScanFromBlock(ctx context.Context, block uint64, callback fabric.DeliveryCallback) error
 }
 
+// txMapper is the subset of events.EventInfoMapper used by DeliveryScanQueryByID.
+// It only needs MapProcessedTx; MapTxData (the block-path method) is not called here.
+type txMapper interface {
+	MapProcessedTx(tx *fabric.ProcessedTransaction) ([]TxInfo, error)
+}
+
 type DeliveryScanQueryByID struct {
 	Delivery blockScanner
 	Ledger   txLedger
-	Mapper   events2.EventInfoMapper[TxInfo]
+	Mapper   txMapper
 }
 
 func (q *DeliveryScanQueryByID) QueryByID(ctx context.Context, lastBlock driver.BlockNum, evicted map[driver.TxID][]events2.ListenerEntry[TxInfo]) (<-chan []TxInfo, error) {
@@ -72,12 +81,8 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.TxI
 			continue
 		}
 
-		// which kind of error do we have here?
-		// TODO: AF In FSC, we have to map the error from Ledger.GetTransactionByID to TxNotFound instead of using substrings
-		if strings.Contains(err.Error(), fmt.Sprintf("TXID [%s] not available", txID)) ||
-			strings.Contains(err.Error(), fmt.Sprintf("no such transaction ID [%s]", txID)) ||
-			errors2.HasType(err, finality.TxNotFound) {
-			// transaction was not found
+		if errors.Is(err, ErrTxNotFound) {
+			// transaction was not found on the ledger; fall back to block scan
 			logger.Errorf("tx [%s] not found on the ledger [%s]", txID, err)
 			startDelivery = true
 
@@ -94,7 +99,6 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.TxI
 	}
 
 	startingBlock := max(FirstBlock, lastBlock-NumberPastBlocks)
-	// startingBlock := uint64(0)
 	logger.DebugfContext(ctx, "start scanning blocks starting from [%d], looking for remaining keys [%s]", startingBlock, keySet)
 
 	// start delivery for the future

--- a/token/services/network/fabric/finality/deliveryqs_test.go
+++ b/token/services/network/fabric/finality/deliveryqs_test.go
@@ -35,7 +35,9 @@ type fakeLedgerResult struct {
 func (f *fakeLedger) GetTransactionByID(txID string) (*fabric.ProcessedTransaction, error) {
 	r, ok := f.results[txID]
 	if !ok {
-		return nil, fmt.Errorf("TXID [%s] not available", txID)
+		// The real ledger's raw string error is normalized by normalizedLedger (deliveryflm.go)
+		// before reaching DeliveryScanQueryByID. Fakes must return the typed sentinel directly.
+		return nil, fmt.Errorf("%w: TXID [%s] not available", finality.ErrTxNotFound, txID)
 	}
 
 	return r.pt, r.err


### PR DESCRIPTION
Closes #1551 

Cleanup pass after @adecaro's note on #1426.

Two things bugged me about the existing code.

`DeliveryScanQueryByID.Mapper` was typed as FSC's full `EventInfoMapper` even though we only ever call `MapProcessedTx`. Narrowed it to a local `txMapper` interface with just that one method. `MapTxData` is for block scanning and doesn't belong here.

The `strings.Contains` error matching for "transaction not found" had an active TODO on it for good reason, any FSC message change would silently break the not-found path. Rather than touching FSC, I added a `normalizedLedger` adapter in `deliveryflm.go` that translates FSC's string errors into a typed `ErrTxNotFound` sentinel. Logic in `deliveryqs.go` now just does `errors.Is(err, ErrTxNotFound)`. When FSC eventually returns a typed error natively, we just drop the adapter.

All four existing unit tests pass unchanged, only `fakeLedger` was updated to return the typed sentinel to match the new contract.