### PR TITLE
perf(bulletproof): optimize ComputeSVector with O(n) dual-butterfly recurrence

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
@@ -478,12 +478,29 @@ func CloneGenerators(LeftGenerators, RightGenerators []*mathlib.G1) ([]*mathlib.
 	return leftGen, rightGen
 }
 
-// ComputeSVector computes the s vector and its entry-wise inverse of s as detailed below:
-// b(i,j) = 1 if (logn - j)^{th} bit of i-1 is 1, else its -1
-// s[i] = \prod_{j=1}^{\log n} x_j^{bits(i,j)}
-// sInv[i] = s[i].Inverse
-// Input: n, challenges = [x_1,\ldots,x_{\log n}]
-// Returns (s, sInv) where sInv[i] = s[i]^{-1}, computed via batch inversion.
+// ComputeSVector computes the s vector and its entry-wise inverse using
+// a dual-butterfly (doubling) recurrence in O(n) multiplications.
+//
+// Each entry is defined as:
+//
+//	s[i] = ∏_{r=0}^{k-1} (bit(i, k-1-r) == 1 ? x_r : x_r^{-1})
+//	sInv[i] = s[i]^{-1}
+//
+// where k = log₂(n) and x_r = challenges[r].
+//
+// The butterfly builds both vectors simultaneously:
+//
+//	Round r: for each existing entry i in [0, 2^r):
+//	  s[i + 2^r]    = s[i]    · x_{k-1-r}        (bit set → challenge)
+//	  s[i]          = s[i]    · x_{k-1-r}^{-1}    (bit unset → inverse)
+//	  sInv[i + 2^r] = sInv[i] · x_{k-1-r}^{-1}   (swapped)
+//	  sInv[i]       = sInv[i] · x_{k-1-r}         (swapped)
+//
+// This replaces the previous O(n·log n) nested-loop implementation and
+// eliminates the final BatchInverse call for sInv.
+//
+// Input: n, challenges = [x_0, …, x_{k-1}] where n = 2^k.
+// Returns (s, sInv) where sInv[i] = s[i]^{-1}.
 func ComputeSVector(n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, []*mathlib.Zr) {
 	log2n := len(challenges)
 
@@ -492,40 +509,36 @@ func ComputeSVector(n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*m
 		panic("n must equal 2^(number of challenges)")
 	}
 
-	// Precompute challenge inverses (log2n inversions instead of O(n*log2n))
+	// Precompute challenge inverses: O(log n) with a single field inversion.
 	challengeInvs := math.BatchInverse(challenges, curve)
 
+	// Pre-allocate both vectors. Entries [1..n-1] are initialised to zero
+	// so that ModMulInPlace can write into them without prior allocation.
 	s := make([]*mathlib.Zr, n)
-
-	for i := 1; i <= n; i++ {
-		// Start with s_i = 1
-		si := math.One(curve)
-
-		// Compute product over j=1 to log2(n).
-		// At round j the generator fold splits on bit (log2n - j) of the
-		// 0-based index: first half (bit=0) picks up x_j^{-1}, second
-		// half (bit=1) picks up x_j — matching reduceGenerators.
-		for j := 1; j <= log2n; j++ {
-			bitPosition := log2n - j
-			iMinus1 := i - 1
-			bitIsSet := (iMinus1 >> bitPosition) & 1
-
-			var factor *mathlib.Zr
-			if bitIsSet == 1 {
-				// second half at round j => x_j
-				factor = challenges[j-1]
-			} else {
-				// first half at round j => x_j^{-1}
-				factor = challengeInvs[j-1]
-			}
-
-			// Multiply: s_i *= factor
-			si = curve.ModMul(si, factor, curve.GroupOrder)
-		}
-
-		s[i-1] = si
+	sInv := make([]*mathlib.Zr, n)
+	s[0] = math.One(curve)
+	sInv[0] = math.One(curve)
+	for i := 1; i < n; i++ {
+		s[i] = curve.NewZrFromInt(0)
+		sInv[i] = curve.NewZrFromInt(0)
 	}
-	sInv := math.BatchInverse(s, curve)
+
+	// Dual butterfly: O(n) total multiplications.
+	for r := range log2n {
+		halfLen := 1 << r
+		c := challenges[log2n-1-r]
+		cInv := challengeInvs[log2n-1-r]
+		for i := range halfLen {
+			// s: bit set → challenge, bit unset → inverse.
+			// Compute s[i+halfLen] BEFORE mutating s[i].
+			curve.ModMulInPlace(s[i+halfLen], s[i], c, curve.GroupOrder)
+			s[i] = curve.ModMul(s[i], cInv, curve.GroupOrder)
+
+			// sInv: factors are swapped relative to s.
+			curve.ModMulInPlace(sInv[i+halfLen], sInv[i], cInv, curve.GroupOrder)
+			sInv[i] = curve.ModMul(sInv[i], c, curve.GroupOrder)
+		}
+	}
 
 	return s, sInv
 }


### PR DESCRIPTION
closes #1686

## Description
This PR optimizes the `ComputeSVector` function in the Inner Product Argument (IPA) module. It replaces the previous implementation with a **dual-butterfly recurrence** (also known as a doubling algorithm) that computes both the $s$ vector and its entry-wise inverse $s^{-1}$ in $O(n)$ total multiplications.
## Key Changes
- **Algorithmic Optimization**: Transitioned from a nested-loop or post-computation inversion approach to a simultaneous doubling recurrence. This reduces the number of multiplications to exactly $2(n-1)$ per vector.
- **Elimination of Full-Vector Batch Inversion**: By computing $s$ and $s^{-1}$ in parallel during the butterfly rounds, the requirement for a final `math.BatchInverse` call on the full $n$-length vector is eliminated.
- **Reduced Allocation Pressure**:
    - Uses `ModMulInPlace` to perform field arithmetic directly on pre-allocated slice elements.
    - Minimizes heap thrashing during the recursive doubling steps.
- **Efficiency**: Only $\log_2(n)$ field inversions are performed (to invert the round challenges) instead of an $O(n)$ batch inversion process.
## Benchmark results
I ran the `TestParallelBenchmarkValidatorTransfer` benchmark for both before and after the changes and we can see an improvement across temporary allocations:

### Before

- ### Serial

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="serial" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10964     (Robust Sample)
Duration         30.019s   (Good Duration)
Real Throughput  365.23/s  Observed Ops/sec (Wall Clock)
Pure Throughput  365.53/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           19.949122ms  
 P50 (Median)  27.147351ms  
 Average       27.357305ms  
 P95           31.486744ms  
 P99           33.583257ms  
 P99.9         37.691675ms  
 Max           43.896044ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.327775ms  
 IQR      3.00118ms   Interquartile Range
 Jitter   2.430605ms  Avg delta per worker
 CV       8.51%       (Acceptable 5-10%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              585574 B/op     Allocated bytes per operation
 Allocs              5827 allocs/op  Allocations per operation
 Alloc Rate          202.52 MB/s     Memory pressure on system
 GC Overhead         3.93%           (High GC Pressure)
 GC Pause            1.178973917s    Total Stop-The-World time
 GC Cycles           3293            Full garbage collection cycles
 Goroutines Created  99              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 19.949122ms-20.751469ms  1      (0.0%)
 20.751469ms-21.586088ms  3      (0.0%)
 21.586088ms-22.454274ms  46     (0.4%)
 22.454274ms-23.357378ms  211   ████ (1.9%)
 23.357378ms-24.296805ms  548   ██████████ (5.0%)
 24.296805ms-25.274016ms  1172  ██████████████████████ (10.7%)
 25.274016ms-26.29053ms   1791  ██████████████████████████████████ (16.3%)
 26.29053ms-27.347927ms   2098  ████████████████████████████████████████ (19.1%)
 27.347927ms-28.447853ms  1966  █████████████████████████████████████ (17.9%)
 28.447853ms-29.592018ms  1377  ██████████████████████████ (12.6%)
 29.592018ms-30.7822ms    870   ████████████████ (7.9%)
 30.7822ms-32.020251ms    484   █████████ (4.4%)
 32.020251ms-33.308097ms  248   ████ (2.3%)
 33.308097ms-34.647739ms  96    █ (0.9%)
 34.647739ms-36.041261ms  32     (0.3%)
 36.041261ms-37.49083ms   9      (0.1%)
 37.49083ms-38.998701ms   6      (0.1%)
 38.998701ms-40.567217ms  2      (0.0%)
 40.567217ms-42.198819ms  2      (0.0%)
 42.198819ms-43.896044ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5827/op). This will trigger frequent GC cycles and increase Max Latency.
[PASS] RunBenchmark looks healthy and statistically sound.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇█▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 374 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (55.97s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (55.95s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      55.992s
```

- ### Pool

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        11469     (Robust Sample)
Duration         30.019s   (Good Duration)
Real Throughput  382.06/s  Observed Ops/sec (Wall Clock)
Pure Throughput  382.42/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           16.379248ms  
 P50 (Median)  25.976179ms  
 Average       26.149081ms  
 P95           31.144593ms  
 P99           33.509933ms  
 P99.9         36.664438ms  
 Max           39.370034ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.795858ms  
 IQR      3.655413ms  Interquartile Range
 Jitter   3.046624ms  Avg delta per worker
 CV       10.69%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              586854 B/op     Allocated bytes per operation
 Allocs              5855 allocs/op  Allocations per operation
 Alloc Rate          212.05 MB/s     Memory pressure on system
 GC Overhead         4.54%           (High GC Pressure)
 GC Pause            1.364181204s    Total Stop-The-World time
 GC Cycles           3257            Full garbage collection cycles
 Goroutines Created  405             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 16.379248ms-17.113449ms  1      (0.0%)
 17.113449ms-17.880561ms  3      (0.0%)
 17.880561ms-18.682058ms  3      (0.0%)
 18.682058ms-19.519483ms  25     (0.2%)
 19.519483ms-20.394446ms  85    █ (0.7%)
 20.394446ms-21.308628ms  205   ████ (1.8%)
 21.308628ms-22.26379ms   490   ██████████ (4.3%)
 22.26379ms-23.261766ms   897   ██████████████████ (7.8%)
 23.261766ms-24.304477ms  1271  ██████████████████████████ (11.1%)
 24.304477ms-25.393927ms  1748  ████████████████████████████████████ (15.2%)
 25.393927ms-26.532212ms  1929  ████████████████████████████████████████ (16.8%)
 26.532212ms-27.721521ms  1755  ████████████████████████████████████ (15.3%)
 27.721521ms-28.96414ms   1310  ███████████████████████████ (11.4%)
 28.96414ms-30.26246ms    838   █████████████████ (7.3%)
 30.26246ms-31.618978ms   485   ██████████ (4.2%)
 31.618978ms-33.036301ms  272   █████ (2.4%)
 33.036301ms-34.517156ms  103   ██ (0.9%)
 34.517156ms-36.064391ms  29     (0.3%)
 36.064391ms-37.68098ms   13     (0.1%)
 37.68098ms-39.370034ms   7      (0.1%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5855/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 395 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.44s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.42s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.464s
```

- ### Unbounded

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10971     (Robust Sample)
Duration         30.022s   (Good Duration)
Real Throughput  365.43/s  Observed Ops/sec (Wall Clock)
Pure Throughput  365.69/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           17.575112ms  
 P50 (Median)  27.144454ms  
 Average       27.345672ms  
 P95           33.054138ms  
 P99           35.979786ms  
 P99.9         39.984741ms  
 Max           49.843426ms  (Stable Tail)

Stability Metrics:
 Std Dev  3.310614ms  
 IQR      4.401416ms  Interquartile Range
 Jitter   3.197001ms  Avg delta per worker
 CV       12.11%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              580016 B/op     Allocated bytes per operation
 Allocs              5827 allocs/op  Allocations per operation
 Alloc Rate          202.55 MB/s     Memory pressure on system
 GC Overhead         4.43%           (High GC Pressure)
 GC Pause            1.329716036s    Total Stop-The-World time
 GC Cycles           3161            Full garbage collection cycles
 Goroutines Created  124             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 17.575112ms-18.51542ms   2      (0.0%)
 18.51542ms-19.506038ms   18     (0.2%)
 19.506038ms-20.549656ms  71    █ (0.6%)
 20.549656ms-21.64911ms   217   ████ (2.0%)
 21.64911ms-22.807387ms   493   ██████████ (4.5%)
 22.807387ms-24.027635ms  905   ███████████████████ (8.2%)
 24.027635ms-25.313169ms  1392  █████████████████████████████ (12.7%)
 25.313169ms-26.667482ms  1740  ████████████████████████████████████ (15.9%)
 26.667482ms-28.094253ms  1883  ████████████████████████████████████████ (17.2%)
 28.094253ms-29.597361ms  1677  ███████████████████████████████████ (15.3%)
 29.597361ms-31.180888ms  1190  █████████████████████████ (10.8%)
 31.180888ms-32.849137ms  776   ████████████████ (7.1%)
 32.849137ms-34.606642ms  361   ███████ (3.3%)
 34.606642ms-36.458177ms  160   ███ (1.5%)
 36.458177ms-38.408773ms  56    █ (0.5%)
 38.408773ms-40.463731ms  20     (0.2%)
 40.463731ms-42.628634ms  5      (0.0%)
 42.628634ms-44.909364ms  1      (0.0%)
 44.909364ms-47.312118ms  2      (0.0%)
 47.312118ms-49.843426ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5827/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▇▇▇▇▇] (Max: 392 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.62s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.60s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.649s
```

### After changes

- ### Serial

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="serial" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        10710     (Robust Sample)
Duration         30.023s   (Good Duration)
Real Throughput  356.73/s  Observed Ops/sec (Wall Clock)
Pure Throughput  357.01/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           20.454824ms  
 P50 (Median)  27.753336ms  
 Average       28.010104ms  
 P95           32.431509ms  
 P99           34.902203ms  
 P99.9         40.372733ms  
 Max           50.912235ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.509371ms  
 IQR      3.127546ms  Interquartile Range
 Jitter   2.452021ms  Avg delta per worker
 CV       8.96%       (Acceptable 5-10%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              572736 B/op     Allocated bytes per operation
 Allocs              5548 allocs/op  Allocations per operation
 Alloc Rate          194.45 MB/s     Memory pressure on system
 GC Overhead         3.79%           (High GC Pressure)
 GC Pause            1.13705042s     Total Stop-The-World time
 GC Cycles           3181            Full garbage collection cycles
 Goroutines Created  83              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 20.454824ms-21.409033ms  2      (0.0%)
 21.409033ms-22.407757ms  29     (0.3%)
 22.407757ms-23.45307ms   126   ██ (1.2%)
 23.45307ms-24.547147ms   455   ███████ (4.2%)
 24.547147ms-25.692262ms  1135  ███████████████████ (10.6%)
 25.692262ms-26.890796ms  1943  ████████████████████████████████ (18.1%)
 26.890796ms-28.145242ms  2380  ████████████████████████████████████████ (22.2%)
 28.145242ms-29.458207ms  2003  █████████████████████████████████ (18.7%)
 29.458207ms-30.832421ms  1312  ██████████████████████ (12.3%)
 30.832421ms-32.270742ms  740   ████████████ (6.9%)
 32.270742ms-33.77616ms   379   ██████ (3.5%)
 33.77616ms-35.351805ms   124   ██ (1.2%)
 35.351805ms-37.000953ms  45     (0.4%)
 37.000953ms-38.727034ms  15     (0.1%)
 38.727034ms-40.533635ms  11     (0.1%)
 40.533635ms-42.424514ms  1      (0.0%)
 42.424514ms-44.403601ms  4      (0.0%)
 44.403601ms-46.475013ms  1      (0.0%)
 46.475013ms-48.643054ms  1      (0.0%)
 48.643054ms-50.912235ms  4      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5548/op). This will trigger frequent GC cycles and increase Max Latency.
[PASS] RunBenchmark looks healthy and statistically sound.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇] (Max: 372 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (56.44s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (56.42s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      56.471s
```

- ### Pool

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="pool" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        11308     (Robust Sample)
Duration         30.021s   (Good Duration)
Real Throughput  376.67/s  Observed Ops/sec (Wall Clock)
Pure Throughput  376.92/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           17.768374ms  
 P50 (Median)  26.298983ms  
 Average       26.530655ms  
 P95           31.753632ms  
 P99           34.511245ms  
 P99.9         38.13997ms   
 Max           42.224321ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.954034ms  
 IQR      3.899799ms  Interquartile Range
 Jitter   3.176312ms  Avg delta per worker
 CV       11.13%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              576478 B/op     Allocated bytes per operation
 Allocs              5574 allocs/op  Allocations per operation
 Alloc Rate          205.63 MB/s     Memory pressure on system
 GC Overhead         4.86%           (High GC Pressure)
 GC Pause            1.458435325s    Total Stop-The-World time
 GC Cycles           3370            Full garbage collection cycles
 Goroutines Created  371             Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 17.768374ms-18.554251ms  12     (0.1%)
 18.554251ms-19.374887ms  19     (0.2%)
 19.374887ms-20.231819ms  47    █ (0.4%)
 20.231819ms-21.126652ms  127   ██ (1.1%)
 21.126652ms-22.061062ms  371   ████████ (3.3%)
 22.061062ms-23.036801ms  637   █████████████ (5.6%)
 23.036801ms-24.055696ms  1090  ███████████████████████ (9.6%)
 24.055696ms-25.119655ms  1417  ██████████████████████████████ (12.5%)
 25.119655ms-26.230672ms  1837  ████████████████████████████████████████ (16.2%)
 26.230672ms-27.390829ms  1734  █████████████████████████████████████ (15.3%)
 27.390829ms-28.602298ms  1464  ███████████████████████████████ (12.9%)
 28.602298ms-29.867349ms  1090  ███████████████████████ (9.6%)
 29.867349ms-31.188352ms  698   ███████████████ (6.2%)
 31.188352ms-32.567781ms  433   █████████ (3.8%)
 32.567781ms-34.008222ms  183   ███ (1.6%)
 34.008222ms-35.512371ms  87    █ (0.8%)
 35.512371ms-37.083048ms  36     (0.3%)
 37.083048ms-38.723194ms  20     (0.2%)
 38.723194ms-40.435882ms  4      (0.0%)
 40.435882ms-42.224321ms  2      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5574/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇▇] (Max: 387 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.48s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.44s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.507s
```

- ### Unbounded

```
go test ./token/core/zkatdlog/nogh/v1/validator     -test.run=TestParallelBenchmarkValidatorTransfer     -test.v -test.timeout 0     -bits="32" -curves="BLS12_381_BBS_GURVY"     -num_inputs="2" -num_outputs="2"     -workers="10" -duration="30s" -setup_samples=128     -executor="unbounded" -proof_type="bf"
=== RUN   TestParallelBenchmarkValidatorTransfer
=== RUN   TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers
Metric           Value     Description
------           -----     -----------
Workers          10        
Total Ops        11469     (Robust Sample)
Duration         30.022s   (Good Duration)
Real Throughput  382.01/s  Observed Ops/sec (Wall Clock)
Pure Throughput  382.21/s  Theoretical Max (Low Overhead)

Latency Distribution:
 Min           17.791435ms  
 P50 (Median)  25.985582ms  
 Average       26.163364ms  
 P95           31.019931ms  
 P99           33.611839ms  
 P99.9         36.734016ms  
 Max           43.623385ms  (Stable Tail)

Stability Metrics:
 Std Dev  2.799477ms  
 IQR      3.693028ms  Interquartile Range
 Jitter   3.020683ms  Avg delta per worker
 CV       10.70%      Moderate Variance (10-20%)

System Health & Reliability:
 Error Rate          0.0000%         (100% Success) (0 errors)
 Memory              576284 B/op     Allocated bytes per operation
 Allocs              5565 allocs/op  Allocations per operation
 Alloc Rate          208.16 MB/s     Memory pressure on system
 GC Overhead         4.42%           (High GC Pressure)
 GC Pause            1.327721661s    Total Stop-The-World time
 GC Cycles           3298            Full garbage collection cycles
 Goroutines Created  84              Net goroutines above baseline during recording

Latency Heatmap (Dynamic Range):
Range                     Freq  Distribution Graph
 17.791435ms-18.60743ms   7      (0.1%)
 18.60743ms-19.46085ms    17     (0.1%)
 19.46085ms-20.353412ms   71    █ (0.6%)
 20.353412ms-21.286911ms  205   ████ (1.8%)
 21.286911ms-22.263224ms  513   ██████████ (4.5%)
 22.263224ms-23.284316ms  898   ██████████████████ (7.8%)
 23.284316ms-24.352239ms  1355  ████████████████████████████ (11.8%)
 24.352239ms-25.469142ms  1805  █████████████████████████████████████ (15.7%)
 25.469142ms-26.637272ms  1920  ████████████████████████████████████████ (16.7%)
 26.637272ms-27.858977ms  1757  ████████████████████████████████████ (15.3%)
 27.858977ms-29.136715ms  1291  ██████████████████████████ (11.3%)
 29.136715ms-30.473055ms  822   █████████████████ (7.2%)
 30.473055ms-31.870687ms  468   █████████ (4.1%)
 31.870687ms-33.33242ms   205   ████ (1.8%)
 33.33242ms-34.861194ms   83    █ (0.7%)
 34.861194ms-36.460085ms  38     (0.3%)
 36.460085ms-38.132309ms  8      (0.1%)
 38.132309ms-39.881228ms  2      (0.0%)
 39.881228ms-41.71036ms   3      (0.0%)
 41.71036ms-43.623385ms   1      (0.0%)

--- Analysis & Recommendations ---
[INFO] High Allocations (5565/op). This will trigger frequent GC cycles and increase Max Latency.
----------------------------------

--- Throughput Timeline ---
Timeline: [▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇█▇▇▇▇▇▇▇▇▇▇] (Max: 394 ops/s)

--- PASS: TestParallelBenchmarkValidatorTransfer (44.63s)
    --- PASS: TestParallelBenchmarkValidatorTransfer/Setup(bits_32,_curve_BLS12_381_BBS_GURVY,_#i_2,_#o_2)_with_10_workers (44.61s)
PASS
ok      github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/validator      44.659s
```

## Observations

We can see a consistent reduction of **~280** `allocs/op`, which is a **~4.8%** decrease from the initial values.
Let me know if this is a good enough change.
Thank you 🙏 