### PR TITLE
perf: optimize BatchInverse allocations using in-place operations

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/math/math.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/math.go
@@ -118,26 +118,36 @@ func BatchInverse(elems []*mathlib.Zr, curve *mathlib.Curve) []*mathlib.Zr {
 	if n == 0 {
 		return nil
 	}
+	if n == 1 {
+		inv := make([]*mathlib.Zr, 1)
+		inv[0] = elems[0].Copy()
+		inv[0].InvModOrder()
+		return inv
+	}
 
 	inv := make([]*mathlib.Zr, n)
 
-	// Forward pass: build prefix products
-	// prefixProd[i] = elems[0] * elems[1] * ... * elems[i]
-	prefixProd := make([]*mathlib.Zr, n)
-	prefixProd[0] = elems[0]
+	// Forward pass: build prefix products in the inv array
+	inv[0] = elems[0] // No copy needed since we don't mutate inv[0]
 	for i := 1; i < n; i++ {
-		prefixProd[i] = curve.ModMul(prefixProd[i-1], elems[i], curve.GroupOrder)
+		inv[i] = curve.ModMul(inv[i-1], elems[i], curve.GroupOrder)
 	}
 
 	// Single inversion of the total product
-	acc := prefixProd[n-1]
+	acc := inv[n-1].Copy()
 	acc.InvModOrder()
 
 	// Backward pass: extract individual inverses
 	for i := n - 1; i >= 1; i-- {
-		inv[i] = curve.ModMul(prefixProd[i-1], acc, curve.GroupOrder)
-		acc = curve.ModMul(acc, elems[i], curve.GroupOrder)
+		// inv[i] = inv[i-1] * acc  where inv[i-1] is the prefix product
+		curve.ModMulInPlace(inv[i], inv[i-1], acc, curve.GroupOrder)
+		// acc = acc * elems[i]
+		curve.ModMulInPlace(acc, acc, elems[i], curve.GroupOrder)
 	}
+	
+	// acc now holds the inverse of elems[0].
+	// Since acc is fully independent (created by Copy() and mutated in place),
+	// we can safely place it directly into the result slice.
 	inv[0] = acc
 
 	return inv

--- a/token/core/zkatdlog/nogh/v1/crypto/math/math.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/math.go
@@ -122,6 +122,7 @@ func BatchInverse(elems []*mathlib.Zr, curve *mathlib.Curve) []*mathlib.Zr {
 		inv := make([]*mathlib.Zr, 1)
 		inv[0] = elems[0].Copy()
 		inv[0].InvModOrder()
+
 		return inv
 	}
 
@@ -144,7 +145,7 @@ func BatchInverse(elems []*mathlib.Zr, curve *mathlib.Curve) []*mathlib.Zr {
 		// acc = acc * elems[i]
 		curve.ModMulInPlace(acc, acc, elems[i], curve.GroupOrder)
 	}
-	
+
 	// acc now holds the inverse of elems[0].
 	// Since acc is fully independent (created by Copy() and mutated in place),
 	// we can safely place it directly into the result slice.


### PR DESCRIPTION
closes #1602 

## Summary

This PR introduces performance optimizations to the `BatchInverse` function in the `math` package (`token/core/zkatdlog/nogh/v1/crypto/math/math.go`). The goal is to reduce memory allocations and improve execution efficiency by leveraging in-place arithmetic and minimizing temporary object creation.

## Changes 

- **Eliminated `prefixProd` Allocation:** Removed the redundant `prefixProd` slice allocation. The `inv` slice is now reused during the forward pass to safely store the prefix products.
- **In-place Operations:** Replaced `curve.ModMul` with `curve.ModMulInPlace` during the backward pass. This avoids the creation of temporary scalars when computing the individual inverses and updating the accumulator (`acc`).
- **Single Element Fast-path:** Added an early return for `n == 1` to avoid unnecessary setup and loop overhead when only a single element requires inversion.

## Benchmark results

I ran `TestParallelBenchmarkValidatorTransfer` for all three execution strategies before and after applying the changes and here are the results:

### Before:

- ### Serial:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="serial" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,curve_BLS12_381_BBS_GURVY,#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        9795      (Robust Sample)
Duration         30.036s   (Good Duration)
Real Throughput  326.11/s  Observed Ops/sec (Wall Clock)
Pure Throughput  326.44/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           22.536677ms  
 P50 (Median)  30.381783ms  
 Average       30.633547ms  
 P95           35.614851ms  
 P99           38.943131ms  
 P99.9         48.630205ms  
 Max           60.967211ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.96674ms   
 IQR      3.674675ms  Interquartile Range
 Jitter   2.606686ms  Avg delta per worker
 CV       9.68%       (Acceptable 5-10%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              604625 B/op     Allocated bytes per operation
 Allocs              6398 allocs/op  Allocations per operation
 Alloc Rate          185.93 MB/s     Memory pressure on system
 GC Overhead         4.30%           (High GC Pressure)
 GC Pause            1.291941605s    Total Stop-The-World time
 GC Cycles           3042            Full garbage collection cycles
 Goroutines Created  87              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 22.536677ms-23.686462ms  14     (0.1%)
 23.686462ms-24.894907ms  62    █ (0.6%)
 24.894907ms-26.165006ms  295   █████ (3.0%)
 26.165006ms-27.499903ms  836   ████████████████ (8.5%)
 27.499903ms-28.902904ms  1608  ██████████████████████████████ (16.4%)
 28.902904ms-30.377484ms  2075  ████████████████████████████████████████ (21.2%)
 30.377484ms-31.927295ms  2039  ███████████████████████████████████████ (20.8%)
 31.927295ms-33.556175ms  1478  ████████████████████████████ (15.1%)
 33.556175ms-35.268158ms  819   ███████████████ (8.4%)
 35.268158ms-37.067483ms  332   ██████ (3.4%)
 37.067483ms-38.958607ms  139   ██ (1.4%)
 38.958607ms-40.946213ms  46     (0.5%)
 40.946213ms-43.035224ms  16     (0.2%)
 43.035224ms-45.230812ms  13     (0.1%)
 45.230812ms-47.538417ms  11     (0.1%)
 47.538417ms-49.963751ms  4      (0.0%)
 49.963751ms-52.512822ms  3      (0.0%)
 52.512822ms-55.191943ms  3      (0.0%)
 55.191943ms-58.007748ms  1      (0.0%)
 58.007748ms-60.967211ms  1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (6398/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▇▇▇▇▇] (Max: 355 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (56.78s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,curve_BLS12_381_BBS_GURVY,#i_2,_#o_2)_with_10_workers (56.76s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      56.816s
```

- ### Pool:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10998     (Robust Sample)
Duration         30.025s   (Good Duration)
Real Throughput  366.30/s  Observed Ops/sec (Wall Clock)
Pure Throughput  366.43/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.374387ms  
 P50 (Median)  27.138555ms  
 Average       27.290084ms  
 P95           32.284568ms  
 P99           34.680477ms  
 P99.9         40.319368ms  
 Max           54.975317ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.925789ms  
 IQR      3.800873ms  Interquartile Range
 Jitter   3.117371ms  Avg delta per worker
 CV       10.72%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              605460 B/op     Allocated bytes per operation
 Allocs              6423 allocs/op  Allocations per operation
 Alloc Rate          208.95 MB/s     Memory pressure on system
 GC Overhead         4.74%           (High GC Pressure)
 GC Pause            1.42191421s     Total Stop-The-World time
 GC Cycles           3160            Full garbage collection cycles
 Goroutines Created  93              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.374387ms-19.409332ms  6      (0.1%)
 19.409332ms-20.502572ms  27     (0.2%)
 20.502572ms-21.657388ms  157   ██ (1.4%)
 21.657388ms-22.87725ms   420   ███████ (3.8%)
 22.87725ms-24.165822ms   891   ███████████████ (8.1%)
 24.165822ms-25.526973ms  1553  ███████████████████████████ (14.1%)
 25.526973ms-26.964791ms  2170  ██████████████████████████████████████ (19.7%)
 26.964791ms-28.483595ms  2251  ████████████████████████████████████████ (20.5%)
 28.483595ms-30.087947ms  1766  ███████████████████████████████ (16.1%)
 30.087947ms-31.782664ms  1012  █████████████████ (9.2%)
 31.782664ms-33.572837ms  503   ████████ (4.6%)
 33.572837ms-35.463842ms  173   ███ (1.6%)
 35.463842ms-37.461359ms  43     (0.4%)
 37.461359ms-39.571387ms  12     (0.1%)
 39.571387ms-41.800263ms  6      (0.1%)
 41.800263ms-44.154682ms  4      (0.0%)
 44.154682ms-46.641714ms  1      (0.0%)
 49.26883ms-52.043919ms   2      (0.0%)
 52.043919ms-54.975317ms  1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (6423/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 377 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.33s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.31s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.360s
```

- ### Unbounded:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        11146     (Robust Sample)
Duration         30.019s   (Good Duration)
Real Throughput  371.30/s  Observed Ops/sec (Wall Clock)
Pure Throughput  371.54/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           16.818331ms  
 P50 (Median)  26.640547ms  
 Average       26.915067ms  
 P95           32.291451ms  
 P99           36.942066ms  
 P99.9         50.357518ms  
 Max           61.415383ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.359861ms  
 IQR      4.085236ms  Interquartile Range
 Jitter   3.157345ms  Avg delta per worker
 CV       12.48%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              604971 B/op     Allocated bytes per operation
 Allocs              6406 allocs/op  Allocations per operation
 Alloc Rate          211.50 MB/s     Memory pressure on system
 GC Overhead         4.53%           (High GC Pressure)
 GC Pause            1.360630545s    Total Stop-The-World time
 GC Cycles           3148            Full garbage collection cycles
 Goroutines Created  190             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 16.818331ms-17.943518ms  5      (0.0%)
 17.943518ms-19.143983ms  15     (0.1%)
 19.143983ms-20.424763ms  85    █ (0.8%)
 20.424763ms-21.79123ms   315   █████ (2.8%)
 21.79123ms-23.249116ms   835   █████████████ (7.5%)
 23.249116ms-24.804539ms  1692  ███████████████████████████ (15.2%)
 24.804539ms-26.464024ms  2346  ██████████████████████████████████████ (21.0%)
 26.464024ms-28.234532ms  2422  ████████████████████████████████████████ (21.7%)
 28.234532ms-30.123492ms  1825  ██████████████████████████████ (16.4%)
 30.123492ms-32.138827ms  1010  ████████████████ (9.1%)
 32.138827ms-34.288993ms  367   ██████ (3.3%)
 34.288993ms-36.583011ms  109   █ (1.0%)
 36.583011ms-39.030504ms  51     (0.5%)
 39.030504ms-41.641741ms  30     (0.3%)
 41.641741ms-44.427676ms  18     (0.2%)
 44.427676ms-47.399996ms  7      (0.1%)
 47.399996ms-50.571172ms  2      (0.0%)
 50.571172ms-53.954508ms  8      (0.1%)
 53.954508ms-57.564197ms  1      (0.0%)
 57.564197ms-61.415383ms  3      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (6406/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▇▆▇▇▇] (Max: 401 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (43.81s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (43.79s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      43.837s
```

### After changes:

- ### Serial:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="serial" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10072     (Robust Sample)
Duration         30.025s   (Good Duration)
Real Throughput  335.46/s  Observed Ops/sec (Wall Clock)
Pure Throughput  335.77/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           22.560481ms  
 P50 (Median)  29.538631ms  
 Average       29.781996ms  
 P95           34.218428ms  
 P99           36.7836ms    
 P99.9         47.496376ms  
 Max           61.792922ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.645342ms  
 IQR      3.199553ms  Interquartile Range
 Jitter   2.529286ms  Avg delta per worker
 CV       8.88%       (Acceptable 5-10%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              582204 B/op     Allocated bytes per operation
 Allocs              5876 allocs/op  Allocations per operation
 Alloc Rate          184.92 MB/s     Memory pressure on system
 GC Overhead         3.88%           (High GC Pressure)
 GC Pause            1.1644414s      Total Stop-The-World time
 GC Cycles           3044            Full garbage collection cycles
 Goroutines Created  50              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 22.560481ms-23.726182ms  15     (0.1%)
 23.726182ms-24.952116ms  114   █ (1.1%)
 24.952116ms-26.241394ms  467   ███████ (4.6%)
 26.241394ms-27.597289ms  1346  █████████████████████ (13.4%)
 27.597289ms-29.023243ms  2219  ████████████████████████████████████ (22.0%)
 29.023243ms-30.522877ms  2461  ████████████████████████████████████████ (24.4%)
 30.522877ms-32.099996ms  1798  █████████████████████████████ (17.9%)
 32.099996ms-33.758606ms  985   ████████████████ (9.8%)
 33.758606ms-35.502915ms  432   ███████ (4.3%)
 35.502915ms-37.337354ms  159   ██ (1.6%)
 37.337354ms-39.266578ms  37     (0.4%)
 39.266578ms-41.295485ms  17     (0.2%)
 41.295485ms-43.429227ms  7      (0.1%)
 43.429227ms-45.673218ms  3      (0.0%)
 45.673218ms-48.033157ms  2      (0.0%)
 50.515034ms-53.12515ms   5      (0.0%)
 53.12515ms-55.870131ms   2      (0.0%)
 55.870131ms-58.756945ms  2      (0.0%)
 58.756945ms-61.792922ms  1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5876/op). This will trigger frequent GC cycles and increase Max Latency.
[PASS] RunBenchmark looks healthy and statistically sound.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 349 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (57.01s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (56.99s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      57.040s
```

- ### Pool:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10394     (Robust Sample)
Duration         30.025s   (Good Duration)
Real Throughput  346.18/s  Observed Ops/sec (Wall Clock)
Pure Throughput  346.38/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           19.254622ms  
 P50 (Median)  28.543536ms  
 Average       28.869801ms  
 P95           34.839459ms  
 P99           38.982581ms  
 P99.9         51.911841ms  
 Max           75.363723ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.62241ms   
 IQR      4.33524ms   Interquartile Range
 Jitter   3.357173ms  Avg delta per worker
 CV       12.55%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              585724 B/op     Allocated bytes per operation
 Allocs              5900 allocs/op  Allocations per operation
 Alloc Rate          190.93 MB/s     Memory pressure on system
 GC Overhead         4.70%           (High GC Pressure)
 GC Pause            1.412143247s    Total Stop-The-World time
 GC Cycles           2889            Full garbage collection cycles
 Goroutines Created  227             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 19.254622ms-20.614194ms  25     (0.2%)
 20.614194ms-22.069766ms  99    █ (1.0%)
 22.069766ms-23.628116ms  385   ██████ (3.7%)
 23.628116ms-25.296501ms  957   ███████████████ (9.2%)
 25.296501ms-27.082692ms  1828  █████████████████████████████ (17.6%)
 27.082692ms-28.995005ms  2440  ████████████████████████████████████████ (23.5%)
 28.995005ms-31.042348ms  2233  ████████████████████████████████████ (21.5%)
 31.042348ms-33.234254ms  1391  ██████████████████████ (13.4%)
 33.234254ms-35.58093ms   659   ██████████ (6.3%)
 35.58093ms-38.093306ms   232   ███ (2.2%)
 38.093306ms-40.783081ms  81    █ (0.8%)
 40.783081ms-43.662782ms  24     (0.2%)
 43.662782ms-46.745818ms  18     (0.2%)
 46.745818ms-50.046549ms  7      (0.1%)
 50.046549ms-53.580345ms  6      (0.1%)
 53.580345ms-57.363662ms  5      (0.0%)
 57.363662ms-61.414121ms  1      (0.0%)
 61.414121ms-65.750583ms  2      (0.0%)
 70.393243ms-75.363723ms  1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5900/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▇▇] (Max: 370 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.61s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.58s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.634s
```

- ### Unbounded:

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10926     (Robust Sample)
Duration         30.028s   (Good Duration)
Real Throughput  363.86/s  Observed Ops/sec (Wall Clock)
Pure Throughput  364.10/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.440966ms  
 P50 (Median)  27.08056ms   
 Average       27.464798ms  
 P95           33.341274ms  
 P99           38.622383ms  
 P99.9         50.738492ms  
 Max           69.953978ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.638267ms  
 IQR      4.231123ms  Interquartile Range
 Jitter   3.161987ms  Avg delta per worker
 CV       13.25%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              576532 B/op     Allocated bytes per operation
 Allocs              5870 allocs/op  Allocations per operation
 Alloc Rate          200.47 MB/s     Memory pressure on system
 GC Overhead         4.59%           (High GC Pressure)
 GC Pause            1.379042705s    Total Stop-The-World time
 GC Cycles           3123            Full garbage collection cycles
 Goroutines Created  209             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.440966ms-19.7122ms    20     (0.2%)
 19.7122ms-21.071067ms    132   ██ (1.2%)
 21.071067ms-22.523608ms  423   ██████ (3.9%)
 22.523608ms-24.076281ms  1066  █████████████████ (9.8%)
 24.076281ms-25.735988ms  1908  ██████████████████████████████ (17.5%)
 25.735988ms-27.510107ms  2488  ████████████████████████████████████████ (22.8%)
 27.510107ms-29.406526ms  2198  ███████████████████████████████████ (20.1%)
 29.406526ms-31.433675ms  1464  ███████████████████████ (13.4%)
 31.433675ms-33.600566ms  734   ███████████ (6.7%)
 33.600566ms-35.916833ms  265   ████ (2.4%)
 35.916833ms-38.392772ms  114   █ (1.0%)
 38.392772ms-41.039391ms  42     (0.4%)
 41.039391ms-43.868456ms  27     (0.2%)
 43.868456ms-46.892543ms  23     (0.2%)
 46.892543ms-50.125097ms  9      (0.1%)
 50.125097ms-53.580488ms  7      (0.1%)
 53.580488ms-57.274077ms  1      (0.0%)
 57.274077ms-61.222285ms  1      (0.0%)
 61.222285ms-65.442665ms  2      (0.0%)
 65.442665ms-69.953978ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5870/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▇▆▇▇▇▇] (Max: 395 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (43.93s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (43.91s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      43.951s
```

## Observation

We can see that the `allocs/op` metric across all the executor strategies reduces considerably (from ~6400 to ~5900), showing an **~8% decrease**.
The rest of the metrics remain unchanged

## Testing

- Existing unit tests for `BatchInverse` pass correctly.
- `go test -race -count=1     ./token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/...     ./token/core/zkatdlog/nogh/v1/crypto/rp/csp/...     ./token/core/zkatdlog/nogh/v1/transfer/...` passes successfully.

Let me know if this is good 🙏 
