### PR TITLE
feat(ttx): WithApprovalMetadata

### DIFF
--- a/token/core/common/driver/mock/network_driver.go
+++ b/token/core/common/driver/mock/network_driver.go
@@ -205,7 +205,7 @@ type Network struct {
 		result1 [][]byte
 		result2 error
 	}
-	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)
+	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)
 	requestApprovalMutex       sync.RWMutex
 	requestApprovalArgsForCall []struct {
 		arg1 view.Context
@@ -213,6 +213,7 @@ type Network struct {
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
+		arg6 driver.TransientMap
 	}
 	requestApprovalReturns struct {
 		result1 driver.Envelope
@@ -1158,7 +1159,7 @@ func (fake *Network) QueryTokensReturnsOnCall(i int, result1 [][]byte, result2 e
 	}{result1, result2}
 }
 
-func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID) (driver.Envelope, error) {
+func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID, arg6 driver.TransientMap) (driver.Envelope, error) {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
@@ -1172,13 +1173,14 @@ func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementS
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
-	}{arg1, arg2, arg3Copy, arg4, arg5})
+		arg6 driver.TransientMap
+	}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	stub := fake.RequestApprovalStub
 	fakeReturns := fake.requestApprovalReturns
-	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
+	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	fake.requestApprovalMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1192,17 +1194,17 @@ func (fake *Network) RequestApprovalCallCount() int {
 	return len(fake.requestApprovalArgsForCall)
 }
 
-func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)) {
+func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)) {
 	fake.requestApprovalMutex.Lock()
 	defer fake.requestApprovalMutex.Unlock()
 	fake.RequestApprovalStub = stub
 }
 
-func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) {
+func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) {
 	fake.requestApprovalMutex.RLock()
 	defer fake.requestApprovalMutex.RUnlock()
 	argsForCall := fake.requestApprovalArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *Network) RequestApprovalReturns(result1 driver.Envelope, result2 error) {

--- a/token/services/auditor/mock/network_driver.go
+++ b/token/services/auditor/mock/network_driver.go
@@ -205,7 +205,7 @@ type Network struct {
 		result1 [][]byte
 		result2 error
 	}
-	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)
+	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)
 	requestApprovalMutex       sync.RWMutex
 	requestApprovalArgsForCall []struct {
 		arg1 view.Context
@@ -213,6 +213,7 @@ type Network struct {
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
+		arg6 driver.TransientMap
 	}
 	requestApprovalReturns struct {
 		result1 driver.Envelope
@@ -1158,7 +1159,7 @@ func (fake *Network) QueryTokensReturnsOnCall(i int, result1 [][]byte, result2 e
 	}{result1, result2}
 }
 
-func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID) (driver.Envelope, error) {
+func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID, arg6 driver.TransientMap) (driver.Envelope, error) {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
@@ -1172,13 +1173,14 @@ func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementS
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
-	}{arg1, arg2, arg3Copy, arg4, arg5})
+		arg6 driver.TransientMap
+	}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	stub := fake.RequestApprovalStub
 	fakeReturns := fake.requestApprovalReturns
-	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
+	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	fake.requestApprovalMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1192,17 +1194,17 @@ func (fake *Network) RequestApprovalCallCount() int {
 	return len(fake.requestApprovalArgsForCall)
 }
 
-func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)) {
+func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)) {
 	fake.requestApprovalMutex.Lock()
 	defer fake.requestApprovalMutex.Unlock()
 	fake.RequestApprovalStub = stub
 }
 
-func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) {
+func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) {
 	fake.requestApprovalMutex.RLock()
 	defer fake.requestApprovalMutex.RUnlock()
 	argsForCall := fake.requestApprovalArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *Network) RequestApprovalReturns(result1 driver.Envelope, result2 error) {

--- a/token/services/network/driver/network.go
+++ b/token/services/network/driver/network.go
@@ -62,7 +62,8 @@ type Network interface {
 	NewEnvelope() Envelope
 
 	// RequestApproval requests an endorsement for a token request from the network's approval service.
-	RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID TxID) (Envelope, error)
+	// metadata carries optional application-level key-value pairs forwarded to the approver.
+	RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID TxID, metadata TransientMap) (Envelope, error)
 
 	// ComputeTxID calculates the ledger-specific transaction ID from an abstract TxID.
 	ComputeTxID(id *TxID) string

--- a/token/services/network/fabric/endorsement/chaincode.go
+++ b/token/services/network/fabric/endorsement/chaincode.go
@@ -27,8 +27,8 @@ func NewChaincodeEndorsementService(tmsID token2.TMSID) *ChaincodeEndorsementSer
 	return &ChaincodeEndorsementService{TMSID: tmsID}
 }
 
-func (e *ChaincodeEndorsementService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
-	env, err := chaincode.NewEndorseView(
+func (e *ChaincodeEndorsementService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID, metadata driver.TransientMap) (driver.Envelope, error) {
+	ev := chaincode.NewEndorseView(
 		e.TMSID.Namespace,
 		InvokeFunction,
 	).WithNetwork(
@@ -44,7 +44,11 @@ func (e *ChaincodeEndorsementService) Endorse(context view.Context, requestRaw [
 			Nonce:   txID.Nonce,
 			Creator: txID.Creator,
 		},
-	).Endorse(context)
+	)
+	for k, v := range metadata {
+		ev = ev.WithTransientEntry(k, v)
+	}
+	env, err := ev.Endorse(context)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/network/fabric/endorsement/fsc/initiator.go
+++ b/token/services/network/fabric/endorsement/fsc/initiator.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package fsc
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -15,6 +16,10 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
 )
+
+// TransientApprovalMetadataKey is the transient map key used to carry optional application-level
+// approval metadata from the initiator to the responder.
+const TransientApprovalMetadataKey = "approval_metadata"
 
 // RequestApprovalView is the initiator of the request approval protocol
 type RequestApprovalView struct {
@@ -26,6 +31,8 @@ type RequestApprovalView struct {
 	Nonce []byte
 	// Endorsers are the identities of the FSC node that play the role of endorser
 	Endorsers []view.Identity
+	// Metadata carries optional application-level key-value pairs forwarded to the approver via transient data.
+	Metadata driver.TransientMap
 
 	// EndorserService is the endorser service
 	EndorserService EndorserService
@@ -41,6 +48,7 @@ func NewRequestApprovalView(
 	nonce []byte,
 	endorsers []view.Identity,
 	endorserService EndorserService,
+	metadata driver.TransientMap,
 ) *RequestApprovalView {
 	return &RequestApprovalView{
 		TMSID:           TMSID,
@@ -49,6 +57,7 @@ func NewRequestApprovalView(
 		Nonce:           nonce,
 		Endorsers:       endorsers,
 		EndorserService: endorserService,
+		Metadata:        metadata,
 	}
 }
 
@@ -75,6 +84,15 @@ func (r *RequestApprovalView) Call(ctx view.Context) (any, error) {
 	}
 	if err := tx.SetTransient(TransientTokenRequestKey, r.RequestRaw); err != nil {
 		return nil, errors.WithMessagef(err, "failed to set token request transient")
+	}
+	if len(r.Metadata) > 0 {
+		metadataRaw, err := json.Marshal(r.Metadata)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "failed to marshal approval metadata")
+		}
+		if err := tx.SetTransient(TransientApprovalMetadataKey, metadataRaw); err != nil {
+			return nil, errors.WithMessagef(err, "failed to set approval metadata transient")
+		}
 	}
 
 	logger.DebugfContext(ctx.Context(), "request endorsement on tx [%s] to [%v]...", tx.ID(), r.Endorsers)

--- a/token/services/network/fabric/endorsement/fsc/initiator_test.go
+++ b/token/services/network/fabric/endorsement/fsc/initiator_test.go
@@ -80,6 +80,7 @@ func mockNewRequestApprovalView(t *testing.T, overrideTMSID *token.TMSID) *MockN
 		nil,
 		nil,
 		es,
+		nil,
 	)
 
 	return &MockNewRequestApprovalView{
@@ -125,6 +126,22 @@ func TestRequestApprovalView(t *testing.T) {
 				assert.Equal(t, m.tmsIDRaw, m.transientMap[fsc.TransientTMSIDKey])
 				assert.Equal(t, m.requestRaw, m.transientMap[fsc.TransientTokenRequestKey])
 				assert.Equal(t, m.env, res)
+			},
+			expectError: false,
+		},
+		{
+			name: "Success with approval metadata",
+			setup: func() *MockNewRequestApprovalView {
+				m := mockNewRequestApprovalView(t, nil)
+				m.view.Metadata = driver.TransientMap{
+					"info": []byte("extra"),
+				}
+
+				return m
+			},
+			verify: func(m *MockNewRequestApprovalView, res any) {
+				assert.Len(t, m.transientMap, 3)
+				assert.Contains(t, m.transientMap, fsc.TransientApprovalMetadataKey)
 			},
 			expectError: false,
 		},

--- a/token/services/network/fabric/endorsement/fsc/responder.go
+++ b/token/services/network/fabric/endorsement/fsc/responder.go
@@ -8,6 +8,7 @@ package fsc
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
@@ -36,6 +37,7 @@ type Request struct {
 	RequestRaw       []byte
 	Actions          []any
 	Meta             map[string][]byte
+	ApprovalMetadata map[string][]byte
 	Tms              *token2.ManagementService
 	PublicParamsHash tdriver.PPHash
 }
@@ -114,10 +116,10 @@ func (r *RequestApprovalResponderView) receive(ctx view.Context) (*Request, erro
 
 	// validate transient
 
-	// check the number of transient keys
+	// check the number of transient keys: 2 required (tmsID + token_request) plus 1 optional (approval_metadata)
 	var tmsID token2.TMSID
-	if len(tx.Transaction.Transient()) != 2 {
-		return nil, errors.Wrapf(ErrInvalidTransient, "invalid number of transient field, expected 2, got %d", len(tx.Transaction.Transient()))
+	if n := len(tx.Transaction.Transient()); n < 2 || n > 3 {
+		return nil, errors.Wrapf(ErrInvalidTransient, "invalid number of transient fields, expected 2 or 3, got %d", n)
 	}
 
 	// TMS ID
@@ -140,6 +142,14 @@ func (r *RequestApprovalResponderView) receive(ctx view.Context) (*Request, erro
 	requestRaw := tx.GetTransient(TransientTokenRequestKey)
 	if len(requestRaw) == 0 {
 		return nil, errors.Wrapf(ErrInvalidTransient, "empty token request")
+	}
+
+	// approval metadata (optional)
+	var approvalMetadata map[string][]byte
+	if raw := tx.GetTransient(TransientApprovalMetadataKey); len(raw) > 0 {
+		if err := json.Unmarshal(raw, &approvalMetadata); err != nil {
+			return nil, errors.Wrapf(ErrInvalidTransient, "failed to unmarshal approval metadata")
+		}
 	}
 
 	// request anchor
@@ -183,6 +193,7 @@ func (r *RequestApprovalResponderView) receive(ctx view.Context) (*Request, erro
 		TMSID:            tmsID,
 		RequestRaw:       requestRaw,
 		Anchor:           requestAnchor,
+		ApprovalMetadata: approvalMetadata,
 		Tms:              tms,
 		PublicParamsHash: tms.PublicParametersManager().PublicParamsHash(),
 	}, nil

--- a/token/services/network/fabric/endorsement/fsc/responder_test.go
+++ b/token/services/network/fabric/endorsement/fsc/responder_test.go
@@ -191,7 +191,7 @@ func TestRequestApprovalResponderView(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid number of transient field",
+			name: "invalid number of transient fields",
 			setup: func() *MockNewRequestApprovalResponderView {
 				m := mockNewRequestApprovalResponderView(t, nil)
 				m.fabricTx.TransientReturns(map[string][]byte{
@@ -202,7 +202,7 @@ func TestRequestApprovalResponderView(t *testing.T) {
 			},
 			expectError:      true,
 			expectErrorType:  fsc.ErrReceivedProposal,
-			expectErrContain: "invalid number of transient field, expected 2, got 1",
+			expectErrContain: "invalid number of transient fields, expected 2 or 3, got 1",
 			verify: func(m *MockNewRequestApprovalResponderView, res any) {
 				assert.Equal(t, 0, m.rws.DoneCallCount())
 			},
@@ -616,6 +616,44 @@ func TestRequestApprovalResponderView(t *testing.T) {
 			expectError: false,
 			verify: func(m *MockNewRequestApprovalResponderView, res any) {
 				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "success with approval metadata",
+			setup: func() *MockNewRequestApprovalResponderView {
+				m := mockNewRequestApprovalResponderView(t, nil)
+				metadataRaw, err := json.Marshal(map[string][]byte{"info": []byte("extra")})
+				require.NoError(t, err)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:            m.tmsIDRaw,
+					fsc.TransientTokenRequestKey:     []byte("a_token_request"),
+					fsc.TransientApprovalMetadataKey: metadataRaw,
+				})
+
+				return m
+			},
+			expectError: false,
+			verify: func(m *MockNewRequestApprovalResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "invalid approval metadata encoding",
+			setup: func() *MockNewRequestApprovalResponderView {
+				m := mockNewRequestApprovalResponderView(t, nil)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:            m.tmsIDRaw,
+					fsc.TransientTokenRequestKey:     []byte("a_token_request"),
+					fsc.TransientApprovalMetadataKey: []byte("not-valid-json"),
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrReceivedProposal,
+			expectErrContain: "failed to unmarshal approval metadata",
+			verify: func(m *MockNewRequestApprovalResponderView, res any) {
+				assert.Equal(t, 0, m.rws.DoneCallCount())
 			},
 		},
 	}

--- a/token/services/network/fabric/endorsement/fsc/service.go
+++ b/token/services/network/fabric/endorsement/fsc/service.go
@@ -106,7 +106,7 @@ func NewEndorsementService(
 	}, nil
 }
 
-func (e *EndorsementService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
+func (e *EndorsementService) Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID, metadata driver.TransientMap) (driver.Envelope, error) {
 	var endorsers []view.Identity
 	switch e.PolicyType {
 	case OneOutNPolicy:
@@ -125,6 +125,7 @@ func (e *EndorsementService) Endorse(context view.Context, requestRaw []byte, si
 		nil,
 		endorsers,
 		e.EndorserService,
+		metadata,
 	))
 	if err != nil {
 		return nil, errors.WithMessagef(err, "failed to request approval")

--- a/token/services/network/fabric/endorsement/fsc/service_test.go
+++ b/token/services/network/fabric/endorsement/fsc/service_test.go
@@ -346,7 +346,7 @@ func TestEndorsementService_Endorse(t *testing.T) {
 			EndorserService: &mock.EndorserService{},
 		}
 
-		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{})
+		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{}, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, env)
@@ -374,7 +374,7 @@ func TestEndorsementService_Endorse(t *testing.T) {
 			EndorserService: &mock.EndorserService{},
 		}
 
-		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{})
+		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{}, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, env)
@@ -397,7 +397,7 @@ func TestEndorsementService_Endorse(t *testing.T) {
 			EndorserService: &mock.EndorserService{},
 		}
 
-		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{})
+		env, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{}, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, env)
@@ -419,7 +419,7 @@ func TestEndorsementService_Endorse(t *testing.T) {
 			EndorserService: &mock.EndorserService{},
 		}
 
-		_, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{})
+		_, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{}, nil)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to request approval")
@@ -441,7 +441,7 @@ func TestEndorsementService_Endorse(t *testing.T) {
 			EndorserService: &mock.EndorserService{},
 		}
 
-		_, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{})
+		_, err := service.Endorse(ctx, []byte("request"), []byte("signer"), driver.TxID{}, nil)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected driver.Envelope")

--- a/token/services/network/fabric/endorsement/provider.go
+++ b/token/services/network/fabric/endorsement/provider.go
@@ -63,7 +63,7 @@ func NewServiceProvider(
 }
 
 type Service interface {
-	Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error)
+	Endorse(context view.Context, requestRaw []byte, signer view.Identity, txID driver.TxID, metadata driver.TransientMap) (driver.Envelope, error)
 }
 
 type loader struct {

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -333,13 +333,13 @@ func (n *Network) NewEnvelope() driver.Envelope {
 }
 
 // RequestApproval requests an endorsement for a token request.
-func (n *Network) RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
+func (n *Network) RequestApproval(context view.Context, tms *token2.ManagementService, requestRaw []byte, signer view.Identity, txID driver.TxID, metadata driver.TransientMap) (driver.Envelope, error) {
 	endorsement, err := n.endorsementServiceProvider.Get(tms.ID())
 	if err != nil {
 		return nil, errors.Wrapf(err, "network not connected [%s]", tms.ID())
 	}
 
-	return endorsement.Endorse(context, requestRaw, signer, txID)
+	return endorsement.Endorse(context, requestRaw, signer, txID, metadata)
 }
 
 // ComputeTxID calculates the Fabric transaction ID based on creator and nonce.

--- a/token/services/network/mocks/network.go
+++ b/token/services/network/mocks/network.go
@@ -205,7 +205,7 @@ type Network struct {
 		result1 [][]byte
 		result2 error
 	}
-	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)
+	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)
 	requestApprovalMutex       sync.RWMutex
 	requestApprovalArgsForCall []struct {
 		arg1 view.Context
@@ -213,6 +213,7 @@ type Network struct {
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
+		arg6 driver.TransientMap
 	}
 	requestApprovalReturns struct {
 		result1 driver.Envelope
@@ -1158,7 +1159,7 @@ func (fake *Network) QueryTokensReturnsOnCall(i int, result1 [][]byte, result2 e
 	}{result1, result2}
 }
 
-func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID) (driver.Envelope, error) {
+func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID, arg6 driver.TransientMap) (driver.Envelope, error) {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
@@ -1172,13 +1173,14 @@ func (fake *Network) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementS
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
-	}{arg1, arg2, arg3Copy, arg4, arg5})
+		arg6 driver.TransientMap
+	}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	stub := fake.RequestApprovalStub
 	fakeReturns := fake.requestApprovalReturns
-	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
+	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	fake.requestApprovalMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1192,17 +1194,17 @@ func (fake *Network) RequestApprovalCallCount() int {
 	return len(fake.requestApprovalArgsForCall)
 }
 
-func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)) {
+func (fake *Network) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)) {
 	fake.requestApprovalMutex.Lock()
 	defer fake.requestApprovalMutex.Unlock()
 	fake.RequestApprovalStub = stub
 }
 
-func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) {
+func (fake *Network) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) {
 	fake.requestApprovalMutex.RLock()
 	defer fake.requestApprovalMutex.RUnlock()
 	argsForCall := fake.requestApprovalArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *Network) RequestApprovalReturns(result1 driver.Envelope, result2 error) {

--- a/token/services/network/network.go
+++ b/token/services/network/network.go
@@ -244,11 +244,12 @@ func (n *Network) NewEnvelope() *Envelope {
 }
 
 // RequestApproval sends a token request to an endorsement service and returns the resulting endorsed envelope.
-func (n *Network) RequestApproval(context view.Context, tms *token.ManagementService, requestRaw []byte, signer view.Identity, txID TxID) (*Envelope, error) {
+// metadata carries optional application-level key-value pairs forwarded to the approver backend.
+func (n *Network) RequestApproval(context view.Context, tms *token.ManagementService, requestRaw []byte, signer view.Identity, txID TxID, metadata driver.TransientMap) (*Envelope, error) {
 	env, err := n.n.RequestApproval(context, tms, requestRaw, signer, driver.TxID{
 		Nonce:   txID.Nonce,
 		Creator: txID.Creator,
-	})
+	}, metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/token/services/network/network_test.go
+++ b/token/services/network/network_test.go
@@ -226,12 +226,12 @@ func TestNetwork(t *testing.T) {
 	require.NoError(t, err)
 
 	txID := network.TxID{Nonce: []byte("nonce"), Creator: []byte("creator")}
-	apprEnv, err := n.RequestApproval(nil, nil, []byte("req"), view.Identity("sig"), txID)
+	apprEnv, err := n.RequestApproval(nil, nil, []byte("req"), view.Identity("sig"), txID, nil)
 	require.NoError(t, err)
 	require.NotNil(t, apprEnv)
 
 	dn.RequestApprovalReturns(nil, errors.New("appr err"))
-	_, err = n.RequestApproval(nil, nil, []byte("req"), view.Identity("sig"), txID)
+	_, err = n.RequestApproval(nil, nil, []byte("req"), view.Identity("sig"), txID, nil)
 	require.Error(t, err)
 
 	cTxID := n.ComputeTxID(&txID)

--- a/token/services/tokens/mock/network.go
+++ b/token/services/tokens/mock/network.go
@@ -205,7 +205,7 @@ type FakeNetwork struct {
 		result1 [][]byte
 		result2 error
 	}
-	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)
+	RequestApprovalStub        func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)
 	requestApprovalMutex       sync.RWMutex
 	requestApprovalArgsForCall []struct {
 		arg1 view.Context
@@ -213,6 +213,7 @@ type FakeNetwork struct {
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
+		arg6 driver.TransientMap
 	}
 	requestApprovalReturns struct {
 		result1 driver.Envelope
@@ -1158,7 +1159,7 @@ func (fake *FakeNetwork) QueryTokensReturnsOnCall(i int, result1 [][]byte, resul
 	}{result1, result2}
 }
 
-func (fake *FakeNetwork) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID) (driver.Envelope, error) {
+func (fake *FakeNetwork) RequestApproval(arg1 view.Context, arg2 *tokena.ManagementService, arg3 []byte, arg4 view.Identity, arg5 driver.TxID, arg6 driver.TransientMap) (driver.Envelope, error) {
 	var arg3Copy []byte
 	if arg3 != nil {
 		arg3Copy = make([]byte, len(arg3))
@@ -1172,13 +1173,14 @@ func (fake *FakeNetwork) RequestApproval(arg1 view.Context, arg2 *tokena.Managem
 		arg3 []byte
 		arg4 view.Identity
 		arg5 driver.TxID
-	}{arg1, arg2, arg3Copy, arg4, arg5})
+		arg6 driver.TransientMap
+	}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	stub := fake.RequestApprovalStub
 	fakeReturns := fake.requestApprovalReturns
-	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5})
+	fake.recordInvocation("RequestApproval", []interface{}{arg1, arg2, arg3Copy, arg4, arg5, arg6})
 	fake.requestApprovalMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1192,17 +1194,17 @@ func (fake *FakeNetwork) RequestApprovalCallCount() int {
 	return len(fake.requestApprovalArgsForCall)
 }
 
-func (fake *FakeNetwork) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) (driver.Envelope, error)) {
+func (fake *FakeNetwork) RequestApprovalCalls(stub func(view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) (driver.Envelope, error)) {
 	fake.requestApprovalMutex.Lock()
 	defer fake.requestApprovalMutex.Unlock()
 	fake.RequestApprovalStub = stub
 }
 
-func (fake *FakeNetwork) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID) {
+func (fake *FakeNetwork) RequestApprovalArgsForCall(i int) (view.Context, *tokena.ManagementService, []byte, view.Identity, driver.TxID, driver.TransientMap) {
 	fake.requestApprovalMutex.RLock()
 	defer fake.requestApprovalMutex.RUnlock()
 	argsForCall := fake.requestApprovalArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeNetwork) RequestApprovalReturns(result1 driver.Envelope, result2 error) {

--- a/token/services/ttx/collectendorsements.go
+++ b/token/services/ttx/collectendorsements.go
@@ -376,6 +376,7 @@ func (c *CollectEndorsementsView) requestApproval(context view.Context) (*networ
 		requestRaw,
 		c.tx.Signer,
 		c.tx.TxID,
+		c.Opts.ApprovalMetadata,
 	)
 	if err != nil {
 		return nil, err

--- a/token/services/ttx/endorse_opts.go
+++ b/token/services/ttx/endorse_opts.go
@@ -25,6 +25,9 @@ type EndorsementsOpts struct {
 	// in the list produce a nil slot in the PolicySignature, which is valid for
 	// OR branches.  When nil, all component identities are contacted (default).
 	PolicySigners []token.Identity
+	// ApprovalMetadata carries optional application-level metadata forwarded to approvers.
+	// Each driver decides how to deliver this information to the approver backend.
+	ApprovalMetadata map[string][]byte
 }
 
 func (o *EndorsementsOpts) ExternalWalletSigner(id string) ExternalWalletSigner {
@@ -103,6 +106,17 @@ func WithExternalWalletSigner(walletID string, ews ExternalWalletSigner) Endorse
 			o.ExternalWalletSigners = map[string]ExternalWalletSigner{}
 		}
 		o.ExternalWalletSigners[walletID] = ews
+
+		return nil
+	}
+}
+
+// WithApprovalMetadata attaches application-level metadata to be forwarded to the approver.
+// Each key-value pair is delivered to the approver backend in a driver-specific way
+// (e.g. transient data for Fabric FSC endorsement, extra transient entries for chaincode).
+func WithApprovalMetadata(metadata map[string][]byte) EndorsementsOpt {
+	return func(o *EndorsementsOpts) error {
+		o.ApprovalMetadata = metadata
 
 		return nil
 	}

--- a/token/services/ttx/endorse_opts_test.go
+++ b/token/services/ttx/endorse_opts_test.go
@@ -164,6 +164,7 @@ func TestEndorsementsOpts_ExternalWalletSigner_NilMap(t *testing.T) {
 func TestCompileCollectEndorsementsOpts_AllOptions(t *testing.T) {
 	signer := &mock.ExternalWalletSigner{}
 	walletID := "wallet-all"
+	metadata := map[string][]byte{"k": []byte("v")}
 
 	opts, err := ttx.CompileCollectEndorsementsOpts(
 		ttx.WithSkipAuditing(),
@@ -171,6 +172,7 @@ func TestCompileCollectEndorsementsOpts_AllOptions(t *testing.T) {
 		ttx.WithSkipApproval(),
 		ttx.WithSkipDistributeEnv(),
 		ttx.WithExternalWalletSigner(walletID, signer),
+		ttx.WithApprovalMetadata(metadata),
 	)
 
 	require.NoError(t, err)
@@ -180,6 +182,7 @@ func TestCompileCollectEndorsementsOpts_AllOptions(t *testing.T) {
 	assert.True(t, opts.SkipDistributeEnv)
 	require.NotNil(t, opts.ExternalWalletSigners)
 	assert.Equal(t, signer, opts.ExternalWalletSigners[walletID])
+	assert.Equal(t, metadata, opts.ApprovalMetadata)
 }
 
 // TestCompileCollectEndorsementsOpts_PartialOptions verifies partial option combinations.
@@ -208,6 +211,41 @@ func TestEndorsementsOpts_ExternalWalletSigner_EmptyID(t *testing.T) {
 
 	result := opts.ExternalWalletSigner("")
 	assert.Equal(t, signer, result)
+}
+
+// TestWithApprovalMetadata verifies the WithApprovalMetadata option sets the metadata map.
+func TestWithApprovalMetadata(t *testing.T) {
+	metadata := map[string][]byte{
+		"key1": []byte("value1"),
+		"key2": []byte("value2"),
+	}
+
+	opts, err := ttx.CompileCollectEndorsementsOpts(
+		ttx.WithApprovalMetadata(metadata),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, metadata, opts.ApprovalMetadata)
+}
+
+// TestWithApprovalMetadata_Nil verifies nil metadata is accepted without error.
+func TestWithApprovalMetadata_Nil(t *testing.T) {
+	opts, err := ttx.CompileCollectEndorsementsOpts(
+		ttx.WithApprovalMetadata(nil),
+	)
+
+	require.NoError(t, err)
+	assert.Nil(t, opts.ApprovalMetadata)
+}
+
+// TestWithApprovalMetadata_Empty verifies an empty metadata map is accepted.
+func TestWithApprovalMetadata_Empty(t *testing.T) {
+	opts, err := ttx.CompileCollectEndorsementsOpts(
+		ttx.WithApprovalMetadata(map[string][]byte{}),
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, opts.ApprovalMetadata)
 }
 
 // TestWithExternalWalletSigner_NilSigner verifies nil signer can be set.


### PR DESCRIPTION
Closes #1684.

I added a `WithApprovalMetadata` option to `CollectEndorsementsView` so applications can pass extra context to approvers. The metadata flows through the full call chain down to the network driver.

- **FSC path** , serialised as a JSON blob into a `approval_metadata` transient field; the responder extracts it into `Request.ApprovalMetadata`
- **Chaincode path**,  each key injected as a separate `WithTransientEntry`
- Backward compatible: no metadata means no extra transient field, count stays at 2