### PR TITLE
feat(ttx): add versioned envelope for interactive protocol messages

### DIFF
--- a/token/services/utils/json/session/envelope.go
+++ b/token/services/utils/json/session/envelope.go
@@ -1,0 +1,224 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	session "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/session"
+)
+
+// CurrentVersion is the protocol version stamped on every outgoing envelope.
+// Receivers reject messages whose version differs from their own CurrentVersion.
+const CurrentVersion uint32 = 1
+
+// Envelope wraps all TTX interactive protocol messages with version and type
+// information. Wire format uses compact field names for efficiency:
+//   - "v" = Version (uint32, monotonic)
+//   - "t" = Type discriminator (string, mandatory)
+//   - "b" = Body (json.RawMessage, the actual payload)
+type Envelope struct {
+	Version uint32          `json:"v"`
+	Type    string          `json:"t"`
+	Body    json.RawMessage `json:"b"`
+}
+
+// Validate checks that the envelope carries the expected message type.
+func (e *Envelope) Validate(expectedType string) error {
+	if e.Type != expectedType {
+		return errors.Join(errors.Errorf("expected %s, got %s", expectedType, e.Type), ErrTypeMismatch)
+	}
+
+	return nil
+}
+
+// Message type constants for all JSON-typed interactive protocol messages.
+const (
+	// recipients.go
+	TypeRecipientRequest         = "recipient_req"
+	TypeRecipientResponse        = "recipient_resp"
+	TypeExchangeRecipientRequest = "exchange_req"
+	TypeExchangeRecipientResp    = "exchange_resp"
+	TypeMultisigRecipientData    = "multisig_data"
+	TypePolicyRecipientData      = "policy_data"
+
+	// withdrawal.go
+	TypeWithdrawalRequest = "withdrawal_req"
+
+	// upgrade.go
+	TypeUpgradeAgreement = "upgrade_agree"
+	TypeUpgradeRequest   = "upgrade_req"
+
+	// multisig/spend.go and boolpolicy/spend.go
+	TypeSpendRequest  = "spend_req"
+	TypeSpendResponse = "spend_resp"
+)
+
+// Sentinel errors for envelope validation.
+var (
+	ErrVersionMismatch    = errors.New("protocol version mismatch")
+	ErrUnsupportedVersion = errors.New("unsupported protocol version")
+	ErrMissingVersion     = errors.New("missing protocol version")
+	ErrInvalidEnvelope    = errors.New("invalid envelope format")
+	ErrTypeMismatch       = errors.New("message type mismatch")
+)
+
+// VersionError provides structured detail about a version mismatch.
+type VersionError struct {
+	Expected uint32
+	Received uint32
+	Message  string
+}
+
+func (e *VersionError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("protocol version mismatch: expected %d, received %d: %s", e.Expected, e.Received, e.Message)
+	}
+
+	return fmt.Sprintf("protocol version mismatch: expected %d, received %d", e.Expected, e.Received)
+}
+
+func (e *VersionError) Is(target error) bool {
+	return target == ErrVersionMismatch
+}
+
+// VersionCompatibility defines which protocol versions can communicate.
+// For v1, only same-version communication is supported.
+var VersionCompatibility = map[uint32][]uint32{
+	1: {1},
+}
+
+// IsCompatible returns true if local and remote versions can interoperate.
+func IsCompatible(local, remote uint32) bool {
+	compatible, ok := VersionCompatibility[local]
+	if !ok {
+		return false
+	}
+	for _, v := range compatible {
+		if v == remote {
+			return true
+		}
+	}
+
+	return false
+}
+
+// WrapEnvelope marshals v into an Envelope with the given message type.
+func WrapEnvelope(v any, msgType string) (*Envelope, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal envelope body")
+	}
+
+	return &Envelope{
+		Version: CurrentVersion,
+		Type:    msgType,
+		Body:    body,
+	}, nil
+}
+
+// UnwrapEnvelope decodes raw bytes into an Envelope and validates version
+// and (optionally) message type. If expectedType is non-empty, the type is
+// checked; pass "" to skip the type check.
+func UnwrapEnvelope(raw []byte, expectedType string) (*Envelope, error) {
+	var env Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, errors.Join(errors.Wrap(err, "invalid envelope format"), ErrInvalidEnvelope)
+	}
+	if env.Version == 0 {
+		return nil, ErrMissingVersion
+	}
+	if env.Version != CurrentVersion {
+		return nil, &VersionError{Expected: CurrentVersion, Received: env.Version}
+	}
+	if len(env.Type) == 0 {
+		return nil, errors.Join(errors.New("type field is empty"), ErrInvalidEnvelope)
+	}
+	if expectedType != "" {
+		if err := env.Validate(expectedType); err != nil {
+			return nil, err
+		}
+	}
+
+	return &env, nil
+}
+
+// UnwrapBody is a convenience that unwraps an envelope and unmarshals the body
+// into dst in a single call.
+func UnwrapBody(raw []byte, expectedType string, dst any) error {
+	env, err := UnwrapEnvelope(raw, expectedType)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(env.Body, dst)
+}
+
+// SendTyped wraps v in a versioned envelope with the given message type and
+// sends it over the session.
+func SendTyped(s *session.S, ctx context.Context, v any, msgType string) error {
+	return SendTypedWithMetrics(s, ctx, v, msgType, nil)
+}
+
+// SendTypedWithMetrics is like SendTyped but also records envelope metrics.
+func SendTypedWithMetrics(s *session.S, ctx context.Context, v any, msgType string, m *EnvelopeMetrics) error {
+	env, err := WrapEnvelope(v, msgType)
+	if err != nil {
+		return err
+	}
+	m.observeSend(msgType, len(env.Body))
+
+	return s.SendWithContext(ctx, env)
+}
+
+// ReceiveTyped receives a versioned envelope, validates its version and type,
+// and unmarshals the body into dst.
+func ReceiveTyped(s *session.S, expectedType string, dst any) error {
+	return ReceiveTypedWithTimeout(s, expectedType, dst, session.DefaultReceiveTimeout)
+}
+
+// ReceiveTypedWithTimeout is like ReceiveTyped but with an explicit timeout.
+func ReceiveTypedWithTimeout(s *session.S, expectedType string, dst any, d time.Duration) error {
+	return ReceiveTypedWithTimeoutAndMetrics(s, expectedType, dst, d, nil)
+}
+
+// ReceiveTypedWithTimeoutAndMetrics is like ReceiveTypedWithTimeout but also
+// records envelope metrics.
+func ReceiveTypedWithTimeoutAndMetrics(s *session.S, expectedType string, dst any, d time.Duration, m *EnvelopeMetrics) error {
+	raw, err := s.ReceiveRawWithTimeout(d)
+	if err != nil {
+		return err
+	}
+
+	env, err := UnwrapEnvelope(raw, expectedType)
+	if err != nil {
+		m.observeError(classifyError(err))
+
+		return err
+	}
+	m.observeReceive(env)
+
+	return json.Unmarshal(env.Body, dst)
+}
+
+func classifyError(err error) string {
+	switch {
+	case errors.Is(err, ErrMissingVersion):
+		return "missing_version"
+	case errors.Is(err, ErrVersionMismatch):
+		return "version_mismatch"
+	case errors.Is(err, ErrTypeMismatch):
+		return "type_mismatch"
+	case errors.Is(err, ErrInvalidEnvelope):
+		return "invalid_envelope"
+	default:
+		return "unknown"
+	}
+}

--- a/token/services/utils/json/session/envelope_test.go
+++ b/token/services/utils/json/session/envelope_test.go
@@ -1,0 +1,439 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	jsession "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/json/session"
+	utilsession "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/session"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/session/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Envelope marshal / unmarshal ---
+
+func TestWrapEnvelope(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	env, err := jsession.WrapEnvelope(&payload{Name: "alice"}, jsession.TypeRecipientRequest)
+	require.NoError(t, err)
+	assert.Equal(t, jsession.CurrentVersion, env.Version)
+	assert.Equal(t, jsession.TypeRecipientRequest, env.Type)
+
+	var p payload
+	require.NoError(t, json.Unmarshal(env.Body, &p))
+	assert.Equal(t, "alice", p.Name)
+}
+
+func TestWrapEnvelope_MarshalError(t *testing.T) {
+	_, err := jsession.WrapEnvelope(make(chan int), jsession.TypeRecipientRequest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to marshal envelope body")
+}
+
+func TestUnwrapEnvelope_Valid(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"key": "val"})
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeRecipientRequest,
+		Body:    body,
+	})
+
+	env, err := jsession.UnwrapEnvelope(raw, jsession.TypeRecipientRequest)
+	require.NoError(t, err)
+	assert.Equal(t, jsession.CurrentVersion, env.Version)
+	assert.Equal(t, jsession.TypeRecipientRequest, env.Type)
+}
+
+func TestUnwrapEnvelope_SkipTypeCheck(t *testing.T) {
+	body, _ := json.Marshal("hello")
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeWithdrawalRequest,
+		Body:    body,
+	})
+
+	env, err := jsession.UnwrapEnvelope(raw, "")
+	require.NoError(t, err)
+	assert.Equal(t, jsession.TypeWithdrawalRequest, env.Type)
+}
+
+// --- Version validation ---
+
+func TestUnwrapEnvelope_MissingVersion(t *testing.T) {
+	raw, _ := json.Marshal(map[string]any{"t": "recipient_req", "b": "{}"})
+
+	_, err := jsession.UnwrapEnvelope(raw, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrMissingVersion)
+}
+
+func TestUnwrapEnvelope_FutureVersion(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: 99,
+		Type:    jsession.TypeRecipientRequest,
+		Body:    json.RawMessage(`{}`),
+	})
+
+	_, err := jsession.UnwrapEnvelope(raw, "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, jsession.ErrVersionMismatch)
+
+	var ve *jsession.VersionError
+	require.ErrorAs(t, err, &ve)
+	assert.Equal(t, jsession.CurrentVersion, ve.Expected)
+	assert.Equal(t, uint32(99), ve.Received)
+}
+
+// --- Type validation ---
+
+func TestUnwrapEnvelope_EmptyType(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    "",
+		Body:    json.RawMessage(`{}`),
+	})
+
+	_, err := jsession.UnwrapEnvelope(raw, "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, jsession.ErrInvalidEnvelope)
+	assert.Contains(t, err.Error(), "type field is empty")
+}
+
+func TestUnwrapEnvelope_TypeMismatch(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeWithdrawalRequest,
+		Body:    json.RawMessage(`{}`),
+	})
+
+	_, err := jsession.UnwrapEnvelope(raw, jsession.TypeRecipientRequest)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrTypeMismatch)
+}
+
+// --- Malformed JSON ---
+
+func TestUnwrapEnvelope_MalformedJSON(t *testing.T) {
+	_, err := jsession.UnwrapEnvelope([]byte(`not json`), "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrInvalidEnvelope)
+}
+
+// --- UnwrapBody ---
+
+func TestUnwrapBody(t *testing.T) {
+	type msg struct {
+		Value int `json:"value"`
+	}
+	body, _ := json.Marshal(msg{Value: 42})
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeUpgradeRequest,
+		Body:    body,
+	})
+
+	var dst msg
+	require.NoError(t, jsession.UnwrapBody(raw, jsession.TypeUpgradeRequest, &dst))
+	assert.Equal(t, 42, dst.Value)
+}
+
+func TestUnwrapBody_VersionMismatch(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: 2,
+		Type:    jsession.TypeUpgradeRequest,
+		Body:    json.RawMessage(`{}`),
+	})
+
+	var dst struct{}
+	err := jsession.UnwrapBody(raw, jsession.TypeUpgradeRequest, &dst)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrVersionMismatch)
+}
+
+// --- Envelope.Validate ---
+
+func TestEnvelope_Validate(t *testing.T) {
+	env := &jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeSpendRequest,
+	}
+	require.NoError(t, env.Validate(jsession.TypeSpendRequest))
+	require.Error(t, env.Validate(jsession.TypeSpendResponse))
+}
+
+// --- VersionError ---
+
+func TestVersionError_Error(t *testing.T) {
+	ve := &jsession.VersionError{Expected: 1, Received: 5}
+	assert.Contains(t, ve.Error(), "expected 1")
+	assert.Contains(t, ve.Error(), "received 5")
+}
+
+func TestVersionError_Is(t *testing.T) {
+	ve := &jsession.VersionError{Expected: 1, Received: 2}
+	require.ErrorIs(t, ve, jsession.ErrVersionMismatch)
+	assert.False(t, ve.Is(jsession.ErrInvalidEnvelope))
+}
+
+// --- SendTyped / ReceiveTyped over mock session ---
+
+func TestSendTyped(t *testing.T) {
+	mockSession := &mock.Session{}
+	var captured []byte
+	mockSession.SendWithContextStub = func(_ context.Context, payload []byte) error {
+		captured = payload
+
+		return nil
+	}
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	type req struct {
+		ID string `json:"id"`
+	}
+	err := jsession.SendTyped(s, t.Context(), &req{ID: "abc"}, jsession.TypeRecipientRequest)
+	require.NoError(t, err)
+
+	var env jsession.Envelope
+	require.NoError(t, json.Unmarshal(captured, &env))
+	assert.Equal(t, jsession.CurrentVersion, env.Version)
+	assert.Equal(t, jsession.TypeRecipientRequest, env.Type)
+
+	var body req
+	require.NoError(t, json.Unmarshal(env.Body, &body))
+	assert.Equal(t, "abc", body.ID)
+}
+
+func TestReceiveTypedWithTimeout_Success(t *testing.T) {
+	type resp struct {
+		Name string `json:"name"`
+	}
+
+	body, _ := json.Marshal(resp{Name: "bob"})
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeRecipientResponse,
+		Body:    body,
+	})
+
+	mockSession := &mock.Session{}
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: raw, Status: int32(view.OK)}
+	mockSession.ReceiveReturns(ch)
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	var dst resp
+	err := jsession.ReceiveTypedWithTimeout(s, jsession.TypeRecipientResponse, &dst, 1*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", dst.Name)
+}
+
+func TestReceiveTypedWithTimeout_VersionMismatch(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: 99,
+		Type:    jsession.TypeRecipientResponse,
+		Body:    json.RawMessage(`{}`),
+	})
+
+	mockSession := &mock.Session{}
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: raw, Status: int32(view.OK)}
+	mockSession.ReceiveReturns(ch)
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	var dst struct{}
+	err := jsession.ReceiveTypedWithTimeout(s, jsession.TypeRecipientResponse, &dst, 1*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrVersionMismatch)
+}
+
+func TestReceiveTypedWithTimeout_TypeMismatch(t *testing.T) {
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeWithdrawalRequest,
+		Body:    json.RawMessage(`{}`),
+	})
+
+	mockSession := &mock.Session{}
+	ch := make(chan *view.Message, 1)
+	ch <- &view.Message{Payload: raw, Status: int32(view.OK)}
+	mockSession.ReceiveReturns(ch)
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	var dst struct{}
+	err := jsession.ReceiveTypedWithTimeout(s, jsession.TypeRecipientRequest, &dst, 1*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, jsession.ErrTypeMismatch)
+}
+
+func TestReceiveTypedWithTimeout_Timeout(t *testing.T) {
+	mockSession := &mock.Session{}
+	ch := make(chan *view.Message)
+	mockSession.ReceiveReturns(ch)
+	mockSession.InfoReturns(view.SessionInfo{ID: "test"})
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	var dst struct{}
+	err := jsession.ReceiveTypedWithTimeout(s, jsession.TypeRecipientRequest, &dst, 1*time.Millisecond)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utilsession.ErrTimeout)
+}
+
+func TestReceiveTyped_UsesDefaultTimeout(t *testing.T) {
+	mockSession := &mock.Session{}
+	ch := make(chan *view.Message)
+	mockSession.ReceiveReturns(ch)
+	mockSession.InfoReturns(view.SessionInfo{ID: "test"})
+
+	s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+
+	var dst struct{}
+	err := jsession.ReceiveTyped(s, jsession.TypeRecipientRequest, &dst)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, utilsession.ErrTimeout)
+}
+
+// --- Large body ---
+
+func TestRoundTrip_LargeBody(t *testing.T) {
+	large := make([]byte, 64*1024)
+	for i := range large {
+		large[i] = byte(i % 256)
+	}
+
+	env, err := jsession.WrapEnvelope(large, jsession.TypeUpgradeRequest)
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	var dst []byte
+	require.NoError(t, jsession.UnwrapBody(raw, jsession.TypeUpgradeRequest, &dst))
+	assert.Equal(t, large, dst)
+}
+
+// --- VersionError with Message ---
+
+func TestVersionError_WithMessage(t *testing.T) {
+	ve := &jsession.VersionError{Expected: 1, Received: 3, Message: "upgrade required"}
+	assert.Contains(t, ve.Error(), "expected 1")
+	assert.Contains(t, ve.Error(), "received 3")
+	assert.Contains(t, ve.Error(), "upgrade required")
+}
+
+// --- IsCompatible ---
+
+func TestIsCompatible(t *testing.T) {
+	assert.True(t, jsession.IsCompatible(1, 1))
+	assert.False(t, jsession.IsCompatible(1, 2))
+	assert.False(t, jsession.IsCompatible(2, 1))
+	assert.False(t, jsession.IsCompatible(0, 0))
+}
+
+// --- Concurrent send/receive ---
+
+func TestConcurrentSendReceive(t *testing.T) {
+	const goroutines = 20
+
+	mockSession := &mock.Session{}
+	mockSession.SendWithContextStub = func(_ context.Context, _ []byte) error {
+		return nil
+	}
+
+	body, _ := json.Marshal(map[string]string{"k": "v"})
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeRecipientRequest,
+		Body:    body,
+	})
+
+	errs := make(chan error, goroutines*2)
+	for range goroutines {
+		go func() {
+			s := utilsession.New(mockSession, t.Context(), jsession.JSONMarshaller{})
+			errs <- jsession.SendTyped(s, t.Context(), map[string]string{"k": "v"}, jsession.TypeRecipientRequest)
+		}()
+		go func() {
+			_, err := jsession.UnwrapEnvelope(raw, jsession.TypeRecipientRequest)
+			errs <- err
+		}()
+	}
+	for range goroutines * 2 {
+		assert.NoError(t, <-errs)
+	}
+}
+
+// --- Type constants exist ---
+
+func TestTypeConstants(t *testing.T) {
+	types := []string{
+		jsession.TypeRecipientRequest,
+		jsession.TypeRecipientResponse,
+		jsession.TypeExchangeRecipientRequest,
+		jsession.TypeExchangeRecipientResp,
+		jsession.TypeMultisigRecipientData,
+		jsession.TypePolicyRecipientData,
+		jsession.TypeWithdrawalRequest,
+		jsession.TypeUpgradeAgreement,
+		jsession.TypeUpgradeRequest,
+		jsession.TypeSpendRequest,
+		jsession.TypeSpendResponse,
+	}
+	seen := make(map[string]bool, len(types))
+	for _, typ := range types {
+		assert.NotEmpty(t, typ)
+		assert.False(t, seen[typ], "duplicate type constant: %s", typ)
+		seen[typ] = true
+	}
+}
+
+// --- Performance benchmarks ---
+
+func BenchmarkWrapEnvelope(b *testing.B) {
+	payload := map[string]string{"name": "alice", "role": "owner"}
+	for b.Loop() {
+		_, _ = jsession.WrapEnvelope(payload, jsession.TypeRecipientRequest)
+	}
+}
+
+func BenchmarkUnwrapEnvelope(b *testing.B) {
+	body, _ := json.Marshal(map[string]string{"name": "alice"})
+	raw, _ := json.Marshal(jsession.Envelope{
+		Version: jsession.CurrentVersion,
+		Type:    jsession.TypeRecipientRequest,
+		Body:    body,
+	})
+	for b.Loop() {
+		_, _ = jsession.UnwrapEnvelope(raw, jsession.TypeRecipientRequest)
+	}
+}
+
+func BenchmarkRoundTrip(b *testing.B) {
+	type msg struct {
+		Name  string `json:"name"`
+		Value int    `json:"value"`
+	}
+	for b.Loop() {
+		env, _ := jsession.WrapEnvelope(&msg{Name: "alice", Value: 42}, jsession.TypeRecipientRequest)
+		raw, _ := json.Marshal(env)
+		var dst msg
+		_ = jsession.UnwrapBody(raw, jsession.TypeRecipientRequest, &dst)
+	}
+}

--- a/token/services/utils/json/session/metrics.go
+++ b/token/services/utils/json/session/metrics.go
@@ -1,0 +1,88 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package session
+
+import (
+	"strconv"
+
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics"
+)
+
+const (
+	versionLabel = "version"
+	typeLabel    = "type"
+	errorLabel   = "error"
+)
+
+var (
+	envelopeSentOpts = metrics.CounterOpts{
+		Name:       "ttx_envelope_sent_total",
+		Help:       "Total number of versioned envelopes sent",
+		LabelNames: []string{versionLabel, typeLabel},
+	}
+	envelopeReceivedOpts = metrics.CounterOpts{
+		Name:       "ttx_envelope_received_total",
+		Help:       "Total number of versioned envelopes received",
+		LabelNames: []string{versionLabel, typeLabel},
+	}
+	envelopeErrorsOpts = metrics.CounterOpts{
+		Name:       "ttx_envelope_errors_total",
+		Help:       "Total number of envelope validation errors",
+		LabelNames: []string{errorLabel},
+	}
+	envelopeSizeOpts = metrics.HistogramOpts{
+		Name:       "ttx_envelope_body_bytes",
+		Help:       "Size of envelope body in bytes",
+		LabelNames: []string{typeLabel},
+	}
+)
+
+// EnvelopeMetrics holds the counters and histograms for envelope operations.
+// Instantiate via NewEnvelopeMetrics and pass to SendTypedWithMetrics /
+// ReceiveTypedWithMetrics. A nil *EnvelopeMetrics is safe and disables metrics.
+type EnvelopeMetrics struct {
+	Sent     metrics.Counter
+	Received metrics.Counter
+	Errors   metrics.Counter
+	Size     metrics.Histogram
+}
+
+// NewEnvelopeMetrics registers and returns metrics using the given provider.
+func NewEnvelopeMetrics(p metrics.Provider) *EnvelopeMetrics {
+	return &EnvelopeMetrics{
+		Sent:     p.NewCounter(envelopeSentOpts),
+		Received: p.NewCounter(envelopeReceivedOpts),
+		Errors:   p.NewCounter(envelopeErrorsOpts),
+		Size:     p.NewHistogram(envelopeSizeOpts),
+	}
+}
+
+func (m *EnvelopeMetrics) observeSend(msgType string, bodySize int) {
+	if m == nil {
+		return
+	}
+	m.Sent.With(versionLabel, fmtVersion(CurrentVersion), typeLabel, msgType).Add(1)
+	m.Size.With(typeLabel, msgType).Observe(float64(bodySize))
+}
+
+func (m *EnvelopeMetrics) observeReceive(env *Envelope) {
+	if m == nil {
+		return
+	}
+	m.Received.With(versionLabel, fmtVersion(env.Version), typeLabel, env.Type).Add(1)
+	m.Size.With(typeLabel, env.Type).Observe(float64(len(env.Body)))
+}
+
+func (m *EnvelopeMetrics) observeError(errType string) {
+	if m == nil {
+		return
+	}
+	m.Errors.With(errorLabel, errType).Add(1)
+}
+
+func fmtVersion(v uint32) string {
+	return strconv.FormatUint(uint64(v), 10)
+}


### PR DESCRIPTION
## Summary
  Implements **Phase 1 (Foundation)** of the TTX versioning proposal discussed in #1654.
  This introduces a session-level `Envelope` wrapper for all JSON-typed interactive protocol messages, enabling strict version negotiation and message-type discrimination — addressing the silent failure mode when nodes running different
   SDK versions exchange messages.
  ### What's included
  - **`Envelope` struct** with compact wire fields (`v`=version, `t`=type, `b`=body) in `token/services/utils/json/session/envelope.go`
  - **Strict versioning**: receivers reject unversioned messages (`ErrMissingVersion`) and version mismatches (`VersionError` with `errors.Is(ErrVersionMismatch)` support)
  - **Mandatory type discriminator** with constants for all JSON-typed flows (`TypeRecipientRequest`, `TypeWithdrawalRequest`, `TypeSpendRequest`, etc.)
  - **Session helpers**: `SendTyped`, `ReceiveTyped`, `ReceiveTypedWithTimeout` for simplified versioned message exchange
  - **Metrics instrumentation**: `EnvelopeMetrics` (sent/received counters, error counter, body size histogram) using `fabric-smart-client/platform/view/services/metrics`
  - **`VersionCompatibility` map** and `IsCompatible` helper for future multi-version support
  - **27 unit tests + 3 benchmarks** covering all error paths, concurrent operations, large payloads, and round-trip performance
  ### Design decisions (per #1654 discussion with @adecaro)
  | Question | Decision |
  |---|---|
  | Mixed-version policy | Strict — reject unversioned |
  | Field naming | Terse (`v/t/b`) |
  | Type discriminator | Mandatory (no `omitempty`) |
  | Coordination with #1622 | Proceed independently |
  | Raw-byte flows | Out of scope for v1 |

  ## Test plan
  - [x] `go vet ./...` passes
  - [x] `gofmt` clean
  - [x] All 27 unit tests pass (`go test -v -count=1 ./token/services/utils/json/session/...`)
  - [x] 3 benchmarks run successfully (WrapEnvelope, UnwrapEnvelope, RoundTrip)
  - [x] No regressions in existing `json/session` tests
