### PR TITLE
docs(ttx): document recipient identity message flows (#1606)

### DIFF
--- a/docs/services/ttx.md
+++ b/docs/services/ttx.md
@@ -70,6 +70,95 @@ The `RequestRecipientIdentityView` allows an initiator to request a fresh recipi
 *   The initiator receives the necessary audit information to verify the identity's validity against the TMS public parameters.
 *   Both parties update their local `IdentityInfo` stores to map the new identity to the correct FSC node.
 
+### Recipient Protocol Flows (`recipients.go`)
+
+The recipient identity protocols are implemented in `token/services/ttx/recipients.go`. The diagrams below document the on-wire messages exchanged by the initiator and responder views.
+`RecipientData` can carry `Identity`, `AuditInfo`, `TokenMetadata`, and `TokenMetadataAuditInfo`.
+
+Wire messages use JSON sessions (`token/services/utils/json/session`); the diagrams name the Go types being sent or received.
+
+**Response paths (today).** In `RespondRequestRecipientIdentityView`, after the wallet lookup:
+
+- If `recipientRequest.RecipientData != nil`, the responder checks `OwnerWallet.Contains` for `RecipientData.Identity`, then sends **the same** `RecipientData` value back on the session (echo path). The responder does **not** substitute wallet-held `AuditInfo` / metadata into that payload; what goes on the wire is the initiator-supplied structure (after the contains check).
+- If `recipientRequest.RecipientData == nil`, the responder calls `OwnerWallet.GetRecipientData` and sends that **wallet-produced** `RecipientData` (fresh path).
+
+In both cases the initiator receives a full `RecipientData` over the wire. The initiator then calls `WalletManager.RegisterRecipientIdentity` with that payload and updates the endpoint resolver. **Protocol hardening** may replace full-object responses with a minimal acknowledgement (or another minimal wire type) so the responder does not ship an entire `RecipientData` when a slimmer response suffices; that is a separate code change from this documentation.
+
+**Multisig.** When `RecipientRequest.MultiSig` is true, the initiator may send an additional `MultisigRecipientData` after the first exchange; the responder registers identities and updates bindings as in code.
+
+#### `RequestRecipientIdentityView` / `RespondRequestRecipientIdentityView`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant I as Initiator
+    participant R as Responder
+
+    rect rgba(230, 230, 250, 0.35)
+        Note over I,R: Phase 1 - Identity request
+        I->>R: RecipientRequest{TMSID, WalletID, RecipientData?, MultiSig}
+    end
+
+    rect rgba(255, 245, 238, 0.5)
+        Note over R: Phase 2 - Responder decision
+        alt RecipientRequest.RecipientData != nil
+            R->>R: Verify wallet contains RecipientData.Identity
+            R-->>I: RecipientData (echo path)
+        else RecipientRequest.RecipientData == nil
+            R->>R: Generate RecipientData from wallet
+            R-->>I: RecipientData (fresh data path)
+        end
+    end
+
+    rect rgba(240, 255, 240, 0.45)
+        Note over I,R: Phase 3 - Local registration and bindings
+        I->>I: RegisterRecipientIdentity(RecipientData)
+        I->>I: endpoint.Bind(requested FSC identity, RecipientData.Identity)
+        R->>R: endpoint.Bind(context.Me, RecipientData.Identity)
+    end
+
+    rect rgba(245, 245, 245, 0.55)
+        Note over I,R: Optional multisig extension
+        opt MultiSig == true
+            I-->>R: MultisigRecipientData{RecipientData, Nodes, Recipients}
+            R->>R: RegisterRecipientIdentity(multisig data)
+            R->>R: endpoint.Bind(each Node -> Recipient)
+        end
+    end
+
+    Note over I,R: Full RecipientData on wire today (echo of request vs wallet-generated)
+```
+
+#### `ExchangeRecipientIdentitiesView` / `RespondExchangeRecipientIdentitiesView`
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant I as Initiator
+    participant R as Responder
+
+    rect rgba(230, 230, 250, 0.35)
+        Note over I,R: Phase 1 - Exchange request
+        I->>R: ExchangeRecipientRequest{TMSID, WalletID, RecipientData(local)}
+    end
+
+    rect rgba(255, 245, 238, 0.5)
+        Note over R: Phase 2 - Responder processing
+        R->>R: RegisterRecipientIdentity(request.RecipientData)
+        R->>R: GetRecipientData(responder wallet)
+        R-->>I: RecipientData(responder)
+    end
+
+    rect rgba(240, 255, 240, 0.45)
+        Note over I,R: Phase 3 - Local registration and bindings
+        I->>I: RegisterRecipientIdentity(remote RecipientData)
+        I->>I: endpoint.Bind(other FSC identity, remote RecipientData.Identity)
+        R->>R: endpoint.Bind(session caller, request.RecipientData.Identity)
+    end
+
+    Note over I,R: Full RecipientData on wire today (responder sends local wallet RecipientData)
+```
+
 ## Token Operations
 
 The TTX service supports three primary operations through the `TokenRequest` API:


### PR DESCRIPTION
## Summary
  Closes #1606.
  Documents the initiator/responder message flows implemented in `token/services/ttx/recipients.go` in `docs/services/ttx.md`:
  - `RequestRecipientIdentityView` / `RespondRequestRecipientIdentityView` — request/response, echo vs wallet-generated paths, optional multisig follow-up
  - `ExchangeRecipientIdentitiesView` / `RespondExchangeRecipientIdentitiesView` — exchange request/response and bindings
  Also describes which `RecipientData` fields may appear on the wire and clarifies the echo path (responder does not merge wallet fields into the echoed object). Notes that tightening the protocol (e.g. minimal or ack-only 
  responses) is follow-up implementation work beyond this documentation change.
  ## Test plan
  - [x] `make checks`
