### PR TITLE
fix(sql): replace non-atomic check-then-insert with atomic upsert in WalletStore.StoreIdentity

### DIFF
--- a/token/services/storage/db/sql/common/wallet.go
+++ b/token/services/storage/db/sql/common/wallet.go
@@ -87,14 +87,10 @@ func (db *WalletStore) GetWalletIDs(ctx context.Context, roleID int) ([]driver.W
 }
 
 func (db *WalletStore) StoreIdentity(ctx context.Context, identity token.Identity, eID string, wID driver.WalletID, roleID int, meta []byte) error {
-	// TODO AF Use upsert
-	if db.IdentityExists(ctx, identity, wID, roleID) {
-		return nil
-	}
-
 	query, args := q.InsertInto(db.table.Wallets).
 		Fields("identity_hash", "meta", "wallet_id", "role_id", "created_at", "enrollment_id").
 		Row(identity.UniqueID(), meta, wID, roleID, time.Now().UTC(), eID).
+		OnConflictDoNothing().
 		Format()
 	logging.Debug(logger, query)
 

--- a/token/services/storage/db/sql/common/wallet_test_utils.go
+++ b/token/services/storage/db/sql/common/wallet_test_utils.go
@@ -107,14 +107,9 @@ func TestStoreIdentity(t *testing.T, store walletStoreConstructor) {
 	walletID := driver.WalletID("my wallet")
 	roleID := 5
 
-	mockDB.
-		ExpectQuery("SELECT wallet_id FROM WALLETS WHERE \\(identity_hash = \\$1\\) AND \\(wallet_id = \\$2\\) AND \\(role_id = \\$3\\)").
-		WithArgs(tokenID.UniqueID(), walletID, roleID).
-		WillReturnRows(mockDB.NewRows([]string{"wallet_id"}))
-
 	mockDB.ExpectExec("INSERT INTO WALLETS "+
 		"\\(identity_hash, meta, wallet_id, role_id, created_at, enrollment_id\\) "+
-		"VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6\\)").
+		"VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6\\) ON CONFLICT DO NOTHING").
 		WithArgs(tokenID.UniqueID(), []uint8(nil), walletID, roleID, sqlmock.AnyArg(), eID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -122,4 +117,38 @@ func TestStoreIdentity(t *testing.T, store walletStoreConstructor) {
 
 	gomega.Expect(mockDB.ExpectationsWereMet()).To(gomega.Succeed())
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
+func TestStoreIdentityIdempotent(t *testing.T, store walletStoreConstructor) {
+	gomega.RegisterTestingT(t)
+	db, mockDB, err := sqlmock.New()
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	tokenID := token.Identity([]byte("1234"))
+	eID := "5678"
+	walletID := driver.WalletID("my wallet")
+	roleID := 5
+
+	insertQuery := "INSERT INTO WALLETS " +
+		"\\(identity_hash, meta, wallet_id, role_id, created_at, enrollment_id\\) " +
+		"VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6\\) ON CONFLICT DO NOTHING"
+
+	// First call: row inserted (1 row affected)
+	mockDB.ExpectExec(insertQuery).
+		WithArgs(tokenID.UniqueID(), []uint8(nil), walletID, roleID, sqlmock.AnyArg(), eID).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	// Second call: conflict, 0 rows affected — must still return nil
+	mockDB.ExpectExec(insertQuery).
+		WithArgs(tokenID.UniqueID(), []uint8(nil), walletID, roleID, sqlmock.AnyArg(), eID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	s := store(db)
+	err = s.StoreIdentity(t.Context(), tokenID, eID, walletID, roleID, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	err = s.StoreIdentity(t.Context(), tokenID, eID, walletID, roleID, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	gomega.Expect(mockDB.ExpectationsWereMet()).To(gomega.Succeed())
 }

--- a/token/services/storage/db/sql/postgres/wallet_test.go
+++ b/token/services/storage/db/sql/postgres/wallet_test.go
@@ -40,3 +40,7 @@ func TestIdentityExists(t *testing.T) {
 func TestStoreIdentity(t *testing.T) {
 	common2.TestStoreIdentity(t, mockWalletStore)
 }
+
+func TestStoreIdentityIdempotent(t *testing.T) {
+	common2.TestStoreIdentityIdempotent(t, mockWalletStore)
+}

--- a/token/services/storage/db/sql/sqlite/wallet_test.go
+++ b/token/services/storage/db/sql/sqlite/wallet_test.go
@@ -40,3 +40,7 @@ func TestIdentityExists(t *testing.T) {
 func TestStoreIdentity(t *testing.T) {
 	common2.TestStoreIdentity(t, mockWalletStore)
 }
+
+func TestStoreIdentityIdempotent(t *testing.T) {
+	common2.TestStoreIdentityIdempotent(t, mockWalletStore)
+}


### PR DESCRIPTION
Fixes #1661

## Problem

`WalletStore.StoreIdentity` used a non-atomic check-then-insert pattern:

```go
// TODO AF Use upsert
if db.IdentityExists(ctx, identity, wID, roleID) {
    return nil
}
// ... INSERT ...
```

Between the `IdentityExists` SELECT and the subsequent INSERT, a concurrent
goroutine or node can insert the same row, causing a duplicate-key constraint
error. The original author already acknowledged this with the `// TODO AF Use upsert`
comment at `wallet.go:90`.

## Fix

Replace the two-step read-then-write with a single atomic statement:

```go
q.InsertInto(db.table.Wallets).
    Fields(identity_hash, meta, wallet_id, role_id, created_at, enrollment_id).
    Row(identity.UniqueID(), meta, wID, roleID, time.Now().UTC(), eID).
    OnConflictDoNothing().
    Format()
```

`INSERT ... ON CONFLICT DO NOTHING` is natively supported by both PostgreSQL
and SQLite, and the FSC query builder already exposes `OnConflictDoNothing()`.
The operation is now atomic at the database level — no race window, no duplicate-key
errors under concurrent writers.

## Changes

| File | Change |
|------|--------|
| `token/services/storage/db/sql/common/wallet.go` | Remove `IdentityExists` guard and `// TODO AF Use upsert` comment; add `.OnConflictDoNothing()` to the INSERT chain |
| `token/services/storage/db/sql/common/wallet_test_utils.go` | Update `TestStoreIdentity` mock (remove stale SELECT expectation, add `ON CONFLICT DO NOTHING` to INSERT regex); add `TestStoreIdentityIdempotent` |
| `token/services/storage/db/sql/sqlite/wallet_test.go` | Register `TestStoreIdentityIdempotent` |
| `token/services/storage/db/sql/postgres/wallet_test.go` | Register `TestStoreIdentityIdempotent` |

## Test plan

- [x] `go test ./token/services/storage/db/sql/common/...` — all pass including `TestStoreIdentityIdempotent`
- [x] `go test ./token/services/storage/db/sql/sqlite/...` — all pass
- [x] `golangci-lint run ./token/services/storage/db/sql/...` — 0 issues

`TestStoreIdentityIdempotent` calls `StoreIdentity` twice with the same
identity; the second call returns 0 rows affected (conflict silently ignored)
and must still return `nil` — which it does.