### PR TITLE
token: return wallet balances as big integers

### DIFF
--- a/integration/token/dvp/views/balance.go
+++ b/integration/token/dvp/views/balance.go
@@ -9,7 +9,6 @@ package views
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
@@ -45,7 +44,7 @@ func (b *BalanceView) Call(context view.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	return Balance{Quantity: strconv.FormatUint(balance, 10), Type: b.Type}, nil
+	return Balance{Quantity: balance.String(), Type: b.Type}, nil
 }
 
 type BalanceViewFactory struct{}

--- a/integration/token/fungible/views/accept.go
+++ b/integration/token/fungible/views/accept.go
@@ -7,6 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package views
 
 import (
+	"math/big"
+
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
@@ -44,7 +46,7 @@ func (a *AcceptCashView) Call(context view.Context) (interface{}, error) {
 		}
 		balance, err := ttx.MyWallet(context, token.WithTMSID(tx.TMSID())).Balance(context.Context(), ttx.WithType(output.Type))
 		assert.NoError(err, "failed retrieving balance for type [%s]", output.Type)
-		assert.True(balance <= 3000, "cannot have more than 3000 unspent quantity for type [%s]", output.Type)
+		assert.True(balance.Cmp(big.NewInt(3000)) <= 0, "cannot have more than 3000 unspent quantity for type [%s]", output.Type)
 	}
 
 	// If everything is fine, the recipient accepts and sends back her signature.

--- a/integration/token/fungible/views/balance.go
+++ b/integration/token/fungible/views/balance.go
@@ -67,8 +67,8 @@ func (b *BalanceView) Call(context view.Context) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		if sum.ToBigInt().Uint64() != balance {
-			return nil, errors.Errorf("balance doesn't match [%d]!=[%d]", balance, sum.ToBigInt().Uint64())
+		if sum.ToBigInt().Cmp(balance) != 0 {
+			return nil, errors.Errorf("balance doesn't match [%s]!=[%s]", balance.String(), sum.Decimal())
 		}
 	}
 

--- a/integration/token/interop/views/balance.go
+++ b/integration/token/interop/views/balance.go
@@ -8,7 +8,6 @@ package views
 
 import (
 	"encoding/json"
-	"strconv"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/assert"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
@@ -67,7 +66,7 @@ func (b *BalanceView) Call(context view.Context) (interface{}, error) {
 	assert.NoError(err, "failed to compute the sum of the htlc expired tokens")
 
 	return BalanceResult{
-		Quantity: strconv.FormatUint(balance, 10),
+		Quantity: balance.String(),
 		Locked:   lockedSum.Decimal(),
 		Expired:  expiredSum.Decimal(),
 		Type:     b.Type,

--- a/token/driver/mock/ow.go
+++ b/token/driver/mock/ow.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -10,18 +11,18 @@ import (
 )
 
 type OwnerWallet struct {
-	BalanceStub        func(context.Context, *driver.ListTokensOptions) (uint64, error)
+	BalanceStub        func(context.Context, *driver.ListTokensOptions) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
 		arg2 *driver.ListTokensOptions
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	ContainsStub        func(context.Context, driver.Identity) bool
@@ -200,7 +201,7 @@ type OwnerWallet struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OwnerWallet) Balance(arg1 context.Context, arg2 *driver.ListTokensOptions) (uint64, error) {
+func (fake *OwnerWallet) Balance(arg1 context.Context, arg2 *driver.ListTokensOptions) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -226,7 +227,7 @@ func (fake *OwnerWallet) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *OwnerWallet) BalanceCalls(stub func(context.Context, *driver.ListTokensOptions) (uint64, error)) {
+func (fake *OwnerWallet) BalanceCalls(stub func(context.Context, *driver.ListTokensOptions) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -239,28 +240,28 @@ func (fake *OwnerWallet) BalanceArgsForCall(i int) (context.Context, *driver.Lis
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *OwnerWallet) BalanceReturns(result1 uint64, result2 error) {
+func (fake *OwnerWallet) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OwnerWallet) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *OwnerWallet) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/driver/mock/qe.go
+++ b/token/driver/mock/qe.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -10,7 +11,7 @@ import (
 )
 
 type QueryEngine struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -18,11 +19,11 @@ type QueryEngine struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	GetStatusStub        func(context.Context, string) (driver.TxStatus, string, error)
@@ -242,7 +243,7 @@ type QueryEngine struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *QueryEngine) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *QueryEngine) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -269,7 +270,7 @@ func (fake *QueryEngine) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *QueryEngine) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *QueryEngine) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -282,28 +283,28 @@ func (fake *QueryEngine) BalanceArgsForCall(i int) (context.Context, string, tok
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *QueryEngine) BalanceReturns(result1 uint64, result2 error) {
+func (fake *QueryEngine) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *QueryEngine) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *QueryEngine) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/driver/mock/token_vault.go
+++ b/token/driver/mock/token_vault.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -10,7 +11,7 @@ import (
 )
 
 type TokenVault struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -18,11 +19,11 @@ type TokenVault struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	GetTokenOutputsStub        func(context.Context, []*token.ID, driver.QueryCallbackFunc) error
@@ -115,7 +116,7 @@ type TokenVault struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *TokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -142,7 +143,7 @@ func (fake *TokenVault) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *TokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *TokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -155,28 +156,28 @@ func (fake *TokenVault) BalanceArgsForCall(i int) (context.Context, string, toke
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *TokenVault) BalanceReturns(result1 uint64, result2 error) {
+func (fake *TokenVault) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *TokenVault) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *TokenVault) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -8,6 +8,7 @@ package driver
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -97,7 +98,7 @@ type QueryEngine interface {
 	// WhoDeletedTokens identifies which transaction deleted the specified tokens.
 	WhoDeletedTokens(ctx context.Context, inputs ...*token.ID) ([]string, []bool, error)
 	// Balance calculates the total value of unspent tokens of a specific type owned by a wallet.
-	Balance(ctx context.Context, id string, tokenType token.Type) (uint64, error)
+	Balance(ctx context.Context, id string, tokenType token.Type) (*big.Int, error)
 }
 
 //go:generate counterfeiter -o mock/token_vault.go -fake-name TokenVault . TokenVault
@@ -109,7 +110,7 @@ type TokenVault interface {
 	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (UnspentTokensIterator, error)
 	ListHistoryIssuedTokens(ctx context.Context) (*token.IssuedTokens, error)
 	PublicParams(ctx context.Context) ([]byte, error)
-	Balance(ctx context.Context, id string, tokenType token.Type) (uint64, error)
+	Balance(ctx context.Context, id string, tokenType token.Type) (*big.Int, error)
 }
 
 //go:generate counterfeiter -o mock/ledger_token.go -fake-name LedgerToken . LedgerToken

--- a/token/driver/wallet.go
+++ b/token/driver/wallet.go
@@ -8,6 +8,7 @@ package driver
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/token"
@@ -125,8 +126,8 @@ type OwnerWallet interface {
 	// ListTokensIterator returns an iterator of unspent tokens owned by this wallet filtered using the passed options.
 	ListTokensIterator(opts *ListTokensOptions) (UnspentTokensIterator, error)
 
-	// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
-	Balance(ctx context.Context, opts *ListTokensOptions) (uint64, error)
+	// Balance returns the sum of the amounts of the tokens with type and EID equal to those passed as arguments.
+	Balance(ctx context.Context, opts *ListTokensOptions) (*big.Int, error)
 
 	// EnrollmentID returns the enrollment ID of the owner wallet
 	EnrollmentID() string

--- a/token/services/identity/role/mock/otv.go
+++ b/token/services/identity/role/mock/otv.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -11,7 +12,7 @@ import (
 )
 
 type OwnerTokenVault struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -19,11 +20,11 @@ type OwnerTokenVault struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	UnspentTokensIteratorByStub        func(context.Context, string, token.Type) (driver.UnspentTokensIterator, error)
@@ -45,7 +46,7 @@ type OwnerTokenVault struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OwnerTokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *OwnerTokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -72,7 +73,7 @@ func (fake *OwnerTokenVault) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *OwnerTokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *OwnerTokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -85,28 +86,28 @@ func (fake *OwnerTokenVault) BalanceArgsForCall(i int) (context.Context, string,
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *OwnerTokenVault) BalanceReturns(result1 uint64, result2 error) {
+func (fake *OwnerTokenVault) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *OwnerTokenVault) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *OwnerTokenVault) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/services/identity/role/mock/tv.go
+++ b/token/services/identity/role/mock/tv.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -11,7 +12,7 @@ import (
 )
 
 type TokenVault struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -19,11 +20,11 @@ type TokenVault struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	ListHistoryIssuedTokensStub        func(context.Context) (*token.IssuedTokens, error)
@@ -58,7 +59,7 @@ type TokenVault struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *TokenVault) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -85,7 +86,7 @@ func (fake *TokenVault) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *TokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *TokenVault) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -98,28 +99,28 @@ func (fake *TokenVault) BalanceArgsForCall(i int) (context.Context, string, toke
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *TokenVault) BalanceReturns(result1 uint64, result2 error) {
+func (fake *TokenVault) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *TokenVault) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *TokenVault) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/services/identity/role/wallets.go
+++ b/token/services/identity/role/wallets.go
@@ -8,6 +8,7 @@ package role
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/common/utils/collections/iterators"
@@ -34,7 +35,7 @@ type UnspentTokensIterator = driver.UnspentTokensIterator
 //go:generate counterfeiter -o mock/otv.go -fake-name OwnerTokenVault . OwnerTokenVault
 type OwnerTokenVault interface {
 	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (UnspentTokensIterator, error)
-	Balance(ctx context.Context, id string, tokenType token.Type) (uint64, error)
+	Balance(ctx context.Context, id string, tokenType token.Type) (*big.Int, error)
 }
 
 // IdentityProvider is a type alias for IdentityProvider. It exposes
@@ -379,10 +380,10 @@ func (w *LongTermOwnerWallet) ListTokens(opts *driver.ListTokensOptions) (*token
 
 // Balance returns the on-chain balance for the wallet for the given token
 // type in the listing options.
-func (w *LongTermOwnerWallet) Balance(ctx context.Context, opts *driver.ListTokensOptions) (uint64, error) {
+func (w *LongTermOwnerWallet) Balance(ctx context.Context, opts *driver.ListTokensOptions) (*big.Int, error) {
 	balance, err := w.TokenVault.Balance(ctx, w.WalletID, opts.TokenType)
 	if err != nil {
-		return 0, errors.Wrap(err, "token selection failed")
+		return nil, errors.Wrap(err, "token selection failed")
 	}
 
 	return balance, nil

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -8,6 +8,7 @@ package role_test
 
 import (
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
@@ -217,7 +218,7 @@ func TestLongTermOwnerWallet(t *testing.T) {
 		}
 
 		tv.UnspentTokensIteratorByReturns(it, nil)
-		tv.BalanceReturns(30, nil)
+		tv.BalanceReturns(big.NewInt(30), nil)
 
 		// ListTokens
 		tokens, err := w.ListTokens(&driver.ListTokensOptions{Context: t.Context(), TokenType: "T1"})
@@ -233,7 +234,7 @@ func TestLongTermOwnerWallet(t *testing.T) {
 		// Balance
 		bal, err := w.Balance(t.Context(), &driver.ListTokensOptions{Context: t.Context()})
 		require.NoError(t, err)
-		assert.Equal(t, uint64(30), bal)
+		assert.Zero(t, big.NewInt(30).Cmp(bal))
 	})
 
 	t.Run("GetSigner", func(t *testing.T) {

--- a/token/services/identity/role/wfactory.go
+++ b/token/services/identity/role/wfactory.go
@@ -8,6 +8,7 @@ package role
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/metrics"
@@ -21,7 +22,7 @@ import (
 type TokenVault interface {
 	UnspentTokensIteratorBy(ctx context.Context, id string, tokenType token.Type) (driver.UnspentTokensIterator, error)
 	ListHistoryIssuedTokens(ctx context.Context) (*token.IssuedTokens, error)
-	Balance(ctx context.Context, id string, tokenType token.Type) (uint64, error)
+	Balance(ctx context.Context, id string, tokenType token.Type) (*big.Int, error)
 }
 
 //go:generate counterfeiter -o mock/wc.go -fake-name WalletsConfiguration . WalletsConfiguration

--- a/token/services/storage/db/dbtest/tokens.go
+++ b/token/services/storage/db/dbtest/tokens.go
@@ -8,6 +8,7 @@ package dbtest
 
 import (
 	"fmt"
+	"math/big"
 	"sync"
 	"testing"
 
@@ -72,6 +73,7 @@ var tokensCases = []struct {
 	{"PublicParams", TPublicParams},
 	{"Certification", TCertification},
 	{"QueryTokenDetails", TQueryTokenDetails},
+	{"BalanceSupportsLargeSums", TBalanceSupportsLargeSums},
 	{"TTokenTypes", TTokenTypes},
 	{"ListUnspentTokensByWallets", TListUnspentTokensByWallets},
 }
@@ -896,7 +898,7 @@ func TQueryTokenDetails(t *testing.T, db TestTokenDB) {
 	assertEqual(t, tx1, res[0])
 	balance, err := db.Balance(ctx, "alice", "TST1")
 	require.NoError(t, err)
-	assert.Equal(t, res[0].Amount, balance)
+	assert.Zero(t, new(big.Int).SetUint64(res[0].Amount).Cmp(balance))
 
 	// alice TST
 	res, err = db.QueryTokenDetails(ctx, driver2.QueryTokenDetailsParams{WalletID: "alice", TokenType: TST})
@@ -905,7 +907,7 @@ func TQueryTokenDetails(t *testing.T, db TestTokenDB) {
 	assertEqual(t, tx2, res[0])
 	balance, err = db.Balance(ctx, "alice", TST)
 	require.NoError(t, err)
-	assert.Equal(t, res[0].Amount, balance)
+	assert.Zero(t, new(big.Int).SetUint64(res[0].Amount).Cmp(balance))
 
 	// bob TST
 	res, err = db.QueryTokenDetails(ctx, driver2.QueryTokenDetailsParams{WalletID: "bob", TokenType: TST})
@@ -914,7 +916,7 @@ func TQueryTokenDetails(t *testing.T, db TestTokenDB) {
 	assertEqual(t, tx21, res[0])
 	balance, err = db.Balance(ctx, "bob", TST)
 	require.NoError(t, err)
-	assert.Equal(t, res[0].Amount, balance)
+	assert.Zero(t, new(big.Int).SetUint64(res[0].Amount).Cmp(balance))
 
 	// spent
 	require.NoError(t, db.DeleteTokens(ctx, "delby", &token.ID{TxId: "tx2", Index: 1}))
@@ -938,6 +940,42 @@ func TQueryTokenDetails(t *testing.T, db TestTokenDB) {
 	assert.Len(t, res, 2)
 	assertEqual(t, tx1, res[0])
 	assertEqual(t, tx2, res[1])
+}
+
+func TBalanceSupportsLargeSums(t *testing.T, db TestTokenDB) {
+	t.Helper()
+	ctx := t.Context()
+	tx, err := db.NewTokenDBTransaction()
+	require.NoError(t, err)
+
+	max := uint64(^uint64(0) >> 1)
+	for i, txID := range []string{"overflow-1", "overflow-2", "overflow-3"} {
+		err = tx.StoreToken(ctx, driver2.TokenRecord{
+			TxID:           txID,
+			Index:          0,
+			IssuerRaw:      []byte{},
+			OwnerRaw:       []byte{1, 2, 3},
+			OwnerType:      "idemix",
+			OwnerIdentity:  []byte("owner"),
+			Ledger:         []byte("ledger"),
+			LedgerMetadata: []byte{},
+			Quantity:       fmt.Sprintf("0x%x", max),
+			Type:           "BIG",
+			Amount:         max,
+			Owner:          true,
+			Auditor:        false,
+			Issuer:         false,
+		}, []string{"alice"})
+		require.NoError(t, err, "store token %d", i)
+	}
+	require.NoError(t, tx.Commit())
+
+	balance, err := db.Balance(ctx, "alice", "BIG")
+	require.NoError(t, err)
+
+	expected := new(big.Int).SetUint64(max)
+	expected.Mul(expected, big.NewInt(3))
+	assert.Zero(t, expected.Cmp(balance))
 }
 
 func TTokenTypes(t *testing.T, db TestTokenDB) {

--- a/token/services/storage/db/driver/token.go
+++ b/token/services/storage/db/driver/token.go
@@ -9,6 +9,7 @@ package driver
 import (
 	"context"
 	"errors"
+	"math/big"
 	"time"
 
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
@@ -230,7 +231,7 @@ type TokenStore interface {
 	// QueryTokenDetails provides detailed information about tokens
 	QueryTokenDetails(ctx context.Context, params QueryTokenDetailsParams) ([]TokenDetails, error)
 	// Balance returns the sun of the amounts of the tokens with type and EID equal to those passed as arguments.
-	Balance(ctx context.Context, ownerEID string, typ token.Type) (uint64, error)
+	Balance(ctx context.Context, ownerEID string, typ token.Type) (*big.Int, error)
 	// SetSupportedTokenFormats sets the supported token formats
 	SetSupportedTokenFormats(formats []token.Format) error
 	// Notifier returns a TokenNotifier for this store to subscribe to token changes.

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/big"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -363,17 +364,17 @@ func (db *TokenStore) queryLedgerTokens(ctx context.Context, details driver.Quer
 	}), nil
 }
 
-// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
-func (db *TokenStore) Balance(ctx context.Context, walletID string, typ token.Type) (uint64, error) {
+// Balance returns the sum of the amounts of the tokens with type and EID equal to those passed as arguments.
+func (db *TokenStore) Balance(ctx context.Context, walletID string, typ token.Type) (*big.Int, error) {
 	return db.balance(ctx, driver.QueryTokenDetailsParams{
 		WalletID:  walletID,
 		TokenType: typ,
 	})
 }
 
-func (db *TokenStore) balance(ctx context.Context, opts driver.QueryTokenDetailsParams) (uint64, error) {
+func (db *TokenStore) balance(ctx context.Context, opts driver.QueryTokenDetailsParams) (*big.Int, error) {
 	tokenTable, ownershipTable := q.Table(db.table.Tokens), q.Table(db.table.Ownership)
-	query, args := q.Select().FieldsByName("SUM(amount)").
+	query, args := q.Select().FieldsByName("amount").
 		From(tokenTable.Join(ownershipTable, cond.And(
 			cond.Cmp(tokenTable.Field("tx_id"), "=", ownershipTable.Field("tx_id")),
 			cond.Cmp(tokenTable.Field("idx"), "=", ownershipTable.Field("idx"))),
@@ -381,12 +382,32 @@ func (db *TokenStore) balance(ctx context.Context, opts driver.QueryTokenDetails
 		Where(HasTokenDetails(opts, tokenTable)).
 		Format(db.ci)
 
-	sum, err := common.QueryUnique[*uint64](db.readDB, query, args...)
-	if err != nil || sum == nil {
-		return 0, err
+	rows, err := db.readDB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error querying db")
+	}
+	defer rows.Close()
+
+	sum := big.NewInt(0)
+	for rows.Next() {
+		var amount sql.NullString
+		if err := rows.Scan(&amount); err != nil {
+			return nil, errors.Wrapf(err, "error scanning balance amount")
+		}
+		if !amount.Valid || len(amount.String) == 0 {
+			continue
+		}
+		value, ok := new(big.Int).SetString(amount.String, 10)
+		if !ok {
+			return nil, errors.Errorf("failed parsing balance amount [%s]", amount.String)
+		}
+		sum.Add(sum, value)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrapf(err, "error iterating balance amounts")
 	}
 
-	return *sum, nil
+	return sum, nil
 }
 
 // ListUnspentTokensBy returns the list of unspent tokens, filtered by owner and token type

--- a/token/services/tokens/mock/query_engine.go
+++ b/token/services/tokens/mock/query_engine.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -10,7 +11,7 @@ import (
 )
 
 type FakeQueryEngine struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -18,11 +19,11 @@ type FakeQueryEngine struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	GetStatusStub        func(context.Context, string) (driver.TxStatus, string, error)
@@ -242,7 +243,7 @@ type FakeQueryEngine struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeQueryEngine) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *FakeQueryEngine) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -269,7 +270,7 @@ func (fake *FakeQueryEngine) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *FakeQueryEngine) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *FakeQueryEngine) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -282,28 +283,28 @@ func (fake *FakeQueryEngine) BalanceArgsForCall(i int) (context.Context, string,
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeQueryEngine) BalanceReturns(result1 uint64, result2 error) {
+func (fake *FakeQueryEngine) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeQueryEngine) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *FakeQueryEngine) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/services/tokens/mock/token_store.go
+++ b/token/services/tokens/mock/token_store.go
@@ -3,6 +3,7 @@ package mock
 
 import (
 	"context"
+	"math/big"
 	"sync"
 
 	drivera "github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -11,7 +12,7 @@ import (
 )
 
 type FakeTokenStore struct {
-	BalanceStub        func(context.Context, string, token.Type) (uint64, error)
+	BalanceStub        func(context.Context, string, token.Type) (*big.Int, error)
 	balanceMutex       sync.RWMutex
 	balanceArgsForCall []struct {
 		arg1 context.Context
@@ -19,11 +20,11 @@ type FakeTokenStore struct {
 		arg3 token.Type
 	}
 	balanceReturns struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	balanceReturnsOnCall map[int]struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}
 	CloseStub        func() error
@@ -437,7 +438,7 @@ type FakeTokenStore struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeTokenStore) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (uint64, error) {
+func (fake *FakeTokenStore) Balance(arg1 context.Context, arg2 string, arg3 token.Type) (*big.Int, error) {
 	fake.balanceMutex.Lock()
 	ret, specificReturn := fake.balanceReturnsOnCall[len(fake.balanceArgsForCall)]
 	fake.balanceArgsForCall = append(fake.balanceArgsForCall, struct {
@@ -464,7 +465,7 @@ func (fake *FakeTokenStore) BalanceCallCount() int {
 	return len(fake.balanceArgsForCall)
 }
 
-func (fake *FakeTokenStore) BalanceCalls(stub func(context.Context, string, token.Type) (uint64, error)) {
+func (fake *FakeTokenStore) BalanceCalls(stub func(context.Context, string, token.Type) (*big.Int, error)) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = stub
@@ -477,28 +478,28 @@ func (fake *FakeTokenStore) BalanceArgsForCall(i int) (context.Context, string, 
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *FakeTokenStore) BalanceReturns(result1 uint64, result2 error) {
+func (fake *FakeTokenStore) BalanceReturns(result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	fake.balanceReturns = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeTokenStore) BalanceReturnsOnCall(i int, result1 uint64, result2 error) {
+func (fake *FakeTokenStore) BalanceReturnsOnCall(i int, result1 *big.Int, result2 error) {
 	fake.balanceMutex.Lock()
 	defer fake.balanceMutex.Unlock()
 	fake.BalanceStub = nil
 	if fake.balanceReturnsOnCall == nil {
 		fake.balanceReturnsOnCall = make(map[int]struct {
-			result1 uint64
+			result1 *big.Int
 			result2 error
 		})
 	}
 	fake.balanceReturnsOnCall[i] = struct {
-		result1 uint64
+		result1 *big.Int
 		result2 error
 	}{result1, result2}
 }

--- a/token/wallet.go
+++ b/token/wallet.go
@@ -9,6 +9,7 @@ package token
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/driver"
@@ -299,15 +300,15 @@ func (o *OwnerWallet) ListUnspentTokensIterator(opts ...ListTokensOption) (*Unsp
 	return &UnspentTokensIterator{UnspentTokensIterator: it}, nil
 }
 
-// Balance returns the sun of the amounts, with 64 bits of precision, of the tokens with type and EID equal to those passed as arguments.
-func (o *OwnerWallet) Balance(ctx context.Context, opts ...ListTokensOption) (uint64, error) {
+// Balance returns the sum of the amounts of the tokens with type and EID equal to those passed as arguments.
+func (o *OwnerWallet) Balance(ctx context.Context, opts ...ListTokensOption) (*big.Int, error) {
 	compiledOpts, err := CompileListTokensOption(opts...)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	sum, err := o.w.Balance(ctx, compiledOpts)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	return sum, nil

--- a/token/wallet_test.go
+++ b/token/wallet_test.go
@@ -9,6 +9,7 @@ package token
 
 import (
 	"context"
+	"math/big"
 	"testing"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -567,7 +568,7 @@ func TestOwnerWallet_ListUnspentTokensIterator(t *testing.T) {
 // TestOwnerWallet_Balance verifies Balance
 func TestOwnerWallet_Balance(t *testing.T) {
 	mockOW := &mock.OwnerWallet{}
-	mockOW.BalanceReturns(uint64(1000), nil)
+	mockOW.BalanceReturns(big.NewInt(1000), nil)
 
 	wallet := &OwnerWallet{w: mockOW}
 	ctx := context.Background()
@@ -575,7 +576,7 @@ func TestOwnerWallet_Balance(t *testing.T) {
 	balance, err := wallet.Balance(ctx, WithType("USD"))
 
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1000), balance)
+	assert.Zero(t, big.NewInt(1000).Cmp(balance))
 }
 
 // TestOwnerWallet_RegisterRecipient verifies RegisterRecipient
@@ -758,7 +759,7 @@ func TestOwnerWallet_ListUnspentTokensIterator_Error(t *testing.T) {
 func TestOwnerWallet_Balance_Error(t *testing.T) {
 	mockOW := &mock.OwnerWallet{}
 	expectedErr := errors.New("failed to get balance")
-	mockOW.BalanceReturns(0, expectedErr)
+	mockOW.BalanceReturns(nil, expectedErr)
 
 	wallet := &OwnerWallet{w: mockOW}
 	ctx := context.Background()
@@ -767,7 +768,7 @@ func TestOwnerWallet_Balance_Error(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, expectedErr, err)
-	assert.Equal(t, uint64(0), balance)
+	assert.Nil(t, balance)
 }
 
 // TestIssuerWallet_ListIssuedTokens_Error verifies error handling


### PR DESCRIPTION
## Summary
- change owner-wallet and token-vault balance APIs to return `*big.Int`
- compute SQL balances by streaming `amount` rows into a Go `big.Int` accumulator instead of relying on `SUM(amount)`
- update the balance views and checks to serialize balances as decimal strings
- add a regression test that covers balances larger than `uint64`

## Testing
- go test ./token
- go test ./token/services/identity/role
- go test ./token/services/storage/db/sql/common
- go test ./token/services/storage/db/sql/sqlite
- go test ./integration/token/fungible/views ./integration/token/interop/views ./integration/token/dvp/views

Fixes #1693