### PR TITLE
perf(csp): cache Lagrange denominator inverses to eliminate O(n²) recomputation

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache.go
@@ -1,0 +1,142 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"sync"
+
+	mathlib "github.com/IBM/mathlib"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+)
+
+// lagrangeDenomCache caches the precomputed denominator inverses for Lagrange
+// interpolation. The denominators d_i = ∏_{j≠i}(i-j) depend only on n (the
+// number of evaluation points), not on the challenge c. Caching them eliminates
+// O(n²) field multiplications on every proof/verify call that shares the same n.
+//
+// The cache is keyed by (curveID, n) and stores the batch-inverted denominators
+// as native gnark-crypto field elements, avoiding big.Int round-trips on lookup.
+//
+// Thread safety: a sync.Map is used so concurrent proof generations with the
+// same parameters share a single precomputed entry without locking.
+var lagrangeDenomCache sync.Map // key: lagrangeCacheKey → *lagrangeCacheEntry
+
+type lagrangeCacheKey struct {
+	curveID mathlib.CurveID
+	n       uint64
+	partial bool // true → partial (2n+1 points), false → full (n+1 points)
+}
+
+// lagrangeCacheEntry holds the precomputed batch-inverted denominators for a
+// specific (curveID, n, partial) triple. The slice is immutable after creation.
+type lagrangeCacheEntry struct {
+	// denomInvsBLS stores inverted denominators as BLS12-381 fr.Element values.
+	// Populated only when curveID is a BLS12-381 variant.
+	denomInvsBLS []*bls12381fr.Element
+	// denomInvsBN254 stores inverted denominators as BN254 fr.Element values.
+	// Populated only when curveID is BN254.
+	denomInvsBN254 []*bn254fr.Element
+}
+
+// getOrComputeDenomInvsBLS returns the cached (or freshly computed) batch-inverted
+// Lagrange denominators for BLS12-381 curves.
+//
+// For the full variant (partial=false) the evaluation points are {0,1,...,n} and
+// d_i = ∏_{j≠i}(i-j).
+//
+// For the partial variant (partial=true) the evaluation points are {0,1,...,2n}
+// but only the n+1 relevant indices {0, n+1, ..., 2n} are returned.
+func getOrComputeDenomInvsBLS(n uint64, partial bool) []*bls12381fr.Element {
+	key := lagrangeCacheKey{curveID: mathlib.BLS12_381_BBS_GURVY, n: n, partial: partial}
+	if v, ok := lagrangeDenomCache.Load(key); ok {
+		return v.(*lagrangeCacheEntry).denomInvsBLS
+	}
+
+	invs := computeDenomInvs[bls12381fr.Element, *bls12381fr.Element](n, partial)
+	entry := &lagrangeCacheEntry{denomInvsBLS: invs}
+	// Store only if not already present (another goroutine may have raced us).
+	actual, _ := lagrangeDenomCache.LoadOrStore(key, entry)
+
+	return actual.(*lagrangeCacheEntry).denomInvsBLS
+}
+
+// getOrComputeDenomInvsBN254 is the BN254 counterpart of getOrComputeDenomInvsBLS.
+func getOrComputeDenomInvsBN254(n uint64, partial bool) []*bn254fr.Element {
+	key := lagrangeCacheKey{curveID: mathlib.BN254, n: n, partial: partial}
+	if v, ok := lagrangeDenomCache.Load(key); ok {
+		return v.(*lagrangeCacheEntry).denomInvsBN254
+	}
+
+	invs := computeDenomInvs[bn254fr.Element, *bn254fr.Element](n, partial)
+	entry := &lagrangeCacheEntry{denomInvsBN254: invs}
+	actual, _ := lagrangeDenomCache.LoadOrStore(key, entry)
+
+	return actual.(*lagrangeCacheEntry).denomInvsBN254
+}
+
+// computeDenomInvs computes and batch-inverts the Lagrange denominators for the
+// given parameters using native gnark-crypto arithmetic (no big.Int).
+//
+// Full variant (partial=false):
+//
+//	m = n+1 evaluation points {0,...,n}
+//	d_i = ∏_{j=0, j≠i}^{n} (i-j)   for i = 0..n
+//
+// Partial variant (partial=true):
+//
+//	total = 2n+1 evaluation points {0,...,2n}
+//	relevant indices = {0, n+1, ..., 2n}  (n+1 entries)
+//	d_k = ∏_{j=0, j≠relevant[k]}^{2n} (relevant[k]-j)
+func computeDenomInvs[T any, E gnarkFr[T]](n uint64, partial bool) []E {
+	if !partial {
+		m := int(n) + 1 // #nosec G115
+		denoms := make([]T, m)
+		denomsE := make([]E, m)
+		for i := range denoms {
+			denomsE[i] = E(&denoms[i])
+			denomsE[i].SetOne()
+			var diff T
+			diffE := E(&diff)
+			for j := range m {
+				if j == i {
+					continue
+				}
+				diffE.SetInt64(int64(i - j))
+				denomsE[i].Mul(denomsE[i], diffE)
+			}
+		}
+
+		return nativeBatchInverse[T, E](denomsE)
+	}
+
+	// Partial: relevant indices are {0, n+1, ..., 2n}.
+	total := 2*int(n) + 1             // #nosec G115
+	relevant := make([]int, int(n)+1) // #nosec G115
+	relevant[0] = 0
+	for k := 1; k <= int(n); k++ { // #nosec G115
+		relevant[k] = int(n) + k // #nosec G115
+	}
+
+	denoms := make([]T, len(relevant))
+	denomsE := make([]E, len(relevant))
+	for k := range relevant {
+		denomsE[k] = E(&denoms[k])
+		denomsE[k].SetOne()
+		var diff T
+		diffE := E(&diff)
+		for j := range total {
+			if j == relevant[k] {
+				continue
+			}
+			diffE.SetInt64(int64(relevant[k] - j))
+			denomsE[k].Mul(denomsE[k], diffE)
+		}
+	}
+
+	return nativeBatchInverse[T, E](denomsE)
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLagrangeCacheCorrectness verifies that cached denominator inverses produce
+// the same Lagrange multipliers as the uncached path.
+func TestLagrangeCacheCorrectness(t *testing.T) {
+	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
+	ns := []uint64{4, 8, 16}
+
+	for _, curveID := range curves {
+		curve := math.Curves[curveID]
+		rand, err := curve.Rand()
+		require.NoError(t, err)
+
+		for _, n := range ns {
+			c := curve.NewRandomZr(rand)
+
+			// Cached path (via nativeLagrangeMultipliers which uses the cache).
+			cached, ok, err := nativeLagrangeMultipliers(n, c, curve)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			// Fallback path (big.Int based, no cache).
+			fallback, err := getLagrangeMultipliers(n, c, curve)
+			require.NoError(t, err)
+
+			require.Len(t, cached, len(fallback))
+			for i := range cached {
+				assert.True(t, cached[i].Equals(fallback[i]),
+					"curve=%d n=%d i=%d: cached and fallback results differ", curveID, n, i)
+			}
+		}
+	}
+}
+
+// TestLagrangeCacheCorrectnessPartial verifies cached partial Lagrange multipliers.
+func TestLagrangeCacheCorrectnessPartial(t *testing.T) {
+	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
+	ns := []uint64{4, 8, 16}
+
+	for _, curveID := range curves {
+		curve := math.Curves[curveID]
+		rand, err := curve.Rand()
+		require.NoError(t, err)
+
+		for _, n := range ns {
+			c := curve.NewRandomZr(rand)
+
+			cached, ok, err := nativeLagrangeMultipliersPartial(n, c, curve)
+			require.NoError(t, err)
+			require.True(t, ok)
+
+			fallback, err := getLagrangeMultipliersPartial(n, c, curve)
+			require.NoError(t, err)
+
+			require.Len(t, cached, len(fallback))
+			for i := range cached {
+				assert.True(t, cached[i].Equals(fallback[i]),
+					"curve=%d n=%d i=%d: cached and fallback partial results differ", curveID, n, i)
+			}
+		}
+	}
+}
+
+// TestLagrangeCacheIdempotent verifies that repeated cache lookups return
+// identical results (cache hit path is correct).
+func TestLagrangeCacheIdempotent(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	rand, err := curve.Rand()
+	require.NoError(t, err)
+
+	n := uint64(8)
+	c := curve.NewRandomZr(rand)
+
+	r1, ok1, err := nativeLagrangeMultipliers(n, c, curve)
+	require.NoError(t, err)
+	require.True(t, ok1)
+
+	r2, ok2, err := nativeLagrangeMultipliers(n, c, curve)
+	require.NoError(t, err)
+	require.True(t, ok2)
+
+	require.Len(t, r1, len(r2))
+	for i := range r1 {
+		assert.True(t, r1[i].Equals(r2[i]), "repeated calls should return identical results at index %d", i)
+	}
+}
+
+// BenchmarkLagrangeMultipliersCached benchmarks the cached path (warm cache).
+func BenchmarkLagrangeMultipliersCached(b *testing.B) {
+	curve := math.Curves[math.BN254]
+	rand, err := curve.Rand()
+	require.NoError(b, err)
+
+	n := uint64(32)
+	c := curve.NewRandomZr(rand)
+
+	// Warm the cache.
+	_, _, _ = nativeLagrangeMultipliers(n, c, curve)
+
+	b.ResetTimer()
+	for range b.N {
+		c = curve.NewRandomZr(rand)
+		_, _, _ = nativeLagrangeMultipliers(n, c, curve)
+	}
+}
+
+// BenchmarkLagrangeMultipliersColdCache benchmarks the first call (cold cache, denom computation included).
+func BenchmarkLagrangeMultipliersColdCache(b *testing.B) {
+	curve := math.Curves[math.BN254]
+	rand, err := curve.Rand()
+	require.NoError(b, err)
+
+	n := uint64(32)
+
+	b.ResetTimer()
+	for range b.N {
+		// Clear cache entry to simulate cold start.
+		lagrangeDenomCache.Delete(lagrangeCacheKey{curveID: math.BN254, n: n, partial: false})
+		c := curve.NewRandomZr(rand)
+		_, _, _ = nativeLagrangeMultipliers(n, c, curve)
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
@@ -91,7 +91,10 @@ func nativeBatchInverse[T any, E gnarkFr[T]](elems []E) []E {
 // getLagrangeMultipliers. Conversions between mathlib.Zr and fr.Element occur
 // only once at the boundary (once for input c, n+1 times for the output slice),
 // so the O(n²) arithmetic runs entirely in native Montgomery form.
-func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, error) {
+//
+// The denominator inverses d_i^{-1} = (∏_{j≠i}(i-j))^{-1} depend only on n,
+// not on c, so they are retrieved from the cache (computed once per n).
+func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	m := int(n) + 1 // #nosec G115
 
 	// Convert c once.
@@ -107,32 +110,20 @@ func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, 
 		cMinusJE[j].Sub(cE, E(&jE))
 	}
 
-	// Compute numerator and denominator for each Lagrange basis polynomial L_i(c).
+	// Compute numerator for each Lagrange basis polynomial L_i(c).
+	// Denominators come from the cache — no O(n²) recomputation.
 	numers := make([]T, m)
-	denoms := make([]T, m)
 	numersE := make([]E, m)
-	denomsE := make([]E, m)
 	for i := range numers {
 		numersE[i] = E(&numers[i])
-		denomsE[i] = E(&denoms[i])
-	}
-
-	for i := range m {
 		numersE[i].SetOne()
-		denomsE[i].SetOne()
-		var diff T
-		diffE := E(&diff)
 		for j := range m {
 			if j == i {
 				continue
 			}
 			numersE[i].Mul(numersE[i], cMinusJE[j])
-			diffE.SetInt64(int64(i - j)) // handles negative i-j correctly
-			denomsE[i].Mul(denomsE[i], diffE)
 		}
 	}
-
-	denomInvs := nativeBatchInverse[T, E](denomsE)
 
 	result := make([]*mathlib.Zr, m)
 	for i := range m {
@@ -146,7 +137,8 @@ func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, 
 
 // getLagrangeMultipliersPartialNative is the native fr.Element implementation of
 // getLagrangeMultipliersPartial. Same boundary-only conversion strategy.
-func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, error) {
+// Denominator inverses are retrieved from the cache.
+func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	total := 2*int(n) + 1 // #nosec G115 // all evaluation points: 0..2n
 
 	cE := nativeFromZr[T, E](c)
@@ -169,30 +161,20 @@ func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathl
 	}
 
 	numers := make([]T, len(relevant))
-	denoms := make([]T, len(relevant))
 	numersE := make([]E, len(relevant))
-	denomsE := make([]E, len(relevant))
 	for k := range relevant {
 		numersE[k] = E(&numers[k])
-		denomsE[k] = E(&denoms[k])
 	}
 
 	for k, i := range relevant {
 		numersE[k].SetOne()
-		denomsE[k].SetOne()
-		var diff T
-		diffE := E(&diff)
 		for j := range total {
 			if j == i {
 				continue
 			}
 			numersE[k].Mul(numersE[k], cMinusJE[j])
-			diffE.SetInt64(int64(i - j))
-			denomsE[k].Mul(denomsE[k], diffE)
 		}
 	}
-
-	denomInvs := nativeBatchInverse[T, E](denomsE)
 
 	result := make([]*mathlib.Zr, len(relevant))
 	for k := range relevant {
@@ -205,7 +187,8 @@ func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathl
 }
 
 // interpolateNative is the native fr.Element implementation of interpolate.
-func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, error) {
+// Denominator inverses are retrieved from the cache.
+func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	m := int(n) + 1 // #nosec G115
 
 	// Convert all input values to native elements once.
@@ -224,24 +207,6 @@ func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr,
 			valsE[i].SetBigInt(valuesOverN[i].BigInt())
 		}
 	}
-
-	// d_i = ∏_{j≠i}(i-j)  for i = 0..n  (denominator of the i-th basis polynomial)
-	denoms := make([]T, m)
-	denomsE := make([]E, m)
-	for i := range denoms {
-		denomsE[i] = E(&denoms[i])
-		denomsE[i].SetOne()
-		var diff T
-		diffE := E(&diff)
-		for j := range m {
-			if j == i {
-				continue
-			}
-			diffE.SetInt64(int64(i - j))
-			denomsE[i].Mul(denomsE[i], diffE)
-		}
-	}
-	denomInvs := nativeBatchInverse[T, E](denomsE)
 
 	// First m entries are the inputs verbatim.
 	result := make([]*mathlib.Zr, 2*int(n)+1) // #nosec G115
@@ -280,15 +245,17 @@ func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr,
 }
 
 // nativeLagrangeMultipliers dispatches getLagrangeMultipliers to the native
-// fr.Element implementation for supported curves.
+// fr.Element implementation for supported curves, using cached denominator inverses.
 func nativeLagrangeMultipliers(n uint64, c *mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, bool, error) {
 	switch curve.GroupOrder.CurveID() {
 	case mathlib.BLS12_381, mathlib.BLS12_381_GURVY, mathlib.BLS12_381_BBS, mathlib.BLS12_381_BBS_GURVY:
-		r, err := getLagrangeMultipliersNative[bls12381fr.Element, *bls12381fr.Element](n, c, curve)
+		denomInvs := getOrComputeDenomInvsBLS(n, false)
+		r, err := getLagrangeMultipliersNative[bls12381fr.Element, *bls12381fr.Element](n, c, curve, denomInvs)
 
 		return r, true, err
 	case mathlib.BN254:
-		r, err := getLagrangeMultipliersNative[bn254fr.Element, *bn254fr.Element](n, c, curve)
+		denomInvs := getOrComputeDenomInvsBN254(n, false)
+		r, err := getLagrangeMultipliersNative[bn254fr.Element, *bn254fr.Element](n, c, curve, denomInvs)
 
 		return r, true, err
 	}
@@ -297,15 +264,17 @@ func nativeLagrangeMultipliers(n uint64, c *mathlib.Zr, curve *mathlib.Curve) ([
 }
 
 // nativeLagrangeMultipliersPartial dispatches getLagrangeMultipliersPartial to
-// the native fr.Element implementation for supported curves.
+// the native fr.Element implementation for supported curves, using cached denominator inverses.
 func nativeLagrangeMultipliersPartial(n uint64, c *mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, bool, error) {
 	switch curve.GroupOrder.CurveID() {
 	case mathlib.BLS12_381, mathlib.BLS12_381_GURVY, mathlib.BLS12_381_BBS, mathlib.BLS12_381_BBS_GURVY:
-		r, err := getLagrangeMultipliersPartialNative[bls12381fr.Element, *bls12381fr.Element](n, c, curve)
+		denomInvs := getOrComputeDenomInvsBLS(n, true)
+		r, err := getLagrangeMultipliersPartialNative[bls12381fr.Element, *bls12381fr.Element](n, c, curve, denomInvs)
 
 		return r, true, err
 	case mathlib.BN254:
-		r, err := getLagrangeMultipliersPartialNative[bn254fr.Element, *bn254fr.Element](n, c, curve)
+		denomInvs := getOrComputeDenomInvsBN254(n, true)
+		r, err := getLagrangeMultipliersPartialNative[bn254fr.Element, *bn254fr.Element](n, c, curve, denomInvs)
 
 		return r, true, err
 	}
@@ -314,15 +283,17 @@ func nativeLagrangeMultipliersPartial(n uint64, c *mathlib.Zr, curve *mathlib.Cu
 }
 
 // nativeInterpolate dispatches interpolate to the native fr.Element
-// implementation for supported curves.
+// implementation for supported curves, using cached denominator inverses.
 func nativeInterpolate(n uint64, vals []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, bool, error) {
 	switch curve.GroupOrder.CurveID() {
 	case mathlib.BLS12_381, mathlib.BLS12_381_GURVY, mathlib.BLS12_381_BBS, mathlib.BLS12_381_BBS_GURVY:
-		r, err := interpolateNative[bls12381fr.Element, *bls12381fr.Element](n, vals, curve)
+		denomInvs := getOrComputeDenomInvsBLS(n, false)
+		r, err := interpolateNative[bls12381fr.Element, *bls12381fr.Element](n, vals, curve, denomInvs)
 
 		return r, true, err
 	case mathlib.BN254:
-		r, err := interpolateNative[bn254fr.Element, *bn254fr.Element](n, vals, curve)
+		denomInvs := getOrComputeDenomInvsBN254(n, false)
+		r, err := interpolateNative[bn254fr.Element, *bn254fr.Element](n, vals, curve, denomInvs)
 
 		return r, true, err
 	}


### PR DESCRIPTION
Part of #1432

## Problem

In the CSP range proof, both `getLagrangeMultipliers` and
`getLagrangeMultipliersPartial` compute the denominator factors

    d_i = ∏_{j≠i}(i-j)

from scratch on every proof generation and verification call. These
denominators depend only on `n` (the number of bits), not on the
per-proof Fiat-Shamir challenge `c`. For a 32-bit range proof this
means ~1000 native field multiplications + a batch inversion are
repeated identically on every call.

## Fix

Introduce a `sync.Map` cache keyed by `(curveID, n, partial)` that
stores the batch-inverted denominators as gnark-crypto `fr.Element`
values (no `big.Int` round-trips on lookup).

After the first call for a given `(curveID, n)` the denominator
computation is skipped entirely. Subsequent calls only compute the
O(n²) numerators (which must vary with `c`) and do a single
element-wise multiply against the cached inverses.

## Changes

- `lagrange_cache.go` — cache implementation using `sync.Map`,
  generic `computeDenomInvs[T, E]` helper, and per-curve typed
  accessors for BN254 and BLS12-381
- `lagrange_native.go` — `getLagrangeMultipliersNative` and
  `getLagrangeMultipliersPartialNative` now accept pre-computed
  `denomInvs`; dispatch functions fetch from cache before calling
  the native path
- `lagrange_cache_test.go` — correctness tests (cached == fallback
  for BN254 and BLS12-381, n ∈ {4, 8, 16}) and warm/cold cache
  benchmarks

## Testing

- `go test ./token/core/zkatdlog/nogh/v1/crypto/...` — PASS
- All existing native Lagrange tests pass unchanged
- 3 new correctness tests added: `TestLagrangeCacheCorrectness`,
  `TestLagrangeCacheCorrectnessPartial`, `TestLagrangeCacheIdempotent`

## Notes

- No change to proof format or serialization
- Thread-safe: `sync.Map.LoadOrStore` prevents duplicate computation
  under concurrent proof generation
- Fallback (non-native) path is unchanged
