### PR TITLE
chore(logging): switch storage and db info logs to debug

### DIFF
--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -376,7 +376,7 @@ func (l *LocalMembership) Load(ctx context.Context, identities []idriver.Configu
 
 	// load identities from configuration
 	for i, identityConfiguration := range ics {
-		l.logger.Infof("load identity configuration [%+v]", identityConfiguration)
+		l.logger.Debugf("load identity configuration [%+v]", identityConfiguration)
 		if err := l.registerIdentityConfiguration(ctx, &identityConfiguration, defaults[i]); err != nil {
 			// we log the error so the user can fix it but it shouldn't stop the loading of the service.
 			l.logger.Errorf("failed loading identity with err [%s]", err)
@@ -426,7 +426,7 @@ func (l *LocalMembership) subscribeNotifier() error {
 	}
 
 	err = notifier.Subscribe(func(operation idriver.Operation, record idriver.IdentityConfigurationRecord) {
-		l.logger.Infof("received notification: [%v][%v]", operation, record)
+		l.logger.Debugf("received notification: [%v][%v]", operation, record)
 		// we care only about insertions in the identity configurations table
 		if operation != idriver.Insert {
 			return
@@ -469,7 +469,7 @@ func (l *LocalMembership) handleConfig(id, typ, url string) {
 		return
 	}
 
-	l.logger.Infof("load identity configuration [%+v]", config)
+	l.logger.Debugf("load identity configuration [%+v]", config)
 	if err := l.registerIdentityConfiguration(context.Background(), config, false); err != nil {
 		l.logger.Errorf("failed loading identity with err [%s]", err)
 	}
@@ -763,7 +763,7 @@ func (l *LocalMembership) refreshAndGet(ctx context.Context, label string) *Loca
 			continue
 		}
 
-		l.logger.InfofContext(ctx, "load identity configuration [%+v]", identityConfiguration)
+		l.logger.DebugfContext(ctx, "load identity configuration [%+v]", identityConfiguration)
 		if err := l.registerIdentityConfiguration(ctx, &identityConfiguration, false); err != nil {
 			l.logger.ErrorfContext(ctx, "failed loading identity with err [%s]", err)
 		}

--- a/token/services/network/fabricx/lookup/gocron.go
+++ b/token/services/network/fabricx/lookup/gocron.go
@@ -75,7 +75,7 @@ func (n *CronListenerManager) PermanentLookupListenerSupported() bool {
 // the value of a key changes. It schedules a recurring job that polls
 // the query service at the configured permanent interval.
 func (n *CronListenerManager) AddPermanentLookupListener(namespace string, key string, listener Listener) error {
-	logger.Infof("AddPermanentLookupListener [%s:%s]", namespace, key)
+	logger.Debugf("AddPermanentLookupListener [%s:%s]", namespace, key)
 
 	job := NewPermanentJob(namespace, key, listener, n.queryService)
 	j, err := n.scheduler.NewJob(
@@ -99,7 +99,7 @@ func (n *CronListenerManager) AddPermanentLookupListener(namespace string, key s
 // repeatedly until the key is found or the configured deadline is reached.
 // The job is automatically removed after completion.
 func (n *CronListenerManager) AddLookupListener(namespace string, key string, listener lookup.Listener) error {
-	logger.Infof("AddLookupListener [%s:%s]", namespace, key)
+	logger.Debugf("AddLookupListener [%s:%s]", namespace, key)
 
 	deadline := time.Now().Add(n.config.OnceDeadline())
 
@@ -108,10 +108,10 @@ func (n *CronListenerManager) AddLookupListener(namespace string, key string, li
 	var err error
 
 	task := gocron.NewTask(func() {
-		logger.Infof("[KeyCheck] check for key [%s:%s]", namespace, key)
+		logger.Debugf("[KeyCheck] check for key [%s:%s]", namespace, key)
 		v, err := n.queryService.GetState(namespace, key)
 		if err == nil && v != nil && len(v.Raw) != 0 {
-			logger.Infof("[KeyCheck] key [%s:%s] found, notify listener", namespace, key)
+			logger.Debugf("[KeyCheck] key [%s:%s] found, notify listener", namespace, key)
 			listener.OnStatus(context.Background(), key, v.Raw)
 
 			// Stop the job, no error is expected here
@@ -121,7 +121,7 @@ func (n *CronListenerManager) AddLookupListener(namespace string, key string, li
 		}
 
 		if time.Now().After(deadline) {
-			logger.Infof("[KeyCheck] key [%s:%s] not found, deadline reached", namespace, key)
+			logger.Debugf("[KeyCheck] key [%s:%s] not found, deadline reached", namespace, key)
 			listener.OnError(context.Background(), key, errors.Errorf("key [%s:%s] not found", namespace, key))
 
 			// Stop the job, no error is expected here
@@ -150,7 +150,7 @@ func (n *CronListenerManager) AddLookupListener(namespace string, key string, li
 // RemoveLookupListener stops and removes the gocron job associated
 // with the provided listener.
 func (n *CronListenerManager) RemoveLookupListener(id string, listener Listener) error {
-	logger.Infof("RemoveLookupListener [%s]", id)
+	logger.Debugf("RemoveLookupListener [%s]", id)
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
@@ -215,7 +215,7 @@ func NewPermanentJob(namespace string, key string, listener Listener, queryServi
 // hash with the last seen hash and notifies the listener only if a change
 // is detected.
 func (j *PermanentJob) Run() {
-	logger.Infof("[PermanentKeyCheck] check for key [%s:%s]", j.namespace, j.key)
+	logger.Debugf("[PermanentKeyCheck] check for key [%s:%s]", j.namespace, j.key)
 	v, err := j.queryService.GetState(j.namespace, j.key)
 	if err == nil && v != nil && len(v.Raw) != 0 {
 		newHash := token.Hashable(v.Raw).Raw()

--- a/token/services/network/fabricx/tms/common.go
+++ b/token/services/network/fabricx/tms/common.go
@@ -109,7 +109,7 @@ func (p *fnsBroadcaster) Broadcast(network, channel string, txID driver.TxID, en
 		return errors.Wrapf(err, "failed broadcasting on [%s,%s]", network, channel)
 	}
 
-	logger.Infof("Wait for finality")
+	logger.Debugf("Wait for finality")
 
 	return <-final
 }
@@ -119,7 +119,7 @@ func (p *fnsBroadcaster) Broadcast(network, channel string, txID driver.TxID, en
 // handle EOF errors, which can occur during network startup or when
 // block 0 is not yet available.
 func getFinality(finality driver.Finality, txID string) error {
-	logger.Infof("wait for finality [txID=%v]", txID)
+	logger.Debugf("wait for finality [txID=%v]", txID)
 	for range finalityEOFRetries {
 		err := finality.IsFinal(context.Background(), txID)
 		if err == nil {

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -1388,7 +1388,7 @@ func (t *TokenTransaction) SetSpendableBySupportedTokenFormats(ctx context.Conte
 		return errors.Wrapf(err, "error setting spendable flag to true for token types [%v]", formats)
 	} else {
 		rows, _ := res.RowsAffected()
-		logger.InfofContext(ctx, "rows affected [%d]", rows)
+		logger.DebugfContext(ctx, "rows affected [%d]", rows)
 	}
 
 	return nil

--- a/token/services/storage/db/sql/postgres/notifier.go
+++ b/token/services/storage/db/sql/postgres/notifier.go
@@ -158,7 +158,7 @@ func (db *Notifier) dispatch(operation driver.Operation, m map[driver.ColumnKey]
 	copy(subscribers, db.subscribers)
 	db.mu.RUnlock()
 
-	logger.Infof("dispatching to [%d] subscribers", len(subscribers))
+	logger.Debugf("dispatching to [%d] subscribers", len(subscribers))
 	for _, callback := range subscribers {
 		if callback == nil {
 			logger.Errorf("a nil callback found for [%s], skip it", db.table)
@@ -399,7 +399,7 @@ func (h *notificationHandler) HandleNotification(ctx context.Context, notificati
 
 		return nil
 	}
-	logger.InfofContext(ctx, "new event received on table [%s]: %s", notification.Channel, notification.Payload)
+	logger.DebugfContext(ctx, "new event received on table [%s]: %s", notification.Channel, notification.Payload)
 	op, vals, err := h.parsePayload(notification.Payload)
 	if err != nil {
 		logger.Errorf("failed parsing payload [%s]: %s", notification.Payload, err.Error())

--- a/token/services/storage/db/sql/postgres/recovery.go
+++ b/token/services/storage/db/sql/postgres/recovery.go
@@ -65,7 +65,7 @@ func NewAdvisoryLock(ctx context.Context, db *sql.DB, lockID int64) (*AdvisoryLo
 		return nil, false, nil
 	}
 
-	logger.Infof("Acquired advisory lock %d", lockID)
+	logger.Debugf("Acquired advisory lock %d", lockID)
 
 	return &AdvisoryLock{
 		db:     db,
@@ -89,7 +89,7 @@ func (l *AdvisoryLock) Close() error {
 	if err != nil {
 		l.logger.Warnf("Failed to explicitly release advisory lock %d: %v (will auto-release on connection close)", l.lockID, err)
 	} else {
-		l.logger.Infof("Released advisory lock %d", l.lockID)
+		l.logger.Debugf("Released advisory lock %d", l.lockID)
 	}
 
 	// Close the connection (this also releases the lock if unlock failed)

--- a/token/services/storage/db/sql/postgres/transactions.go
+++ b/token/services/storage/db/sql/postgres/transactions.go
@@ -185,7 +185,7 @@ func (db *TransactionStore) ClaimPendingTransactions(ctx context.Context, params
 		return nil, errors.Wrapf(err, "failed to read claimed transactions")
 	}
 
-	logger.Infof("Claimed %d pending transactions for owner %s", len(claimed), params.Owner)
+	logger.Debugf("Claimed %d pending transactions for owner %s", len(claimed), params.Owner)
 
 	return claimed, nil
 }
@@ -237,7 +237,7 @@ func (db *TransactionStore) ReleaseRecoveryClaim(ctx context.Context, txID strin
 	if rowsAffected == 0 {
 		logger.Warnf("No recovery claim released for tx %s (not owned by %s or already released)", txID, owner)
 	} else {
-		logger.Infof("Released recovery claim for tx %s", txID)
+		logger.Debugf("Released recovery claim for tx %s", txID)
 	}
 
 	return nil
@@ -266,7 +266,7 @@ func (db *TransactionStore) CleanupExpiredClaims(ctx context.Context) (int, erro
 		return 0, errors.Wrapf(err, "failed to get rows affected during cleanup")
 	}
 
-	logger.Infof("Cleaned up %d expired recovery claims", rowsAffected)
+	logger.Debugf("Cleaned up %d expired recovery claims", rowsAffected)
 
 	return int(rowsAffected), nil
 }

--- a/token/services/storage/recovery/manager.go
+++ b/token/services/storage/recovery/manager.go
@@ -234,7 +234,7 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 		return nil
 	}
 
-	m.logger.Infof("claimed %d pending transaction(s) needing recovery", len(records))
+	m.logger.Debugf("claimed %d pending transaction(s) needing recovery", len(records))
 
 	work := make(chan *ttxdb.RecoveryClaim)
 	errCh := make(chan error, len(records))
@@ -277,7 +277,7 @@ func (m *Manager) recoverTransactions(ctx context.Context) error {
 	if failures > 0 {
 		m.logger.Warnf("completed recovery sweep: claimed=%d, succeeded=%d, failed=%d", len(records), len(records)-failures, failures)
 	} else {
-		m.logger.Infof("completed recovery sweep: claimed=%d, all succeeded", len(records))
+		m.logger.Debugf("completed recovery sweep: claimed=%d, all succeeded", len(records))
 	}
 
 	return firstErr

--- a/token/services/ttx/external.go
+++ b/token/services/ttx/external.go
@@ -161,7 +161,7 @@ func (s *StreamExternalWalletSignerClient) init() {
 				s.input <- req
 			}
 		case Done:
-			logger.Infof("no more signatures required")
+			logger.Debugf("no more signatures required")
 			close(s.input)
 
 			return

--- a/token/services/ttx/finality/recovery.go
+++ b/token/services/ttx/finality/recovery.go
@@ -136,7 +136,7 @@ func (h *TTXRecoveryHandler) applyFinalityLogic(ctx context.Context, txID string
 	default:
 		// Transaction is not yet finalized (Busy or Unknown status)
 		// This is a normal transient state - don't treat as error to avoid unnecessary claim churn
-		h.logger.Infof("transaction [%s] has status [%d], not yet finalized - will retry on next scan", txID, status)
+		h.logger.Debugf("transaction [%s] has status [%d], not yet finalized - will retry on next scan", txID, status)
 
 		// Return nil to release claim gracefully without error
 		// The transaction will be picked up again on the next scan after TTL expires


### PR DESCRIPTION
Switch Storage & DB Info Logs to Debug Level (#1727)

## Description
Converts noisy, high-frequency DB and recovery log statements from `INFO` to `DEBUG` level in the storage layer. This quiets down operational logs during background polling cycles, database lock management, and transaction recovery sweeps.

## Key Changes
- **Advisory Locks** (`token/services/storage/db/sql/postgres/recovery.go`): Moved advisory lock acquire/release logs to `DEBUG`.
- **Recovery Claims** (`token/services/storage/db/sql/postgres/transactions.go`): Moved transaction recovery claim, release, and cleanup logs to `DEBUG`.
- **Event Notifications** (`token/services/storage/db/sql/postgres/notifier.go`): Moved event dispatching and payload receipt logs to `DEBUG`.
- **Rows Affected Operations** (`token/services/storage/db/sql/common/tokens.go`): Moved query rows affected logs to `DEBUG`.

## Verification
- Code formatted with `gofmt` and `goimports`.
- Static analysis verified clean using `staticcheck ./token/services/storage/...`.
- Unit tests successfully passed for SQLite and Memory storage backends.