### PR TITLE
fix(cmd-tokengen-unit-tests): do not rewrite existing testdata

### DIFF
--- a/cmd/tokengen/main_test.go
+++ b/cmd/tokengen/main_test.go
@@ -42,9 +42,9 @@ func TestGenFullSuccess(t *testing.T) {
 	gt.Expect(err).NotTo(HaveOccurred())
 	defer gexec.CleanupBuildArtifacts()
 
-	// tempOutput := t.TempDir()
-	// defer utils.IgnoreErrorWithOneArg(os.RemoveAll, tempOutput)
-	tempOutput := "./testdata"
+	tempOutput := t.TempDir()
+	defer utils.IgnoreErrorWithOneArg(os.RemoveAll, tempOutput)
+	// tempOutput := "./testdata"
 	testGenRun(
 		gt,
 		tokengen,


### PR DESCRIPTION
fix test that was rewriting content in the `testdata` folder at each execution