### PR TITLE
test(token): improve coverage for token/token package (#1348)

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/executor/executor.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/executor/executor.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package rp
+package executor
 
 import (
 	"runtime"

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/executor/executor_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/executor/executor_test.go
@@ -4,7 +4,7 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package rp
+package executor
 
 import (
 	"sync"

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -85,8 +85,15 @@ func ToQuantity(q string, precision uint64) (Quantity, error) {
 }
 
 // ToQuantitySum computes the sum of the quantities of the tokens in the iterator.
+// ToQuantitySum computes the sum of the quantities of the tokens in the iterator.
 func ToQuantitySum(precision uint64) iterators.Reducer[*UnspentToken, Quantity] {
-	return iterators.NewReducer(NewZeroQuantity(precision), func(sum Quantity, tok *UnspentToken) (Quantity, error) {
+	return iterators.NewReducer(NewZeroQuantity(precision), func(sum Quantity, tok *UnspentToken) (res Quantity, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.Errorf("failed to sum quantities: %v", r)
+			}
+		}()
+
 		q, err := ToQuantity(tok.Quantity, precision)
 		if err != nil {
 			return nil, err

--- a/token/token/quantity.go
+++ b/token/token/quantity.go
@@ -86,7 +86,13 @@ func ToQuantity(q string, precision uint64) (Quantity, error) {
 
 // ToQuantitySum computes the sum of the quantities of the tokens in the iterator.
 func ToQuantitySum(precision uint64) iterators.Reducer[*UnspentToken, Quantity] {
-	return iterators.NewReducer(NewZeroQuantity(precision), func(sum Quantity, tok *UnspentToken) (Quantity, error) {
+	return iterators.NewReducer(NewZeroQuantity(precision), func(sum Quantity, tok *UnspentToken) (res Quantity, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.Errorf("failed to sum quantities: %v", r)
+			}
+		}()
+
 		q, err := ToQuantity(tok.Quantity, precision)
 		if err != nil {
 			return nil, err

--- a/token/token/quantity_test.go
+++ b/token/token/quantity_test.go
@@ -20,22 +20,22 @@ import (
 
 func TestToQuantity(t *testing.T) {
 	_, err := token.ToQuantity(ToHex(100), 0)
-	assert.Equal(t, "precision must be larger than 0", err.Error())
+	require.EqualError(t, err, "precision must be larger than 0")
 
 	_, err = token.ToQuantity(IntToHex(-100), 64)
-	assert.Equal(t, "invalid input [0x-64,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0x-64,64]")
 
 	_, err = token.ToQuantity("abc", 64)
-	assert.Equal(t, "invalid input [abc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [abc,64]")
 
 	_, err = token.ToQuantity("0babc", 64)
-	assert.Equal(t, "invalid input [0babc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0babc,64]")
 
 	_, err = token.ToQuantity("0abc", 64)
-	assert.Equal(t, "invalid input [0abc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0abc,64]")
 
 	_, err = token.ToQuantity("0xabc", 2)
-	assert.Equal(t, "0xabc has precision 12 > 2", err.Error())
+	require.EqualError(t, err, "0xabc has precision 12 > 2")
 
 	_, err = token.ToQuantity("10231", 64)
 	require.NoError(t, err)
@@ -53,19 +53,19 @@ func TestToQuantity(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = token.ToQuantity(IntToHex(-100), 128)
-	assert.Equal(t, "invalid input [0x-64,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0x-64,128]")
 
 	_, err = token.ToQuantity("abc", 128)
-	assert.Equal(t, "invalid input [abc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [abc,128]")
 
 	_, err = token.ToQuantity("0babc", 128)
-	assert.Equal(t, "invalid input [0babc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0babc,128]")
 
 	_, err = token.ToQuantity("0abc", 128)
-	assert.Equal(t, "invalid input [0abc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0abc,128]")
 
 	_, err = token.ToQuantity("0xabc", 2)
-	assert.Equal(t, "0xabc has precision 12 > 2", err.Error())
+	require.EqualError(t, err, "0xabc has precision 12 > 2")
 
 	_, err = token.ToQuantity("10231", 128)
 	require.NoError(t, err)
@@ -788,5 +788,101 @@ func TestCmpPanicOnInvalidType(t *testing.T) {
 		assert.Panics(t, func() {
 			q.Cmp(invalid)
 		})
+	})
+}
+
+func TestBigQuantity_ToBigInt(t *testing.T) {
+	q, err := token.NewUBigQuantity("42", 128)
+	require.NoError(t, err)
+
+	bi := q.ToBigInt()
+	assert.Equal(t, int64(42), bi.Int64())
+
+	// Verify copy semantics: mutating the result does not affect the original
+	bi.SetInt64(999)
+	assert.Equal(t, "42", q.Decimal())
+}
+
+func TestUInt64Quantity_ToBigInt(t *testing.T) {
+	q := token.NewQuantityFromUInt64(12345)
+
+	bi := q.ToBigInt()
+	assert.Equal(t, int64(12345), bi.Int64())
+}
+
+func TestQuantity_TypeMismatchReturnsError(t *testing.T) {
+	u64, err := token.UInt64ToQuantity(10, 64)
+	require.NoError(t, err)
+
+	big128, err := token.NewUBigQuantity("10", 128)
+	require.NoError(t, err)
+
+	_, err = big128.Add(u64)
+	require.Error(t, err)
+
+	_, err = big128.Sub(u64)
+	require.Error(t, err)
+
+	_, err = u64.(*token.UInt64Quantity).Add(big128)
+	require.Error(t, err)
+
+	_, err = u64.(*token.UInt64Quantity).Sub(big128)
+	require.Error(t, err)
+}
+
+func TestUInt64ToQuantity_BigQuantityPath(t *testing.T) {
+	// Non-64 precision should return a BigQuantity
+	q, err := token.UInt64ToQuantity(100, 128)
+	require.NoError(t, err)
+
+	_, ok := q.(*token.BigQuantity)
+	assert.True(t, ok, "expected BigQuantity for precision 128")
+	assert.Equal(t, "100", q.Decimal())
+}
+
+func TestToQuantity_NegativeDecimal(t *testing.T) {
+	_, err := token.ToQuantity("-100", 64)
+	require.EqualError(t, err, "quantity must be larger than 0")
+
+	_, err = token.ToQuantity("-1", 128)
+	require.EqualError(t, err, "quantity must be larger than 0")
+}
+
+func TestToQuantitySum(t *testing.T) {
+	t.Run("Valid sum", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+		var err error
+
+		s, err = reducer.Reduce(s, &token.UnspentToken{Quantity: "10"})
+		require.NoError(t, err)
+
+		s, err = reducer.Reduce(s, &token.UnspentToken{Quantity: "20"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "30", s.Decimal())
+	})
+
+	t.Run("Invalid parsing", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+		_, err := reducer.Reduce(s, &token.UnspentToken{Quantity: "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
+	})
+
+	t.Run("Overflow panic recovery", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+		var err error
+
+		// Add max uint64
+		s, err = reducer.Reduce(s, &token.UnspentToken{Quantity: strconv.FormatUint(math.MaxUint64, 10)})
+		require.NoError(t, err)
+
+		// Add 1 more to trigger panic
+		_, err = reducer.Reduce(s, &token.UnspentToken{Quantity: "1"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds uint64")
 	})
 }

--- a/token/token/quantity_test.go
+++ b/token/token/quantity_test.go
@@ -20,22 +20,22 @@ import (
 
 func TestToQuantity(t *testing.T) {
 	_, err := token.ToQuantity(ToHex(100), 0)
-	assert.Equal(t, "precision must be larger than 0", err.Error())
+	require.EqualError(t, err, "precision must be larger than 0")
 
 	_, err = token.ToQuantity(IntToHex(-100), 64)
-	assert.Equal(t, "invalid input [0x-64,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0x-64,64]")
 
 	_, err = token.ToQuantity("abc", 64)
-	assert.Equal(t, "invalid input [abc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [abc,64]")
 
 	_, err = token.ToQuantity("0babc", 64)
-	assert.Equal(t, "invalid input [0babc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0babc,64]")
 
 	_, err = token.ToQuantity("0abc", 64)
-	assert.Equal(t, "invalid input [0abc,64]", err.Error())
+	require.EqualError(t, err, "invalid input [0abc,64]")
 
 	_, err = token.ToQuantity("0xabc", 2)
-	assert.Equal(t, "0xabc has precision 12 > 2", err.Error())
+	require.EqualError(t, err, "0xabc has precision 12 > 2")
 
 	_, err = token.ToQuantity("10231", 64)
 	require.NoError(t, err)
@@ -53,19 +53,19 @@ func TestToQuantity(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = token.ToQuantity(IntToHex(-100), 128)
-	assert.Equal(t, "invalid input [0x-64,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0x-64,128]")
 
 	_, err = token.ToQuantity("abc", 128)
-	assert.Equal(t, "invalid input [abc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [abc,128]")
 
 	_, err = token.ToQuantity("0babc", 128)
-	assert.Equal(t, "invalid input [0babc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0babc,128]")
 
 	_, err = token.ToQuantity("0abc", 128)
-	assert.Equal(t, "invalid input [0abc,128]", err.Error())
+	require.EqualError(t, err, "invalid input [0abc,128]")
 
 	_, err = token.ToQuantity("0xabc", 2)
-	assert.Equal(t, "0xabc has precision 12 > 2", err.Error())
+	require.EqualError(t, err, "0xabc has precision 12 > 2")
 
 	_, err = token.ToQuantity("10231", 128)
 	require.NoError(t, err)
@@ -788,5 +788,98 @@ func TestCmpPanicOnInvalidType(t *testing.T) {
 		assert.Panics(t, func() {
 			q.Cmp(invalid)
 		})
+	})
+}
+
+func TestBigQuantity_ToBigInt(t *testing.T) {
+	q, err := token.NewUBigQuantity("42", 128)
+	require.NoError(t, err)
+
+	bi := q.ToBigInt()
+	assert.Equal(t, int64(42), bi.Int64())
+
+	// Verify copy semantics: mutating the result does not affect the original
+	bi.SetInt64(999)
+	assert.Equal(t, "42", q.Decimal())
+}
+
+func TestUInt64Quantity_ToBigInt(t *testing.T) {
+	q := token.NewQuantityFromUInt64(12345)
+
+	bi := q.ToBigInt()
+	assert.Equal(t, int64(12345), bi.Int64())
+}
+
+func TestQuantity_TypeMismatchReturnsError(t *testing.T) {
+	u64, err := token.UInt64ToQuantity(10, 64)
+	require.NoError(t, err)
+
+	big128, err := token.NewUBigQuantity("10", 128)
+	require.NoError(t, err)
+
+	_, err = big128.Add(u64)
+	require.Error(t, err)
+
+	_, err = big128.Sub(u64)
+	require.Error(t, err)
+
+	_, err = u64.(*token.UInt64Quantity).Add(big128)
+	require.Error(t, err)
+
+	_, err = u64.(*token.UInt64Quantity).Sub(big128)
+	require.Error(t, err)
+}
+
+func TestUInt64ToQuantity_BigQuantityPath(t *testing.T) {
+	// Non-64 precision should return a BigQuantity
+	q, err := token.UInt64ToQuantity(100, 128)
+	require.NoError(t, err)
+
+	_, ok := q.(*token.BigQuantity)
+	assert.True(t, ok, "expected BigQuantity for precision 128")
+	assert.Equal(t, "100", q.Decimal())
+}
+
+func TestToQuantity_NegativeDecimal(t *testing.T) {
+	_, err := token.ToQuantity("-100", 64)
+	require.EqualError(t, err, "quantity must be larger than 0")
+
+	_, err = token.ToQuantity("-1", 128)
+	require.EqualError(t, err, "quantity must be larger than 0")
+}
+
+func TestToQuantitySum(t *testing.T) {
+	t.Run("Valid sum", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+		var err error
+
+		s, err = reducer.Reduce(s, &token.UnspentToken{Quantity: "10"})
+		require.NoError(t, err)
+
+		s, err = reducer.Reduce(s, &token.UnspentToken{Quantity: "20"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "30", s.Decimal())
+	})
+
+	t.Run("Invalid parsing", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+		_, err := reducer.Reduce(s, &token.UnspentToken{Quantity: "invalid"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid input")
+	})
+
+	t.Run("Panic recovery", func(t *testing.T) {
+		reducer := token.ToQuantitySum(64)
+		s := reducer.Produce()
+
+		var err error
+		require.NotPanics(t, func() {
+			_, err = reducer.Reduce(s, (*token.UnspentToken)(nil))
+		})
+
+		require.Error(t, err)
 	})
 }

--- a/token/token/token_test.go
+++ b/token/token/token_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestID_Equal(t *testing.T) {
+	id1 := token.ID{TxId: "tx1", Index: 0}
+	id2 := token.ID{TxId: "tx1", Index: 0}
+	id3 := token.ID{TxId: "tx2", Index: 0}
+	id4 := token.ID{TxId: "tx1", Index: 1}
+
+	assert.True(t, id1.Equal(id2))
+	assert.False(t, id1.Equal(id3))
+	assert.False(t, id1.Equal(id4))
+	assert.True(t, token.ID{}.Equal(token.ID{}))
+}
+
+func TestID_String(t *testing.T) {
+	id := token.ID{TxId: "tx1", Index: 0}
+	assert.Equal(t, "[tx1:0]", id.String())
+
+	id2 := token.ID{TxId: "abc", Index: 42}
+	assert.Equal(t, "[abc:42]", id2.String())
+
+	assert.Equal(t, "[:0]", token.ID{}.String())
+}
+
+func TestLedgerToken_Equal(t *testing.T) {
+	lt1 := token.LedgerToken{
+		ID:            token.ID{TxId: "tx1", Index: 0},
+		Format:        "fabtoken",
+		Token:         []byte("data1"),
+		TokenMetadata: []byte("meta1"),
+	}
+	lt2 := token.LedgerToken{
+		ID:            token.ID{TxId: "tx1", Index: 0},
+		Format:        "fabtoken",
+		Token:         []byte("data1"),
+		TokenMetadata: []byte("meta1"),
+	}
+
+	assert.True(t, lt1.Equal(lt2))
+
+	// Different ID
+	lt3 := lt2
+	lt3.ID = token.ID{TxId: "tx2", Index: 0}
+	assert.False(t, lt1.Equal(lt3))
+
+	// Different Format
+	lt4 := lt2
+	lt4.Format = "zkatdlog"
+	assert.False(t, lt1.Equal(lt4))
+
+	// Different Token
+	lt5 := lt2
+	lt5.Token = []byte("data2")
+	assert.False(t, lt1.Equal(lt5))
+
+	// Different TokenMetadata
+	lt6 := lt2
+	lt6.TokenMetadata = []byte("meta2")
+	assert.False(t, lt1.Equal(lt6))
+
+	// Both empty
+	assert.True(t, token.LedgerToken{}.Equal(token.LedgerToken{}))
+}
+
+func TestIssuedTokens_Count(t *testing.T) {
+	empty := &token.IssuedTokens{}
+	assert.Equal(t, 0, empty.Count())
+
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+		},
+	}
+	assert.Equal(t, 2, it.Count())
+}
+
+func TestIssuedTokens_Sum(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "USD", Quantity: "200"},
+			{Type: "EUR", Quantity: "50"},
+		},
+	}
+
+	sum := it.Sum(64)
+	assert.Equal(t, "350", sum.Decimal())
+
+	// Empty list sums to zero
+	empty := &token.IssuedTokens{}
+	assert.Equal(t, "0", empty.Sum(64).Decimal())
+}
+
+func TestIssuedTokens_ByType(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+			{Type: "USD", Quantity: "300"},
+		},
+	}
+
+	usd := it.ByType("USD")
+	assert.Equal(t, 2, usd.Count())
+	assert.Equal(t, "400", usd.Sum(64).Decimal())
+
+	eur := it.ByType("EUR")
+	assert.Equal(t, 1, eur.Count())
+
+	// No match
+	gbp := it.ByType("GBP")
+	assert.Equal(t, 0, gbp.Count())
+}
+
+func TestUnspentToken_String(t *testing.T) {
+	ut := token.UnspentToken{
+		Id:       token.ID{TxId: "tx1", Index: 3},
+		Owner:    []byte("owner1"),
+		Type:     "USD",
+		Quantity: "100",
+	}
+	assert.Equal(t, "[tx1:3]", ut.String())
+}
+
+func TestUnspentTokens_Count(t *testing.T) {
+	empty := &token.UnspentTokens{}
+	assert.Equal(t, 0, empty.Count())
+
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+		},
+	}
+	assert.Equal(t, 2, ut.Count())
+}
+
+func TestUnspentTokens_Sum(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "USD", Quantity: "250"},
+		},
+	}
+
+	sum := ut.Sum(64)
+	assert.Equal(t, "350", sum.Decimal())
+
+	// Empty list sums to zero
+	empty := &token.UnspentTokens{}
+	assert.Equal(t, "0", empty.Sum(64).Decimal())
+}
+
+func TestUnspentTokens_ByType(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+			{Type: "USD", Quantity: "300"},
+		},
+	}
+
+	usd := ut.ByType("USD")
+	assert.Equal(t, 2, usd.Count())
+	assert.Equal(t, "400", usd.Sum(64).Decimal())
+
+	// No match
+	gbp := ut.ByType("GBP")
+	assert.Equal(t, 0, gbp.Count())
+}
+
+func TestUnspentTokens_At(t *testing.T) {
+	t0 := &token.UnspentToken{Id: token.ID{TxId: "tx0", Index: 0}, Type: "USD", Quantity: "100"}
+	t1 := &token.UnspentToken{Id: token.ID{TxId: "tx1", Index: 1}, Type: "EUR", Quantity: "200"}
+
+	ut := &token.UnspentTokens{Tokens: []*token.UnspentToken{t0, t1}}
+
+	assert.Equal(t, t0, ut.At(0))
+	assert.Equal(t, t1, ut.At(1))
+}
+
+func TestIssuedTokens_Sum_Panic(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "invalid"},
+		},
+	}
+	assert.Panics(t, func() {
+		it.Sum(64)
+	})
+}
+
+func TestUnspentTokens_Sum_Panic(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "invalid"},
+		},
+	}
+	assert.Panics(t, func() {
+		ut.Sum(64)
+	})
+}

--- a/token/token/token_test.go
+++ b/token/token/token_test.go
@@ -1,0 +1,218 @@
+/*
+// This file contains unit tests for token logic including validation, conversion, and edge cases not covered in quantity tests.
+
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestID_Equal(t *testing.T) {
+	id1 := token.ID{TxId: "tx1", Index: 0}
+	id2 := token.ID{TxId: "tx1", Index: 0}
+	id3 := token.ID{TxId: "tx2", Index: 0}
+	id4 := token.ID{TxId: "tx1", Index: 1}
+
+	assert.True(t, id1.Equal(id2))
+	assert.False(t, id1.Equal(id3))
+	assert.False(t, id1.Equal(id4))
+	assert.True(t, token.ID{}.Equal(token.ID{}))
+}
+
+func TestID_String(t *testing.T) {
+	id := token.ID{TxId: "tx1", Index: 0}
+	assert.Equal(t, "[tx1:0]", id.String())
+
+	id2 := token.ID{TxId: "abc", Index: 42}
+	assert.Equal(t, "[abc:42]", id2.String())
+
+	assert.Equal(t, "[:0]", token.ID{}.String())
+}
+
+func TestLedgerToken_Equal(t *testing.T) {
+	lt1 := token.LedgerToken{
+		ID:            token.ID{TxId: "tx1", Index: 0},
+		Format:        "fabtoken",
+		Token:         []byte("data1"),
+		TokenMetadata: []byte("meta1"),
+	}
+	lt2 := token.LedgerToken{
+		ID:            token.ID{TxId: "tx1", Index: 0},
+		Format:        "fabtoken",
+		Token:         []byte("data1"),
+		TokenMetadata: []byte("meta1"),
+	}
+
+	assert.True(t, lt1.Equal(lt2))
+
+	// Different ID
+	lt3 := lt2
+	lt3.ID = token.ID{TxId: "tx2", Index: 0}
+	assert.False(t, lt1.Equal(lt3))
+
+	// Different Format
+	lt4 := lt2
+	lt4.Format = "zkatdlog"
+	assert.False(t, lt1.Equal(lt4))
+
+	// Different Token
+	lt5 := lt2
+	lt5.Token = []byte("data2")
+	assert.False(t, lt1.Equal(lt5))
+
+	// Different TokenMetadata
+	lt6 := lt2
+	lt6.TokenMetadata = []byte("meta2")
+	assert.False(t, lt1.Equal(lt6))
+
+	// Both empty
+	assert.True(t, token.LedgerToken{}.Equal(token.LedgerToken{}))
+}
+
+func TestIssuedTokens_Count(t *testing.T) {
+	empty := &token.IssuedTokens{}
+	assert.Equal(t, 0, empty.Count())
+
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+		},
+	}
+	assert.Equal(t, 2, it.Count())
+}
+
+func TestIssuedTokens_Sum(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "USD", Quantity: "200"},
+			{Type: "EUR", Quantity: "50"},
+		},
+	}
+
+	sum := it.Sum(64)
+	assert.Equal(t, "350", sum.Decimal())
+
+	// Empty list sums to zero
+	empty := &token.IssuedTokens{}
+	assert.Equal(t, "0", empty.Sum(64).Decimal())
+}
+
+func TestIssuedTokens_ByType(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+			{Type: "USD", Quantity: "300"},
+		},
+	}
+
+	usd := it.ByType("USD")
+	assert.Equal(t, 2, usd.Count())
+	assert.Equal(t, "400", usd.Sum(64).Decimal())
+
+	eur := it.ByType("EUR")
+	assert.Equal(t, 1, eur.Count())
+
+	// No match
+	gbp := it.ByType("GBP")
+	assert.Equal(t, 0, gbp.Count())
+}
+
+func TestUnspentToken_String(t *testing.T) {
+	ut := token.UnspentToken{
+		Id:       token.ID{TxId: "tx1", Index: 3},
+		Owner:    []byte("owner1"),
+		Type:     "USD",
+		Quantity: "100",
+	}
+	assert.Equal(t, "[tx1:3]", ut.String())
+}
+
+func TestUnspentTokens_Count(t *testing.T) {
+	empty := &token.UnspentTokens{}
+	assert.Equal(t, 0, empty.Count())
+
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+		},
+	}
+	assert.Equal(t, 2, ut.Count())
+}
+
+func TestUnspentTokens_Sum(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "USD", Quantity: "250"},
+		},
+	}
+
+	sum := ut.Sum(64)
+	assert.Equal(t, "350", sum.Decimal())
+
+	// Empty list sums to zero
+	empty := &token.UnspentTokens{}
+	assert.Equal(t, "0", empty.Sum(64).Decimal())
+}
+
+func TestUnspentTokens_ByType(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "100"},
+			{Type: "EUR", Quantity: "200"},
+			{Type: "USD", Quantity: "300"},
+		},
+	}
+
+	usd := ut.ByType("USD")
+	assert.Equal(t, 2, usd.Count())
+	assert.Equal(t, "400", usd.Sum(64).Decimal())
+
+	// No match
+	gbp := ut.ByType("GBP")
+	assert.Equal(t, 0, gbp.Count())
+}
+
+func TestUnspentTokens_At(t *testing.T) {
+	t0 := &token.UnspentToken{Id: token.ID{TxId: "tx0", Index: 0}, Type: "USD", Quantity: "100"}
+	t1 := &token.UnspentToken{Id: token.ID{TxId: "tx1", Index: 1}, Type: "EUR", Quantity: "200"}
+
+	ut := &token.UnspentTokens{Tokens: []*token.UnspentToken{t0, t1}}
+
+	assert.Equal(t, t0, ut.At(0))
+	assert.Equal(t, t1, ut.At(1))
+}
+
+func TestIssuedTokens_Sum_Panic(t *testing.T) {
+	it := &token.IssuedTokens{
+		Tokens: []*token.IssuedToken{
+			{Type: "USD", Quantity: "invalid"},
+		},
+	}
+	assert.Panics(t, func() {
+		it.Sum(64)
+	})
+}
+
+func TestUnspentTokens_Sum_Panic(t *testing.T) {
+	ut := &token.UnspentTokens{
+		Tokens: []*token.UnspentToken{
+			{Type: "USD", Quantity: "invalid"},
+		},
+	}
+	assert.Panics(t, func() {
+		ut.Sum(64)
+	})
+}


### PR DESCRIPTION
This PR improves test coverage for the `token/token` package and fixes an issue in `ToQuantitySum` where panic recovery was not correctly propagating errors.

It also includes a minimal fix in the `rp/executor` package to align the package name with its import usage, which is required for successful typechecking.

The changes are limited to the relevant files, and I’ve verified locally that `go build`, `go vet`, and `golangci-lint` all pass.
