### PR TITLE
perf: optimize zkatdlog range proof arithmetic and reduce GC allocations 

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
@@ -336,7 +336,7 @@ func (p *rangeProver) preprocess() ([]*math.Zr, []*math.Zr, *math.Zr, *RangeProo
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
-		
+
 		return nativeRPPreprocess[bls12381fr.Element, *bls12381fr.Element](p, left, right, randomLeft, randomRight, y, z, C, D, rho, eta, rand)
 	} else if isBN254 {
 		rand, err := p.Curve.Rand()

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp.go
@@ -8,6 +8,8 @@ package bulletproof
 
 import (
 	math "github.com/IBM/mathlib"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
@@ -249,11 +251,12 @@ func (p *rangeProver) Prove() (*RangeProof, error) {
 	yInv.InvModOrder()
 
 	rightGeneratorsPrime := make([]*math.G1, len(p.RightGenerators))
+	yInv2i := math2.One(p.Curve)
 	for i := range len(p.RightGenerators) {
-		// compute 1/y^i
-		yInv2i := yInv.PowMod(math2.NewCachedZrFromInt(p.Curve, uint64(i))) // #nosec G115
 		// compute the new generators H'_i = H_i^{1/y^i}
 		rightGeneratorsPrime[i] = p.RightGenerators[i].Mul(yInv2i)
+		// next power
+		yInv2i = p.Curve.ModMul(yInv2i, yInv, p.Curve.GroupOrder)
 	}
 	// compute the commitment to left and right
 	com := CommitVector(left, right, p.LeftGenerators, rightGeneratorsPrime, p.Curve)
@@ -326,6 +329,23 @@ func (p *rangeProver) preprocess() ([]*math.Zr, []*math.Zr, *math.Zr, *RangeProo
 	}
 	y := p.Curve.HashToZr(bytesToHash)
 	z := p.Curve.HashToZr(y.Bytes())
+
+	isBLS, isBN254 := math2.DispatchCurve(p.Curve)
+	if isBLS {
+		rand, err := p.Curve.Rand()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		
+		return nativeRPPreprocess[bls12381fr.Element, *bls12381fr.Element](p, left, right, randomLeft, randomRight, y, z, C, D, rho, eta, rand)
+	} else if isBN254 {
+		rand, err := p.Curve.Rand()
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+
+		return nativeRPPreprocess[bn254fr.Element, *bn254fr.Element](p, left, right, randomLeft, randomRight, y, z, C, D, rho, eta, rand)
+	}
 
 	leftPrime := make([]*math.Zr, len(left))
 	rightPrime := make([]*math.Zr, len(right))
@@ -512,6 +532,13 @@ func (v *rangeVerifier) Verify(rp *RangeProof) error {
 	}
 	y := v.Curve.HashToZr(bytesToHash)
 	z := v.Curve.HashToZr(y.Bytes())
+
+	isBLS, isBN254 := math2.DispatchCurve(v.Curve)
+	if isBLS {
+		return nativeRPVerify[bls12381fr.Element, *bls12381fr.Element](v, rp, x, y, z)
+	} else if isBN254 {
+		return nativeRPVerify[bn254fr.Element, *bn254fr.Element](v, rp, x, y, z)
+	}
 	// z^2 and z^3
 	zSquare := z.PowMod(math2.Two(v.Curve))
 	zCube := v.Curve.ModMul(zSquare, z, v.Curve.GroupOrder)

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp_native.go
@@ -1,0 +1,356 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bulletproof
+
+import (
+	"io"
+
+	math "github.com/IBM/mathlib"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
+)
+
+// nativeRPPreprocess performs the preprocessing step for the range proof using native gnark arithmetic.
+// It computes the initial vectors leftPrime, rightPrime, randRightPrime, and zPrime,
+// evaluates polynomial parts t1 and t2, and prepares the output required to construct the RangeProof.
+func nativeRPPreprocess[T any, E math2.GnarkFr[T]](
+	p *rangeProver,
+	left, right, randomLeft, randomRight []*math.Zr,
+	y, z *math.Zr,
+	C, D *math.G1,
+	rho, eta *math.Zr,
+	randReader io.Reader,
+) ([]*math.Zr, []*math.Zr, *math.Zr, *RangeProof, error) {
+	n := len(left)
+	var yE_ T
+	math2.SetNativeFromZr[T, E](y, E(&yE_))
+	yE := E(&yE_)
+	var zE_ T
+	math2.SetNativeFromZr[T, E](z, E(&zE_))
+	zE := E(&zE_)
+
+	var zSquareE T
+	E(&zSquareE).Mul(zE, zE)
+
+	leftPrimeE := make([]T, n)
+	rightPrimeE := make([]T, n)
+	randRightPrimeE := make([]T, n)
+	zPrimeE := make([]T, n)
+
+	var y2iE T
+	E(&y2iE).SetOne()
+	var twoE T
+	E(&twoE).SetInt64(2)
+	var twoPowE T
+	E(&twoPowE).SetOne()
+
+	for i := range n {
+		var lE_, rE_, rrE_ T
+		math2.SetNativeFromZr[T, E](left[i], E(&lE_))
+		math2.SetNativeFromZr[T, E](right[i], E(&rE_))
+		math2.SetNativeFromZr[T, E](randomRight[i], E(&rrE_))
+		lE := E(&lE_)
+		rE := E(&rE_)
+		rrE := E(&rrE_)
+
+		// leftPrime[i] = left[i] - z
+		E(&leftPrimeE[i]).Sub(lE, zE)
+
+		// rightPrime[i] = (right[i] + z) * y^i
+		E(&rightPrimeE[i]).Add(rE, zE)
+		E(&rightPrimeE[i]).Mul(E(&rightPrimeE[i]), E(&y2iE))
+
+		// randRightPrime[i] = randomRight[i] * y^i
+		E(&randRightPrimeE[i]).Mul(rrE, E(&y2iE))
+
+		// zPrime[i] = z^2 * 2^i
+		E(&zPrimeE[i]).Mul(E(&zSquareE), E(&twoPowE))
+
+		// update y^i and 2^i
+		E(&y2iE).Mul(E(&y2iE), yE)
+		E(&twoPowE).Mul(E(&twoPowE), E(&twoE))
+	}
+
+	var t1E T
+	E(&t1E).SetZero()
+	var tmp T
+
+	for i := range n {
+		var rlE_ T
+		math2.SetNativeFromZr[T, E](randomLeft[i], E(&rlE_))
+		rlE := E(&rlE_)
+
+		// leftPrime * randRightPrime
+		E(&tmp).Mul(E(&leftPrimeE[i]), E(&randRightPrimeE[i]))
+		E(&t1E).Add(E(&t1E), E(&tmp))
+
+		// rightPrime * randomLeft
+		E(&tmp).Mul(E(&rightPrimeE[i]), rlE)
+		E(&t1E).Add(E(&t1E), E(&tmp))
+
+		// zPrime * randomLeft
+		E(&tmp).Mul(E(&zPrimeE[i]), rlE)
+		E(&t1E).Add(E(&t1E), E(&tmp))
+	}
+
+	t1 := math2.NativeToZr[T, E](E(&t1E), p.Curve)
+
+	tau1 := p.Curve.NewRandomZr(randReader)
+	T1 := p.CommitmentGenerators[0].Mul2(t1, p.CommitmentGenerators[1], tau1)
+
+	var t2E T
+	E(&t2E).SetZero()
+	for i := range n {
+		var rlE_ T
+		math2.SetNativeFromZr[T, E](randomLeft[i], E(&rlE_))
+		rlE := E(&rlE_)
+		E(&tmp).Mul(rlE, E(&randRightPrimeE[i]))
+		E(&t2E).Add(E(&t2E), E(&tmp))
+	}
+	t2 := math2.NativeToZr[T, E](E(&t2E), p.Curve)
+
+	tau2 := p.Curve.NewRandomZr(randReader)
+	T2 := p.CommitmentGenerators[0].Mul2(t2, p.CommitmentGenerators[1], tau2)
+
+	array := common.GetG1Array([]*math.G1{T1, T2})
+	bytesToHash, err := array.Bytes()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	x := p.Curve.HashToZr(bytesToHash)
+	var xE_ T
+	math2.SetNativeFromZr[T, E](x, E(&xE_))
+	xE := E(&xE_)
+
+	var xSquareE T
+	E(&xSquareE).Mul(xE, xE)
+
+	for i := range n {
+		var rlE_ T
+		math2.SetNativeFromZr[T, E](randomLeft[i], E(&rlE_))
+		rlE := E(&rlE_)
+
+		// left[i] = leftPrime[i] + x * randomLeft[i]
+		E(&tmp).Mul(xE, rlE)
+		E(&leftPrimeE[i]).Add(E(&leftPrimeE[i]), E(&tmp))
+		left[i] = math2.NativeToZr[T, E](E(&leftPrimeE[i]), p.Curve)
+
+		// right[i] = rightPrime[i] + x * randRightPrime[i] + zPrime[i]
+		E(&tmp).Mul(xE, E(&randRightPrimeE[i]))
+		E(&rightPrimeE[i]).Add(E(&rightPrimeE[i]), E(&tmp))
+		E(&rightPrimeE[i]).Add(E(&rightPrimeE[i]), E(&zPrimeE[i]))
+		right[i] = math2.NativeToZr[T, E](E(&rightPrimeE[i]), p.Curve)
+	}
+
+	var tau1E_, tau2E_, bfE_ T
+	math2.SetNativeFromZr[T, E](tau1, E(&tau1E_))
+	math2.SetNativeFromZr[T, E](tau2, E(&tau2E_))
+	math2.SetNativeFromZr[T, E](p.blindingFactor, E(&bfE_))
+	tau1E := E(&tau1E_)
+	tau2E := E(&tau2E_)
+	bfE := E(&bfE_)
+
+	var tauE T
+	E(&tauE).SetZero()
+	E(&tmp).Mul(xE, tau1E)
+	E(&tauE).Add(E(&tauE), E(&tmp))
+
+	E(&tmp).Mul(E(&xSquareE), tau2E)
+	E(&tauE).Add(E(&tauE), E(&tmp))
+
+	E(&tmp).Mul(E(&zSquareE), bfE)
+	E(&tauE).Add(E(&tauE), E(&tmp))
+
+	tau := math2.NativeToZr[T, E](E(&tauE), p.Curve)
+
+	var rhoE_, etaE_ T
+	math2.SetNativeFromZr[T, E](rho, E(&rhoE_))
+	math2.SetNativeFromZr[T, E](eta, E(&etaE_))
+	rhoE := E(&rhoE_)
+	etaE := E(&etaE_)
+	var deltaE T
+	E(&deltaE).Mul(etaE, xE)
+	E(&deltaE).Add(E(&deltaE), rhoE)
+
+	delta := math2.NativeToZr[T, E](E(&deltaE), p.Curve)
+
+	rp := &RangeProof{
+		Data: &RangeProofData{
+			T1:    T1,
+			T2:    T2,
+			C:     C,
+			D:     D,
+			Tau:   tau,
+			Delta: delta,
+		},
+	}
+
+	return left, right, y, rp, nil
+}
+
+// nativeRPVerify performs the outer verification for the range proof using native gnark arithmetic.
+// It computes the polynomial evaluation of the range constraint and ensures that the
+// resulting commitment equations hold before delegating the inner product to nativeRPVerifyIPA.
+func nativeRPVerify[T any, E math2.GnarkFr[T]](v *rangeVerifier, rp *RangeProof, x, y, z *math.Zr) error {
+	n := len(v.RightGenerators)
+	var yE_ T
+	math2.SetNativeFromZr[T, E](y, E(&yE_))
+	yE := E(&yE_)
+	var zE_ T
+	math2.SetNativeFromZr[T, E](z, E(&zE_))
+	zE := E(&zE_)
+
+	var zSquareE T
+	E(&zSquareE).Mul(zE, zE)
+	var zCubeE T
+	E(&zCubeE).Mul(E(&zSquareE), zE)
+
+	yPowE := make([]T, n)
+	var ipyE T
+	E(&ipyE).SetZero()
+
+	var y2iE T
+	E(&y2iE).SetOne()
+
+	var ip2E T
+	E(&ip2E).SetZero()
+	var twoE T
+	E(&twoE).SetInt64(2)
+	var twoPowE T
+	E(&twoPowE).SetOne()
+
+	for i := range n {
+		yPowE[i] = y2iE
+		E(&ipyE).Add(E(&ipyE), E(&y2iE))
+		E(&ip2E).Add(E(&ip2E), E(&twoPowE))
+
+		E(&y2iE).Mul(E(&y2iE), yE)
+		E(&twoPowE).Mul(E(&twoPowE), E(&twoE))
+	}
+
+	var polEvalE T
+	E(&polEvalE).Sub(zE, E(&zSquareE))
+	E(&polEvalE).Mul(E(&polEvalE), E(&ipyE))
+
+	var tmpE T
+	E(&tmpE).Mul(E(&zCubeE), E(&ip2E))
+
+	E(&polEvalE).Sub(E(&polEvalE), E(&tmpE))
+
+	polEval := math2.NativeToZr[T, E](E(&polEvalE), v.Curve)
+	zSquare := math2.NativeToZr[T, E](E(&zSquareE), v.Curve)
+	var xE_ T
+	math2.SetNativeFromZr[T, E](x, E(&xE_))
+	xE := E(&xE_)
+	var xSquareE T
+	E(&xSquareE).Mul(xE, xE)
+	xSquare := math2.NativeToZr[T, E](E(&xSquareE), v.Curve)
+
+	// com is should be equal to v.Commitment^{z^2} if p.Value falls within range
+	com := v.CommitmentGenerators[0].Mul(rp.Data.InnerProduct)
+	com.Add(v.CommitmentGenerators[1].Mul(rp.Data.Tau))
+	com.Sub(rp.Data.T1.Mul(x))
+	com.Sub(rp.Data.T2.Mul(xSquare))
+
+	comPrime := v.Commitment.Mul2(zSquare, v.CommitmentGenerators[0], polEval)
+
+	if !com.Equals(comPrime) {
+		return errors.New("invalid range proof")
+	}
+
+	return nativeRPVerifyIPA[T, E](v, rp, xE, yPowE, zE, E(&zSquareE))
+}
+
+// nativeRPVerifyIPA performs the inner product argument (IPA) verification step for the range proof.
+// It constructs the updated right generators and scalar vectors using native gnark arithmetic,
+// computes the final commitment, and delegates the remaining steps to the standard IPAVerifier.
+func nativeRPVerifyIPA[T any, E math2.GnarkFr[T]](v *rangeVerifier, rp *RangeProof, xE E, yPowE []T, zE, zSquareE E) error {
+	n := len(v.LeftGenerators)
+
+	yPowPtrs := make([]E, n)
+	for i := range n {
+		yPowPtrs[i] = E(&yPowE[i])
+	}
+	yInv := math2.NativeBatchInverse[T, E](yPowPtrs)
+
+	ziScalars := make([]*math.Zr, n)
+	var twoE T
+	E(&twoE).SetInt64(2)
+	var twoPowE T
+	E(&twoPowE).SetOne()
+	var tmpE T
+	var tmp2E T
+
+	for i := range n {
+		// zi = z * y^i + z^2 * 2^i
+		E(&tmpE).Mul(zE, E(&yPowE[i]))
+		E(&tmp2E).Mul(zSquareE, E(&twoPowE))
+		E(&tmpE).Add(E(&tmpE), E(&tmp2E))
+
+		ziScalars[i] = math2.NativeToZr[T, E](E(&tmpE), v.Curve)
+		E(&twoPowE).Mul(E(&twoPowE), E(&twoE))
+	}
+
+	rightGeneratorsPrime := make([]*math.G1, n)
+	for i := range n {
+		yInvZr := math2.NativeToZr[T, E](yInv[i], v.Curve)
+		rightGeneratorsPrime[i] = v.RightGenerators[i].Mul(yInvZr)
+	}
+
+	var zNegE T
+	E(&zNegE).SetZero()
+	E(&zNegE).Sub(E(&zNegE), zE)
+	zNeg := math2.NativeToZr[T, E](E(&zNegE), v.Curve)
+
+	var deltaE_ T
+	math2.SetNativeFromZr[T, E](rp.Data.Delta, E(&deltaE_))
+	deltaE := E(&deltaE_)
+	var deltaNegE T
+	E(&deltaNegE).SetZero()
+	E(&deltaNegE).Sub(E(&deltaNegE), deltaE)
+	deltaNeg := math2.NativeToZr[T, E](E(&deltaNegE), v.Curve)
+
+	allPoints := make([]*math.G1, 0, 2*n+3)
+	allScalars := make([]*math.Zr, 0, 2*n+3)
+
+	x := math2.NativeToZr[T, E](xE, v.Curve)
+
+	allPoints = append(allPoints, rp.Data.D)
+	allScalars = append(allScalars, x)
+
+	allPoints = append(allPoints, rp.Data.C)
+	allScalars = append(allScalars, v.Curve.NewZrFromInt(1))
+
+	for i := range n {
+		allPoints = append(allPoints, v.LeftGenerators[i])
+		allScalars = append(allScalars, zNeg)
+	}
+
+	for i := range n {
+		allPoints = append(allPoints, rightGeneratorsPrime[i])
+		allScalars = append(allScalars, ziScalars[i])
+	}
+
+	allPoints = append(allPoints, v.P)
+	allScalars = append(allScalars, deltaNeg)
+
+	com := v.Curve.MultiScalarMul(allPoints, allScalars)
+
+	ipv := NewIPAVerifier(
+		rp.Data.InnerProduct,
+		v.Q,
+		v.LeftGenerators,
+		rightGeneratorsPrime,
+		com,
+		v.NumberOfRounds,
+		v.Curve,
+		v.Provider,
+	)
+
+	return ipv.Verify(rp.IPA)
+}


### PR DESCRIPTION
closes #1621 

## Description

This PR introduces critical performance enhancements to the `zkatdlog` driver by mitigating a severe garbage collection bottleneck in the Zero-Knowledge Range Proof (Bulletproof) and Inner Product Argument (IPA) pipelines.

Previously, computing cryptographic loops using `mathlib.Zr` induced immense garbage collection pressure due to continuous, temporary heap allocations (via `math/big.nat.make`). This PR bridges the gap to `gnark-crypto`'s stack-allocated primitives for complex polynomial/matrix arithmetic, providing massive throughput gains and zero-allocation critical paths.

## Changes made

1. **New Native Execution Path (`rp_native.go`)**:
   - Implemented `nativeRPPreprocess`: Refactored the prover's challenge folding and vector commitments to execute entirely in stack-allocated gnark types.
   - Implemented `nativeRPVerify` & `nativeRPVerifyIPA`: Refactored the range proof verification equations and iterative IPA updates to use `gnark-crypto` field elements natively.

2. **Curve-Aware Routing (`rp.go`)**:
   - Modified `rp.go` to detect the underlying curve (e.g., BLS12-381 or BN254) and inject the appropriate gnark generic constraint `math2.GnarkFr[T]` into the native arithmetic runners.
   - Utilizes newly optimized boundary conversions (`SetNativeFromZr` and `NativeToZr`) to securely pass data into and out of the stack-allocated loops without mutating shared state.

3. **Performance Impact**:
   - Eliminates redundant allocations in `y^i` / `2^i` scaling, inner product calculations, and polynomial evaluations.
   - Significantly reduces `allocs/op` and overall memory footprint during high-throughput token minting/transfer transactions.

## Testing 

I ran the `TestParallelBFProver` benchmark test with 16 workers on my device and got the following results:

- ### Before

```
go test -v ./token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/... -run TestParallelBFProver -count=1
=== RUN   TestParallelBFProver
=== RUN   TestParallelBFProver/Setup(bits_32,curve_BN254,#i_2,_#o_2)_with_16_workers
Metric           Value     Description
------           -----     -----------
Workers          16        
Total Ops        519       (Low Sample Size)
Duration         1.02s     (Good Duration)
Real Throughput  508.64/s  Observed Ops/sec (Wall Clock)
Pure Throughput  519.66/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           21.029658ms  
 P50 (Median)  30.566884ms  
 Average       30.789503ms  
 P95           37.625419ms  
 P99           40.380371ms  
 P99.9         43.242542ms  
 Max           43.444939ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.739383ms  
 IQR      4.689892ms  Interquartile Range
 Jitter   4.424061ms  Avg delta per worker
 CV       12.14%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              870324 B/op     Allocated bytes per operation
 Allocs              8943 allocs/op  Allocations per operation
 Alloc Rate          406.90 MB/s     Memory pressure on system
 GC Overhead         8.65%           (Severe GC Thrashing)
 GC Pause            88.250346ms     Total Stop-The-World time
 GC Cycles           205             Full garbage collection cycles
 Goroutines Created  0               Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 21.029658ms-21.806579ms  4     ██ (0.8%)
 21.806579ms-22.612204ms  1      (0.2%)
 22.612204ms-23.447592ms  3     █ (0.6%)
 23.447592ms-24.313842ms  5     ██ (1.0%)
 24.313842ms-25.212096ms  13    ███████ (2.5%)
 25.212096ms-26.143534ms  28    ████████████████ (5.4%)
 26.143534ms-27.109384ms  33    ███████████████████ (6.4%)
 27.109384ms-28.110916ms  32    ██████████████████ (6.2%)
 28.110916ms-29.149449ms  64    █████████████████████████████████████ (12.3%)
 29.149449ms-30.226349ms  58    █████████████████████████████████ (11.2%)
 30.226349ms-31.343035ms  53    ██████████████████████████████ (10.2%)
 31.343035ms-32.500975ms  69    ████████████████████████████████████████ (13.3%)
 32.500975ms-33.701695ms  50    ████████████████████████████ (9.6%)
 33.701695ms-34.946774ms  39    ██████████████████████ (7.5%)
 34.946774ms-36.237851ms  25    ██████████████ (4.8%)
 36.237851ms-37.576627ms  15    ████████ (2.9%)
 37.576627ms-38.964862ms  17    █████████ (3.3%)
 38.964862ms-40.404384ms  4     ██ (0.8%)
 40.404384ms-41.897088ms  3     █ (0.6%)
 41.897088ms-43.444939ms  3     █ (0.6%)

--- Analysis & Recommendations ---
[WARN] Low sample size (519). Results may not be statistically significant. Run for longer.
[INFO] High Allocations (8943/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------
--- PASS: TestParallelBFProver (4.20s)
    --- PASS: TestParallelBFProver/Setup(bits_32,curve_BN254,#i_2,_#o_2)_with_16_workers (4.20s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof  4.221s
```

- ### After

```
go test -v ./token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/... -run TestParallelBFProver -count=1
=== RUN   TestParallelBFProver
=== RUN   TestParallelBFProver/Setup(bits_32,curve_BN254,#i_2,_#o_2)_with_16_workers
Metric           Value     Description
------           -----     -----------
Workers          16        
Total Ops        541       (Low Sample Size)
Duration         1.018s    (Good Duration)
Real Throughput  531.34/s  Observed Ops/sec (Wall Clock)
Pure Throughput  543.78/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.510867ms  
 P50 (Median)  28.805833ms  
 Average       29.423784ms  
 P95           37.108546ms  
 P99           41.692725ms  
 P99.9         45.140579ms  
 Max           45.301542ms  (Stable Tail)

Stability Metrics:
 Std Dev  4.216845ms  
 IQR      5.091647ms  Interquartile Range
 Jitter   4.332139ms  Avg delta per worker
 CV       14.33%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              748129 B/op     Allocated bytes per operation
 Allocs              7307 allocs/op  Allocations per operation
 Alloc Rate          360.75 MB/s     Memory pressure on system
 GC Overhead         6.97%           (Severe GC Thrashing)
 GC Pause            70.946051ms     Total Stop-The-World time
 GC Cycles           161             Full garbage collection cycles
 Goroutines Created  102             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.510867ms-19.358026ms  2      (0.4%)
 19.358026ms-20.243955ms  2      (0.4%)
 20.243955ms-21.17043ms   3     █ (0.6%)
 21.17043ms-22.139306ms   4     █ (0.7%)
 22.139306ms-23.152522ms  17    ███████ (3.1%)
 23.152522ms-24.212109ms  20    █████████ (3.7%)
 24.212109ms-25.320188ms  28    █████████████ (5.2%)
 25.320188ms-26.478979ms  54    █████████████████████████ (10.0%)
 26.478979ms-27.690803ms  62    ████████████████████████████ (11.5%)
 27.690803ms-28.958087ms  86    ████████████████████████████████████████ (15.9%)
 28.958087ms-30.283368ms  63    █████████████████████████████ (11.6%)
 30.283368ms-31.669302ms  62    ████████████████████████████ (11.5%)
 31.669302ms-33.118663ms  46    █████████████████████ (8.5%)
 33.118663ms-34.634356ms  33    ███████████████ (6.1%)
 34.634356ms-36.219414ms  24    ███████████ (4.4%)
 36.219414ms-37.877014ms  13    ██████ (2.4%)
 37.877014ms-39.610475ms  12    █████ (2.2%)
 39.610475ms-41.423268ms  4     █ (0.7%)
 41.423268ms-43.319025ms  3     █ (0.6%)
 43.319025ms-45.301542ms  3     █ (0.6%)

--- Analysis & Recommendations ---
[WARN] Low sample size (541). Results may not be statistically significant. Run for longer.
[INFO] High Allocations (7307/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------
--- PASS: TestParallelBFProver (4.21s)
    --- PASS: TestParallelBFProver/Setup(bits_32,curve_BN254,#i_2,_#o_2)_with_16_workers (4.21s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof  4.236s
```

We can see that the `allocs/op` metric went down considerably from **8943** to **7307**, which is an **~18%** reduction
The memory also went down from **870 KB/op** to **748 KB/op** (**~14% reduction**)
The latency does not seem to have any regression

Let me know if this is good 🙏