### PR TITLE
feat: implement mkdocs scaffolding and github actions automation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: docs
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install mkdocs-material 
+      - run: mkdocs gh-deploy --force

--- a/Makefile
+++ b/Makefile
@@ -239,3 +239,15 @@ update-all-deps-latest: ## Update all dependencies in all Go modules to their la
 		echo "=> Updating dependencies in $$dir"; \
 		(cd $$dir && go get ./...@latest && go mod tidy); \
 	done
+
+
+.PHONY: docs-install docs-serve docs-build
+
+docs-install:
+	pip install mkdocs-material
+
+docs-serve:
+	mkdocs serve
+
+docs-build:
+	mkdocs build

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,21 @@
+site_name: Fabric Token SDK
+theme:
+  name: material
+  palette:
+    primary: indigo
+    accent: indigo
+  features:
+    - navigation.sections
+    - navigation.expand
+
+nav:
+  - Home: index.md
+  - Core Concepts:
+      - Overview: tokensdk.md
+      - Token API: tokenapi.md
+      - API Usage: token_sdk_usage.md
+      - Driver API: driverapi.md
+  - Development:
+      - Guidelines: development/general.md
+      - Testing: development/testing.md
+  - Evolution: evolution_summary.md


### PR DESCRIPTION
Hi @adecaro, as assigned in Issue #1656, I have implemented the documentation scaffolding.

Changes:

Added mkdocs.yml with Material theme.

Set up .github/workflows/docs.yml for automated deployment via GitHub Actions (using Python 3.12).

Updated Makefile with docs-install, docs-serve, and docs-build targets.

Initialized docs/index.md with the SDK overview.

Ready for review!