### PR TITLE
docs(readme): fix Go workflow badge and link mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Fabric Token SDK
 [![License](https://img.shields.io/badge/license-Apache%202-blue)](LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/hyperledger-labs/fabric-token-sdk)](https://goreportcard.com/badge/github.com/hyperledger-labs/fabric-token-sdk)
-[![Go](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/tests.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/go.yml)
+[![Go](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/tests.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/tests.yml)
 [![CodeQL](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/hyperledger-labs/fabric-token-sdk/actions/workflows/codeql-analysis.yml)
 [![Coverage Status](https://coveralls.io/repos/github/hyperledger-labs/fabric-token-sdk/badge.svg?branch=main)](https://coveralls.io/github/hyperledger-labs/fabric-token-sdk?branch=main)
 


### PR DESCRIPTION
## Summary

While going through the README, I noticed that the Go workflow badge and its link were pointing to different workflow files.

## Changes

Updated the badge to match the workflow file used in the link.

## Why this matters

Keeps the README consistent and avoids confusion when checking the workflow status.

Fixes #1573