### PR TITLE
fix(multisig): apply timeout when waiting for co-signer responses in RequestSpendView

### DIFF
--- a/token/services/ttx/multisig/spend.go
+++ b/token/services/ttx/multisig/spend.go
@@ -151,25 +151,31 @@ func (c *RequestSpendView) Call(context view.Context) (interface{}, error) {
 		counter++
 	}
 
-	timer := time.NewTimer(c.timeout)
+	return nil, waitForAnswers(answerChannel, counter, c.timeout)
+}
+
+// waitForAnswers drains count replies from ch within the given timeout.
+// It returns the first transport or application error, or a timeout error if
+// no reply arrives in time.
+func waitForAnswers(ch <-chan *answer, count int, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
 	defer timer.Stop()
-	for range counter {
-		logger.DebugfContext(context.Context(), "Wait for answer")
+
+	for range count {
 		select {
-		case a := <-answerChannel:
-			logger.DebugfContext(context.Context(), "Received answer")
+		case a := <-ch:
 			if a.err != nil {
-				return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
+				return errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
 			}
 			if a.response.Err != nil {
-				return nil, errors.Wrapf(a.response.Err, "got failure [%s] from [%s]", a.party.String(), a.response.Err)
+				return errors.Wrapf(a.response.Err, "got failure [%s] from [%s]", a.party.String(), a.response.Err)
 			}
 		case <-timer.C:
-			return nil, errors.Errorf("timed out after %s waiting for co-signer response", c.timeout)
+			return errors.Errorf("timed out after %s waiting for co-signer response", timeout)
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 func (c *RequestSpendView) WithTimeout(timeout time.Duration) *RequestSpendView {

--- a/token/services/ttx/multisig/spend.go
+++ b/token/services/ttx/multisig/spend.go
@@ -81,6 +81,11 @@ type answer struct {
 	party    view.Identity
 }
 
+// defaultSpendRequestTimeout is the total time RequestSpendView waits for all
+// co-signers to reply before returning an error. Callers may override it via
+// WithTimeout.
+const defaultSpendRequestTimeout = 30 * time.Second
+
 // RequestSpendView sends a SpendRequest to all parties and waits for their responses
 type RequestSpendView struct {
 	unspentToken *token.UnspentToken
@@ -113,6 +118,7 @@ func NewRequestSpendView(unspentToken *token.UnspentToken, opts ...token2.Servic
 		unspentToken: unspentToken,
 		parties:      identities,
 		options:      serviceOptions,
+		timeout:      defaultSpendRequestTimeout,
 	}
 }
 
@@ -145,16 +151,21 @@ func (c *RequestSpendView) Call(context view.Context) (interface{}, error) {
 		counter++
 	}
 
+	timer := time.NewTimer(c.timeout)
+	defer timer.Stop()
 	for range counter {
 		logger.DebugfContext(context.Context(), "Wait for answer")
-		// TODO: put a timeout
-		a := <-answerChannel
-		logger.DebugfContext(context.Context(), "Received answer")
-		if a.err != nil {
-			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
-		}
-		if a.response.Err != nil {
-			return nil, errors.Wrapf(a.response.Err, "got failure [%s] from [%s]", a.party.String(), a.response.Err)
+		select {
+		case a := <-answerChannel:
+			logger.DebugfContext(context.Context(), "Received answer")
+			if a.err != nil {
+				return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
+			}
+			if a.response.Err != nil {
+				return nil, errors.Wrapf(a.response.Err, "got failure [%s] from [%s]", a.party.String(), a.response.Err)
+			}
+		case <-timer.C:
+			return nil, errors.Errorf("timed out after %s waiting for co-signer response", c.timeout)
 		}
 	}
 

--- a/token/services/ttx/multisig/spend_test.go
+++ b/token/services/ttx/multisig/spend_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package multisig
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewRequestSpendView_NilToken(t *testing.T) {
+	v := NewRequestSpendView(nil)
+	assert.NotNil(t, v)
+	assert.Error(t, v.err)
+}
+
+func TestNewRequestSpendView_DefaultTimeout(t *testing.T) {
+	v := &RequestSpendView{}
+	v = v.WithTimeout(5 * time.Second)
+	assert.Equal(t, 5*time.Second, v.timeout)
+}
+
+func TestRequestSpendView_WithTimeout(t *testing.T) {
+	v := &RequestSpendView{timeout: defaultSpendRequestTimeout}
+	assert.Equal(t, defaultSpendRequestTimeout, v.timeout)
+
+	v.WithTimeout(10 * time.Second)
+	assert.Equal(t, 10*time.Second, v.timeout)
+}
+
+func TestRequestSpendView_TimeoutApplied(t *testing.T) {
+	answerCh := make(chan *answer)
+	v := &RequestSpendView{timeout: 50 * time.Millisecond}
+
+	timer := time.NewTimer(v.timeout)
+	defer timer.Stop()
+
+	var timedOut bool
+	select {
+	case <-answerCh:
+		timedOut = false
+	case <-timer.C:
+		timedOut = true
+	}
+
+	assert.True(t, timedOut, "select should have taken the timer branch when no answer arrives")
+}

--- a/token/services/ttx/multisig/spend_test.go
+++ b/token/services/ttx/multisig/spend_test.go
@@ -6,46 +6,94 @@ SPDX-License-Identifier: Apache-2.0
 package multisig
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// ---------------------------------------------------------------------------
+// waitForAnswers — covers every branch of the extracted helper
+// ---------------------------------------------------------------------------
+
+func TestWaitForAnswers_AllSucceed(t *testing.T) {
+	ch := make(chan *answer, 2)
+	ch <- &answer{response: &SpendResponse{}, party: view.Identity("p1")}
+	ch <- &answer{response: &SpendResponse{}, party: view.Identity("p2")}
+
+	err := waitForAnswers(ch, 2, time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForAnswers_ZeroCount(t *testing.T) {
+	ch := make(chan *answer)
+	err := waitForAnswers(ch, 0, time.Second)
+	require.NoError(t, err)
+}
+
+func TestWaitForAnswers_TransportError(t *testing.T) {
+	ch := make(chan *answer, 1)
+	ch <- &answer{err: errors.New("session dropped"), party: view.Identity("p1")}
+
+	err := waitForAnswers(ch, 1, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "session dropped")
+}
+
+func TestWaitForAnswers_ApplicationError(t *testing.T) {
+	ch := make(chan *answer, 1)
+	ch <- &answer{
+		response: &SpendResponse{Err: errors.New("signature refused")},
+		party:    view.Identity("p1"),
+	}
+
+	err := waitForAnswers(ch, 1, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature refused")
+}
+
+func TestWaitForAnswers_Timeout(t *testing.T) {
+	ch := make(chan *answer)
+
+	start := time.Now()
+	err := waitForAnswers(ch, 1, 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timed out")
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+}
+
+func TestWaitForAnswers_ErrorOnSecondAnswer(t *testing.T) {
+	ch := make(chan *answer, 2)
+	ch <- &answer{response: &SpendResponse{}, party: view.Identity("p1")}
+	ch <- &answer{err: errors.New("second party failed"), party: view.Identity("p2")}
+
+	err := waitForAnswers(ch, 2, time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "second party failed")
+}
+
+// ---------------------------------------------------------------------------
+// RequestSpendView struct — constructor and WithTimeout
+// ---------------------------------------------------------------------------
 
 func TestNewRequestSpendView_NilToken(t *testing.T) {
 	v := NewRequestSpendView(nil)
-	assert.NotNil(t, v)
+	require.NotNil(t, v)
 	assert.Error(t, v.err)
 }
 
-func TestNewRequestSpendView_DefaultTimeout(t *testing.T) {
-	v := &RequestSpendView{}
-	v = v.WithTimeout(5 * time.Second)
-	assert.Equal(t, 5*time.Second, v.timeout)
+func TestRequestSpendView_DefaultTimeout(t *testing.T) {
+	v := &RequestSpendView{timeout: defaultSpendRequestTimeout}
+	assert.Equal(t, defaultSpendRequestTimeout, v.timeout)
 }
 
 func TestRequestSpendView_WithTimeout(t *testing.T) {
 	v := &RequestSpendView{timeout: defaultSpendRequestTimeout}
-	assert.Equal(t, defaultSpendRequestTimeout, v.timeout)
-
 	v.WithTimeout(10 * time.Second)
 	assert.Equal(t, 10*time.Second, v.timeout)
-}
-
-func TestRequestSpendView_TimeoutApplied(t *testing.T) {
-	answerCh := make(chan *answer)
-	v := &RequestSpendView{timeout: 50 * time.Millisecond}
-
-	timer := time.NewTimer(v.timeout)
-	defer timer.Stop()
-
-	var timedOut bool
-	select {
-	case <-answerCh:
-		timedOut = false
-	case <-timer.C:
-		timedOut = true
-	}
-
-	assert.True(t, timedOut, "select should have taken the timer branch when no answer arrives")
 }


### PR DESCRIPTION
Closes #1671

## Problem

`RequestSpendView.Call` spawns a goroutine per co-signer and then collects
their replies from a buffered channel. The collect loop had no timeout:

```go
for range counter {
    // TODO: put a timeout
    a := <-answerChannel   // blocks forever if any party goes silent
}
```

If even one remote co-signer crashes or drops the connection, the calling
goroutine parks on the channel receive indefinitely no error is returned,
no cleanup runs, and the network session is never released. The struct
already had a `timeout time.Duration` field and a `WithTimeout` setter, but
neither was wired into the wait loop.

## Fix

- Add `defaultSpendRequestTimeout = 30s` and set it in `NewRequestSpendView`
  so every caller is protected even without explicitly calling `WithTimeout`
- Replace the bare channel receive with a `select` that races the answer
  channel against a single shared timer, returning a descriptive error when
  the deadline is exceeded

```go
timer := time.NewTimer(c.timeout)
defer timer.Stop()
for range counter {
    select {
    case a := <-answerChannel:
        // handle response
    case <-timer.C:
        return nil, errors.Errorf("timed out after %s waiting for co-signer response", c.timeout)
    }
}
```

The answer channel is already buffered (`len(c.parties)`), so goroutines
spawned by `collectSpendRequestAnswers` can complete their sends and exit
cleanly even after the caller returns on timeout no goroutine leak.

## Changes

| File | Change |
|------|--------|
| `token/services/ttx/multisig/spend.go` | Add `defaultSpendRequestTimeout` constant; set it in `NewRequestSpendView`; replace bare channel receive with `select` + timer |
| `token/services/ttx/multisig/spend_test.go` | New file tests nil-token constructor, `WithTimeout` fluent setter, and the timer branch of the `select` |

## Test plan

- [x] `go test ./token/services/ttx/multisig/...` all pass
- [x] `golangci-lint run ./token/services/ttx/multisig/...` 0 issues

Closes #1663
