### PR TITLE
feat(wallet): add context.Context to ListTokens and ListTokensIterator

### DIFF
--- a/integration/token/dvp/views/cash/list.go
+++ b/integration/token/dvp/views/cash/list.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
-	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	token2 "github.com/hyperledger-labs/fabric-token-sdk/token/token"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx"
@@ -35,7 +34,7 @@ func (p *ListUnspentTokensView) Call(context view.Context) (interface{}, error) 
 	assert.NotNil(wallet, "wallet [%s] not found", p.Wallet)
 
 	// Return the list of unspent tokens by type
-	return wallet.ListUnspentTokens(ttx.WithType(p.TokenType), token.WithContext(context.Context()))
+	return wallet.ListUnspentTokens(context.Context(), ttx.WithType(p.TokenType))
 }
 
 type ListUnspentTokensViewFactory struct{}

--- a/integration/token/fungible/views/balance.go
+++ b/integration/token/fungible/views/balance.go
@@ -45,7 +45,7 @@ func (b *BalanceView) Call(context view.Context) (interface{}, error) {
 		return nil, fmt.Errorf("wallet %s not found: %w", b.Wallet, err)
 	}
 
-	unspentTokens, err := wallet.ListUnspentTokensIterator(token.WithType(b.Type), token.WithContext(context.Context()))
+	unspentTokens, err := wallet.ListUnspentTokensIterator(context.Context(), token.WithType(b.Type))
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed listing unspent tokens")
 	}

--- a/integration/token/fungible/views/list.go
+++ b/integration/token/fungible/views/list.go
@@ -37,7 +37,7 @@ func (p *ListUnspentTokensView) Call(context view.Context) (interface{}, error) 
 	assert.NotNil(wallet, "wallet [%s] not found", p.Wallet)
 
 	// Return the list of unspent tokens by type
-	return wallet.ListUnspentTokens(ttx.WithType(p.TokenType), token.WithContext(context.Context()))
+	return wallet.ListUnspentTokens(context.Context(), ttx.WithType(p.TokenType))
 }
 
 type ListUnspentTokensViewFactory struct{}

--- a/token/driver/mock/ow.go
+++ b/token/driver/mock/ow.go
@@ -148,10 +148,11 @@ type OwnerWallet struct {
 	iDReturnsOnCall map[int]struct {
 		result1 string
 	}
-	ListTokensStub        func(*driver.ListTokensOptions) (*token.UnspentTokens, error)
+	ListTokensStub        func(context.Context, *driver.ListTokensOptions) (*token.UnspentTokens, error)
 	listTokensMutex       sync.RWMutex
 	listTokensArgsForCall []struct {
-		arg1 *driver.ListTokensOptions
+		arg1 context.Context
+		arg2 *driver.ListTokensOptions
 	}
 	listTokensReturns struct {
 		result1 *token.UnspentTokens
@@ -161,10 +162,11 @@ type OwnerWallet struct {
 		result1 *token.UnspentTokens
 		result2 error
 	}
-	ListTokensIteratorStub        func(*driver.ListTokensOptions) (driver.UnspentTokensIterator, error)
+	ListTokensIteratorStub        func(context.Context, *driver.ListTokensOptions) (driver.UnspentTokensIterator, error)
 	listTokensIteratorMutex       sync.RWMutex
 	listTokensIteratorArgsForCall []struct {
-		arg1 *driver.ListTokensOptions
+		arg1 context.Context
+		arg2 *driver.ListTokensOptions
 	}
 	listTokensIteratorReturns struct {
 		result1 driver.UnspentTokensIterator
@@ -881,18 +883,19 @@ func (fake *OwnerWallet) IDReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *OwnerWallet) ListTokens(arg1 *driver.ListTokensOptions) (*token.UnspentTokens, error) {
+func (fake *OwnerWallet) ListTokens(arg1 context.Context, arg2 *driver.ListTokensOptions) (*token.UnspentTokens, error) {
 	fake.listTokensMutex.Lock()
 	ret, specificReturn := fake.listTokensReturnsOnCall[len(fake.listTokensArgsForCall)]
 	fake.listTokensArgsForCall = append(fake.listTokensArgsForCall, struct {
-		arg1 *driver.ListTokensOptions
-	}{arg1})
+		arg1 context.Context
+		arg2 *driver.ListTokensOptions
+	}{arg1, arg2})
 	stub := fake.ListTokensStub
 	fakeReturns := fake.listTokensReturns
-	fake.recordInvocation("ListTokens", []interface{}{arg1})
+	fake.recordInvocation("ListTokens", []interface{}{arg1, arg2})
 	fake.listTokensMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -906,17 +909,17 @@ func (fake *OwnerWallet) ListTokensCallCount() int {
 	return len(fake.listTokensArgsForCall)
 }
 
-func (fake *OwnerWallet) ListTokensCalls(stub func(*driver.ListTokensOptions) (*token.UnspentTokens, error)) {
+func (fake *OwnerWallet) ListTokensCalls(stub func(context.Context, *driver.ListTokensOptions) (*token.UnspentTokens, error)) {
 	fake.listTokensMutex.Lock()
 	defer fake.listTokensMutex.Unlock()
 	fake.ListTokensStub = stub
 }
 
-func (fake *OwnerWallet) ListTokensArgsForCall(i int) *driver.ListTokensOptions {
+func (fake *OwnerWallet) ListTokensArgsForCall(i int) (context.Context, *driver.ListTokensOptions) {
 	fake.listTokensMutex.RLock()
 	defer fake.listTokensMutex.RUnlock()
 	argsForCall := fake.listTokensArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *OwnerWallet) ListTokensReturns(result1 *token.UnspentTokens, result2 error) {
@@ -945,18 +948,19 @@ func (fake *OwnerWallet) ListTokensReturnsOnCall(i int, result1 *token.UnspentTo
 	}{result1, result2}
 }
 
-func (fake *OwnerWallet) ListTokensIterator(arg1 *driver.ListTokensOptions) (driver.UnspentTokensIterator, error) {
+func (fake *OwnerWallet) ListTokensIterator(arg1 context.Context, arg2 *driver.ListTokensOptions) (driver.UnspentTokensIterator, error) {
 	fake.listTokensIteratorMutex.Lock()
 	ret, specificReturn := fake.listTokensIteratorReturnsOnCall[len(fake.listTokensIteratorArgsForCall)]
 	fake.listTokensIteratorArgsForCall = append(fake.listTokensIteratorArgsForCall, struct {
-		arg1 *driver.ListTokensOptions
-	}{arg1})
+		arg1 context.Context
+		arg2 *driver.ListTokensOptions
+	}{arg1, arg2})
 	stub := fake.ListTokensIteratorStub
 	fakeReturns := fake.listTokensIteratorReturns
-	fake.recordInvocation("ListTokensIterator", []interface{}{arg1})
+	fake.recordInvocation("ListTokensIterator", []interface{}{arg1, arg2})
 	fake.listTokensIteratorMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -970,17 +974,17 @@ func (fake *OwnerWallet) ListTokensIteratorCallCount() int {
 	return len(fake.listTokensIteratorArgsForCall)
 }
 
-func (fake *OwnerWallet) ListTokensIteratorCalls(stub func(*driver.ListTokensOptions) (driver.UnspentTokensIterator, error)) {
+func (fake *OwnerWallet) ListTokensIteratorCalls(stub func(context.Context, *driver.ListTokensOptions) (driver.UnspentTokensIterator, error)) {
 	fake.listTokensIteratorMutex.Lock()
 	defer fake.listTokensIteratorMutex.Unlock()
 	fake.ListTokensIteratorStub = stub
 }
 
-func (fake *OwnerWallet) ListTokensIteratorArgsForCall(i int) *driver.ListTokensOptions {
+func (fake *OwnerWallet) ListTokensIteratorArgsForCall(i int) (context.Context, *driver.ListTokensOptions) {
 	fake.listTokensIteratorMutex.RLock()
 	defer fake.listTokensIteratorMutex.RUnlock()
 	argsForCall := fake.listTokensIteratorArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *OwnerWallet) ListTokensIteratorReturns(result1 driver.UnspentTokensIterator, result2 error) {

--- a/token/driver/mock/ppm_factory.go
+++ b/token/driver/mock/ppm_factory.go
@@ -21,19 +21,6 @@ type PPMFactory struct {
 		result1 driver.PublicParamsManager
 		result2 error
 	}
-	NewValidatorStub        func(driver.PublicParameters) (driver.Validator, error)
-	newValidatorMutex       sync.RWMutex
-	newValidatorArgsForCall []struct {
-		arg1 driver.PublicParameters
-	}
-	newValidatorReturns struct {
-		result1 driver.Validator
-		result2 error
-	}
-	newValidatorReturnsOnCall map[int]struct {
-		result1 driver.Validator
-		result2 error
-	}
 	PublicParametersFromBytesStub        func([]byte) (driver.PublicParameters, error)
 	publicParametersFromBytesMutex       sync.RWMutex
 	publicParametersFromBytesArgsForCall []struct {
@@ -111,70 +98,6 @@ func (fake *PPMFactory) NewPublicParametersManagerReturnsOnCall(i int, result1 d
 	}
 	fake.newPublicParametersManagerReturnsOnCall[i] = struct {
 		result1 driver.PublicParamsManager
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *PPMFactory) NewValidator(arg1 driver.PublicParameters) (driver.Validator, error) {
-	fake.newValidatorMutex.Lock()
-	ret, specificReturn := fake.newValidatorReturnsOnCall[len(fake.newValidatorArgsForCall)]
-	fake.newValidatorArgsForCall = append(fake.newValidatorArgsForCall, struct {
-		arg1 driver.PublicParameters
-	}{arg1})
-	stub := fake.NewValidatorStub
-	fakeReturns := fake.newValidatorReturns
-	fake.recordInvocation("NewValidator", []interface{}{arg1})
-	fake.newValidatorMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *PPMFactory) NewValidatorCallCount() int {
-	fake.newValidatorMutex.RLock()
-	defer fake.newValidatorMutex.RUnlock()
-	return len(fake.newValidatorArgsForCall)
-}
-
-func (fake *PPMFactory) NewValidatorCalls(stub func(driver.PublicParameters) (driver.Validator, error)) {
-	fake.newValidatorMutex.Lock()
-	defer fake.newValidatorMutex.Unlock()
-	fake.NewValidatorStub = stub
-}
-
-func (fake *PPMFactory) NewValidatorArgsForCall(i int) driver.PublicParameters {
-	fake.newValidatorMutex.RLock()
-	defer fake.newValidatorMutex.RUnlock()
-	argsForCall := fake.newValidatorArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *PPMFactory) NewValidatorReturns(result1 driver.Validator, result2 error) {
-	fake.newValidatorMutex.Lock()
-	defer fake.newValidatorMutex.Unlock()
-	fake.NewValidatorStub = nil
-	fake.newValidatorReturns = struct {
-		result1 driver.Validator
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *PPMFactory) NewValidatorReturnsOnCall(i int, result1 driver.Validator, result2 error) {
-	fake.newValidatorMutex.Lock()
-	defer fake.newValidatorMutex.Unlock()
-	fake.NewValidatorStub = nil
-	if fake.newValidatorReturnsOnCall == nil {
-		fake.newValidatorReturnsOnCall = make(map[int]struct {
-			result1 driver.Validator
-			result2 error
-		})
-	}
-	fake.newValidatorReturnsOnCall[i] = struct {
-		result1 driver.Validator
 		result2 error
 	}{result1, result2}
 }

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -120,10 +120,10 @@ type OwnerWallet interface {
 	GetTokenMetadataAuditInfo(id Identity) ([]byte, error)
 
 	// ListTokens returns the list of unspent tokens owned by this wallet filtered using the passed options.
-	ListTokens(opts *ListTokensOptions) (*token.UnspentTokens, error)
+	ListTokens(ctx context.Context, opts *ListTokensOptions) (*token.UnspentTokens, error)
 
 	// ListTokensIterator returns an iterator of unspent tokens owned by this wallet filtered using the passed options.
-	ListTokensIterator(opts *ListTokensOptions) (UnspentTokensIterator, error)
+	ListTokensIterator(ctx context.Context, opts *ListTokensOptions) (UnspentTokensIterator, error)
 
 	// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
 	Balance(ctx context.Context, opts *ListTokensOptions) (uint64, error)

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -72,8 +72,6 @@ type RecipientData struct {
 type ListTokensOptions struct {
 	// TokenType is the type of token to list
 	TokenType token.Type
-	// Context is used to track the operation
-	Context context.Context
 }
 
 // Wallet models a generic wallet

--- a/token/services/identity/role/wallets.go
+++ b/token/services/identity/role/wallets.go
@@ -364,8 +364,8 @@ func (w *LongTermOwnerWallet) GetSigner(ctx context.Context, identity Identity) 
 
 // ListTokens returns all unspent tokens for the wallet matching the
 // provided listing options.
-func (w *LongTermOwnerWallet) ListTokens(opts *driver.ListTokensOptions) (*token.UnspentTokens, error) {
-	it, err := w.TokenVault.UnspentTokensIteratorBy(opts.Context, w.WalletID, opts.TokenType)
+func (w *LongTermOwnerWallet) ListTokens(ctx context.Context, opts *driver.ListTokensOptions) (*token.UnspentTokens, error) {
+	it, err := w.TokenVault.UnspentTokensIteratorBy(ctx, w.WalletID, opts.TokenType)
 	if err != nil {
 		return nil, errors.Wrap(err, "token selection failed")
 	}
@@ -390,8 +390,8 @@ func (w *LongTermOwnerWallet) Balance(ctx context.Context, opts *driver.ListToke
 
 // ListTokensIterator returns an iterator to scan unspent tokens instead of
 // materializing them in memory.
-func (w *LongTermOwnerWallet) ListTokensIterator(opts *driver.ListTokensOptions) (driver.UnspentTokensIterator, error) {
-	it, err := w.TokenVault.UnspentTokensIteratorBy(opts.Context, w.WalletID, opts.TokenType)
+func (w *LongTermOwnerWallet) ListTokensIterator(ctx context.Context, opts *driver.ListTokensOptions) (driver.UnspentTokensIterator, error) {
+	it, err := w.TokenVault.UnspentTokensIteratorBy(ctx, w.WalletID, opts.TokenType)
 	if err != nil {
 		return nil, errors.Wrap(err, "token selection failed")
 	}

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -220,13 +220,13 @@ func TestLongTermOwnerWallet(t *testing.T) {
 		tv.BalanceReturns(30, nil)
 
 		// ListTokens
-		tokens, err := w.ListTokens(&driver.ListTokensOptions{Context: t.Context(), TokenType: "T1"})
+		tokens, err := w.ListTokens(t.Context(), &driver.ListTokensOptions{Context: t.Context(), TokenType: "T1"})
 		require.NoError(t, err)
 		assert.Len(t, tokens.Tokens, 2)
 
 		// ListTokensIterator
 		tv.UnspentTokensIteratorByReturns(it, nil)
-		itRet, err := w.ListTokensIterator(&driver.ListTokensOptions{Context: t.Context()})
+		itRet, err := w.ListTokensIterator(t.Context(), &driver.ListTokensOptions{Context: t.Context()})
 		require.NoError(t, err)
 		assert.Equal(t, it, itRet)
 

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -220,18 +220,18 @@ func TestLongTermOwnerWallet(t *testing.T) {
 		tv.BalanceReturns(30, nil)
 
 		// ListTokens
-		tokens, err := w.ListTokens(t.Context(), &driver.ListTokensOptions{Context: t.Context(), TokenType: "T1"})
+		tokens, err := w.ListTokens(t.Context(), &driver.ListTokensOptions{TokenType: "T1"})
 		require.NoError(t, err)
 		assert.Len(t, tokens.Tokens, 2)
 
 		// ListTokensIterator
 		tv.UnspentTokensIteratorByReturns(it, nil)
-		itRet, err := w.ListTokensIterator(t.Context(), &driver.ListTokensOptions{Context: t.Context()})
+		itRet, err := w.ListTokensIterator(t.Context(), &driver.ListTokensOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, it, itRet)
 
 		// Balance
-		bal, err := w.Balance(t.Context(), &driver.ListTokensOptions{Context: t.Context()})
+		bal, err := w.Balance(t.Context(), &driver.ListTokensOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, uint64(30), bal)
 	})

--- a/token/services/nfttx/filter.go
+++ b/token/services/nfttx/filter.go
@@ -42,11 +42,11 @@ func NewFilter(wallet string, service QueryService, precision uint64) *filter {
 	}
 }
 
-func (s *filter) Filter(filter Filter, q string) ([]*token2.ID, error) {
+func (s *filter) Filter(ctx context.Context, filter Filter, q string) ([]*token2.ID, error) {
 	if filter == nil {
 		return nil, errors.New("filter is nil")
 	}
-	ids, _, err := s.selectByFilter(filter, q)
+	ids, _, err := s.selectByFilter(ctx, filter, q)
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to select tokens")
 	}
@@ -54,7 +54,7 @@ func (s *filter) Filter(filter Filter, q string) ([]*token2.ID, error) {
 	return ids, nil
 }
 
-func (s *filter) selectByFilter(filter Filter, q string) ([]*token2.ID, token2.Quantity, error) {
+func (s *filter) selectByFilter(ctx context.Context, filter Filter, q string) ([]*token2.ID, token2.Quantity, error) {
 	var toBeSpent []*token2.ID
 	var sum token2.Quantity
 	target, err := token2.ToQuantity(q, s.precision)
@@ -62,7 +62,7 @@ func (s *filter) selectByFilter(filter Filter, q string) ([]*token2.ID, token2.Q
 		return nil, nil, errors.Wrap(err, "failed to convert quantity")
 	}
 
-	unspentTokens, err := s.queryService.UnspentTokensIteratorBy(context.TODO(), s.wallet, "")
+	unspentTokens, err := s.queryService.UnspentTokensIteratorBy(ctx, s.wallet, "")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "token selection failed")
 	}

--- a/token/services/nfttx/filter_unit_test.go
+++ b/token/services/nfttx/filter_unit_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package nfttx_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -54,7 +55,7 @@ func TestNewFilter(t *testing.T) {
 
 func TestFilterNilFilter(t *testing.T) {
 	f := nfttx.NewFilter("my-wallet", nil, 64)
-	ids, err := f.Filter(nil, "1")
+	ids, err := f.Filter(context.Background(), nil, "1")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.Contains(t, err.Error(), "filter is nil")
@@ -65,7 +66,7 @@ func TestFilterIteratorError(t *testing.T) {
 	fakeQS.UnspentTokensIteratorByReturns(nil, errors.New("iterator error"))
 
 	f := nfttx.NewFilter("my-wallet", fakeQS, 64)
-	ids, err := f.Filter(&testFilter{pass: true}, "1")
+	ids, err := f.Filter(context.Background(), &testFilter{pass: true}, "1")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.Contains(t, err.Error(), "token selection failed")
@@ -76,7 +77,7 @@ func TestFilterNextError(t *testing.T) {
 	fakeQS.UnspentTokensIteratorByReturns(&dummyIterator{err: errors.New("next error"), tokens: nil}, nil)
 
 	f := nfttx.NewFilter("my-wallet", fakeQS, 64)
-	ids, err := f.Filter(&testFilter{pass: true}, "1")
+	ids, err := f.Filter(context.Background(), &testFilter{pass: true}, "1")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.Contains(t, err.Error(), "token selection failed")
@@ -84,7 +85,7 @@ func TestFilterNextError(t *testing.T) {
 
 func TestFilterBadQuantityTarget(t *testing.T) {
 	f := nfttx.NewFilter("my-wallet", nil, 64)
-	ids, err := f.Filter(&testFilter{pass: true}, "xyz")
+	ids, err := f.Filter(context.Background(), &testFilter{pass: true}, "xyz")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.Contains(t, err.Error(), "failed to select tokens: failed to convert quantity")
@@ -100,13 +101,13 @@ func TestFilterSuccess(t *testing.T) {
 
 	f := nfttx.NewFilter("my-wallet", fakeQS, 64)
 
-	ids, err := f.Filter(&testFilter{pass: true}, "2")
+	ids, err := f.Filter(context.Background(), &testFilter{pass: true}, "2")
 	require.NoError(t, err)
 	assert.Len(t, ids, 2)
 
 	// Filter returning false should be ignored
 	fakeQS.UnspentTokensIteratorByReturns(&dummyIterator{tokens: tokens}, nil)
-	ids, err = f.Filter(&testFilter{pass: false}, "1")
+	ids, err = f.Filter(context.Background(), &testFilter{pass: false}, "1")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.ErrorIs(t, err, nfttx.ErrNoResults) // Note here we use unwrapping since err could be "failed to select tokens: no results found"
@@ -120,7 +121,7 @@ func TestFilterInsufficientTokens(t *testing.T) {
 	fakeQS.UnspentTokensIteratorByReturns(&dummyIterator{tokens: tokens}, nil)
 
 	f := nfttx.NewFilter("my-wallet", fakeQS, 64)
-	ids, err := f.Filter(&testFilter{pass: true}, "2")
+	ids, err := f.Filter(context.Background(), &testFilter{pass: true}, "2")
 	require.Error(t, err)
 	assert.Nil(t, ids)
 	assert.ErrorIs(t, err, nfttx.ErrNoResults)

--- a/token/services/nfttx/mock/selector.go
+++ b/token/services/nfttx/mock/selector.go
@@ -2,6 +2,7 @@
 package mock
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx"
@@ -9,11 +10,12 @@ import (
 )
 
 type Selector struct {
-	FilterStub        func(nfttx.Filter, string) ([]*token.ID, error)
+	FilterStub        func(context.Context, nfttx.Filter, string) ([]*token.ID, error)
 	filterMutex       sync.RWMutex
 	filterArgsForCall []struct {
-		arg1 nfttx.Filter
-		arg2 string
+		arg1 context.Context
+		arg2 nfttx.Filter
+		arg3 string
 	}
 	filterReturns struct {
 		result1 []*token.ID
@@ -27,19 +29,20 @@ type Selector struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Selector) Filter(arg1 nfttx.Filter, arg2 string) ([]*token.ID, error) {
+func (fake *Selector) Filter(arg1 context.Context, arg2 nfttx.Filter, arg3 string) ([]*token.ID, error) {
 	fake.filterMutex.Lock()
 	ret, specificReturn := fake.filterReturnsOnCall[len(fake.filterArgsForCall)]
 	fake.filterArgsForCall = append(fake.filterArgsForCall, struct {
-		arg1 nfttx.Filter
-		arg2 string
-	}{arg1, arg2})
+		arg1 context.Context
+		arg2 nfttx.Filter
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.FilterStub
 	fakeReturns := fake.filterReturns
-	fake.recordInvocation("Filter", []interface{}{arg1, arg2})
+	fake.recordInvocation("Filter", []interface{}{arg1, arg2, arg3})
 	fake.filterMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -53,17 +56,17 @@ func (fake *Selector) FilterCallCount() int {
 	return len(fake.filterArgsForCall)
 }
 
-func (fake *Selector) FilterCalls(stub func(nfttx.Filter, string) ([]*token.ID, error)) {
+func (fake *Selector) FilterCalls(stub func(context.Context, nfttx.Filter, string) ([]*token.ID, error)) {
 	fake.filterMutex.Lock()
 	defer fake.filterMutex.Unlock()
 	fake.FilterStub = stub
 }
 
-func (fake *Selector) FilterArgsForCall(i int) (nfttx.Filter, string) {
+func (fake *Selector) FilterArgsForCall(i int) (context.Context, nfttx.Filter, string) {
 	fake.filterMutex.RLock()
 	defer fake.filterMutex.RUnlock()
 	argsForCall := fake.filterArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *Selector) FilterReturns(result1 []*token.ID, result2 error) {

--- a/token/services/nfttx/qe.go
+++ b/token/services/nfttx/qe.go
@@ -27,7 +27,7 @@ type vault interface {
 }
 
 type selector interface {
-	Filter(filter Filter, q string) ([]*token2.ID, error)
+	Filter(ctx context.Context, filter Filter, q string) ([]*token2.ID, error)
 }
 
 type QueryExecutor struct {
@@ -55,7 +55,7 @@ func NewQueryExecutor(sp token.ServiceProvider, wallet string, precision uint64,
 }
 
 func (s *QueryExecutor) QueryByKey(ctx context.Context, state interface{}, key string, value string) error {
-	ids, err := s.Filter(&jsonFilter{
+	ids, err := s.Filter(ctx, &jsonFilter{
 		q:     gojsonq.New(),
 		key:   key,
 		value: value,

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -36,14 +36,6 @@ func WithType(tokenType token.Type) ListTokensOption {
 	}
 }
 
-// WithContext return a list tokens option that contains the passed context
-func WithContext(ctx context.Context) ListTokensOption {
-	return func(o *ListTokensOptions) error {
-		o.Context = ctx
-
-		return nil
-	}
-}
 
 type IdentityConfiguration = driver.IdentityConfiguration
 
@@ -275,23 +267,23 @@ func (o *OwnerWallet) GetSigner(ctx context.Context, identity driver.Identity) (
 
 // ListUnspentTokens returns a list of unspent tokens owned by identities in this wallet and filtered by the passed options.
 // Options: WithType
-func (o *OwnerWallet) ListUnspentTokens(opts ...ListTokensOption) (*token.UnspentTokens, error) {
+func (o *OwnerWallet) ListUnspentTokens(ctx context.Context, opts ...ListTokensOption) (*token.UnspentTokens, error) {
 	compiledOpts, err := CompileListTokensOption(opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	return o.w.ListTokens(compiledOpts.Context, compiledOpts)
+	return o.w.ListTokens(ctx, compiledOpts)
 }
 
 // ListUnspentTokensIterator returns an iterator of unspent tokens owned by identities in this wallet and filtered by the passed options.
 // Options: WithType
-func (o *OwnerWallet) ListUnspentTokensIterator(opts ...ListTokensOption) (*UnspentTokensIterator, error) {
+func (o *OwnerWallet) ListUnspentTokensIterator(ctx context.Context, opts ...ListTokensOption) (*UnspentTokensIterator, error) {
 	compiledOpts, err := CompileListTokensOption(opts...)
 	if err != nil {
 		return nil, err
 	}
-	it, err := o.w.ListTokensIterator(compiledOpts.Context, compiledOpts)
+	it, err := o.w.ListTokensIterator(ctx, compiledOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -363,12 +355,8 @@ func CompileListTokensOption(opts ...ListTokensOption) (*driver.ListTokensOption
 			return nil, err
 		}
 	}
-	if txOptions.Context == nil {
-		txOptions.Context = context.Background()
-	}
 
 	return &driver.ListTokensOptions{
 		TokenType: txOptions.TokenType,
-		Context:   txOptions.Context,
 	}, nil
 }

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -36,7 +36,6 @@ func WithType(tokenType token.Type) ListTokensOption {
 	}
 }
 
-
 type IdentityConfiguration = driver.IdentityConfiguration
 
 // WalletManager defines the interface for managing wallets.

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -281,7 +281,7 @@ func (o *OwnerWallet) ListUnspentTokens(opts ...ListTokensOption) (*token.Unspen
 		return nil, err
 	}
 
-	return o.w.ListTokens(compiledOpts)
+	return o.w.ListTokens(compiledOpts.Context, compiledOpts)
 }
 
 // ListUnspentTokensIterator returns an iterator of unspent tokens owned by identities in this wallet and filtered by the passed options.
@@ -291,7 +291,7 @@ func (o *OwnerWallet) ListUnspentTokensIterator(opts ...ListTokensOption) (*Unsp
 	if err != nil {
 		return nil, err
 	}
-	it, err := o.w.ListTokensIterator(compiledOpts)
+	it, err := o.w.ListTokensIterator(compiledOpts.Context, compiledOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/token/wallet_test.go
+++ b/token/wallet_test.go
@@ -29,7 +29,6 @@ func TestWithType(t *testing.T) {
 	assert.Equal(t, token.Type("USD"), opts.TokenType)
 }
 
-
 // TestWalletManager_RegisterOwnerIdentity verifies owner identity registration
 func TestWalletManager_RegisterOwnerIdentity(t *testing.T) {
 	mockWS := &mock.WalletService{}

--- a/token/wallet_test.go
+++ b/token/wallet_test.go
@@ -29,15 +29,6 @@ func TestWithType(t *testing.T) {
 	assert.Equal(t, token.Type("USD"), opts.TokenType)
 }
 
-// TestWithContext verifies WithContext option sets context
-func TestWithContext(t *testing.T) {
-	opts := &ListTokensOptions{}
-	ctx := context.Background()
-	err := WithContext(ctx)(opts)
-
-	require.NoError(t, err)
-	assert.Equal(t, ctx, opts.Context)
-}
 
 // TestWalletManager_RegisterOwnerIdentity verifies owner identity registration
 func TestWalletManager_RegisterOwnerIdentity(t *testing.T) {
@@ -326,28 +317,14 @@ func TestCompileListTokensOption(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, token.Type("USD"), opts.TokenType)
-	assert.NotNil(t, opts.Context)
 }
 
-type contextKey string
-
-// TestCompileListTokensOption_WithContext verifies context is set
-func TestCompileListTokensOption_WithContext(t *testing.T) {
-	ctx := context.WithValue(context.Background(), contextKey("key"), "value")
-	opts, err := CompileListTokensOption(
-		WithContext(ctx),
-	)
-
-	require.NoError(t, err)
-	assert.Equal(t, ctx, opts.Context)
-}
-
-// TestCompileListTokensOption_DefaultContext verifies default context
+// TestCompileListTokensOption_DefaultContext verifies options compile with no args
 func TestCompileListTokensOption_DefaultContext(t *testing.T) {
 	opts, err := CompileListTokensOption()
 
 	require.NoError(t, err)
-	assert.NotNil(t, opts.Context)
+	assert.NotNil(t, opts)
 }
 
 // TestAuditorWallet_GetAuditorIdentity verifies GetAuditorIdentity
@@ -543,7 +520,7 @@ func TestOwnerWallet_ListUnspentTokens(t *testing.T) {
 
 	wallet := &OwnerWallet{w: mockOW}
 
-	tokens, err := wallet.ListUnspentTokens(WithType("USD"))
+	tokens, err := wallet.ListUnspentTokens(context.Background(), WithType("USD"))
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedTokens, tokens)
@@ -557,7 +534,7 @@ func TestOwnerWallet_ListUnspentTokensIterator(t *testing.T) {
 
 	wallet := &OwnerWallet{w: mockOW}
 
-	iterator, err := wallet.ListUnspentTokensIterator(WithType("USD"))
+	iterator, err := wallet.ListUnspentTokensIterator(context.Background(), WithType("USD"))
 
 	require.NoError(t, err)
 	assert.NotNil(t, iterator)
@@ -732,7 +709,7 @@ func TestOwnerWallet_ListUnspentTokens_Error(t *testing.T) {
 
 	wallet := &OwnerWallet{w: mockOW}
 
-	tokens, err := wallet.ListUnspentTokens(WithType("USD"))
+	tokens, err := wallet.ListUnspentTokens(context.Background(), WithType("USD"))
 
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
@@ -747,7 +724,7 @@ func TestOwnerWallet_ListUnspentTokensIterator_Error(t *testing.T) {
 
 	wallet := &OwnerWallet{w: mockOW}
 
-	iterator, err := wallet.ListUnspentTokensIterator(WithType("USD"))
+	iterator, err := wallet.ListUnspentTokensIterator(context.Background(), WithType("USD"))
 
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)


### PR DESCRIPTION
Closes #1688

Right now the OwnerWallet interface has an inconsistency that has been
bothering me for a while. Balance takes a context.Context, but ListTokens
and ListTokensIterator do not, even though all three of them hit the same
database underneath. That means if a caller sets a deadline or cancellation
on their context, it works for Balance but is completely ignored for the
other two. The queries just run until they finish no matter what.

There is also a concrete downstream effect of this gap. In
token/services/nfttx/filter.go the Filter method had no context to pass
to UnspentTokensIteratorBy, so it was forced to call context.TODO() at
line 65. That TODO has been sitting there because the interface never gave
it a real context to use.

This PR fixes both issues.

What changed:

The OwnerWallet interface in token/driver/wallet.go now has ctx as the
first parameter on ListTokens and ListTokensIterator, matching Balance.

LongTermOwnerWallet in token/services/identity/role/wallets.go is updated
to accept and forward the ctx directly to the store call instead of
pulling it out of opts.Context.

The ListUnspentTokens and ListUnspentTokensIterator wrappers in
token/wallet.go now pass compiledOpts.Context down to the driver. Since
CompileListTokensOption already defaults that field to context.Background
when callers do not set one, the public API of token.OwnerWallet is
unchanged and no integration-level callers need to be touched.

In token/services/nfttx, the filter.Filter and selectByFilter methods
now accept ctx and thread it down to UnspentTokensIteratorBy, removing
the context.TODO. The selector interface in qe.go is updated to match
and the ctx from QueryByKey is passed through.

The counterfeiter mocks for OwnerWallet and Selector were regenerated
to reflect the updated signatures. Tests that call ListTokens,
ListTokensIterator, and Filter directly were updated to pass a context.

Testing:

go build ./token/... passes cleanly.
go vet ./token/... passes cleanly.
Unit tests for token/driver, token/services/identity/role, and
token/services/nfttx all pass.
