### PR TITLE
fix: add Chrome installation for linkspector action

### DIFF
--- a/.github/workflows/md_links.yml
+++ b/.github/workflows/md_links.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Install Chrome for Puppeteer
+        run: npx puppeteer browsers install chrome
+      
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
Linkspector's Puppeteer now requires Chrome, which isn't pre-installed on GitHub runners. Added explicit Chrome installation step to resolve the "Could not find Chrome" error.

Fixes CI/CD pipeline failure.