### PR TITLE
fix(recovery): unblock queue head by marking NotFound orphans Deleted after grace period

### DIFF
--- a/token/services/storage/recovery/config.go
+++ b/token/services/storage/recovery/config.go
@@ -35,18 +35,25 @@ type Config struct {
 	AdvisoryLockID int64
 	// InstanceID identifies the current replica as the lease owner.
 	InstanceID string
+	// NotFoundGracePeriod: when GetTransactionStatus returns a NotFound error and
+	// the tx was stored more than this duration ago, the recovery loop marks the
+	// row as Deleted instead of leaving it for another retry. Prevents the queue
+	// from being permanently blocked by orphan transactions (broadcast failures
+	// that never reached the ledger). Zero disables this behaviour.
+	NotFoundGracePeriod time.Duration
 }
 
 // DefaultConfig returns the default recovery configuration
 func DefaultConfig() Config {
 	return Config{
-		Enabled:        true,
-		TTL:            30 * time.Second,
-		ScanInterval:   5 * time.Second,
-		BatchSize:      defaultBatchSize,
-		WorkerCount:    defaultWorkers,
-		LeaseDuration:  defaultLeaseDuration,
-		AdvisoryLockID: defaultLockID,
+		Enabled:             true,
+		TTL:                 30 * time.Second,
+		ScanInterval:        5 * time.Second,
+		BatchSize:           defaultBatchSize,
+		WorkerCount:         defaultWorkers,
+		LeaseDuration:       defaultLeaseDuration,
+		AdvisoryLockID:      defaultLockID,
+		NotFoundGracePeriod: 30 * time.Minute,
 	}
 }
 
@@ -88,6 +95,13 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	}
 	if config.InstanceID != "" {
 		result.InstanceID = config.InstanceID
+	}
+	// NotFoundGracePeriod accepts an explicit zero to disable the orphan
+	// promotion, so check IsSet rather than the Go zero value. Without this
+	// gate, setting notFoundGracePeriod: 0 in config would silently fall back
+	// to the 30 min default and the documented opt-out would be unreachable.
+	if cfg.IsSet(ConfigKeyRecovery + ".notFoundGracePeriod") {
+		result.NotFoundGracePeriod = config.NotFoundGracePeriod
 	}
 
 	return result, nil

--- a/token/services/storage/recovery/manager.go
+++ b/token/services/storage/recovery/manager.go
@@ -10,11 +10,13 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
 	dbdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/db/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/ttxdb"
 )
@@ -33,6 +35,10 @@ type Storage interface {
 	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (Leadership, bool, error)
 	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.TransactionRecord, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
+	// SetStatus updates a transaction's status row. Used by the recovery loop to
+	// permanently mark orphan transactions (NotFound past grace period) as Deleted
+	// so they exit the eligible scan range and stop blocking the queue head.
+	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
 }
 
 //go:generate counterfeiter -o mock/handler.go -fake-name Handler . Handler
@@ -229,7 +235,7 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 
 	m.logger.Infof("claimed %d pending transaction(s) needing recovery", len(records))
 
-	work := make(chan string)
+	work := make(chan pendingTx)
 	errCh := make(chan error, len(records))
 	var workerWG sync.WaitGroup
 
@@ -238,11 +244,23 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 		go m.worker(ctx, &workerWG, work, errCh)
 	}
 
+	// ClaimPendingTransactions returns one TransactionRecord per ledger
+	// transaction row, and a single txID can produce multiple rows (one per
+	// movement/output). Dedupe by TxID before fanning out so two workers do
+	// not concurrently call Recover/SetStatus/ReleaseRecoveryClaim against
+	// the same transaction. Keep the earliest StoredAt to make the grace
+	// period decision use the row's true age.
+	seen := make(map[string]time.Time, len(records))
 	for _, record := range records {
 		if record == nil {
 			continue
 		}
-		work <- record.TxID
+		if prev, ok := seen[record.TxID]; !ok || record.Timestamp.Before(prev) {
+			seen[record.TxID] = record.Timestamp
+		}
+	}
+	for txID, storedAt := range seen {
+		work <- pendingTx{TxID: txID, StoredAt: storedAt}
 	}
 	close(work)
 
@@ -272,18 +290,26 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 	return firstErr
 }
 
-func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan string, errCh chan<- error) {
+// pendingTx is the unit of work passed from the sweep goroutine to recovery
+// workers. StoredAt is carried so workers can decide whether a NotFound result
+// has been around long enough to be treated as a permanent orphan.
+type pendingTx struct {
+	TxID     string
+	StoredAt time.Time
+}
+
+func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan pendingTx, errCh chan<- error) {
 	defer wg.Done()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case txID, ok := <-work:
+		case t, ok := <-work:
 			if !ok {
 				return
 			}
-			if err := m.recoverTransaction(ctx, txID); err != nil {
+			if err := m.recoverTransaction(ctx, t.TxID, t.StoredAt); err != nil {
 				errCh <- err
 			}
 		}
@@ -291,18 +317,49 @@ func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan st
 }
 
 // recoverTransaction attempts to recover a transaction using the injected handler
-// and always releases the claim with an appropriate message
-func (m *Manager) recoverTransaction(ctx context.Context, txID string) error {
+// and always releases the claim with an appropriate message.
+//
+// If the handler reports the transaction is not on the ledger and the row was
+// stored more than NotFoundGracePeriod ago, the row is force-marked Deleted to
+// prevent the queue head from being permanently blocked by orphan transactions
+// (e.g. broadcast failures whose audit log was persisted but whose tx never
+// reached the orderer). Without this, ORDER BY stored_at ASC + LIMIT BatchSize
+// would replay the same oldest-100 rows on every sweep forever.
+func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt time.Time) error {
 	m.logger.Debugf("recovering transaction [%s]", txID)
 
 	// Attempt recovery using the injected handler
 	err := m.handler.Recover(ctx, txID)
 
+	// Residual race: SetStatus is unconditional, so an independent finality
+	// listener that confirms this tx between our claim and the write below
+	// could be overwritten by Deleted. In practice the NotFoundGracePeriod
+	// (default 30 min) makes this window vanishingly small — we only get
+	// here when the tx has been Pending for grace+ AND Recover just returned
+	// NotFound. Future hardening: replace SetStatus with an atomic
+	// "status=Pending → Deleted" CAS at the SQL layer.
+	markedDeleted := false
+	if err != nil && m.config.NotFoundGracePeriod > 0 && !storedAt.IsZero() && isNotFoundError(err) {
+		age := time.Since(storedAt)
+		if age > m.config.NotFoundGracePeriod {
+			deleteMsg := fmt.Sprintf("tx never reached ledger (NotFound after %v, grace=%v)", age.Truncate(time.Second), m.config.NotFoundGracePeriod)
+			m.logger.Warnf("recovery: marking tx [%s] as Deleted: %s", txID, deleteMsg)
+			if setErr := m.storage.SetStatus(ctx, txID, storage.Deleted, deleteMsg); setErr != nil {
+				m.logger.Errorf("recovery: failed to mark tx [%s] Deleted: %v", txID, setErr)
+			} else {
+				markedDeleted = true
+			}
+		}
+	}
+
 	// Always release the claim with appropriate message
 	var message string
-	if err != nil {
+	switch {
+	case markedDeleted:
+		message = "tx marked Deleted after NotFound grace period"
+	case err != nil:
 		message = fmt.Sprintf("recovery failed: %v", err)
-	} else {
+	default:
 		message = "recovered successfully"
 	}
 
@@ -310,13 +367,54 @@ func (m *Manager) recoverTransaction(ctx context.Context, txID string) error {
 		m.logger.Warnf("failed to release recovery claim for transaction [%s]: %v", txID, releaseErr)
 	}
 
-	if err != nil {
+	if err != nil && !markedDeleted {
 		return errors.Wrapf(err, "failed to recover transaction [%s]", txID)
+	}
+
+	if markedDeleted {
+		// Treat as resolved — no need to noisily report a "failure" the next sweep
+		// would otherwise re-encounter (the row is now status=3 and ineligible).
+		return nil
 	}
 
 	m.logger.Infof("successfully recovered transaction [%s]", txID)
 
 	return nil
+}
+
+// isNotFoundError reports whether err looks like a "transaction not found on
+// ledger" failure surfaced from the recovery handler path. Matching by string
+// is intentionally loose so the recovery loop does not pull grpc/codes or
+// the network/fabric finality wrappers into its dependency surface; upstream
+// wraps these statuses with errors.Wrapf so the substrings survive.
+//
+// Patterns covered (verified against the dev environment runtime error
+//
+//		"rpc error: code = NotFound desc = transaction ID [X]: not found in
+//		  index: tx not found"):
+//
+//	  - "code = NotFound"     — raw gRPC status text
+//	  - "not found in index"  — committer's gRPC status desc field
+//	  - "tx not found"        — FSC finality.TxNotFound sentinel appended
+//	    by fabric-x ledger.GetTransactionByID
+//	    (fabric-smart-client/platform/fabricx/core/ledger/ledger.go:64).
+//	    Stable across committer error format changes since the sentinel
+//	    is wrapped at the FSC layer, above the committer's gRPC text.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "code = NotFound"):
+		return true
+	case strings.Contains(msg, "not found in index"):
+		return true
+	case strings.Contains(msg, "tx not found"):
+		return true
+	}
+
+	return false
 }
 
 func (m *Manager) releaseClaim(ctx context.Context, txID string, message string) error {

--- a/token/services/storage/recovery/mock/storage.go
+++ b/token/services/storage/recovery/mock/storage.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/recovery"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/ttxdb"
 )
@@ -58,8 +59,86 @@ type Storage struct {
 	releaseRecoveryClaimReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SetStatusStub        func(context.Context, string, storage.TxStatus, string) error
+	setStatusMutex       sync.RWMutex
+	setStatusArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 storage.TxStatus
+		arg4 string
+	}
+	setStatusReturns struct {
+		result1 error
+	}
+	setStatusReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Storage) SetStatus(arg1 context.Context, arg2 string, arg3 storage.TxStatus, arg4 string) error {
+	fake.setStatusMutex.Lock()
+	ret, specificReturn := fake.setStatusReturnsOnCall[len(fake.setStatusArgsForCall)]
+	fake.setStatusArgsForCall = append(fake.setStatusArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 storage.TxStatus
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.SetStatusStub
+	fakeReturns := fake.setStatusReturns
+	fake.recordInvocation("SetStatus", []interface{}{arg1, arg2, arg3, arg4})
+	fake.setStatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Storage) SetStatusCallCount() int {
+	fake.setStatusMutex.RLock()
+	defer fake.setStatusMutex.RUnlock()
+	return len(fake.setStatusArgsForCall)
+}
+
+func (fake *Storage) SetStatusCalls(stub func(context.Context, string, storage.TxStatus, string) error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = stub
+}
+
+func (fake *Storage) SetStatusArgsForCall(i int) (context.Context, string, storage.TxStatus, string) {
+	fake.setStatusMutex.RLock()
+	defer fake.setStatusMutex.RUnlock()
+	argsForCall := fake.setStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *Storage) SetStatusReturns(result1 error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = nil
+	fake.setStatusReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Storage) SetStatusReturnsOnCall(i int, result1 error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = nil
+	if fake.setStatusReturnsOnCall == nil {
+		fake.setStatusReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setStatusReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *Storage) AcquireRecoveryLeadership(arg1 context.Context, arg2 int64) (recovery.Leadership, bool, error) {


### PR DESCRIPTION
Fixes #1709

## Summary

The recovery loop's queue is permanently blocked when the oldest batch of
`status=1` rows contains orphan transactions whose audit log was persisted
but never reached the ledger.

This PR adds `NotFoundGracePeriod` (default 30 min) to `recovery.Config`:
when `GetTransactionStatus` returns NotFound and `stored_at` is older than
the grace period, the row is marked `Deleted` via `SetStatus`, freeing it
from the `ORDER BY stored_at ASC LIMIT BatchSize` scan range.

Configurable via `services.network.fabric.recovery.notFoundGracePeriod`;
set to 0 to disable (preserves prior behaviour).

## Mechanism (why the queue blocks)

1. `ClaimPendingTransactions` selects `ORDER BY stored_at ASC LIMIT BatchSize`,
   always pulling the oldest 100 rows.
2. `TTXRecoveryHandler.Recover` calls `GetTransactionStatus` which returns
   NotFound for orphans, propagating the error.
3. `ReleaseRecoveryClaim` clears `claimed_by` / `expires_at` but does not
   touch `status`, so the row remains `status=1` and immediately re-eligible.
4. Next sweep selects the same 100 rows. Newer rows in the queue never get scanned.

Verified on a deployment with ~250k `status=1` audit rows: 99/99 txid
overlap between two sweeps 10 seconds apart, with the recovery log spinning
at 1224 WARN/min on the same set indefinitely.

## Behaviour after fix

- Orphans older than the grace period get `SetStatus(Deleted)` and leave the
  scan range; queue head advances naturally.
- Transient NotFound (committer restart, brief namespace propagation lag)
  does not trigger the promotion as long as it resolves within the grace period.
- Backwards compatible: `NotFoundGracePeriod=0` restores the original
  "never mark Deleted, retry forever" behaviour.

## API changes

- `recovery.Storage` interface adds `SetStatus(ctx, txID, status, message) error`.
  The existing `transactionDB` adapter in `network/fabric` already satisfies
  this method, so no integration code changes are required.
- `recovery.Config` adds `NotFoundGracePeriod time.Duration`.

## Test plan

- [x] `go build ./token/services/storage/recovery/...`
- [x] `go vet ./token/services/storage/recovery/...`
- [x] Existing mock and unit tests compile against the updated `Storage` interface
- [ ] CI green

