### PR TITLE
 fix(identity): order recipient registration after MatchIdentity and add rollback

### DIFF
--- a/token/services/identity/provider.go
+++ b/token/services/identity/provider.go
@@ -24,6 +24,8 @@ import (
 var (
 	// This makes sure that Provider implements driver.IdentityProvider
 	_ driver.IdentityProvider = &Provider{}
+	// This makes sure that Provider can roll back partial recipient registration
+	_ RecipientRegistrationRollback = &Provider{}
 )
 
 // StorageProvider returns storage services scoped to a specific token
@@ -225,6 +227,13 @@ func (p *Provider) RegisterRecipientIdentity(ctx context.Context, id driver.Iden
 	p.isMeCache.Add(id.UniqueID(), false)
 
 	return nil
+}
+
+// RollbackPartialRecipientRegistration clears in-memory marks written by
+// RegisterRecipientIdentity when RegisterRecipientData did not complete.
+func (p *Provider) RollbackPartialRecipientRegistration(ctx context.Context, id driver.Identity) {
+	p.Logger.DebugfContext(ctx, "rolling back partial recipient registration for identity [%s]", id)
+	p.isMeCache.Delete(id.UniqueID())
 }
 
 // RegisterIdentityDescriptor stores the given identity descriptor in the configured storage.

--- a/token/services/identity/provider_test.go
+++ b/token/services/identity/provider_test.go
@@ -174,6 +174,21 @@ func TestProvider_EnrollmentIDHelpers(t *testing.T) {
 	assert.Equal(t, "rh2", erh)
 }
 
+func TestProvider_RollbackPartialRecipientRegistration(t *testing.T) {
+	storage := &idmock.Storage{}
+	des := &idmock.Deserializer{}
+	nbs := &idmock.NetworkBinderService{}
+	eidu := &idmock.EnrollmentIDUnmarshaler{}
+
+	p := identity.NewProvider(logging.MustGetLogger(), storage, des, nbs, eidu)
+
+	id := driver.Identity("recipient_id")
+	require.NoError(t, p.RegisterRecipientIdentity(t.Context(), id))
+
+	var rb identity.RecipientRegistrationRollback = p
+	rb.RollbackPartialRecipientRegistration(t.Context(), id)
+}
+
 func TestProvider_GetAuditInfo(t *testing.T) {
 	storage := &idmock.Storage{}
 	des := &idmock.Deserializer{}

--- a/token/services/identity/recipient_registration_rollback.go
+++ b/token/services/identity/recipient_registration_rollback.go
@@ -1,0 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package identity
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+)
+
+// RecipientRegistrationRollback is implemented by identity providers that record
+// side effects in RegisterRecipientIdentity before RegisterRecipientData.
+// If RegisterRecipientData never succeeds, the implementation should undo those
+// effects so the node is not left in a half-registered state.
+type RecipientRegistrationRollback interface {
+	RollbackPartialRecipientRegistration(ctx context.Context, id driver.Identity)
+}

--- a/token/services/identity/wallet/service.go
+++ b/token/services/identity/wallet/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	tdriver "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/identity"
 	idriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/identity/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils"
@@ -100,29 +101,32 @@ func (s *Service) GetEIDAndRH(ctx context.Context, identity tdriver.Identity, au
 // RegisterRecipientIdentity registers the passed identity as a third-party recipient identity.
 // The function performs these steps:
 //   - validate the input
+//   - match the identity against the provided audit info using the Deserializer (before any provider registration)
 //   - ask the IdentityProvider to register the recipient identity
-//   - match the identity against the provided audit info using the Deserializer
-//   - obtain the owner verifier and register it with the IdentityProvider
 //   - store the recipient data via the IdentityProvider
+//
+// If RegisterRecipientData fails after RegisterRecipientIdentity succeeds, the IdentityProvider
+// may implement identity.RecipientRegistrationRollback so partial registration can be undone.
 func (s *Service) RegisterRecipientIdentity(ctx context.Context, data *tdriver.RecipientData) error {
 	if data == nil {
 		return errors.Wrapf(ErrNilRecipientData, "invalid recipient data")
 	}
 
-	// RegisterRecipientIdentity register the passed identity as a third-party recipient identity.
+	s.Logger.DebugfContext(ctx, "register recipient identity [%s] with audit info [%s]", data.Identity, utils.Hashable(data.AuditInfo))
+
+	if err := s.Deserializer.MatchIdentity(ctx, data.Identity, data.AuditInfo); err != nil {
+		return errors.Wrapf(err, "failed to match identity to audit information for [%s]:[%s]", data.Identity, utils.Hashable(data.AuditInfo))
+	}
+
 	if err := s.IdentityProvider.RegisterRecipientIdentity(ctx, data.Identity); err != nil {
 		return errors.Wrapf(err, "failed to register recipient identity")
 	}
 
-	s.Logger.DebugfContext(ctx, "register recipient identity [%s] with audit info [%s]", data.Identity, utils.Hashable(data.AuditInfo))
-
-	// match identity and audit info
-	err := s.Deserializer.MatchIdentity(ctx, data.Identity, data.AuditInfo)
-	if err != nil {
-		return errors.Wrapf(err, "failed to match identity to audit infor for [%s]:[%s]", data.Identity, utils.Hashable(data.AuditInfo))
-	}
-
 	if err := s.IdentityProvider.RegisterRecipientData(ctx, data); err != nil {
+		if rb, ok := s.IdentityProvider.(identity.RecipientRegistrationRollback); ok {
+			rb.RollbackPartialRecipientRegistration(ctx, data.Identity)
+		}
+
 		return errors.Wrapf(err, "failed registering audit info for owner [%s]", data.Identity)
 	}
 

--- a/token/services/identity/wallet/service_test.go
+++ b/token/services/identity/wallet/service_test.go
@@ -116,6 +116,43 @@ func TestRegisterRecipientIdentityFailuresAndSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// ipWithRollback embeds the generated mock and adds identity.RecipientRegistrationRollback for rollback tests.
+type ipWithRollback struct {
+	*dmock.IdentityProvider
+	rollbackCalls int
+}
+
+func (r *ipWithRollback) RollbackPartialRecipientRegistration(ctx context.Context, id driver.Identity) {
+	r.rollbackCalls++
+}
+
+func TestRegisterRecipientIdentity_MatchIdentityFailureSkipsIdentityProvider(t *testing.T) {
+	ctx := t.Context()
+	ip := &dmock.IdentityProvider{}
+	d := &dmock.Deserializer{}
+	d.MatchIdentityReturns(errors.New("mismatch"))
+	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
+
+	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	require.Error(t, err)
+	require.Zero(t, ip.RegisterRecipientIdentityCallCount())
+	require.Equal(t, 1, d.MatchIdentityCallCount())
+}
+
+func TestRegisterRecipientIdentity_RollbackWhenRegisterRecipientDataFails(t *testing.T) {
+	ctx := t.Context()
+	base := &dmock.IdentityProvider{}
+	base.RegisterRecipientIdentityReturns(nil)
+	base.RegisterRecipientDataReturns(errors.New("rrd"))
+	ip := &ipWithRollback{IdentityProvider: base}
+	d := &dmock.Deserializer{}
+	regSvc := wallet.NewService(&logging.MockLogger{}, ip, d, nil)
+
+	err := regSvc.RegisterRecipientIdentity(ctx, &driver.RecipientData{Identity: driver.Identity("id"), AuditInfo: []byte("ai")})
+	require.Error(t, err)
+	require.Equal(t, 1, ip.rollbackCalls)
+}
+
 func TestWalletAndLookupFunctions(t *testing.T) {
 	ctx := t.Context()
 	ownerReg := &wmock.RoleRegistry{}


### PR DESCRIPTION
Closes #1615

 ## Summary
  Reorders `RegisterRecipientIdentity` so **`MatchIdentity` runs before any `IdentityProvider` registration**, and invokes **`RecipientRegistrationRollback`** when **`RegisterRecipientData` fails** after a successful 
  **`RegisterRecipientIdentity`**, so the identity provider is not left in a half-applied state when supported.
  Follow-up to the discussion on [PR #1607](https://github.com/hyperledger-labs/fabric-token-sdk/pull/1607).
  ## Problem
  Previously the flow was:
  1. `RegisterRecipientIdentity` (identity provider)
  2. `MatchIdentity` (deserializer)
  3. `RegisterRecipientData` (identity provider / storage)
  If **`MatchIdentity` failed**, the provider had **already** run **`RegisterRecipientIdentity`**. For implementations that record partial side effects there (for example in-memory marks), that is unnecessary work and can leave **inconsistent state** if a later step never succeeds.
  If **`RegisterRecipientData` failed** after **`RegisterRecipientIdentity` succeeded**, there was **no rollback** of provider-side partial registration.
  ## Solution
  - Run **`MatchIdentity` first** so a mismatch **does not touch** the identity provider.
  - Keep **`RegisterRecipientIdentity`** then **`RegisterRecipientData`**.
  - If **`RegisterRecipientData` returns an error** after **`RegisterRecipientIdentity` succeeded**, call **`RollbackPartialRecipientRegistration`** when the provider implements **`identity.RecipientRegistrationRollback`** (the concrete **`identity.Provider`** clears the recipient **`isMeCache`** entry; with the default **`NoCache`** this is a no-op but remains correct for real caches).
  ## Changes
  | Area | Change |
  |------|--------|
  | `token/services/identity/wallet/service.go` | New order + rollback on `RegisterRecipientData` failure |
  | `token/services/identity/recipient_registration_rollback.go` | New optional rollback interface |
  | `token/services/identity/provider.go` | Implement rollback + compile-time assertion |
  | `token/services/identity/wallet/service_test.go` | Tests for ordering and rollback |
  | `token/services/identity/provider_test.go` | Smoke test for rollback hook |
  ## Test plan
  - [x] `go test ./token/services/identity/wallet/... ./token/services/identity -count=1 -short`
  - [x] `go vet ./...` — clean.
  - [x] `make checks` — clean (license, gofmt, goimports, vet, misspell, ineffassign, staticcheck).
  - [x] `make lint-auto-fix` — reports `0 issues.`

  ## Runtime smoke-tests:
  - [x] `tokengen --help` lists only `gen`, `update`, `pp`, `certifier-keygen`, `version`.
  - [x] `tokengen artifacts` returns a clean cobra error: `Error: unknown command "artifacts" for "tokengen"`.
  - [x] `artifactgen artifacts --help` preserves the original flag set (`-t/--topology`, `-o/--output`, `-p/--port`) and their defaults.
  - [x] `artifactgen artifacts` (no args) returns the original behaviour: `Error: expecting topology file path`.

