### PR TITLE
refactor: centralize gnark native field operations in math module

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/math/native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/native.go
@@ -1,0 +1,109 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package math
+
+import (
+	"math/big"
+	"sync"
+
+	mathlib "github.com/IBM/mathlib"
+)
+
+// GnarkFr is the pointer constraint satisfied by gnark-crypto fr.Element types
+// such as bls12-381/fr.Element and bn254/fr.Element.
+//
+// The convention for all methods follows gnark-crypto: the receiver is the
+// output, e.g. z.Mul(x, y) sets z = x·y and returns z.
+type GnarkFr[T any] interface {
+	*T
+	SetBigInt(*big.Int) *T
+	BigInt(*big.Int) *big.Int
+	Add(*T, *T) *T
+	Sub(*T, *T) *T
+	Mul(*T, *T) *T
+	SetInt64(int64) *T
+	SetOne() *T
+	SetZero() *T
+	Inverse(*T) *T
+	Bytes() [32]byte
+}
+
+var bigIntPool = sync.Pool{
+	New: func() interface{} {
+		return new(big.Int)
+	},
+}
+
+// NativeElem allocates and returns a new zero-valued field element of type E.
+func NativeElem[T any, E GnarkFr[T]]() E { return E(new(T)) }
+
+// NativeFromZr converts *mathlib.Zr to a native field element via big.Int.
+// Only one big.Int conversion happens here.
+func NativeFromZr[T any, E GnarkFr[T]](z *mathlib.Zr) E {
+	e := NativeElem[T, E]()
+	e.SetBigInt(z.BigInt())
+
+	return e
+}
+
+// SetNativeFromZr sets an existing native field element from a *mathlib.Zr via big.Int.
+// This avoids allocating a new field element.
+func SetNativeFromZr[T any, E GnarkFr[T]](z *mathlib.Zr, e E) {
+	e.SetBigInt(z.BigInt())
+}
+
+// NativeToZr converts a native field element back to *mathlib.Zr via byte representation.
+func NativeToZr[T any, E GnarkFr[T]](e E, curve *mathlib.Curve) *mathlib.Zr {
+	b := e.Bytes()
+	return curve.NewZrFromBytes(b[:])
+}
+
+// NativeBatchInverse computes the modular inverse of every element in elems
+// using Montgomery's batch-inversion trick: 2(n-1) multiplications + 1 inversion.
+// A zero input element yields a zero output.
+func NativeBatchInverse[T any, E GnarkFr[T]](elems []E) []E {
+	n := len(elems)
+	if n == 0 {
+		return nil
+	}
+
+	// prefix[i] = elems[0] · elems[1] · … · elems[i]
+	prefix := make([]T, n)
+	prefix[0] = *elems[0]
+	for i := 1; i < n; i++ {
+		E(&prefix[i]).Mul(E(&prefix[i-1]), elems[i])
+	}
+
+	// acc = prefix[n-1]^{-1}
+	var acc T
+	E(&acc).Inverse(E(&prefix[n-1]))
+
+	// Unwind: result[i] = acc · prefix[i-1], then acc ← acc · elems[i]
+	result := make([]T, n)
+	resultE := make([]E, n)
+	for i := range result {
+		resultE[i] = E(&result[i])
+	}
+	for i := n - 1; i > 0; i-- {
+		resultE[i].Mul(E(&acc), E(&prefix[i-1]))
+		E(&acc).Mul(E(&acc), elems[i])
+	}
+	result[0] = acc
+
+	return resultE
+}
+
+// DispatchCurve returns true for BLS and BN254 curves based on the curve ID.
+func DispatchCurve(curve *mathlib.Curve) (isBLS bool, isBN254 bool) {
+	switch curve.GroupOrder.CurveID() {
+	case mathlib.BLS12_381, mathlib.BLS12_381_GURVY, mathlib.BLS12_381_BBS, mathlib.BLS12_381_BBS_GURVY:
+		return true, false
+	case mathlib.BN254:
+		return false, true
+	}
+	return false, false
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/math/native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/native.go
@@ -8,7 +8,6 @@ package math
 
 import (
 	"math/big"
-	"sync"
 
 	mathlib "github.com/IBM/mathlib"
 )
@@ -32,12 +31,6 @@ type GnarkFr[T any] interface {
 	Bytes() [32]byte
 }
 
-var bigIntPool = sync.Pool{
-	New: func() interface{} {
-		return new(big.Int)
-	},
-}
-
 // NativeElem allocates and returns a new zero-valued field element of type E.
 func NativeElem[T any, E GnarkFr[T]]() E { return E(new(T)) }
 
@@ -59,6 +52,7 @@ func SetNativeFromZr[T any, E GnarkFr[T]](z *mathlib.Zr, e E) {
 // NativeToZr converts a native field element back to *mathlib.Zr via byte representation.
 func NativeToZr[T any, E GnarkFr[T]](e E, curve *mathlib.Curve) *mathlib.Zr {
 	b := e.Bytes()
+
 	return curve.NewZrFromBytes(b[:])
 }
 
@@ -105,5 +99,6 @@ func DispatchCurve(curve *mathlib.Curve) (isBLS bool, isBN254 bool) {
 	case mathlib.BN254:
 		return false, true
 	}
+
 	return false, false
 }

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_cache.go
@@ -12,6 +12,7 @@ import (
 	mathlib "github.com/IBM/mathlib"
 	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
 )
 
 // lagrangeDenomCache caches the precomputed denominator inverses for Lagrange
@@ -92,7 +93,7 @@ func getOrComputeDenomInvsBN254(n uint64, partial bool) []*bn254fr.Element {
 //	total = 2n+1 evaluation points {0,...,2n}
 //	relevant indices = {0, n+1, ..., 2n}  (n+1 entries)
 //	d_k = ∏_{j=0, j≠relevant[k]}^{2n} (relevant[k]-j)
-func computeDenomInvs[T any, E gnarkFr[T]](n uint64, partial bool) []E {
+func computeDenomInvs[T any, E math2.GnarkFr[T]](n uint64, partial bool) []E {
 	if !partial {
 		m := int(n) + 1 // #nosec G115
 		denoms := make([]T, m)
@@ -111,7 +112,7 @@ func computeDenomInvs[T any, E gnarkFr[T]](n uint64, partial bool) []E {
 			}
 		}
 
-		return nativeBatchInverse[T, E](denomsE)
+		return math2.NativeBatchInverse[T, E](denomsE)
 	}
 
 	// Partial: relevant indices are {0, n+1, ..., 2n}.
@@ -138,5 +139,5 @@ func computeDenomInvs[T any, E gnarkFr[T]](n uint64, partial bool) []E {
 		}
 	}
 
-	return nativeBatchInverse[T, E](denomsE)
+	return math2.NativeBatchInverse[T, E](denomsE)
 }

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native.go
@@ -7,85 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package csp
 
 import (
-	"math/big"
-
 	mathlib "github.com/IBM/mathlib"
 	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
 )
-
-// gnarkFr is the pointer constraint satisfied by gnark-crypto fr.Element types
-// such as bls12-381/fr.Element and bn254/fr.Element.
-//
-// The convention for all methods follows gnark-crypto: the receiver is the
-// output, e.g. z.Mul(x, y) sets z = x·y and returns z.
-type gnarkFr[T any] interface {
-	*T
-	SetBigInt(*big.Int) *T
-	BigInt(*big.Int) *big.Int
-	Add(*T, *T) *T
-	Sub(*T, *T) *T
-	Mul(*T, *T) *T
-	SetInt64(int64) *T
-	SetOne() *T
-	SetZero() *T
-	Inverse(*T) *T
-}
-
-// nativeElem allocates and returns a new zero-valued field element of type E.
-func nativeElem[T any, E gnarkFr[T]]() E { return E(new(T)) }
-
-// nativeFromZr converts *mathlib.Zr to a native field element via big.Int.
-// Only one big.Int conversion happens here.
-func nativeFromZr[T any, E gnarkFr[T]](z *mathlib.Zr) E {
-	e := nativeElem[T, E]()
-	e.SetBigInt(z.BigInt())
-
-	return e
-}
-
-// nativeToZr converts a native field element back to *mathlib.Zr via big.Int.
-func nativeToZr[T any, E gnarkFr[T]](e E, curve *mathlib.Curve) *mathlib.Zr {
-	var bi big.Int
-	e.BigInt(&bi)
-
-	return curve.NewZrFromBigInt(&bi)
-}
-
-// nativeBatchInverse computes the modular inverse of every element in elems
-// using Montgomery's batch-inversion trick: 2(n-1) multiplications + 1 inversion.
-// A zero input element yields a zero output.
-func nativeBatchInverse[T any, E gnarkFr[T]](elems []E) []E {
-	n := len(elems)
-	if n == 0 {
-		return nil
-	}
-
-	// prefix[i] = elems[0] · elems[1] · … · elems[i]
-	prefix := make([]T, n)
-	prefix[0] = *elems[0]
-	for i := 1; i < n; i++ {
-		E(&prefix[i]).Mul(E(&prefix[i-1]), elems[i])
-	}
-
-	// acc = prefix[n-1]^{-1}
-	var acc T
-	E(&acc).Inverse(E(&prefix[n-1]))
-
-	// Unwind: result[i] = acc · prefix[i-1], then acc ← acc · elems[i]
-	result := make([]T, n)
-	resultE := make([]E, n)
-	for i := range result {
-		resultE[i] = E(&result[i])
-	}
-	for i := n - 1; i > 0; i-- {
-		resultE[i].Mul(E(&acc), E(&prefix[i-1]))
-		E(&acc).Mul(E(&acc), elems[i])
-	}
-	result[0] = acc
-
-	return resultE
-}
 
 // getLagrangeMultipliersNative is the native fr.Element implementation of
 // getLagrangeMultipliers. Conversions between mathlib.Zr and fr.Element occur
@@ -94,11 +20,11 @@ func nativeBatchInverse[T any, E gnarkFr[T]](elems []E) []E {
 //
 // The denominator inverses d_i^{-1} = (∏_{j≠i}(i-j))^{-1} depend only on n,
 // not on c, so they are retrieved from the cache (computed once per n).
-func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
+func getLagrangeMultipliersNative[T any, E math2.GnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	m := int(n) + 1 // #nosec G115
 
 	// Convert c once.
-	cE := nativeFromZr[T, E](c)
+	cE := math2.NativeFromZr[T, E](c)
 
 	// cMinusJ[j] = c - j  for j = 0..n
 	cMinusJ := make([]T, m)
@@ -129,7 +55,7 @@ func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, 
 	for i := range m {
 		var prod T
 		E(&prod).Mul(numersE[i], denomInvs[i])
-		result[i] = nativeToZr[T, E](E(&prod), curve)
+		result[i] = math2.NativeToZr[T, E](E(&prod), curve)
 	}
 
 	return result, nil
@@ -138,10 +64,10 @@ func getLagrangeMultipliersNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, 
 // getLagrangeMultipliersPartialNative is the native fr.Element implementation of
 // getLagrangeMultipliersPartial. Same boundary-only conversion strategy.
 // Denominator inverses are retrieved from the cache.
-func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
+func getLagrangeMultipliersPartialNative[T any, E math2.GnarkFr[T]](n uint64, c *mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	total := 2*int(n) + 1 // #nosec G115 // all evaluation points: 0..2n
 
-	cE := nativeFromZr[T, E](c)
+	cE := math2.NativeFromZr[T, E](c)
 
 	// cMinusJ[j] = c - j  for j = 0..2n
 	cMinusJ := make([]T, total)
@@ -180,7 +106,7 @@ func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathl
 	for k := range relevant {
 		var prod T
 		E(&prod).Mul(numersE[k], denomInvs[k])
-		result[k] = nativeToZr[T, E](E(&prod), curve)
+		result[k] = math2.NativeToZr[T, E](E(&prod), curve)
 	}
 
 	return result, nil
@@ -188,7 +114,7 @@ func getLagrangeMultipliersPartialNative[T any, E gnarkFr[T]](n uint64, c *mathl
 
 // interpolateNative is the native fr.Element implementation of interpolate.
 // Denominator inverses are retrieved from the cache.
-func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
+func interpolateNative[T any, E math2.GnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr, curve *mathlib.Curve, denomInvs []E) ([]*mathlib.Zr, error) {
 	m := int(n) + 1 // #nosec G115
 
 	// Convert all input values to native elements once.
@@ -226,7 +152,7 @@ func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr,
 			pxE.Mul(pxE, xMinusJE[j])
 		}
 
-		xMinusJInvs := nativeBatchInverse[T, E](xMinusJE)
+		xMinusJInvs := math2.NativeBatchInverse[T, E](xMinusJE)
 
 		var val T
 		valE := E(&val)
@@ -238,7 +164,7 @@ func interpolateNative[T any, E gnarkFr[T]](n uint64, valuesOverN []*mathlib.Zr,
 			liE.Mul(liE, valsE[i])
 			valE.Add(valE, liE)
 		}
-		result[x] = nativeToZr[T, E](valE, curve)
+		result[x] = math2.NativeToZr[T, E](valE, curve)
 	}
 
 	return result, nil

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/lagrange_native_test.go
@@ -13,6 +13,7 @@ import (
 	math "github.com/IBM/mathlib"
 	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -212,8 +213,8 @@ func TestNativeFromZrToZrRoundTripBLS12381(t *testing.T) {
 	// Convert to native and back
 	switch curve.GroupOrder.CurveID() {
 	case math.BLS12_381, math.BLS12_381_GURVY, math.BLS12_381_BBS, math.BLS12_381_BBS_GURVY:
-		native := nativeFromZr[bls12381fr.Element, *bls12381fr.Element](original)
-		recovered := nativeToZr[bls12381fr.Element, *bls12381fr.Element](native, curve)
+		native := math2.NativeFromZr[bls12381fr.Element, *bls12381fr.Element](original)
+		recovered := math2.NativeToZr[bls12381fr.Element, *bls12381fr.Element](native, curve)
 		assert.True(t, original.Equals(recovered), "round-trip conversion should preserve value")
 	}
 }
@@ -232,8 +233,8 @@ func TestNativeFromZrToZrRoundTripBN254(t *testing.T) {
 	// Convert to native and back
 	switch curve.GroupOrder.CurveID() {
 	case math.BN254:
-		native := nativeFromZr[bn254fr.Element, *bn254fr.Element](original)
-		recovered := nativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
+		native := math2.NativeFromZr[bn254fr.Element, *bn254fr.Element](original)
+		recovered := math2.NativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
 		assert.True(t, original.Equals(recovered), "round-trip conversion should preserve value")
 	}
 }
@@ -251,10 +252,10 @@ func TestNativeBatchInverseBLS12381(t *testing.T) {
 	elems := make([]*bls12381fr.Element, n)
 	for i := range elems {
 		zr := curve.NewRandomZr(rand)
-		elems[i] = nativeFromZr[bls12381fr.Element, *bls12381fr.Element](zr)
+		elems[i] = math2.NativeFromZr[bls12381fr.Element, *bls12381fr.Element](zr)
 	}
 
-	invs := nativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
+	invs := math2.NativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
 	require.Len(t, invs, n)
 
 	// Verify each inverse
@@ -282,10 +283,10 @@ func TestNativeBatchInverseBN254(t *testing.T) {
 	elems := make([]*bn254fr.Element, n)
 	for i := range elems {
 		zr := curve.NewRandomZr(rand)
-		elems[i] = nativeFromZr[bn254fr.Element, *bn254fr.Element](zr)
+		elems[i] = math2.NativeFromZr[bn254fr.Element, *bn254fr.Element](zr)
 	}
 
-	invs := nativeBatchInverse[bn254fr.Element, *bn254fr.Element](elems)
+	invs := math2.NativeBatchInverse[bn254fr.Element, *bn254fr.Element](elems)
 	require.Len(t, invs, n)
 
 	// Verify each inverse
@@ -306,7 +307,7 @@ func TestNativeBatchInverseBN254(t *testing.T) {
 // Then the result should be nil.
 func TestNativeBatchInverseEmpty(t *testing.T) {
 	var elems []*bls12381fr.Element
-	invs := nativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
+	invs := math2.NativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
 	assert.Nil(t, invs, "batch inverse of empty slice should return nil")
 }
 
@@ -320,10 +321,10 @@ func TestNativeBatchInverseSingle(t *testing.T) {
 	require.NoError(t, err)
 
 	zr := curve.NewRandomZr(rand)
-	elem := nativeFromZr[bls12381fr.Element, *bls12381fr.Element](zr)
+	elem := math2.NativeFromZr[bls12381fr.Element, *bls12381fr.Element](zr)
 	elems := []*bls12381fr.Element{elem}
 
-	invs := nativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
+	invs := math2.NativeBatchInverse[bls12381fr.Element, *bls12381fr.Element](elems)
 	require.Len(t, invs, 1)
 
 	var prod bls12381fr.Element
@@ -343,8 +344,8 @@ func TestNativeConversionZeroValue(t *testing.T) {
 	curve := math.Curves[math.BN254]
 	zero := curve.NewZrFromInt(0)
 
-	native := nativeFromZr[bn254fr.Element, *bn254fr.Element](zero)
-	recovered := nativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
+	native := math2.NativeFromZr[bn254fr.Element, *bn254fr.Element](zero)
+	recovered := math2.NativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
 
 	assert.True(t, zero.Equals(recovered), "zero value should round-trip correctly")
 }
@@ -357,8 +358,8 @@ func TestNativeConversionOneValue(t *testing.T) {
 	curve := math.Curves[math.BN254]
 	one := curve.NewZrFromInt(1)
 
-	native := nativeFromZr[bn254fr.Element, *bn254fr.Element](one)
-	recovered := nativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
+	native := math2.NativeFromZr[bn254fr.Element, *bn254fr.Element](one)
+	recovered := math2.NativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
 
 	assert.True(t, one.Equals(recovered), "one value should round-trip correctly")
 }
@@ -376,8 +377,8 @@ func TestNativeConversionLargeValue(t *testing.T) {
 	largeInt.Sub(largeInt, big.NewInt(1))
 	large := curve.NewZrFromBytes(largeInt.Bytes())
 
-	native := nativeFromZr[bn254fr.Element, *bn254fr.Element](large)
-	recovered := nativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
+	native := math2.NativeFromZr[bn254fr.Element, *bn254fr.Element](large)
+	recovered := math2.NativeToZr[bn254fr.Element, *bn254fr.Element](native, curve)
 
 	assert.True(t, large.Equals(recovered), "large value should round-trip correctly")
 }


### PR DESCRIPTION
closes #1617 

## Description

This PR refactors the `zkatdlog` driver's native scalar arithmetic by centralizing the `gnark` native field operations into the `crypto/math` package.

Previously, the `gnarkFr` constraint interface and its associated helper functions (`nativeFromZr`, `nativeToZr`, `nativeBatchInverse`) were defined locally within the `rp/csp` package. This caused duplication and limited the reusability of these zero-allocation operations across other cryptographic components. 

By moving these to a dedicated `crypto/math/native.go` file and exporting them (`GnarkFr`, `NativeFromZr`, `NativeToZr`, `NativeBatchInverse`), they are now universally accessible to both the Bulletproof (`rp/bulletproof`) and CSP (`rp/csp`) modules.

### Changes Made:
- **Created `crypto/math/native.go`**: Centralized the exported `GnarkFr` generic interface and the unified `NativeFromZr`, `NativeToZr`, and `NativeBatchInverse` functions.
- **Refactored `rp/csp/lagrange_native.go` & `lagrange_cache.go`**: Removed the redundant local type/function definitions and updated all calls to utilize the new `math` package exports.
- **Refactored `rp/bulletproof/rp.go`**: Updated the Range Proof logic to adopt the shared `math` package for native field arithmetic.
- **Updated Tests**: Adjusted `lagrange_native_test.go` to test the new centralized implementations, ensuring the type conversions and zero-allocation logic remain mathematically sound.

## Motivation

This centralization is part of our ongoing effort to optimize the `zkatdlog` driver's proof generation performance. By centralizing the highly-optimized, zero-allocation field arithmetic primitives, we eliminate duplicate code, reduce maintenance overhead, and guarantee that all ZK proof constructions consistently benefit from the reduction in garbage collection (GC) pressure.
