### PR TITLE
token: add ethereum network driver scaffold

### DIFF
--- a/token/services/network/ethereum/driver.go
+++ b/token/services/network/ethereum/driver.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ethereum
+
+import (
+	"errors"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+)
+
+const (
+	// DriverName identifies the scaffold for an Ethereum/EVM-backed token network driver.
+	DriverName = "ethereum"
+)
+
+var (
+	// ErrNotImplemented marks the parts of the Ethereum driver that are intentionally left for
+	// follow-up implementation slices.
+	ErrNotImplemented = errors.New("ethereum network driver: not implemented")
+)
+
+// Driver is the first scaffold for an Ethereum/EVM token network driver.
+//
+// This slice only establishes the package boundary and the driver/network types so later PRs can
+// build transport, finality, public parameter fetching, and endorsement support incrementally.
+type Driver struct{}
+
+// NewDriver returns a new Ethereum driver scaffold.
+func NewDriver() *Driver {
+	return &Driver{}
+}
+
+// New returns a new Ethereum network scaffold for the passed network and channel.
+func (d *Driver) New(network, channel string) (driver.Network, error) {
+	return NewNetwork(network, channel), nil
+}

--- a/token/services/network/ethereum/envelope.go
+++ b/token/services/network/ethereum/envelope.go
@@ -1,0 +1,44 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ethereum
+
+import (
+	"encoding/json"
+)
+
+// Envelope is a lightweight placeholder for a future Ethereum transaction envelope.
+//
+// The scaffold keeps serialization simple so tests and later driver slices have a stable type to
+// build on without committing yet to a concrete backend or transaction format.
+type Envelope struct {
+	Tx string `json:"tx,omitempty"`
+}
+
+// Bytes marshals the envelope to bytes.
+func (e *Envelope) Bytes() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// FromBytes unmarshals the envelope from bytes.
+func (e *Envelope) FromBytes(raw []byte) error {
+	return json.Unmarshal(raw, e)
+}
+
+// TxID returns the ID carried by the scaffold envelope.
+func (e *Envelope) TxID() string {
+	return e.Tx
+}
+
+// String returns a JSON representation of the envelope.
+func (e *Envelope) String() string {
+	raw, err := e.Bytes()
+	if err != nil {
+		return "{}"
+	}
+
+	return string(raw)
+}

--- a/token/services/network/ethereum/network.go
+++ b/token/services/network/ethereum/network.go
@@ -1,0 +1,145 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ethereum
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
+
+type localMembership struct{}
+
+func (l *localMembership) DefaultIdentity() view.Identity {
+	return nil
+}
+
+func (l *localMembership) AnonymousIdentity() (view.Identity, error) {
+	return nil, ErrNotImplemented
+}
+
+// Network is the first scaffold for an Ethereum/EVM-backed token network.
+//
+// The scaffold deliberately leaves ledger interaction, approval flow, finality, and query support
+// for follow-up slices while already exposing a stable implementation of the driver.Network
+// contract.
+type Network struct {
+	network         string
+	channel         string
+	localMembership driver.LocalMembership
+}
+
+// NewNetwork returns a new Ethereum network scaffold.
+func NewNetwork(network, channel string) *Network {
+	return &Network{
+		network:         network,
+		channel:         channel,
+		localMembership: &localMembership{},
+	}
+}
+
+// Name returns the configured network identifier.
+func (n *Network) Name() string {
+	return n.network
+}
+
+// Channel returns the configured channel or logical partition identifier.
+func (n *Network) Channel() string {
+	return n.channel
+}
+
+// Normalize fills missing network and channel values from the scaffold configuration.
+func (n *Network) Normalize(opt *token2.ServiceOptions) (*token2.ServiceOptions, error) {
+	if opt == nil {
+		return nil, fmt.Errorf("service options are required")
+	}
+	if len(opt.Network) == 0 {
+		opt.Network = n.network
+	}
+	if len(opt.Channel) == 0 {
+		opt.Channel = n.channel
+	}
+
+	return opt, nil
+}
+
+// Connect is deferred to a later slice once a concrete Ethereum backend abstraction is introduced.
+func (n *Network) Connect(ns string) ([]token2.ServiceOption, error) {
+	return nil, ErrNotImplemented
+}
+
+// Broadcast is deferred to a later slice once a concrete Ethereum backend abstraction is introduced.
+func (n *Network) Broadcast(ctx context.Context, blob interface{}) error {
+	return ErrNotImplemented
+}
+
+// NewEnvelope returns an empty Ethereum envelope scaffold.
+func (n *Network) NewEnvelope() driver.Envelope {
+	return &Envelope{}
+}
+
+// RequestApproval is deferred to a later slice once the endorsement envelope and backend flow are defined.
+func (n *Network) RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
+	return nil, ErrNotImplemented
+}
+
+// ComputeTxID returns a deterministic scaffold transaction identifier derived from the abstract TxID.
+func (n *Network) ComputeTxID(id *driver.TxID) string {
+	if id == nil {
+		return ""
+	}
+	sum := sha256.Sum256(append(append([]byte{}, id.Nonce...), id.Creator...))
+
+	return hex.EncodeToString(sum[:])
+}
+
+// FetchPublicParameters is deferred to a later slice once contract access is defined.
+func (n *Network) FetchPublicParameters(namespace string) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// QueryTokens is deferred to a later slice once state query support is defined.
+func (n *Network) QueryTokens(ctx context.Context, namespace string, IDs []*token.ID) ([][]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// AreTokensSpent is deferred to a later slice once state query support is defined.
+func (n *Network) AreTokensSpent(ctx context.Context, namespace string, tokenIDs []*token.ID, meta []string) ([]bool, error) {
+	return nil, ErrNotImplemented
+}
+
+// LocalMembership returns the scaffold local membership implementation.
+func (n *Network) LocalMembership() driver.LocalMembership {
+	return n.localMembership
+}
+
+// AddFinalityListener is deferred to a later slice once finality integration is defined.
+func (n *Network) AddFinalityListener(namespace string, txID string, listener driver.FinalityListener) error {
+	return ErrNotImplemented
+}
+
+// GetTransactionStatus is deferred to a later slice once finality integration is defined.
+func (n *Network) GetTransactionStatus(ctx context.Context, namespace, txID string) (status int, tokenRequestHash []byte, message string, err error) {
+	return driver.Unknown, nil, "", ErrNotImplemented
+}
+
+// LookupTransferMetadataKey is deferred to a later slice once Ethereum metadata layout is defined.
+func (n *Network) LookupTransferMetadataKey(namespace string, key string, timeout time.Duration) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// Ledger is deferred to a later slice once a ledger abstraction is introduced.
+func (n *Network) Ledger() (driver.Ledger, error) {
+	return nil, ErrNotImplemented
+}

--- a/token/services/network/ethereum/network_test.go
+++ b/token/services/network/ethereum/network_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ethereum
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	token2 "github.com/hyperledger-labs/fabric-token-sdk/token"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDriver(t *testing.T) {
+	d := NewDriver()
+	require.NotNil(t, d)
+
+	nw, err := d.New("evm-net", "chain-a")
+	require.NoError(t, err)
+	require.IsType(t, &Network{}, nw)
+}
+
+func TestEnvelopeRoundTrip(t *testing.T) {
+	env := &Envelope{Tx: "tx-id"}
+
+	raw, err := env.Bytes()
+	require.NoError(t, err)
+
+	other := &Envelope{}
+	require.NoError(t, other.FromBytes(raw))
+	require.Equal(t, "tx-id", other.TxID())
+	require.Contains(t, other.String(), "tx-id")
+}
+
+func TestNetworkScaffold(t *testing.T) {
+	n := NewNetwork("evm-net", "chain-a")
+
+	require.Equal(t, "evm-net", n.Name())
+	require.Equal(t, "chain-a", n.Channel())
+
+	opts, err := n.Normalize(&token2.ServiceOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "evm-net", opts.Network)
+	require.Equal(t, "chain-a", opts.Channel)
+
+	txID := n.ComputeTxID(&driver.TxID{Nonce: []byte("nonce"), Creator: []byte("creator")})
+	require.Len(t, txID, 64)
+
+	_, err = n.Connect("ns")
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	err = n.Broadcast(context.Background(), []byte("payload"))
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	_, err = n.RequestApproval(nil, nil, nil, nil, driver.TxID{})
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	_, err = n.FetchPublicParameters("ns")
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	_, err = n.QueryTokens(context.Background(), "ns", []*token.ID{{TxId: "tx", Index: 1}})
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	_, err = n.AreTokensSpent(context.Background(), "ns", []*token.ID{{TxId: "tx", Index: 1}}, nil)
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	err = n.AddFinalityListener("ns", "tx", nil)
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	status, tokenRequestHash, message, err := n.GetTransactionStatus(context.Background(), "ns", "tx")
+	require.ErrorIs(t, err, ErrNotImplemented)
+	require.Equal(t, driver.Unknown, status)
+	require.Nil(t, tokenRequestHash)
+	require.Empty(t, message)
+
+	_, err = n.LookupTransferMetadataKey("ns", "k", time.Second)
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	_, err = n.Ledger()
+	require.ErrorIs(t, err, ErrNotImplemented)
+
+	require.NotNil(t, n.NewEnvelope())
+	require.NotNil(t, n.LocalMembership())
+
+	_, err = n.LocalMembership().AnonymousIdentity()
+	require.ErrorIs(t, err, ErrNotImplemented)
+}


### PR DESCRIPTION
## Summary
- add an initial `token/services/network/ethereum` package scaffold
- introduce placeholder `Driver`, `Network`, and `Envelope` types for an Ethereum/EVM-backed token network
- add focused unit tests for the scaffold behavior

## Why
Issue #1648 is now framed as an EPIC and is too large to land in a single PR.

This change is an intentionally small first slice that establishes the package boundary and driver shape so follow-up PRs can add:
- backend abstraction and construction
- transaction lifecycle support
- public parameter retrieval
- finality tracking
- endorser-based approval flow

## Scope
This PR does **not** claim to implement the full Ethereum driver. The scaffold returns explicit `not implemented` errors for the methods that belong to later implementation slices.

## Testing
- `go test ./token/services/network/ethereum`

Refs #1648
