### PR TITLE
perf(csp): optimize range proof prover with native gnark arithmetic

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
@@ -10,6 +10,8 @@ import (
 	"math/big"
 
 	mathlib "github.com/IBM/mathlib"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
@@ -276,12 +278,30 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 	if err != nil {
 		return nil, errors.New("Unable to obtain partial lagrange multipliers")
 	}
-	u := math.InnerProduct(aCoeffs, mu, rp.Curve)
+	// Compute u = <aCoeffs, mu> — dispatch to native for supported curves.
+	isBLS, isBN254 := math.DispatchCurve(rp.Curve)
+	var u *mathlib.Zr
+	if isBLS {
+		u = nativeRPInnerProduct[bls12381fr.Element, *bls12381fr.Element](aCoeffs, mu, rp.Curve)
+	} else if isBN254 {
+		u = nativeRPInnerProduct[bn254fr.Element, *bn254fr.Element](aCoeffs, mu, rp.Curve)
+	} else {
+		u = math.InnerProduct(aCoeffs, mu, rp.Curve)
+	}
 
 	tr.Absorb(u.Bytes())
 	gamma, err := tr.Squeeze()
 	if err != nil {
 		return nil, errors.New("Unable to obtain challenge gamma")
+	}
+
+	// Compute paddedSize for lf/wit (next power of 2 >= 2n+4).
+	witSize := 2*n + 4
+	cspRounds := uint64(0)
+	paddedSize := uint64(1)
+	for paddedSize < witSize {
+		paddedSize <<= 1
+		cspRounds++
 	}
 
 	// Extended commitment: pCommExt = pComm + eta * VCommitment.
@@ -299,45 +319,50 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 	gExt[2*n+2] = rp.VGenerators[0].Mul(eta)
 	gExt[2*n+3] = rp.VGenerators[1].Mul(eta)
 
-	// Build aggregated linear form lf = L1 + gamma*L2 + gamma^2*L3 over pExt.
-	//
-	// pExt layout  [0..n]=aCoeffs  [n+1..2n+1]=bCoeffs  [2n+2]=v  [2n+3]=r
-	//
-	// L1: eta*2^{i-1} at [1..n], -eta at [2n+2]          → checks eta*(Σ a_i·2^{i-1} - v) = 0
-	// L2: mu[i]       at [0..n]                            → checks a(c) = u
-	// L3: nu[k]       at [n+1..2n+1] (k=0..n)             → checks b(c) = u*(u-1)
-	gammaSquare := rp.Curve.ModMul(gamma, gamma, rp.Curve.GroupOrder)
-	lf := make([]*mathlib.Zr, len(pExt))
-	for i := range lf {
-		lf[i] = math.Zero(rp.Curve)
-	}
-	// L1 contribution1s.
-	for i := uint64(1); i <= n; i++ {
-		lf[i] = rp.Curve.ModMul(eta, math.PowerOfTwo(rp.Curve, i-1), rp.Curve.GroupOrder)
-	}
-	negEta := eta.Copy()
-	negEta.Neg()
-	lf[2*n+2] = negEta
-	// L2 contributions: add gamma*mu[i] at positions 0..n.
-	for i := uint64(0); i <= n; i++ {
-		lf[i] = rp.Curve.ModAddMul2(
-			lf[i], math.One(rp.Curve),
-			gamma, mu[i],
+	// Build aggregated linear form, and compute lVal.
+	// Dispatch to native gnark arithmetic for supported curves.
+	var lf []*mathlib.Zr
+	var lVal *mathlib.Zr
+	if isBLS {
+		lf, _, lVal = nativeRPBuildLF[bls12381fr.Element, *bls12381fr.Element](
+			n, eta, gamma, mu, nu, aCoeffs, u, rp.Curve)
+	} else if isBN254 {
+		lf, _, lVal = nativeRPBuildLF[bn254fr.Element, *bn254fr.Element](
+			n, eta, gamma, mu, nu, aCoeffs, u, rp.Curve)
+	} else {
+		gammaSquare := rp.Curve.ModMul(gamma, gamma, rp.Curve.GroupOrder)
+		lf = make([]*mathlib.Zr, len(pExt))
+		for i := range lf {
+			lf[i] = math.Zero(rp.Curve)
+		}
+		// L1 contribution1s.
+		for i := uint64(1); i <= n; i++ {
+			lf[i] = rp.Curve.ModMul(eta, math.PowerOfTwo(rp.Curve, i-1), rp.Curve.GroupOrder)
+		}
+		negEta := eta.Copy()
+		negEta.Neg()
+		lf[2*n+2] = negEta
+		// L2 contributions: add gamma*mu[i] at positions 0..n.
+		for i := uint64(0); i <= n; i++ {
+			lf[i] = rp.Curve.ModAddMul2(
+				lf[i], math.One(rp.Curve),
+				gamma, mu[i],
+				rp.Curve.GroupOrder,
+			)
+		}
+		// L3 contributions: gamma^2*nu[k] at positions n+1..2n+1.
+		for k := uint64(0); k <= n; k++ {
+			lf[n+1+k] = rp.Curve.ModMul(gammaSquare, nu[k], rp.Curve.GroupOrder)
+		}
+
+		// Claimed value: lVal = gamma*u + gamma^2*u*(u-1)  (L1(pExt)=0 for honest prover).
+		uMinus1 := rp.Curve.ModSub(u, math.One(rp.Curve), rp.Curve.GroupOrder)
+		lVal = rp.Curve.ModAddMul2(
+			gamma, u,
+			gammaSquare, rp.Curve.ModMul(u, uMinus1, rp.Curve.GroupOrder),
 			rp.Curve.GroupOrder,
 		)
 	}
-	// L3 contributions: gamma^2*nu[k] at positions n+1..2n+1.
-	for k := uint64(0); k <= n; k++ {
-		lf[n+1+k] = rp.Curve.ModMul(gammaSquare, nu[k], rp.Curve.GroupOrder)
-	}
-
-	// Claimed value: lVal = gamma*u + gamma^2*u*(u-1)  (L1(pExt)=0 for honest prover).
-	uMinus1 := rp.Curve.ModSub(u, math.One(rp.Curve), rp.Curve.GroupOrder)
-	lVal := rp.Curve.ModAddMul2(
-		gamma, u,
-		gammaSquare, rp.Curve.ModMul(u, uMinus1, rp.Curve.GroupOrder),
-		rp.Curve.GroupOrder,
-	)
 
 	// ZK blinding: random sBlind, commit it, evaluate L on it.
 	sBlind := make([]*mathlib.Zr, len(pExt))
@@ -345,7 +370,15 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 		sBlind[i] = rp.Curve.NewRandomZr(rand)
 	}
 	sComm := rp.Curve.MultiScalarMul(gExt, sBlind)
-	sVal := math.InnerProduct(lf, sBlind, rp.Curve)
+	// Compute sVal = ⟨lf, sBlind⟩ — dispatch to native for supported curves.
+	var sVal *mathlib.Zr
+	if isBLS {
+		sVal = nativeRPInnerProduct[bls12381fr.Element, *bls12381fr.Element](lf, sBlind, rp.Curve)
+	} else if isBN254 {
+		sVal = nativeRPInnerProduct[bn254fr.Element, *bn254fr.Element](lf, sBlind, rp.Curve)
+	} else {
+		sVal = math.InnerProduct(lf, sBlind, rp.Curve)
+	}
 	tr.Absorb(sComm.Bytes())
 	tr.Absorb(sVal.Bytes())
 
@@ -354,33 +387,34 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 		return nil, errors.New("Unable to obtain challenge rho")
 	}
 
-	// Blinded witness: wit = pExt + rho*sBlind  so that
-	//   MSM(gExt, wit) = pCommExt + rho*sComm
-	//   L(wit)         = lVal + rho*sVal
-	wit := make([]*mathlib.Zr, len(pExt))
-	for i := range pExt {
-		wit[i] = rp.Curve.ModAddMul2(
-			pExt[i], math.One(rp.Curve),
-			rho, sBlind[i],
+	// Compute wit and witVal — dispatch to native for supported curves.
+	var wit []*mathlib.Zr
+	var witVal *mathlib.Zr
+	if isBLS {
+		wit, witVal = nativeRPBlindWitness[bls12381fr.Element, *bls12381fr.Element](
+			sBlind, pExt, rho, lVal, sVal, rp.Curve)
+	} else if isBN254 {
+		wit, witVal = nativeRPBlindWitness[bn254fr.Element, *bn254fr.Element](
+			sBlind, pExt, rho, lVal, sVal, rp.Curve)
+	} else {
+		wit = make([]*mathlib.Zr, len(pExt))
+		for i := range pExt {
+			wit[i] = rp.Curve.ModAddMul2(
+				pExt[i], math.One(rp.Curve),
+				rho, sBlind[i],
+				rp.Curve.GroupOrder,
+			)
+		}
+		witVal = rp.Curve.ModAddMul2(
+			lVal, math.One(rp.Curve),
+			rho, sVal,
 			rp.Curve.GroupOrder,
 		)
 	}
 	witComm := pCommExt.Copy()
 	witComm.Add(sComm.Mul(rho))
-	witVal := rp.Curve.ModAddMul2(
-		lVal, math.One(rp.Curve),
-		rho, sVal,
-		rp.Curve.GroupOrder,
-	)
 
 	// Pad witness / generators / linear form to the next power of 2 for CSP.
-	witSize := uint64(len(wit))
-	cspRounds := uint64(0)
-	paddedSize := uint64(1)
-	for paddedSize < witSize {
-		paddedSize <<= 1
-		cspRounds++
-	}
 	for uint64(len(wit)) < paddedSize {
 		wit = append(wit, math.Zero(rp.Curve))
 		gExt = append(gExt, rp.Curve.GenG1)

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_native.go
@@ -1,0 +1,190 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	mathlib "github.com/IBM/mathlib"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
+)
+
+// nativeRPBuildLF constructs the aggregated linear form lf = L1 + gamma·L2 + gamma²·L3,
+// computes u (either from aCoeffs for the prover or directly from proofU for the verifier),
+// and evaluates lVal = gamma·u + gamma²·u·(u-1).
+//
+// All O(n) scalar multiplications and additions run in native gnark Montgomery form,
+// avoiding big.Int round-trips through mathlib.Zr.
+//
+// Parameters:
+//   - n: number of bits (NumberOfBits)
+//   - eta, gamma: Fiat-Shamir challenges
+//   - mu: Lagrange multipliers over {0,...,n} (length n+1)
+//   - nu: partial Lagrange multipliers over {0, n+1,...,2n} (length n+1)
+//   - aCoeffs: polynomial coefficients (length n+1), non-nil for prover
+//   - proofU: evaluator's claimed u value, non-nil for verifier
+//   - paddedSize: total size of the extended generator/lf vector (≥ 2n+4)
+//   - curve: the mathematical curve
+//
+// Returns:
+//   - lf: the aggregated linear form vector of length paddedSize (padded with zeros)
+//   - u: prover evaluation a(c) or verifier's proof.u
+//   - lVal: gamma·u + gamma²·u·(u-1)
+func nativeRPBuildLF[T any, E math2.GnarkFr[T]](
+	n uint64,
+	eta, gamma *mathlib.Zr,
+	mu, nu []*mathlib.Zr,
+	aCoeffs []*mathlib.Zr, // non-nil for prover
+	proofU *mathlib.Zr, // non-nil for verifier
+	curve *mathlib.Curve,
+) ([]*mathlib.Zr, *mathlib.Zr, *mathlib.Zr) {
+	// Convert challenges to native form once.
+	etaE := math2.NativeFromZr[T, E](eta)
+	gammaE := math2.NativeFromZr[T, E](gamma)
+	var gammaSqE T
+	E(&gammaSqE).Mul(gammaE, gammaE)
+
+	// Convert mu and nu to native form.
+	muE := make([]T, n+1)
+	for i := uint64(0); i <= n; i++ {
+		math2.SetNativeFromZr[T, E](mu[i], E(&muE[i]))
+	}
+	nuE := make([]T, n+1)
+	for i := uint64(0); i <= n; i++ {
+		math2.SetNativeFromZr[T, E](nu[i], E(&nuE[i]))
+	}
+
+	// Build lf in native form (size 2n+4, then pad to paddedSize).
+	lfSize := 2*n + 4
+	lfE := make([]T, lfSize)
+
+	// lf[0] = zero initially (will be updated by L2)
+	// lf[i] for i=1..n: L1 contribution = eta * 2^{i-1}
+	var twoE T
+	E(&twoE).SetInt64(2)
+	var powE T
+	E(&powE).SetOne() // 2^0 = 1
+
+	for i := uint64(1); i <= n; i++ {
+		E(&lfE[i]).Mul(etaE, E(&powE))
+		E(&powE).Mul(E(&powE), E(&twoE))
+	}
+
+	// lf[2n+2] = -eta
+	var negEtaE T
+	E(&negEtaE).SetZero()
+	E(&negEtaE).Sub(E(&negEtaE), etaE)
+	lfE[2*n+2] = negEtaE
+
+	// L2 contributions: lf[i] += gamma * mu[i] for i=0..n
+	var tmpE T
+	for i := uint64(0); i <= n; i++ {
+		E(&tmpE).Mul(gammaE, E(&muE[i]))
+		E(&lfE[i]).Add(E(&lfE[i]), E(&tmpE))
+	}
+
+	// L3 contributions: lf[n+1+k] = gamma^2 * nu[k] for k=0..n
+	for k := uint64(0); k <= n; k++ {
+		E(&lfE[n+1+k]).Mul(E(&gammaSqE), E(&nuE[k]))
+	}
+
+	// Convert lf to mathlib.Zr.
+	lf := make([]*mathlib.Zr, lfSize)
+	for i := range lfSize {
+		lf[i] = math2.NativeToZr[T, E](E(&lfE[i]), curve)
+	}
+
+	// Compute u: either from aCoeffs (prover) or proofU (verifier).
+	var uE T
+	if aCoeffs != nil {
+		// u = <aCoeffs, mu> via native inner product
+		E(&uE).SetZero()
+		for i := uint64(0); i <= n; i++ {
+			var aE T
+			math2.SetNativeFromZr[T, E](aCoeffs[i], E(&aE))
+			E(&tmpE).Mul(E(&aE), E(&muE[i]))
+			E(&uE).Add(E(&uE), E(&tmpE))
+		}
+	} else {
+		math2.SetNativeFromZr[T, E](proofU, E(&uE))
+	}
+	u := math2.NativeToZr[T, E](E(&uE), curve)
+
+	// lVal = gamma * u + gamma^2 * u * (u - 1)
+	var oneE T
+	E(&oneE).SetOne()
+	var uMinus1E T
+	E(&uMinus1E).Sub(E(&uE), E(&oneE))
+
+	var lValE T
+	E(&lValE).Mul(gammaE, E(&uE))        // gamma * u
+	E(&tmpE).Mul(E(&uE), E(&uMinus1E))   // u * (u-1)
+	E(&tmpE).Mul(E(&gammaSqE), E(&tmpE)) // gamma^2 * u * (u-1)
+	E(&lValE).Add(E(&lValE), E(&tmpE))   // gamma*u + gamma^2*u*(u-1)
+	lVal := math2.NativeToZr[T, E](E(&lValE), curve)
+
+	return lf, u, lVal
+}
+
+// nativeRPInnerProduct computes the inner product ⟨lf, sBlind⟩ using native gnark
+// arithmetic. Called before rho is available.
+func nativeRPInnerProduct[T any, E math2.GnarkFr[T]](
+	lf, sBlind []*mathlib.Zr,
+	curve *mathlib.Curve,
+) *mathlib.Zr {
+	m := len(lf)
+
+	var sValE T
+	E(&sValE).SetZero()
+	var tmpE, lfI, sbI T
+	for i := range m {
+		math2.SetNativeFromZr[T, E](lf[i], E(&lfI))
+		math2.SetNativeFromZr[T, E](sBlind[i], E(&sbI))
+		E(&tmpE).Mul(E(&lfI), E(&sbI))
+		E(&sValE).Add(E(&sValE), E(&tmpE))
+	}
+
+	return math2.NativeToZr[T, E](E(&sValE), curve)
+}
+
+// nativeRPBlindWitness computes the blinded witness and evaluation after rho is known:
+//   - wit[i] = pExt[i] + rho · sBlind[i]  (nil if sBlind is nil, e.g. for verifier)
+//   - witVal  = lVal    + rho · sVal
+//
+// All scalar arithmetic runs in native gnark Montgomery form.
+// When called from the verifier, sBlind and pExt may be nil; in that case only
+// witVal is computed and wit is returned as nil.
+func nativeRPBlindWitness[T any, E math2.GnarkFr[T]](
+	sBlind, pExt []*mathlib.Zr,
+	rho, lVal, sVal *mathlib.Zr,
+	curve *mathlib.Curve,
+) ([]*mathlib.Zr, *mathlib.Zr) {
+	rhoE := math2.NativeFromZr[T, E](rho)
+
+	// wit[i] = pExt[i] + rho * sBlind[i] — skipped when called from verifier.
+	var wit []*mathlib.Zr
+	if sBlind != nil && pExt != nil {
+		m := len(pExt)
+		wit = make([]*mathlib.Zr, m)
+		var tmpE, sbI, pI T
+		for i := range m {
+			math2.SetNativeFromZr[T, E](sBlind[i], E(&sbI))
+			math2.SetNativeFromZr[T, E](pExt[i], E(&pI))
+			E(&tmpE).Mul(rhoE, E(&sbI))
+			E(&tmpE).Add(E(&pI), E(&tmpE))
+			wit[i] = math2.NativeToZr[T, E](E(&tmpE), curve)
+		}
+	}
+
+	// witVal = lVal + rho * sVal
+	lValE := math2.NativeFromZr[T, E](lVal)
+	sValE := math2.NativeFromZr[T, E](sVal)
+	var witValE T
+	E(&witValE).Mul(rhoE, sValE)
+	E(&witValE).Add(lValE, E(&witValE))
+	witVal := math2.NativeToZr[T, E](E(&witValE), curve)
+
+	return wit, witVal
+}


### PR DESCRIPTION
closes #1675

## Description

Currently, the CSP Range Proof generation (`Prove` function in `rp.go`) heavily relies on `mathlib.Zr` scalar operations for building linear forms, computing inner products, and generating blinded witnesses. Because `mathlib` wraps `gnark-crypto`, every scalar multiplication or addition executed in these O(n) loops requires `big.Int` object allocations and round-trip conversions.

This PR bypasses the `mathlib.Zr` abstraction during the heaviest cryptographic loops in the Prover, dispatching directly to the underlying `gnark-crypto` Montgomery form arithmetic for supported curves (`BN254` and `BLS12-381`). 

## Changes

1. **Introduced Native Prover Primitives (`rp_native.go`)**: 
   - `nativeRPBuildLF`: Constructs the aggregated linear form natively.
   - `nativeRPInnerProduct`: Computes inner products natively.
   - `nativeRPBlindWitness`: Computes the blinded witness and evaluations using native field arithmetic.
2. **Updated Prover Logic (`rp.go`)**: Modified the CSP prover to check for curve compatibility via `math.DispatchCurve` and route the heavy $O(n)$ allocations to the new native functions.
3. **Scoped Strictly to the Prover**: Kept the `verifier` and `csp.go` entirely untouched to preserve current validation stability. 

## Benchmarks

I ran the `TestParallelBFProver` for the csp range proof process and got the following results:

- ### Before:

```
go test -v ./token/core/zkatdlog/nogh/v1/crypto/rp/csp/... -run TestParallelBFProver -count=1
=== RUN   TestParallelBFProver
=== RUN   TestParallelBFProver/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_16_workers
Metric           Value     Description
------           -----     -----------
Workers          16        
Total Ops        553       (Low Sample Size)
Duration         1.015s    (Good Duration)
Real Throughput  544.58/s  Observed Ops/sec (Wall Clock)
Pure Throughput  555.92/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           15.956174ms  
 P50 (Median)  28.54867ms   
 Average       28.781021ms  
 P95           35.493159ms  
 P99           38.997791ms  
 P99.9         43.633265ms  
 Max           47.084761ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.892847ms  
 IQR      5.09145ms   Interquartile Range
 Jitter   4.209978ms  Avg delta per worker
 CV       13.53%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%          (100% Success) (0 errors)
 Memory              1293899 B/op     Allocated bytes per operation
 Allocs              14151 allocs/op  Allocations per operation
 Alloc Rate          658.73 MB/s      Memory pressure on system
 GC Overhead         8.67%            (Severe GC Thrashing)
 GC Pause            87.991197ms      Total Stop-The-World time
 GC Cycles           201              Full garbage collection cycles
 Goroutines Created  0                Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 15.956174ms-16.843267ms  2      (0.4%)
 18.768151ms-19.811578ms  3     █ (0.5%)
 19.811578ms-20.913015ms  1      (0.2%)
 20.913015ms-22.075687ms  9     ███ (1.6%)
 22.075687ms-23.302999ms  19    ████████ (3.4%)
 23.302999ms-24.598544ms  39    █████████████████ (7.1%)
 24.598544ms-25.966115ms  60    ██████████████████████████ (10.8%)
 25.966115ms-27.409717ms  77    █████████████████████████████████ (13.9%)
 27.409717ms-28.933578ms  91    ████████████████████████████████████████ (16.5%)
 28.933578ms-30.542158ms  80    ███████████████████████████████████ (14.5%)
 30.542158ms-32.240168ms  81    ███████████████████████████████████ (14.6%)
 32.240168ms-34.032581ms  40    █████████████████ (7.2%)
 34.032581ms-35.924643ms  29    ████████████ (5.2%)
 35.924643ms-37.921896ms  11    ████ (2.0%)
 37.921896ms-40.030187ms  8     ███ (1.4%)
 40.030187ms-42.255691ms  2      (0.4%)
 44.604922ms-47.084761ms  1      (0.2%)

--- Analysis & Recommendations ---
[WARN] Low sample size (553). Results may not be statistically significant. Run for longer.
[INFO] High Allocations (14151/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------
--- PASS: TestParallelBFProver (4.18s)
    --- PASS: TestParallelBFProver/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_16_workers (4.18s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/csp  4.207s
```

- ### After:

```
go test -v ./token/core/zkatdlog/nogh/v1/crypto/rp/csp/... -run TestParallelBFProver -count=1
=== RUN   TestParallelBFProver
=== RUN   TestParallelBFProver/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_16_workers
Metric           Value     Description
------           -----     -----------
Workers          16        
Total Ops        559       (Low Sample Size)
Duration         1.016s    (Good Duration)
Real Throughput  550.20/s  Observed Ops/sec (Wall Clock)
Pure Throughput  562.28/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           18.039946ms  
 P50 (Median)  28.389763ms  
 Average       28.455781ms  
 P95           34.418849ms  
 P99           37.613913ms  
 P99.9         38.956758ms  
 Max           39.794254ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.334132ms  
 IQR      4.167685ms  Interquartile Range
 Jitter   3.722971ms  Avg delta per worker
 CV       11.72%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%          (100% Success) (0 errors)
 Memory              1214220 B/op     Allocated bytes per operation
 Allocs              13166 allocs/op  Allocations per operation
 Alloc Rate          626.96 MB/s      Memory pressure on system
 GC Overhead         8.42%            (Severe GC Thrashing)
 GC Pause            85.517627ms      Total Stop-The-World time
 GC Cycles           201              Full garbage collection cycles
 Goroutines Created  50               Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 18.039946ms-18.767848ms  1      (0.2%)
 18.767848ms-19.525121ms  1      (0.2%)
 19.525121ms-20.31295ms   1      (0.2%)
 20.31295ms-21.132567ms   7     ███ (1.3%)
 21.132567ms-21.985255ms  6     ██ (1.1%)
 21.985255ms-22.872349ms  8     ███ (1.4%)
 22.872349ms-23.795236ms  21    █████████ (3.8%)
 23.795236ms-24.755362ms  21    █████████ (3.8%)
 24.755362ms-25.754228ms  43    ████████████████████ (7.7%)
 25.754228ms-26.793398ms  62    █████████████████████████████ (11.1%)
 26.793398ms-27.874498ms  69    ████████████████████████████████ (12.3%)
 27.874498ms-28.999219ms  85    ████████████████████████████████████████ (15.2%)
 28.999219ms-30.169323ms  73    ██████████████████████████████████ (13.1%)
 30.169323ms-31.38664ms   66    ███████████████████████████████ (11.8%)
 31.38664ms-32.653074ms   46    █████████████████████ (8.2%)
 32.653074ms-33.970609ms  20    █████████ (3.6%)
 33.970609ms-35.341306ms  14    ██████ (2.5%)
 35.341306ms-36.767309ms  7     ███ (1.3%)
 36.767309ms-38.250851ms  6     ██ (1.1%)
 38.250851ms-39.794254ms  2      (0.4%)

--- Analysis & Recommendations ---
[WARN] Low sample size (559). Results may not be statistically significant. Run for longer.
[INFO] High Allocations (13166/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------
--- PASS: TestParallelBFProver (4.19s)
    --- PASS: TestParallelBFProver/Setup(bits_32,_curve_BN254,_#i_2,_#o_2)_with_16_workers (4.19s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/csp  4.216s
```

We can observe that the `allocs/op` number went down from **14151** to **13166**, a total of **985** allocs(~**7%** decrease)
the other metrics remain stable with no visible regression

Let me know if this is good 🙏 