### PR TITLE
refactor(recovery): return RecoveryClaim from ClaimPendingTransactions

### DIFF
--- a/token/services/auditor/mock/audit_transaction_store.go
+++ b/token/services/auditor/mock/audit_transaction_store.go
@@ -26,18 +26,18 @@ type AuditTransactionStore struct {
 		result2 bool
 		result3 error
 	}
-	ClaimPendingTransactionsStub        func(context.Context, driver.RecoveryClaimParams) ([]*driver.TransactionRecord, error)
+	ClaimPendingTransactionsStub        func(context.Context, driver.RecoveryClaimParams) ([]*driver.RecoveryClaim, error)
 	claimPendingTransactionsMutex       sync.RWMutex
 	claimPendingTransactionsArgsForCall []struct {
 		arg1 context.Context
 		arg2 driver.RecoveryClaimParams
 	}
 	claimPendingTransactionsReturns struct {
-		result1 []*driver.TransactionRecord
+		result1 []*driver.RecoveryClaim
 		result2 error
 	}
 	claimPendingTransactionsReturnsOnCall map[int]struct {
-		result1 []*driver.TransactionRecord
+		result1 []*driver.RecoveryClaim
 		result2 error
 	}
 	CloseStub        func() error
@@ -263,7 +263,7 @@ func (fake *AuditTransactionStore) AcquireRecoveryLeadershipReturnsOnCall(i int,
 	}{result1, result2, result3}
 }
 
-func (fake *AuditTransactionStore) ClaimPendingTransactions(arg1 context.Context, arg2 driver.RecoveryClaimParams) ([]*driver.TransactionRecord, error) {
+func (fake *AuditTransactionStore) ClaimPendingTransactions(arg1 context.Context, arg2 driver.RecoveryClaimParams) ([]*driver.RecoveryClaim, error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	ret, specificReturn := fake.claimPendingTransactionsReturnsOnCall[len(fake.claimPendingTransactionsArgsForCall)]
 	fake.claimPendingTransactionsArgsForCall = append(fake.claimPendingTransactionsArgsForCall, struct {
@@ -289,7 +289,7 @@ func (fake *AuditTransactionStore) ClaimPendingTransactionsCallCount() int {
 	return len(fake.claimPendingTransactionsArgsForCall)
 }
 
-func (fake *AuditTransactionStore) ClaimPendingTransactionsCalls(stub func(context.Context, driver.RecoveryClaimParams) ([]*driver.TransactionRecord, error)) {
+func (fake *AuditTransactionStore) ClaimPendingTransactionsCalls(stub func(context.Context, driver.RecoveryClaimParams) ([]*driver.RecoveryClaim, error)) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = stub
@@ -302,28 +302,28 @@ func (fake *AuditTransactionStore) ClaimPendingTransactionsArgsForCall(i int) (c
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *AuditTransactionStore) ClaimPendingTransactionsReturns(result1 []*driver.TransactionRecord, result2 error) {
+func (fake *AuditTransactionStore) ClaimPendingTransactionsReturns(result1 []*driver.RecoveryClaim, result2 error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = nil
 	fake.claimPendingTransactionsReturns = struct {
-		result1 []*driver.TransactionRecord
+		result1 []*driver.RecoveryClaim
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *AuditTransactionStore) ClaimPendingTransactionsReturnsOnCall(i int, result1 []*driver.TransactionRecord, result2 error) {
+func (fake *AuditTransactionStore) ClaimPendingTransactionsReturnsOnCall(i int, result1 []*driver.RecoveryClaim, result2 error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = nil
 	if fake.claimPendingTransactionsReturnsOnCall == nil {
 		fake.claimPendingTransactionsReturnsOnCall = make(map[int]struct {
-			result1 []*driver.TransactionRecord
+			result1 []*driver.RecoveryClaim
 			result2 error
 		})
 	}
 	fake.claimPendingTransactionsReturnsOnCall[i] = struct {
-		result1 []*driver.TransactionRecord
+		result1 []*driver.RecoveryClaim
 		result2 error
 	}{result1, result2}
 }

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -618,6 +618,6 @@ type transactionDB interface {
 	GetTokenRequest(ctx context.Context, txID string) ([]byte, error)
 	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
 	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (recovery.Leadership, bool, error)
-	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.TransactionRecord, error)
+	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
 }

--- a/token/services/storage/auditdb/store.go
+++ b/token/services/storage/auditdb/store.go
@@ -102,6 +102,10 @@ type MovementRecord = dbdriver.MovementRecord
 // in that action.
 type TransactionRecord = dbdriver.TransactionRecord
 
+// RecoveryClaim is the minimal projection of a pending transaction row
+// returned by ClaimPendingTransactions for recovery processing.
+type RecoveryClaim = dbdriver.RecoveryClaim
+
 // QueryTransactionsParams defines the parameters for querying movements
 type QueryTransactionsParams = dbdriver.QueryTransactionsParams
 
@@ -331,7 +335,9 @@ func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context, lockID int
 }
 
 // ClaimPendingTransactions returns a claimed batch of Pending transactions older than the given duration.
-func (d *StoreService) ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*TransactionRecord, error) {
+// Each returned RecoveryClaim carries the TxID and StoredAt timestamp the recovery loop needs;
+// the rest of the row is intentionally not projected from SQL.
+func (d *StoreService) ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*RecoveryClaim, error) {
 	storedBefore := time.Now().UTC().Add(-olderThan)
 	logger.DebugfContext(ctx, "claiming pending transactions stored before %s (older than %s), lease duration [%s], limit [%d], owner [%s]",
 		storedBefore, olderThan, leaseDuration, limit, owner)

--- a/token/services/storage/db/driver/audit.go
+++ b/token/services/storage/db/driver/audit.go
@@ -55,7 +55,9 @@ type AuditTransactionStore interface {
 
 	// ClaimPendingTransactions atomically claims a batch of Pending transactions for recovery processing.
 	// Transactions whose recovery lease expired are eligible again.
-	ClaimPendingTransactions(ctx context.Context, params RecoveryClaimParams) ([]*TransactionRecord, error)
+	// Returns the minimal projection (TxID + StoredAt) needed by the recovery loop;
+	// callers do not need the full TransactionRecord.
+	ClaimPendingTransactions(ctx context.Context, params RecoveryClaimParams) ([]*RecoveryClaim, error)
 
 	// ReleaseRecoveryClaim clears the recovery claim metadata for the given transaction if owned by owner.
 	// The message parameter is stored for audit/debugging purposes.

--- a/token/services/storage/db/driver/ttx.go
+++ b/token/services/storage/db/driver/ttx.go
@@ -95,7 +95,9 @@ type TransactionStore interface {
 
 	// ClaimPendingTransactions atomically claims a batch of Pending transactions for recovery processing.
 	// Transactions whose recovery lease expired are eligible again.
-	ClaimPendingTransactions(ctx context.Context, params RecoveryClaimParams) ([]*TransactionRecord, error)
+	// Returns the minimal projection (TxID + StoredAt) needed by the recovery loop;
+	// callers do not need the full TransactionRecord.
+	ClaimPendingTransactions(ctx context.Context, params RecoveryClaimParams) ([]*RecoveryClaim, error)
 
 	// ReleaseRecoveryClaim clears the recovery claim metadata for the given transaction if owned by owner.
 	// The message parameter is stored for audit/debugging purposes.
@@ -122,6 +124,20 @@ type RecoveryClaimParams struct {
 	LeaseDuration time.Duration
 	Limit         int
 	Owner         string
+}
+
+// RecoveryClaim is the minimal projection of a pending transaction row
+// returned by ClaimPendingTransactions. The recovery loop only needs the
+// TxID to act on and the StoredAt timestamp to decide grace-period
+// promotions; the rest of TransactionRecord (action type, amounts,
+// metadata, ...) was always discarded by the caller, so the SQL layer
+// stops projecting it.
+type RecoveryClaim struct {
+	// TxID is the transaction ID claimed for recovery.
+	TxID string
+	// StoredAt is the storage timestamp of the underlying row (UTC), used
+	// by the recovery loop to compute row age for grace-period decisions.
+	StoredAt time.Time
 }
 
 // TransactionRecordReference contains the primary key fields of a transaction request record.

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -327,14 +327,13 @@ func (db *TransactionStore) AcquireRecoveryLeadership(ctx context.Context, lockI
 
 // ClaimPendingTransactions returns a claimed batch of Pending transactions.
 // The default SQL implementation is permissive and does not persist recovery claims.
-func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params dbdriver.RecoveryClaimParams) ([]*dbdriver.TransactionRecord, error) {
+// Only tx_id and stored_at are projected — the recovery loop does not need the
+// rest of the row, and skipping them avoids two metadata JSON unmarshals per row.
+func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params dbdriver.RecoveryClaimParams) ([]*dbdriver.RecoveryClaim, error) {
 	transactionsTable, requestsTable := q.Table(db.table.Transactions), q.Table(db.table.Requests)
 	query, args := q.Select().
 		Fields(
-			transactionsTable.Field("tx_id"), common3.FieldName("action_type"), common3.FieldName("sender_eid"),
-			common3.FieldName("recipient_eid"), common3.FieldName("token_type"), common3.FieldName("amount"),
-			requestsTable.Field("status"), requestsTable.Field("application_metadata"),
-			requestsTable.Field("public_metadata"), transactionsTable.Field("stored_at"),
+			transactionsTable.Field("tx_id"), transactionsTable.Field("stored_at"),
 		).
 		From(transactionsTable.Join(requestsTable,
 			cond.Cmp(transactionsTable.Field("tx_id"), "=", requestsTable.Field("tx_id"))),
@@ -353,19 +352,8 @@ func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params
 		return nil, err
 	}
 
-	results := common.NewIterator(rows, func(r *dbdriver.TransactionRecord) error {
-		var amount BigInt
-		var appMeta []byte
-		var pubMeta []byte
-		if err := rows.Scan(&r.TxID, &r.ActionType, &r.SenderEID, &r.RecipientEID, &r.TokenType, &amount, &r.Status, &appMeta, &pubMeta, &r.Timestamp); err != nil {
-			return err
-		}
-		r.Amount = amount.Int
-
-		return errors2.Join(
-			unmarshal(appMeta, &r.ApplicationMetadata),
-			unmarshal(pubMeta, &r.PublicMetadata),
-		)
+	results := common.NewIterator(rows, func(r *dbdriver.RecoveryClaim) error {
+		return rows.Scan(&r.TxID, &r.StoredAt)
 	})
 
 	return iterators.ReadAllPointers(results)

--- a/token/services/storage/db/sql/postgres/transactions.go
+++ b/token/services/storage/db/sql/postgres/transactions.go
@@ -9,7 +9,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -113,7 +112,11 @@ func NewAuditTransactionStore(dbs *scommon.RWDB, tableNames sqlcommon.TableNames
 
 // ClaimPendingTransactions atomically claims a batch of pending transactions using PostgreSQL's UPDATE...RETURNING.
 // This ensures only one recovery instance can claim a specific transaction.
-func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params tokensdriver.RecoveryClaimParams) ([]*tokensdriver.TransactionRecord, error) {
+// The recovery loop only consumes tx_id + stored_at, so the second SELECT only
+// projects those two columns and joins transactions once (previously joined
+// both tables and unmarshalled two JSON metadata blobs per row that were then
+// discarded by the caller).
+func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params tokensdriver.RecoveryClaimParams) ([]*tokensdriver.RecoveryClaim, error) {
 	logger.Debugf("Claiming pending transactions: owner=%s, olderThan=%s, limit=%d, lease=%s",
 		params.Owner, params.OlderThan, params.Limit, params.LeaseDuration)
 
@@ -121,7 +124,7 @@ func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params
 	// This query:
 	// 1. Finds eligible pending transactions (old enough, not claimed or expired or owned by us)
 	// 2. Atomically updates them with our claim
-	// 3. Returns the full transaction details
+	// 3. Returns (tx_id, stored_at) by joining claimed rows back against the transactions table
 	// #nosec G201
 	query := fmt.Sprintf(`
 		WITH claimed_txs AS (
@@ -146,19 +149,14 @@ func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params
 			)
 			RETURNING tx_id
 		)
-		SELECT
-			t.tx_id, t.action_type, t.sender_eid, t.recipient_eid,
-			t.token_type, t.amount, r.status, r.application_metadata,
-			r.public_metadata, t.stored_at
+		SELECT t.tx_id, t.stored_at
 		FROM claimed_txs c
 		INNER JOIN %s t ON c.tx_id = t.tx_id
-		INNER JOIN %s r ON c.tx_id = r.tx_id
 		ORDER BY t.stored_at ASC`,
 		db.tables.Requests,
 		db.tables.Requests,
 		db.tables.Transactions,
 		db.tables.Transactions,
-		db.tables.Requests,
 	)
 
 	// Convert lease duration to PostgreSQL interval format
@@ -181,20 +179,8 @@ func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params
 	}
 
 	// Parse results
-	results := common.NewIterator(rows, func(r *tokensdriver.TransactionRecord) error {
-		var amount sqlcommon.BigInt
-		var appMeta []byte
-		var pubMeta []byte
-		if err := rows.Scan(&r.TxID, &r.ActionType, &r.SenderEID, &r.RecipientEID, &r.TokenType, &amount, &r.Status, &appMeta, &pubMeta, &r.Timestamp); err != nil {
-			return err
-		}
-		r.Amount = amount.Int
-
-		if err := unmarshalMetadata(appMeta, &r.ApplicationMetadata); err != nil {
-			return err
-		}
-
-		return unmarshalMetadata(pubMeta, &r.PublicMetadata)
+	results := common.NewIterator(rows, func(r *tokensdriver.RecoveryClaim) error {
+		return rows.Scan(&r.TxID, &r.StoredAt)
 	})
 
 	claimed, err := iterators.ReadAllPointers(results)
@@ -313,13 +299,4 @@ func (n *TransactionNotifier) Subscribe(callback func(tokensdriver.Operation, to
 			TxID: m["tx_id"],
 		})
 	})
-}
-
-// unmarshalMetadata unmarshals JSON metadata.
-func unmarshalMetadata(in []byte, out *map[string][]byte) error {
-	if len(in) == 0 {
-		return nil
-	}
-
-	return json.Unmarshal(in, out)
 }

--- a/token/services/storage/recovery/manager.go
+++ b/token/services/storage/recovery/manager.go
@@ -33,7 +33,7 @@ const (
 // Storage defines the interface for querying pending transactions and transaction details
 type Storage interface {
 	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (Leadership, bool, error)
-	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.TransactionRecord, error)
+	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
 	// SetStatus updates a transaction's status row. Used by the recovery loop to
 	// permanently mark orphan transactions (NotFound past grace period) as Deleted
@@ -244,19 +244,19 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 		go m.worker(ctx, &workerWG, work, errCh)
 	}
 
-	// ClaimPendingTransactions returns one TransactionRecord per ledger
-	// transaction row, and a single txID can produce multiple rows (one per
-	// movement/output). Dedupe by TxID before fanning out so two workers do
-	// not concurrently call Recover/SetStatus/ReleaseRecoveryClaim against
-	// the same transaction. Keep the earliest StoredAt to make the grace
-	// period decision use the row's true age.
+	// ClaimPendingTransactions returns one RecoveryClaim per ledger transaction
+	// row, and a single txID can produce multiple rows (one per movement/output).
+	// Dedupe by TxID before fanning out so two workers do not concurrently call
+	// Recover/SetStatus/ReleaseRecoveryClaim against the same transaction. Keep
+	// the earliest StoredAt to make the grace period decision use the row's
+	// true age.
 	seen := make(map[string]time.Time, len(records))
 	for _, record := range records {
 		if record == nil {
 			continue
 		}
-		if prev, ok := seen[record.TxID]; !ok || record.Timestamp.Before(prev) {
-			seen[record.TxID] = record.Timestamp
+		if prev, ok := seen[record.TxID]; !ok || record.StoredAt.Before(prev) {
+			seen[record.TxID] = record.StoredAt
 		}
 	}
 	for txID, storedAt := range seen {

--- a/token/services/storage/recovery/manager_test.go
+++ b/token/services/storage/recovery/manager_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
-	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/recovery"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/recovery/mock"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/ttxdb"
@@ -62,7 +61,7 @@ func TestManager_StartStop(t *testing.T) {
 	leadership := &mock.Leadership{}
 	leadership.CloseReturns(nil)
 	mockDB.AcquireRecoveryLeadershipReturns(leadership, true, nil)
-	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.TransactionRecord{}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
 
 	manager := recovery.NewManager(
 		logger,
@@ -105,10 +104,9 @@ func TestManager_RecoverTransaction(t *testing.T) {
 		InstanceID:     "test-instance",
 	}
 
-	// Create a pending transaction record
-	txRecord := &ttxdb.TransactionRecord{
-		TxID:   "tx123",
-		Status: storage.Pending,
+	// Create a pending transaction claim
+	txRecord := &ttxdb.RecoveryClaim{
+		TxID: "tx123",
 	}
 
 	leadership1 := &mock.Leadership{}
@@ -118,8 +116,8 @@ func TestManager_RecoverTransaction(t *testing.T) {
 
 	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadership1, true, nil)
 	mockDB.AcquireRecoveryLeadershipReturns(leadership2, true, nil)
-	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.TransactionRecord{txRecord}, nil)
-	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.TransactionRecord{}, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
 	mockHandler.RecoverReturns(nil)
 	mockDB.ReleaseRecoveryClaimReturns(nil)
 
@@ -162,10 +160,9 @@ func TestManager_SkipAlreadyRecovered(t *testing.T) {
 		InstanceID:     "test-instance",
 	}
 
-	// Create a pending transaction record
-	txRecord := &ttxdb.TransactionRecord{
-		TxID:   "tx456",
-		Status: storage.Pending,
+	// Create a pending transaction claim
+	txRecord := &ttxdb.RecoveryClaim{
+		TxID: "tx456",
 	}
 
 	leadershipA := &mock.Leadership{}
@@ -178,8 +175,8 @@ func TestManager_SkipAlreadyRecovered(t *testing.T) {
 	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadershipA, true, nil)
 	mockDB.AcquireRecoveryLeadershipReturnsOnCall(1, leadershipB, true, nil)
 	mockDB.AcquireRecoveryLeadershipReturns(leadershipC, true, nil)
-	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.TransactionRecord{txRecord}, nil)
-	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.TransactionRecord{}, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
 	mockHandler.RecoverReturns(nil)
 	mockDB.ReleaseRecoveryClaimReturns(nil)
 

--- a/token/services/storage/recovery/mock/storage.go
+++ b/token/services/storage/recovery/mock/storage.go
@@ -28,7 +28,7 @@ type Storage struct {
 		result2 bool
 		result3 error
 	}
-	ClaimPendingTransactionsStub        func(context.Context, time.Duration, time.Duration, int, string) ([]*ttxdb.TransactionRecord, error)
+	ClaimPendingTransactionsStub        func(context.Context, time.Duration, time.Duration, int, string) ([]*ttxdb.RecoveryClaim, error)
 	claimPendingTransactionsMutex       sync.RWMutex
 	claimPendingTransactionsArgsForCall []struct {
 		arg1 context.Context
@@ -38,11 +38,11 @@ type Storage struct {
 		arg5 string
 	}
 	claimPendingTransactionsReturns struct {
-		result1 []*ttxdb.TransactionRecord
+		result1 []*ttxdb.RecoveryClaim
 		result2 error
 	}
 	claimPendingTransactionsReturnsOnCall map[int]struct {
-		result1 []*ttxdb.TransactionRecord
+		result1 []*ttxdb.RecoveryClaim
 		result2 error
 	}
 	ReleaseRecoveryClaimStub        func(context.Context, string, string, string) error
@@ -75,70 +75,6 @@ type Storage struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *Storage) SetStatus(arg1 context.Context, arg2 string, arg3 storage.TxStatus, arg4 string) error {
-	fake.setStatusMutex.Lock()
-	ret, specificReturn := fake.setStatusReturnsOnCall[len(fake.setStatusArgsForCall)]
-	fake.setStatusArgsForCall = append(fake.setStatusArgsForCall, struct {
-		arg1 context.Context
-		arg2 string
-		arg3 storage.TxStatus
-		arg4 string
-	}{arg1, arg2, arg3, arg4})
-	stub := fake.SetStatusStub
-	fakeReturns := fake.setStatusReturns
-	fake.recordInvocation("SetStatus", []interface{}{arg1, arg2, arg3, arg4})
-	fake.setStatusMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Storage) SetStatusCallCount() int {
-	fake.setStatusMutex.RLock()
-	defer fake.setStatusMutex.RUnlock()
-	return len(fake.setStatusArgsForCall)
-}
-
-func (fake *Storage) SetStatusCalls(stub func(context.Context, string, storage.TxStatus, string) error) {
-	fake.setStatusMutex.Lock()
-	defer fake.setStatusMutex.Unlock()
-	fake.SetStatusStub = stub
-}
-
-func (fake *Storage) SetStatusArgsForCall(i int) (context.Context, string, storage.TxStatus, string) {
-	fake.setStatusMutex.RLock()
-	defer fake.setStatusMutex.RUnlock()
-	argsForCall := fake.setStatusArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
-}
-
-func (fake *Storage) SetStatusReturns(result1 error) {
-	fake.setStatusMutex.Lock()
-	defer fake.setStatusMutex.Unlock()
-	fake.SetStatusStub = nil
-	fake.setStatusReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *Storage) SetStatusReturnsOnCall(i int, result1 error) {
-	fake.setStatusMutex.Lock()
-	defer fake.setStatusMutex.Unlock()
-	fake.SetStatusStub = nil
-	if fake.setStatusReturnsOnCall == nil {
-		fake.setStatusReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setStatusReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *Storage) AcquireRecoveryLeadership(arg1 context.Context, arg2 int64) (recovery.Leadership, bool, error) {
@@ -209,7 +145,7 @@ func (fake *Storage) AcquireRecoveryLeadershipReturnsOnCall(i int, result1 recov
 	}{result1, result2, result3}
 }
 
-func (fake *Storage) ClaimPendingTransactions(arg1 context.Context, arg2 time.Duration, arg3 time.Duration, arg4 int, arg5 string) ([]*ttxdb.TransactionRecord, error) {
+func (fake *Storage) ClaimPendingTransactions(arg1 context.Context, arg2 time.Duration, arg3 time.Duration, arg4 int, arg5 string) ([]*ttxdb.RecoveryClaim, error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	ret, specificReturn := fake.claimPendingTransactionsReturnsOnCall[len(fake.claimPendingTransactionsArgsForCall)]
 	fake.claimPendingTransactionsArgsForCall = append(fake.claimPendingTransactionsArgsForCall, struct {
@@ -238,7 +174,7 @@ func (fake *Storage) ClaimPendingTransactionsCallCount() int {
 	return len(fake.claimPendingTransactionsArgsForCall)
 }
 
-func (fake *Storage) ClaimPendingTransactionsCalls(stub func(context.Context, time.Duration, time.Duration, int, string) ([]*ttxdb.TransactionRecord, error)) {
+func (fake *Storage) ClaimPendingTransactionsCalls(stub func(context.Context, time.Duration, time.Duration, int, string) ([]*ttxdb.RecoveryClaim, error)) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = stub
@@ -251,28 +187,28 @@ func (fake *Storage) ClaimPendingTransactionsArgsForCall(i int) (context.Context
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
-func (fake *Storage) ClaimPendingTransactionsReturns(result1 []*ttxdb.TransactionRecord, result2 error) {
+func (fake *Storage) ClaimPendingTransactionsReturns(result1 []*ttxdb.RecoveryClaim, result2 error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = nil
 	fake.claimPendingTransactionsReturns = struct {
-		result1 []*ttxdb.TransactionRecord
+		result1 []*ttxdb.RecoveryClaim
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *Storage) ClaimPendingTransactionsReturnsOnCall(i int, result1 []*ttxdb.TransactionRecord, result2 error) {
+func (fake *Storage) ClaimPendingTransactionsReturnsOnCall(i int, result1 []*ttxdb.RecoveryClaim, result2 error) {
 	fake.claimPendingTransactionsMutex.Lock()
 	defer fake.claimPendingTransactionsMutex.Unlock()
 	fake.ClaimPendingTransactionsStub = nil
 	if fake.claimPendingTransactionsReturnsOnCall == nil {
 		fake.claimPendingTransactionsReturnsOnCall = make(map[int]struct {
-			result1 []*ttxdb.TransactionRecord
+			result1 []*ttxdb.RecoveryClaim
 			result2 error
 		})
 	}
 	fake.claimPendingTransactionsReturnsOnCall[i] = struct {
-		result1 []*ttxdb.TransactionRecord
+		result1 []*ttxdb.RecoveryClaim
 		result2 error
 	}{result1, result2}
 }
@@ -337,6 +273,70 @@ func (fake *Storage) ReleaseRecoveryClaimReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.releaseRecoveryClaimReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Storage) SetStatus(arg1 context.Context, arg2 string, arg3 storage.TxStatus, arg4 string) error {
+	fake.setStatusMutex.Lock()
+	ret, specificReturn := fake.setStatusReturnsOnCall[len(fake.setStatusArgsForCall)]
+	fake.setStatusArgsForCall = append(fake.setStatusArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 storage.TxStatus
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.SetStatusStub
+	fakeReturns := fake.setStatusReturns
+	fake.recordInvocation("SetStatus", []interface{}{arg1, arg2, arg3, arg4})
+	fake.setStatusMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Storage) SetStatusCallCount() int {
+	fake.setStatusMutex.RLock()
+	defer fake.setStatusMutex.RUnlock()
+	return len(fake.setStatusArgsForCall)
+}
+
+func (fake *Storage) SetStatusCalls(stub func(context.Context, string, storage.TxStatus, string) error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = stub
+}
+
+func (fake *Storage) SetStatusArgsForCall(i int) (context.Context, string, storage.TxStatus, string) {
+	fake.setStatusMutex.RLock()
+	defer fake.setStatusMutex.RUnlock()
+	argsForCall := fake.setStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *Storage) SetStatusReturns(result1 error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = nil
+	fake.setStatusReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Storage) SetStatusReturnsOnCall(i int, result1 error) {
+	fake.setStatusMutex.Lock()
+	defer fake.setStatusMutex.Unlock()
+	fake.SetStatusStub = nil
+	if fake.setStatusReturnsOnCall == nil {
+		fake.setStatusReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setStatusReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }

--- a/token/services/storage/ttxdb/store.go
+++ b/token/services/storage/ttxdb/store.go
@@ -95,6 +95,10 @@ const (
 // in that action.
 type TransactionRecord = dbdriver.TransactionRecord
 
+// RecoveryClaim is the minimal projection of a pending transaction row
+// returned by ClaimPendingTransactions for recovery processing.
+type RecoveryClaim = dbdriver.RecoveryClaim
+
 // MovementRecord is a record of a movement of assets.
 // Given a Token Transaction, a movement record is created for each enrollment ID that participated in the transaction
 // and each token type that was transferred.
@@ -372,7 +376,9 @@ func (d *StoreService) AcquireRecoveryLeadership(ctx context.Context, lockID int
 }
 
 // ClaimPendingTransactions returns a claimed batch of Pending transactions older than the given duration.
-func (d *StoreService) ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*TransactionRecord, error) {
+// Each returned RecoveryClaim carries the TxID and StoredAt timestamp the recovery loop needs;
+// the rest of the row is intentionally not projected from SQL.
+func (d *StoreService) ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*RecoveryClaim, error) {
 	storedBefore := time.Now().UTC().Add(-olderThan)
 	logger.DebugfContext(ctx, "claiming pending transactions stored before %s (older than %s), lease duration [%s], limit [%d], owner [%s]",
 		storedBefore, olderThan, leaseDuration, limit, owner)


### PR DESCRIPTION
Follow-up to #1708, addressing @adecaro's [review comment](https://github.com/hyperledger-labs/fabric-token-sdk/pull/1708#issuecomment-4474440103).

## Summary

`ClaimPendingTransactions` previously returned `[]*TransactionRecord`, but the only consumer (`recovery.Manager`) reads just `TxID` and `StoredAt` — the other ten fields (action type, amounts, application/public metadata, status, ...) were always discarded.

Introduce a dedicated lightweight type in the driver layer, mirroring the existing `RecoveryClaimParams` input type:

```go
type RecoveryClaim struct {
    TxID     string
    StoredAt time.Time
}
```

…and project only the two columns the recovery loop actually needs from SQL.

## Concrete savings

- **One fewer JOIN** in the postgres CTE-based claim query. The second `SELECT` no longer joins back against the requests table.
- **Two JSON unmarshals per row removed** (`application_metadata`, `public_metadata`).
- **Eight unused columns dropped** from the `SELECT` projection in both the common and postgres implementations (`action_type`, `sender_eid`, `recipient_eid`, `token_type`, `amount`, `status`, `application_metadata`, `public_metadata`).

## Scope

The change ripples through 5 layers as predicted in the review thread:

1. `db/driver/{ttx,audit}.go` — new `RecoveryClaim` type + interface signature.
2. `db/sql/common/transactions.go` — SQL projection trimmed to `(tx_id, stored_at)`.
3. `db/sql/postgres/transactions.go` — CTE query trimmed; dead `unmarshalMetadata` + `encoding/json` import removed.
4. `{ttxdb,auditdb}/store.go` — `StoreService` signature + re-exported type alias.
5. `network/fabric/network.go` + `recovery/manager.go` — adapter and `recovery.Storage` interface signatures; field rename `Timestamp` → `StoredAt` at the consumption site.

Mocks regenerated via `counterfeiter v6.12.2` (`recovery/mock/storage.go`, `auditor/mock/audit_transaction_store.go`).

## Behaviour preserved

- The dedupe-by-`TxID` step in `Manager.recoverTransactions` is **kept** because the underlying transactions table still produces one row per movement/output for a given txID; merging that into SQL would change the query shape and is outside the scope of this refactor.
- The `NotFoundGracePeriod` orphan-promotion logic from #1708 is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./token/services/storage/recovery/...` (manager unit tests pass with updated mock + types)
- [x] `go test ./token/services/storage/...` (sqlite + ttxdb + auditdb + tokendb green; postgres integration tests skipped locally — they require `fsc.itests/postgres:latest`)
- [x] `go test ./token/services/auditor/... ./token/services/network/fabric/...`
- [ ] CI green