### PR TITLE
fix: add signature request verification in EndorseView (#1611)

### DIFF
--- a/token/services/ttx/endorse.go
+++ b/token/services/ttx/endorse.go
@@ -120,6 +120,14 @@ func (s *EndorseView) handleSignatureRequests(context view.Context) error {
 			}
 		}
 
+		// Verify the transaction in the signature request matches our local transaction
+		if !bytes.Equal(signatureRequest.TX, s.tx.FromRaw) {
+			return errors.Errorf(
+				"signature request transaction mismatch for signer [%s]",
+				signerIdentity,
+			)
+		}
+
 		// check for the expected identity
 		if !signatureRequest.Signer.Equal(signerIdentity) {
 			return errors.Wrapf(

--- a/token/services/ttx/endorse_test.go
+++ b/token/services/ttx/endorse_test.go
@@ -121,8 +121,12 @@ func newTestEndorseViewContext(t *testing.T, input *TestEndorseViewContextInput)
 	txRaw, err := tx.Bytes()
 	require.NoError(t, err)
 
+	// Set FromRaw to simulate a transaction received from network
+	tx.FromRaw = txRaw
+
 	// first the signature request
 	signatureRequest := &ttx.SignatureRequest{
+		TX:     txRaw,
 		Signer: input.IssuerIdentity,
 	}
 	signatureRequestRaw, err := signatureRequest.Bytes()
@@ -235,6 +239,46 @@ func TestEndorseView(t *testing.T) {
 			errorContains: "signature request's signer does not match the expected signer",
 			expectErr:     ttx.ErrSignerIdentityMismatch,
 			verify: func(ctx *TestEndorseViewContext, _ any) {
+				assert.Equal(t, 0, ctx.session.SendWithContextCallCount())
+			},
+		},
+		{
+			name: "signature request transaction mismatch",
+			prepare: func() *TestEndorseViewContext {
+				c := newTestEndorseViewContext(t, nil)
+
+				// Get the original transaction bytes
+				txRaw, err := c.tx.Bytes()
+				require.NoError(t, err)
+
+				// Replace the channel with one that has a mismatched signature request
+				session := c.session
+				ch := make(chan *view.Message, 2)
+				session.ReceiveReturns(ch)
+
+				// Send signature request with DIFFERENT transaction bytes
+				differentTxBytes := []byte("different_transaction_bytes")
+				signatureRequest := &ttx.SignatureRequest{
+					TX:     differentTxBytes, // Different transaction!
+					Signer: []byte("an_issuer"),
+				}
+				signatureRequestRaw, err := signatureRequest.Bytes()
+				require.NoError(t, err)
+				ch <- &view.Message{
+					Payload: signatureRequestRaw,
+				}
+
+				// Send the original transaction
+				ch <- &view.Message{
+					Payload: txRaw,
+				}
+
+				return c
+			},
+			expectError:   true,
+			errorContains: "signature request transaction mismatch",
+			verify: func(ctx *TestEndorseViewContext, _ any) {
+				// Should not send any signature back
 				assert.Equal(t, 0, ctx.session.SendWithContextCallCount())
 			},
 		},


### PR DESCRIPTION
Addresses a security vulnerability where remote signers would accept and sign transactions without verifying that the SignatureRequest.TX bytes match their locally stored transaction.

See more information in: #1611 