### PR TITLE
feat(recovery): promote NotFound orphans to dedicated Orphan TxStatus

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,6 +197,18 @@ token:
               # This helps with debugging and tracking which instance processed which transactions.
               instanceID:
 
+              # notFoundGracePeriod is the time after which the recovery loop promotes a
+              # transaction whose status query keeps returning NotFound to the terminal
+              # Orphan status. Without this, a transaction whose audit log was persisted
+              # but whose broadcast never reached the ledger would sit at the head of the
+              # `ORDER BY stored_at ASC LIMIT batchSize` claim query forever and prevent
+              # newer rows from being scanned. Default: 30m.
+              # The promoted row is marked Orphan (not Deleted) so operators can tell
+              # broadcast failures apart from ledger-rejected transactions.
+              # Set to 0 to disable the promotion; the row stays Pending and is re-claimed
+              # on every sweep until it either resolves or an operator intervenes.
+              notFoundGracePeriod: 30m
+
       # sections dedicated to the definition of the wallets
       wallets:
         # Default cache size reference that can be used by any wallet that supports caching.
@@ -354,6 +366,7 @@ token:
               leaseDuration: 30s
               advisoryLockID: 8389190333894887286
               instanceID:
+              notFoundGracePeriod: 30m
 ```
 
 Default values:
@@ -366,6 +379,7 @@ Default values:
 - leaseDuration: 30s
 - advisoryLockID: 8389190333894887286 (`0x74746b7265636f76`)
 - instanceID: empty, auto-generated when the recovery manager starts
+- notFoundGracePeriod: 30m (set to 0 to disable promotion to Orphan)
 
 **Parameter Relationships and Tuning:**
 
@@ -374,6 +388,7 @@ Default values:
 - **The manager validates** that `ttl`, `scanInterval`, `batchSize`, `workerCount`, and `leaseDuration` are all greater than zero.
 - **`advisoryLockID`** is used to acquire PostgreSQL advisory-lock leadership so that only one replica performs a recovery sweep at a time. The default value (8389190333894887286 or 0x74746b7265636f76) represents the ASCII string "ttkrecov" (Token Transaction Recovery) encoded as a 64-bit integer.
 - **`instanceID`** is used as the lease owner identifier for claimed transactions; if omitted, the manager generates a unique UUID automatically at startup.
+- **`notFoundGracePeriod`** controls how long a transaction whose status query keeps returning `NotFound` is left in `Pending` before being promoted to the terminal `Orphan` status. This protects the recovery sweep from being permanently blocked by transactions whose audit log was persisted but whose broadcast never reached the ledger. The promoted row is marked `Orphan` rather than `Deleted` so operators can distinguish broadcast failures from ledger-rejected transactions. Raise the default if your network has long catch-up windows after committer/orderer restarts; set it to `0` to disable the promotion entirely.
 
 **Tuning Recommendations:**
 

--- a/docs/services/recovery.md
+++ b/docs/services/recovery.md
@@ -34,8 +34,9 @@ The Handler interface defines how individual transactions are recovered. The TTX
 
 The Storage interface abstracts database operations needed for recovery:
 - `AcquireRecoveryLeadership`: Obtains distributed lock for leader election
-- `ClaimPendingTransactions`: Atomically claims a batch of transactions
+- `ClaimPendingTransactions`: Atomically claims a batch of pending transactions, returning a lightweight `RecoveryClaim` (`TxID` + `StoredAt`) for each row — the recovery loop only needs these two fields, so the SQL projection is kept narrow
 - `ReleaseRecoveryClaim`: Releases claim after processing
+- `SetStatus`: Promotes a transaction to a terminal status. Used by the recovery loop to mark `NotFound`-past-grace-period rows as `Orphan` so they exit the eligible scan range without being conflated with ledger-rejected transactions (`Deleted`)
 
 ## Database Support
 
@@ -69,6 +70,7 @@ recovery:
   leaseDuration: 30s         # Claim lease duration
   advisoryLockID: 8389...    # PostgreSQL lock ID
   instanceID: ""             # Instance identifier
+  notFoundGracePeriod: 30m   # Promote NotFound rows to Orphan after this age (0 disables)
 ```
 
 ## Usage Example
@@ -77,13 +79,14 @@ Creating a recovery manager:
 
 ```go
 config := recovery.Config{
-    Enabled:        true,
-    TTL:            30 * time.Second,
-    ScanInterval:   5 * time.Second,
-    BatchSize:      100,
-    WorkerCount:    4,
-    LeaseDuration:  30 * time.Second,
-    AdvisoryLockID: 8389190333894887286,
+    Enabled:             true,
+    TTL:                 30 * time.Second,
+    ScanInterval:        5 * time.Second,
+    BatchSize:           100,
+    WorkerCount:         4,
+    LeaseDuration:       30 * time.Second,
+    AdvisoryLockID:      8389190333894887286,
+    NotFoundGracePeriod: 30 * time.Minute,
 }
 
 manager := recovery.NewManager(
@@ -122,17 +125,30 @@ func (h *MyHandler) Recover(ctx context.Context, txID string) error {
 
 1. Manager acquires leadership (PostgreSQL advisory lock)
 2. Manager queries for pending transactions older than TTL
-3. Manager atomically claims a batch of transactions
+3. Manager atomically claims a batch of transactions, each returned as a `RecoveryClaim` (`TxID` + `StoredAt`)
 4. Manager distributes claimed transactions to worker pool
 5. Each worker calls `Handler.Recover()` for its transactions
 6. Handler queries network and applies finality logic
-7. Manager releases claims with success/failure message
-8. Process repeats on next scan interval
+7. If the handler reports `NotFound` and the row was stored more than `notFoundGracePeriod` ago, the manager promotes the row to `Orphan` via `SetStatus` so it exits the eligible scan range
+8. Manager releases claims with success/failure message
+9. Process repeats on next scan interval
+
+## Transaction Status Lifecycle
+
+A token request transitions through the following statuses as the recovery loop interacts with it:
+
+- **Pending**: The transaction has been submitted but its finality is not yet known. Only rows in this status are eligible for `ClaimPendingTransactions`; the claim query and its supporting partial index filter on `status = Pending`.
+- **Confirmed**: The transaction has been validated by the ledger and committed locally. Terminal.
+- **Deleted**: The transaction was actively rejected — either by the ledger (`network.Invalid`) or by local validation (token request hash mismatch via the finality listener). Terminal.
+- **Orphan**: The transaction never reached the ledger — the recovery loop saw a persistent `NotFound` from the network past `notFoundGracePeriod`. Terminal in this version, and intentionally distinct from `Deleted` so operators (and future replay tooling) can identify broadcast failures separately from ledger-rejected transactions.
+
+All three terminal statuses (`Confirmed`, `Deleted`, `Orphan`) are excluded from subsequent recovery sweeps by virtue of the `status = Pending` filter on the claim query.
 
 ## Error Handling
 
 - **Transient errors** (Busy status): Released gracefully, retried on next scan
-- **Permanent errors** (Invalid tx): Marked as Deleted in database
+- **Permanent errors** (Invalid tx): Marked as `Deleted` in the database
+- **Orphan transactions** (persistent `NotFound` past `notFoundGracePeriod`): Marked as `Orphan` to indicate the transaction never reached the ledger; distinct from `Deleted` so operators can distinguish broadcast failures from ledger-rejected transactions
 - **Handler errors**: Logged individually, claim released with error message
 - **Network errors**: Propagated to caller, claim released for retry
 

--- a/docs/services/storage.md
+++ b/docs/services/storage.md
@@ -24,7 +24,7 @@ The SDK uses Go's `*big.Int` type throughout the codebase to handle these large 
 ### Transaction & Audit Store (TTXDB / AuditDB)
 These tables track the lifecycle of token requests from assembly to finality. `AuditDB` uses the same schema but is isolated for compliance reporting.
 
-*   **Requests**: Tracks high-level token request state. Contains marshaled requests, current status (Pending, Confirmed, Deleted), and application/public metadata.
+*   **Requests**: Tracks high-level token request state. Contains marshaled requests, current status (Pending, Confirmed, Deleted, Orphan), and application/public metadata.
 *   **Transactions**: Records individual actions (Issue, Transfer, Redeem) within a request, including sender/recipient IDs and amounts (stored as `NUMERIC(78, 0)`).
 *   **Movements**: Aggregates net value changes per enrollment ID (amounts stored as `NUMERIC(78, 0)`). Used to efficiently calculate balances and history.
 *   **Validations**: Stores cryptographic validation metadata produced during the request verification phase.
@@ -112,13 +112,14 @@ It uses a distributed locking mechanism (PostgreSQL advisory locks) to ensure on
 
 The recovery service follows this workflow:
 
-1. **Scan Phase**: The recovery manager periodically scans the transaction database for pending transactions older than the configured TTL
-2. **Claim Phase**: Eligible transactions are claimed by the current instance using a lease mechanism
+1. **Scan Phase**: The recovery manager periodically scans the transaction database for pending transactions older than the configured TTL. The claim query reads only the minimum projection needed (`tx_id`, `stored_at`) and returns a lightweight `RecoveryClaim` for each row, avoiding the cost of materialising the full transaction record on every sweep.
+2. **Claim Phase**: Eligible transactions are claimed by the current instance using a lease mechanism. On PostgreSQL this is an atomic `UPDATE ... RETURNING`; SQLite uses a non-atomic but functionally equivalent permissive claim.
 3. **Recovery Phase**: For each claimed transaction, the recovery handler:
    - Queries the network for the transaction's current status
-   - Based on the status (Valid, Invalid, or Busy), applies the appropriate finality logic
+   - Based on the status (Valid, Invalid, NotFound, or Busy), applies the appropriate finality logic
    - For valid transactions, verifies the token request hash and commits to the local database
-   - For invalid transactions, marks them as deleted
+   - For invalid transactions, marks them as `Deleted`
+   - For transactions whose status keeps returning `NotFound` past the configured `notFoundGracePeriod`, marks them as `Orphan`. This indicates the transaction never reached the ledger (e.g. broadcast failure, mempool drop) and prevents long-stuck rows from blocking the head of the recovery queue, while keeping them distinguishable from ledger-rejected transactions that are marked `Deleted`.
    - For busy (pending) transactions, returns an error and the transaction remains eligible for future recovery
 4. **Lease Management**: Claimed transactions are leased to the instance for a configured duration to prevent stuck transactions from blocking recovery
 

--- a/token/driver/vault.go
+++ b/token/driver/vault.go
@@ -30,6 +30,8 @@ const (
 	Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted
+	// Orphan is the status of a transaction that never reached the ledger (e.g. broadcast failure, mempool drop)
+	Orphan
 )
 
 //go:generate counterfeiter -o mock/uti.go -fake-name UnspentTokensIterator . UnspentTokensIterator

--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -45,6 +45,8 @@ const (
 	Confirmed = auditdb.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = auditdb.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = auditdb.Orphan
 )
 
 const txIdLabel tracing.LabelName = "tx_id"

--- a/token/services/storage/auditdb/store.go
+++ b/token/services/storage/auditdb/store.go
@@ -72,6 +72,8 @@ const (
 	Confirmed = dbdriver.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = dbdriver.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = dbdriver.Orphan
 )
 
 // TxStatusMessage maps TxStatus to string

--- a/token/services/storage/db/driver/common.go
+++ b/token/services/storage/db/driver/common.go
@@ -64,6 +64,8 @@ const (
 	Confirmed = driver2.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = driver2.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = driver2.Orphan
 )
 
 // TxStatusMessage maps TxStatus to string
@@ -72,6 +74,7 @@ var TxStatusMessage = map[TxStatus]string{
 	Pending:   "Pending",
 	Confirmed: "Confirmed",
 	Deleted:   "Deleted",
+	Orphan:    "Orphan",
 }
 
 // MovementRecord is a record of a movement of assets.

--- a/token/services/storage/recovery/config.go
+++ b/token/services/storage/recovery/config.go
@@ -37,9 +37,9 @@ type Config struct {
 	InstanceID string
 	// NotFoundGracePeriod: when GetTransactionStatus returns a NotFound error and
 	// the tx was stored more than this duration ago, the recovery loop marks the
-	// row as Deleted instead of leaving it for another retry. Prevents the queue
-	// from being permanently blocked by orphan transactions (broadcast failures
-	// that never reached the ledger). Zero disables this behaviour.
+	// row as Orphan instead of leaving it for another retry. Prevents the queue
+	// from being permanently blocked by transactions that never reached the
+	// ledger (broadcast failures, mempool drops). Zero disables this behaviour.
 	NotFoundGracePeriod time.Duration
 }
 
@@ -96,7 +96,7 @@ func LoadConfig(cfg *config.Configuration) (Config, error) {
 	if config.InstanceID != "" {
 		result.InstanceID = config.InstanceID
 	}
-	// NotFoundGracePeriod accepts an explicit zero to disable the orphan
+	// NotFoundGracePeriod accepts an explicit zero to disable the Orphan
 	// promotion, so check IsSet rather than the Go zero value. Without this
 	// gate, setting notFoundGracePeriod: 0 in config would silently fall back
 	// to the 30 min default and the documented opt-out would be unreachable.

--- a/token/services/storage/recovery/manager.go
+++ b/token/services/storage/recovery/manager.go
@@ -36,8 +36,9 @@ type Storage interface {
 	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error
 	// SetStatus updates a transaction's status row. Used by the recovery loop to
-	// permanently mark orphan transactions (NotFound past grace period) as Deleted
-	// so they exit the eligible scan range and stop blocking the queue head.
+	// permanently mark orphan transactions (NotFound past grace period) as Orphan
+	// so they exit the eligible scan range and stop blocking the queue head,
+	// while remaining distinguishable from txs the ledger actively rejected.
 	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
 }
 
@@ -304,11 +305,14 @@ func (m *Manager) worker(ctx context.Context, wg *sync.WaitGroup, work <-chan *t
 // and always releases the claim with an appropriate message.
 //
 // If the handler reports the transaction is not on the ledger and the row was
-// stored more than NotFoundGracePeriod ago, the row is force-marked Deleted to
-// prevent the queue head from being permanently blocked by orphan transactions
-// (e.g. broadcast failures whose audit log was persisted but whose tx never
-// reached the orderer). Without this, ORDER BY stored_at ASC + LIMIT BatchSize
-// would replay the same oldest-100 rows on every sweep forever.
+// stored more than NotFoundGracePeriod ago, the row is force-marked Orphan to
+// prevent the queue head from being permanently blocked by transactions that
+// never reached the ledger (e.g. broadcast failures whose audit log was
+// persisted but whose tx never reached the orderer). Without this,
+// ORDER BY stored_at ASC + LIMIT BatchSize would replay the same oldest-100
+// rows on every sweep forever. The status is deliberately distinct from
+// Deleted so operators and downstream tooling can tell broadcast losses apart
+// from txs the ledger actively rejected.
 func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt time.Time) error {
 	m.logger.Debugf("recovering transaction [%s]", txID)
 
@@ -317,21 +321,21 @@ func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt 
 
 	// Residual race: SetStatus is unconditional, so an independent finality
 	// listener that confirms this tx between our claim and the write below
-	// could be overwritten by Deleted. In practice the NotFoundGracePeriod
+	// could be overwritten by Orphan. In practice the NotFoundGracePeriod
 	// (default 30 min) makes this window vanishingly small — we only get
 	// here when the tx has been Pending for grace+ AND Recover just returned
 	// NotFound. Future hardening: replace SetStatus with an atomic
-	// "status=Pending → Deleted" CAS at the SQL layer.
-	markedDeleted := false
+	// "status=Pending → Orphan" CAS at the SQL layer.
+	markedOrphan := false
 	if err != nil && m.config.NotFoundGracePeriod > 0 && !storedAt.IsZero() && isNotFoundError(err) {
 		age := time.Since(storedAt)
 		if age > m.config.NotFoundGracePeriod {
-			deleteMsg := fmt.Sprintf("tx never reached ledger (NotFound after %v, grace=%v)", age.Truncate(time.Second), m.config.NotFoundGracePeriod)
-			m.logger.Warnf("recovery: marking tx [%s] as Deleted: %s", txID, deleteMsg)
-			if setErr := m.storage.SetStatus(ctx, txID, storage.Deleted, deleteMsg); setErr != nil {
-				m.logger.Errorf("recovery: failed to mark tx [%s] Deleted: %v", txID, setErr)
+			orphanMsg := fmt.Sprintf("tx never reached ledger (NotFound after %v, grace=%v)", age.Truncate(time.Second), m.config.NotFoundGracePeriod)
+			m.logger.Warnf("recovery: marking tx [%s] as Orphan: %s", txID, orphanMsg)
+			if setErr := m.storage.SetStatus(ctx, txID, storage.Orphan, orphanMsg); setErr != nil {
+				m.logger.Errorf("recovery: failed to mark tx [%s] Orphan: %v", txID, setErr)
 			} else {
-				markedDeleted = true
+				markedOrphan = true
 			}
 		}
 	}
@@ -339,8 +343,8 @@ func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt 
 	// Always release the claim with appropriate message
 	var message string
 	switch {
-	case markedDeleted:
-		message = "tx marked Deleted after NotFound grace period"
+	case markedOrphan:
+		message = "tx marked Orphan after NotFound grace period"
 	case err != nil:
 		message = fmt.Sprintf("recovery failed: %v", err)
 	default:
@@ -351,13 +355,14 @@ func (m *Manager) recoverTransaction(ctx context.Context, txID string, storedAt 
 		m.logger.Warnf("failed to release recovery claim for transaction [%s]: %v", txID, releaseErr)
 	}
 
-	if err != nil && !markedDeleted {
+	if err != nil && !markedOrphan {
 		return errors.Wrapf(err, "failed to recover transaction [%s]", txID)
 	}
 
-	if markedDeleted {
+	if markedOrphan {
 		// Treat as resolved — no need to noisily report a "failure" the next sweep
-		// would otherwise re-encounter (the row is now status=3 and ineligible).
+		// would otherwise re-encounter (the row is now Orphan and ineligible for
+		// the Pending-only claim filter).
 		return nil
 	}
 

--- a/token/services/storage/recovery/manager_test.go
+++ b/token/services/storage/recovery/manager_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package recovery_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/logging"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/recovery"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/recovery/mock"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/ttxdb"
@@ -199,6 +201,109 @@ func TestManager_SkipAlreadyRecovered(t *testing.T) {
 
 	// Verify Recover was called only once (not on subsequent scans because claim was released)
 	assert.Equal(t, 1, mockHandler.RecoverCallCount())
+}
+
+// TestManager_PromoteOrphanOnNotFoundPastGracePeriod verifies that when the
+// recovery handler returns a NotFound-shaped error and the row was stored more
+// than NotFoundGracePeriod ago, the manager promotes the tx to storage.Orphan
+// (not storage.Deleted) so it stops blocking the sweep queue while staying
+// distinguishable from txs the ledger actively rejected.
+func TestManager_PromoteOrphanOnNotFoundPastGracePeriod(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock.Storage{}
+	mockHandler := &mock.Handler{}
+	config := recovery.Config{
+		Enabled:             true,
+		TTL:                 100 * time.Millisecond,
+		ScanInterval:        100 * time.Millisecond,
+		BatchSize:           100,
+		WorkerCount:         1,
+		LeaseDuration:       time.Second,
+		AdvisoryLockID:      1,
+		InstanceID:          "test-instance",
+		NotFoundGracePeriod: 10 * time.Millisecond,
+	}
+
+	// stored_at well beyond the 10ms grace period so the promotion fires.
+	txRecord := &ttxdb.RecoveryClaim{
+		TxID:     "txOrphan",
+		StoredAt: time.Now().Add(-time.Hour),
+	}
+
+	leadership1 := &mock.Leadership{}
+	leadership1.CloseReturns(nil)
+	leadership2 := &mock.Leadership{}
+	leadership2.CloseReturns(nil)
+
+	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadership1, true, nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership2, true, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
+	// Match isNotFoundError: "tx not found" is the FSC sentinel substring.
+	mockHandler.RecoverReturns(errors.New("rpc error: code = NotFound desc = tx not found"))
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+	mockDB.SetStatusReturns(nil)
+
+	manager := recovery.NewManager(logger, mockDB, mockHandler, config)
+
+	require.NoError(t, manager.Start())
+	// Wait for the initial sweep (jitter up to 1s + handler invocation).
+	time.Sleep(1300 * time.Millisecond)
+	_ = manager.Stop()
+
+	require.GreaterOrEqual(t, mockHandler.RecoverCallCount(), 1)
+	require.Equal(t, 1, mockDB.SetStatusCallCount(), "expected exactly one SetStatus call for the orphan promotion")
+
+	_, gotTxID, gotStatus, gotMsg := mockDB.SetStatusArgsForCall(0)
+	assert.Equal(t, "txOrphan", gotTxID)
+	assert.Equal(t, storage.Orphan, gotStatus, "orphan path must promote to storage.Orphan, not storage.Deleted")
+	assert.Contains(t, gotMsg, "tx never reached ledger")
+}
+
+// TestManager_NoPromotionWhenGracePeriodDisabled verifies that NotFoundGracePeriod=0
+// disables the orphan promotion entirely, even when the row is old and the
+// handler returns NotFound. This is the documented opt-out from
+// recovery.Config.NotFoundGracePeriod.
+func TestManager_NoPromotionWhenGracePeriodDisabled(t *testing.T) {
+	logger := logging.MustGetLogger()
+	mockDB := &mock.Storage{}
+	mockHandler := &mock.Handler{}
+	config := recovery.Config{
+		Enabled:             true,
+		TTL:                 100 * time.Millisecond,
+		ScanInterval:        100 * time.Millisecond,
+		BatchSize:           100,
+		WorkerCount:         1,
+		LeaseDuration:       time.Second,
+		AdvisoryLockID:      1,
+		InstanceID:          "test-instance",
+		NotFoundGracePeriod: 0,
+	}
+
+	txRecord := &ttxdb.RecoveryClaim{
+		TxID:     "txStillPending",
+		StoredAt: time.Now().Add(-time.Hour),
+	}
+
+	leadership1 := &mock.Leadership{}
+	leadership1.CloseReturns(nil)
+	leadership2 := &mock.Leadership{}
+	leadership2.CloseReturns(nil)
+
+	mockDB.AcquireRecoveryLeadershipReturnsOnCall(0, leadership1, true, nil)
+	mockDB.AcquireRecoveryLeadershipReturns(leadership2, true, nil)
+	mockDB.ClaimPendingTransactionsReturnsOnCall(0, []*ttxdb.RecoveryClaim{txRecord}, nil)
+	mockDB.ClaimPendingTransactionsReturns([]*ttxdb.RecoveryClaim{}, nil)
+	mockHandler.RecoverReturns(errors.New("rpc error: code = NotFound desc = tx not found"))
+	mockDB.ReleaseRecoveryClaimReturns(nil)
+
+	manager := recovery.NewManager(logger, mockDB, mockHandler, config)
+
+	require.NoError(t, manager.Start())
+	time.Sleep(1300 * time.Millisecond)
+	_ = manager.Stop()
+
+	assert.Equal(t, 0, mockDB.SetStatusCallCount(), "grace period disabled should never call SetStatus")
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/token/services/storage/storage.go
+++ b/token/services/storage/storage.go
@@ -23,6 +23,8 @@ const (
 	Confirmed = dbdriver.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = dbdriver.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = dbdriver.Orphan
 )
 
 // TxStatusMessage maps TxStatus to string

--- a/token/services/storage/ttxdb/store.go
+++ b/token/services/storage/ttxdb/store.go
@@ -61,6 +61,8 @@ const (
 	Confirmed = dbdriver.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = dbdriver.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = dbdriver.Orphan
 )
 
 // TxStatusMessage maps TxStatus to string

--- a/token/services/ttx/status.go
+++ b/token/services/ttx/status.go
@@ -22,6 +22,8 @@ const (
 	Confirmed TxStatus = storage.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted TxStatus = storage.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan TxStatus = storage.Orphan
 )
 
 // TxStatusMessage maps TxStatus to string

--- a/token/vault.go
+++ b/token/vault.go
@@ -30,6 +30,8 @@ const (
 	Confirmed = driver.Confirmed
 	// Deleted is the status of a transaction that has been deleted due to a failure to commit
 	Deleted = driver.Deleted
+	// Orphan is the status of a transaction that never reached the ledger
+	Orphan = driver.Orphan
 )
 
 // QueryEngine models a token query engine


### PR DESCRIPTION
Closes #1723.

Follow-up to #1715 (review thread).

Per @adecaro's suggestion there:

> I would also probe your opinion on introducing a new state for this
> transactions that are kind of orphaned. This would allows us to find them
> more easily and give them a second chance.

And the agreed plan:

> Yes, this is what I meant. We can introduce this new state in a new PR.

This PR is that new PR — just the state split, no retry mechanism yet.

## Summary

`TxStatus.Deleted` currently overloads two semantically distinct outcomes:

1. **Invalid** — token request hash mismatch (`finality/listener.go:138`,
   `finality/recovery.go:122`) or `network.Invalid` (`listener.go:148`,
   `recovery.go:133`): the ledger or local validation actively rejected the tx.
2. **Orphan** — `recovery/manager.go:331` (added in #1708): the tx never reached
   the ledger; the recovery loop observed `NotFound` past `NotFoundGracePeriod`
   and promoted the row to keep the sweep queue moving.

Operators today can only tell the two apart by parsing the free-text message
column, and any future "second-chance" workflow (re-broadcast, manual replay)
would have no clean handle to filter on.

This PR adds a dedicated `Orphan` value to `TxStatus` (=4, after `Deleted`)
and routes the recovery loop's NotFound-past-grace path to it. `Deleted`
remains reserved for explicit ledger rejection / validation failure.

## What changes

- **`token/driver/vault.go`**: new `Orphan` constant after `Deleted`.
- **`token/services/storage/db/driver/common.go`**: `TxStatusMessage` map gets
  `Orphan: "Orphan"`.
- **Re-exports**: `token/vault.go`, `token/services/storage/storage.go`,
  `token/services/storage/ttxdb/store.go`,
  `token/services/storage/auditdb/store.go`,
  `token/services/ttx/status.go`,
  `token/services/auditor/auditor.go` — each adds the one-line `Orphan = …`
  alias next to the existing `Deleted` alias.
- **`token/services/storage/recovery/manager.go`**: the grace-period path now
  calls `SetStatus(ctx, txID, storage.Orphan, …)` instead of `storage.Deleted`;
  the local `markedDeleted` flag is renamed to `markedOrphan`, log/release
  messages updated, and the `Storage.SetStatus` doc comment refreshed.
- **`token/services/storage/recovery/config.go`**: `NotFoundGracePeriod` doc
  comment updated to reflect the new target status.

## "Second chance" — why this PR keeps lock-cleanup behaviour identical

A retryable orphan still needs its input tokens locked: if the locks were
released the moment we marked the row Orphan, a subsequent retry would have
no inputs to spend. So every other `Deleted`-checking call site is **left
unchanged** in this PR:

| Site | Why it stays unchanged |
|------|------------------------|
| `db/sql/common/tokenlock.go:106`, `db/sql/postgres/tokenlock.go:80` | Status-based lock cleanup filters on `Deleted`. Orphan locks fall through to the existing `OlderThan(created_at, leaseExpiry)` timeout path — they expire on the lease clock, not immediately, preserving the retry window. |
| `selector/simple/inmemory/locker.go:178,226` | Same reasoning at the in-memory layer. |
| `db/common/checks.go:151-157` | Health-check cross-references local `Deleted` against ledger `network.Invalid`. An Orphan-vs-ledger case belongs with the operator workflow that this PR defers. |
| `ttx/finality.go:178,220` | `Finality()` returns `ErrFinalityInvalidTransaction` for `Deleted`. For Orphan it should not — the tx is not invalid, it just never landed. Letting `Finality()` time out naturally is the correct behaviour pending a retry mechanism. |

Net effect: existing consumers that filter on `Deleted` keep behaving
identically; only the recovery loop's output column changes.

## Out of scope (deferred follow-ups)

- The retry / rebroadcast workflow itself (promoting `Orphan` back to `Pending`,
  or to a separate `Retried` state).
- An admin API surface for orphan counts / inspection.
- The residual race fix mentioned in `manager.go:318-324` — replacing the
  unconditional `SetStatus` with an atomic `status=Pending → Orphan` CAS at
  the SQL layer.

Each of these wants its own design discussion and is meaningful only once the
`Orphan` value itself exists in the type system.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l token/` clean
- [x] `go test ./token/services/storage/recovery/...` — adds
  `TestManager_PromoteOrphanOnNotFoundPastGracePeriod` (asserts the recovery
  loop calls `SetStatus(_, _, storage.Orphan, _)` on the grace-period path) and
  `TestManager_NoPromotionWhenGracePeriodDisabled` (asserts
  `NotFoundGracePeriod=0` short-circuits the promotion).
- [x] `go test ./token/services/storage/...` — sqlite, postgres (~53s), ttxdb,
  auditdb, tokendb, walletdb all green.
- [x] `go test ./token/services/ttx/finality/... ./token/services/auditor/...
  ./token/services/selector/...` — green; verifies the intentionally-unchanged
  call sites still behave the same.
- [ ] CI green