### PR TITLE
perf(storage): add hot-path indexes on movements and tokens

### DIFF
--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -884,6 +884,7 @@ func (db *TokenStore) GetSchema() string {
 		CREATE INDEX IF NOT EXISTS idx_spent_%s ON %s ( is_deleted, owner );
 		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
 		CREATE INDEX IF NOT EXISTS idx_owner_wallet_id_%s ON %s ( owner_wallet_id );
+		CREATE INDEX IF NOT EXISTS idx_owner_wallet_part_%s ON %s ( owner_wallet_id, token_type ) WHERE is_deleted = false AND owner = true;
 
 		-- Ownership
 		CREATE TABLE IF NOT EXISTS %s (
@@ -914,6 +915,7 @@ func (db *TokenStore) GetSchema() string {
 		`,
 		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
 		db.table.Tokens,
+		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -472,6 +472,7 @@ func (db *TransactionStore) GetSchema() string {
 			stored_at TIMESTAMP NOT NULL
 		);
 		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
+		CREATE INDEX IF NOT EXISTS idx_eid_storedat_%s ON %s ( enrollment_id, stored_at );
 
 		-- validations
 		CREATE TABLE IF NOT EXISTS %s (
@@ -492,7 +493,7 @@ func (db *TransactionStore) GetSchema() string {
 		`,
 		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
 		db.table.Transactions, db.table.Requests, db.table.Transactions, db.table.Transactions,
-		db.table.Movements, db.table.Requests, db.table.Movements, db.table.Movements,
+		db.table.Movements, db.table.Requests, db.table.Movements, db.table.Movements, db.table.Movements, db.table.Movements,
 		db.table.Validations, db.table.Requests,
 		db.table.TransactionEndorseAck, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,
 	)


### PR DESCRIPTION
## Summary

Adds two indexes to the SQL storage schema that target the dominant hot-path
queries observed in production-style workloads. Both are additive
(`IF NOT EXISTS`), behave identically on SQLite and Postgres, and require no
data migration.

## Background

While stress-testing a deployment with ~450k movements rows and ~260k tokens
rows, two SQL queries dominated `pg_stat_activity` sampling:

1. **Movements rollup** (auditor balance / holdings prefetch): filters
   `movements` by `(enrollment_id, stored_at)`. With no index on those
   columns, Postgres falls back to `Parallel Seq Scan` over the whole table.
2. **Owner-wallet token lookup** (`UnspentTokensIteratorBy`, balance query):
   filters `tokens` by `owner_wallet_id` with the predicate
   `is_deleted = false AND owner = true`. The non-partial
   `idx_owner_wallet_id` lets the planner walk the column but still requires
   a Filter step over a large fraction of dead rows.

## Changes

### `token/services/storage/db/sql/common/transactions.go`

```sql
CREATE INDEX IF NOT EXISTS idx_eid_storedat_%s
  ON %s ( enrollment_id, stored_at );
```

Composite btree on `movements(enrollment_id, stored_at)` to support the
auditor's per-enrollment running totals.

### `token/services/storage/db/sql/common/tokens.go`

```sql
CREATE INDEX IF NOT EXISTS idx_owner_wallet_part_%s
  ON %s ( owner_wallet_id, token_type )
  WHERE is_deleted = false AND owner = true;
```

Partial index whose predicate matches `UnspentTokensIteratorBy`'s exactly,
so the planner walks only live owner-tokens. The existing
`idx_owner_wallet_id` is **kept** because some less common predicates
(`is_deleted = true`, `owner = false`, ownership trace queries) still need
the full-column form.

## Measured impact

Local stress at `c=100`, `d=120s`, ring transfers (single-recipient,
0.50 SOM each), 4500-wallet pool, against a node holding the row counts
above:

| Metric                          | Before    | After     | Δ      |
|---------------------------------|-----------|-----------|--------|
| `movements` query latency       | 29 ms     | 3.8 ms    | -87%   |
| `tokens` owner-wallet query     | 38 ms     | 0.05 ms   | -99%   |
| `av_total` p50 (auditor view)   | 747 ms    | 110 ms    | -85%   |
| `prepare` p50                   | 1160 ms   | 363 ms    | -69%   |
| End-to-end TPS                  | 96        | 128       | +32%   |
| `submit` p99                    | 2.18 s    | 1.06 s    | -51%   |

## Compatibility

- `IF NOT EXISTS` makes both DDL statements idempotent — existing
  deployments pick up the indexes the next time `InitSchema` runs.
- Composite btree and partial indexes (with `WHERE`) are supported on
  both Postgres and SQLite (3.8+).
- No row data is touched; no migration scripts required.

## Test plan

- [x] `go build ./...`
- [x] `go test ./token/services/storage/db/sql/common/...`
- [x] Verified on a Postgres 18 instance: indexes are created on first
      `InitSchema` call and used by the planner (`EXPLAIN` confirms
      `Bitmap Index Scan` / `Index Only Scan`).
- [x] Re-ran the c=100 stress harness post-change; no behavioral change,
      only the latency / TPS numbers above.
