### PR TITLE
docs: add Token SDK metrics reference and identify coverage gaps

### DIFF
--- a/docs/development/monitoring.md
+++ b/docs/development/monitoring.md
@@ -5,3 +5,6 @@ We adopt the monitoring infrastructure provided by the [`Fabric Smart Client`](h
 We use the following two methods to monitor the performance of the application:
 * **Metrics** provide an overview of the overall system performance using aggregated results, e.g. total requests, requests per second, current state of a variable, average duration, percentile of duration
 * **Traces** help us analyze single requests by breaking down their lifecycles into smaller components
+
+For a complete catalog of every metric the Token SDK emits — and a list of areas
+that are not yet instrumented — see the [Metrics Reference](../metrics.md).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,224 @@
+# Token SDK Metrics Reference
+
+This document catalogs every metric emitted by the Token SDK and, in the final
+section, identifies areas of the codebase that are not yet instrumented.
+
+Metrics are produced through the metrics provider supplied by the
+[Fabric Smart Client](https://github.com/hyperledger-labs/fabric-smart-client)
+(Prometheus-compatible). See [development/monitoring.md](development/monitoring.md)
+for the high-level monitoring setup, and [drivers/metrics.md](drivers/metrics.md)
+for the design of the driver-service decorator layer summarized in
+[Driver services](#driver-services) below.
+
+Metric types follow Prometheus conventions:
+
+- **Counter** — monotonically increasing total.
+- **Gauge** — value that can go up or down.
+- **Histogram** — distribution of observed values (durations, sizes).
+
+---
+
+## Driver services
+
+Defined in `token/core/common/metrics/`. Each core driver service is wrapped by a
+decorator that records, per method invocation, a call counter, a duration
+histogram, and an error counter. All carry the labels `network`, `channel`,
+`namespace`, `method`, so metrics can be filtered per TMS and per operation
+(e.g. `Issue`, `Transfer`). The duration histograms are native (sparse) Prometheus
+histograms.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `issue_service_operations_total` | Counter | Total IssueService method invocations |
+| `issue_service_duration_seconds` | Histogram | Duration of IssueService method calls |
+| `issue_service_errors_total` | Counter | Total IssueService method errors |
+| `transfer_service_operations_total` | Counter | Total TransferService method invocations |
+| `transfer_service_duration_seconds` | Histogram | Duration of TransferService method calls |
+| `transfer_service_errors_total` | Counter | Total TransferService method errors |
+| `tokens_service_operations_total` | Counter | Total TokensService method invocations |
+| `tokens_service_duration_seconds` | Histogram | Duration of TokensService method calls |
+| `tokens_service_errors_total` | Counter | Total TokensService method errors |
+| `auditor_service_operations_total` | Counter | Total AuditorService method invocations |
+| `auditor_service_duration_seconds` | Histogram | Duration of AuditorService method calls |
+| `auditor_service_errors_total` | Counter | Total AuditorService method errors |
+| `tokens_upgrade_service_operations_total` | Counter | Total TokensUpgradeService method invocations |
+| `tokens_upgrade_service_duration_seconds` | Histogram | Duration of TokensUpgradeService method calls |
+| `tokens_upgrade_service_errors_total` | Counter | Total TokensUpgradeService method errors |
+
+Labels (all): `network`, `channel`, `namespace`, `method`.
+
+## Transaction lifecycle (ttx)
+
+Defined in `token/services/ttx/metrics.go`. Counts and times the main phases of a
+token transaction. Labels (all): `network`, `channel`, `namespace`.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `endorsed_transactions` | Counter | Number of endorsed transactions |
+| `audit_approved_transactions` | Counter | Number of transactions approved by the auditor |
+| `accepted_transactions` | Counter | Number of accepted transactions |
+| `endorsement_duration_seconds` | Histogram | Duration of the full endorsement collection phase (signatures, audit, chaincode approval) |
+| `audit_approval_duration_seconds` | Histogram | Duration of the auditor approval phase (validation, append, signing) |
+| `ordering_duration_seconds` | Histogram | Duration of the broadcast to the ordering service |
+
+## Finality listener (ttx)
+
+Defined in `token/services/ttx/finality/metrics.go`. Tracks the listener that
+reacts to on-ledger finality. No labels.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `finality_listener_confirmed_total` | Counter | Transactions confirmed on the ledger and committed to local storage |
+| `finality_listener_deleted_total` | Counter | Transactions marked deleted due to an invalid ledger status or token-request hash mismatch |
+| `finality_listener_hash_mismatch_total` | Counter | Transactions rejected because the committed token-request hash did not match the local one |
+| `finality_listener_retry_exhausted_total` | Counter | Transactions abandoned after all finality-processing retries were exhausted |
+| `finality_listener_on_status_duration_seconds` | Histogram | Total OnStatus processing time per transaction, including retries |
+
+## Versioned envelope sessions (ttx)
+
+Defined in `token/services/utils/json/session/metrics.go`. Instruments the
+versioned envelope protocol used by interactive ttx views.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `ttx_envelope_sent_total` | Counter | `version`, `type` | Versioned envelopes sent |
+| `ttx_envelope_received_total` | Counter | `version`, `type` | Versioned envelopes received |
+| `ttx_envelope_errors_total` | Counter | `error` | Envelope validation errors |
+| `ttx_envelope_body_bytes` | Histogram | `type` | Size of the envelope body in bytes |
+
+## Auditor service
+
+Defined in `token/services/auditor/metrics.go`. Instruments the auditor's
+`Audit`/`Append`/`Release` path (distinct from the driver-level
+`auditor_service_*` metrics above). No labels.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `auditor_audit_duration_seconds` | Histogram | Audit() processing time per transaction, including lock acquisition |
+| `auditor_audit_lock_conflicts_total` | Counter | Audit() calls that failed to acquire enrollment-ID locks |
+| `auditor_append_duration_seconds` | Histogram | Append() processing time per transaction |
+| `auditor_append_errors_total` | Counter | Append() calls that failed to write to the audit database |
+| `auditor_releases_total` | Counter | Release() calls (explicit and deferred) |
+
+## Token selection (sherdlock)
+
+Defined in `token/services/selector/sherdlock/metrics.go`.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `unspent_tokens_invocations` | Counter | `fetcher_type` | Number of unspent-token fetch invocations |
+| `selection_duration_seconds` | Histogram | — | Duration of a token selection call |
+| `selection_outcome_total` | Counter | `outcome` | Token selection outcomes by result type |
+| `selection_immediate_retries` | Histogram | — | Distribution of immediate retry counts per selection call |
+
+## Certification (interactive)
+
+Defined in `token/services/certifier/interactive/metrics.go`.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `certified_tokens` | Counter | `network`, `channel`, `namespace` | Number of tokens certified |
+| `certification_request_duration_seconds` | Histogram | `channel`, `namespace` | Certification batch request durations |
+| `certification_errors_total` | Counter | `channel`, `namespace` | Failed certification request attempts |
+| `certification_pending_tokens` | Gauge | `channel`, `namespace` | Tokens waiting in the certification input buffer |
+| `certification_dropped_tokens_total` | Counter | `channel`, `namespace` | Tokens dropped because the certification buffer was full |
+
+## Identity caches
+
+| Metric | Type | Labels | Source | Description |
+|--------|------|--------|--------|-------------|
+| `cache_level` | Gauge | `network`, `channel`, `namespace` | `token/services/identity/idemix/cache/metrics.go` | Fill level of the Idemix credential cache |
+| `recipient_data_cache_level` | Gauge | `network`, `channel`, `namespace` | `token/services/identity/role/metrics.go` | Fill level of the wallet recipient-data cache |
+
+## Fabric-X finality queue
+
+Defined in `token/services/network/fabricx/finality/queue/metrics.go`. No labels.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `finality_queue_pending_events` | Gauge | Finality events currently waiting in the queue buffer |
+| `finality_queue_enqueue_drops_total` | Counter | Finality events dropped because the queue was full |
+| `finality_queue_processing_errors_total` | Counter | Errors returned by `event.Process` in worker goroutines |
+| `finality_queue_processing_duration_seconds` | Histogram | Successful event processing time in worker goroutines |
+
+---
+
+## Coverage gaps and recommended additions
+
+The metrics above concentrate on transaction processing (driver services, the ttx
+lifecycle, finality, auditing, selection). Several layers are currently
+uninstrumented. The items below are ordered by impact.
+
+### 1. Storage / persistence layer (highest priority)
+
+`token/services/storage/...` (token DB, transaction DB, identity/wallet DB,
+keystore) emits **no metrics**. Reads, writes, deletes, query latency, and
+backend errors are invisible, even though this is where every token and
+transaction is ultimately persisted, and the backend (sqlite vs postgres) is a
+common performance and failure boundary.
+
+Recommended:
+
+- `storage_operations_total{store, operation, backend}` — counter (store =
+  tokendb/ttxdb/identitydb/keystore; operation = read/write/delete/query).
+- `storage_operation_duration_seconds{store, operation, backend}` — histogram.
+- `storage_errors_total{store, operation, backend}` — counter.
+
+Write-rate counters here also provide the natural signal for detecting anomalous
+token-insertion activity, which application-level metrics cannot currently see.
+
+### 2. Distributed lock manager
+
+The pluggable auditor `Locker` (`token/services/storage/auditdb/locker/`,
+memory and postgres) has no metrics. The auditor surfaces only
+`auditor_audit_lock_conflicts_total` at the call site; the lock manager itself is
+opaque.
+
+Recommended:
+
+- `auditor_lock_acquisitions_total{result}` — counter (result =
+  acquired/contended/failed).
+- `auditor_lock_wait_duration_seconds` — histogram.
+- `auditor_lock_leases_renewed_total` and `auditor_lock_lost_total` — counters
+  (the postgres locker already detects lease loss via `ErrLockLost`).
+- `auditor_locks_held` — gauge of currently held anchors.
+
+### 3. Standard Fabric network / approval path
+
+Only the Fabric-X finality queue is instrumented. The standard Fabric network
+service path (request-approval / broadcast / finality) has no counters or
+latency histograms of its own; the ttx layer only times ordering via
+`ordering_duration_seconds`.
+
+Recommended: request-approval and broadcast counters, durations, and error
+counters for the Fabric network driver, mirroring the Fabric-X queue metrics.
+
+### 4. Validation / double-spend
+
+Token-request validation (`token/services/...` validators) is not instrumented.
+
+Recommended:
+
+- `validation_invocations_total` and `validation_failures_total{reason}` —
+  counters.
+- `validation_duration_seconds` — histogram.
+- A dedicated double-spend / duplicate-detection counter.
+
+### 5. Transaction-level failure counter
+
+The lifecycle exposes `endorsed`, `audit_approved`, and `accepted` counters but
+no symmetric failure counter; failures are only visible indirectly through
+per-service `*_errors_total` and `finality_listener_deleted_total`.
+
+Recommended: `transactions_failed_total{phase, reason}` with the same
+`network`/`channel`/`namespace` labels as the other lifecycle counters, so success
+and failure rates can be compared directly.
+
+### 6. Wallet / identity resolution
+
+Only cache fill levels are gauged (`cache_level`, `recipient_data_cache_level`).
+There are no counters for wallet lookups or signer/verifier resolution, so cache
+hit/miss ratios cannot be derived.
+
+Recommended: `wallet_lookups_total{result}` (hit/miss) and a resolution duration
+histogram.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,11 @@ for the high-level monitoring setup, and [drivers/metrics.md](drivers/metrics.md
 for the design of the driver-service decorator layer summarized in
 [Driver services](#driver-services) below.
 
+A ready-to-import Grafana dashboard covering all the metrics in this document
+is available at [monitoring/grafana/token-sdk.json](monitoring/grafana/token-sdk.json)
+(see [monitoring/grafana/README.md](monitoring/grafana/README.md) for import
+instructions and the panel layout).
+
 Metric types follow Prometheus conventions:
 
 - **Counter** — monotonically increasing total.
@@ -149,6 +154,12 @@ The metrics above concentrate on transaction processing (driver services, the tt
 lifecycle, finality, auditing, selection). Several layers are currently
 uninstrumented. The items below are ordered by impact.
 
+> Note: the Fabric Smart Client already instruments view execution (per-view
+> count and duration) at the platform layer. The suggestions below intentionally
+> stay domain-specific (per-store / per-operation / per-phase counters) so they
+> add semantics the FSC view instrumentation cannot infer, rather than
+> duplicating it.
+
 ### 1. Storage / persistence layer (highest priority)
 
 `token/services/storage/...` (token DB, transaction DB, identity/wallet DB,
@@ -164,7 +175,13 @@ Recommended:
 - `storage_operation_duration_seconds{store, operation, backend}` — histogram.
 - `storage_errors_total{store, operation, backend}` — counter.
 
-Write-rate counters here also provide the natural signal for detecting anomalous
+These complement, rather than duplicate, what the database backend already
+exposes (e.g. `pg_stat_statements` via `postgres_exporter`). The SDK-level
+metrics carry semantic labels the DB layer cannot infer without per-query
+parsing — `store=tokendb, operation=write` instead of an opaque
+`INSERT INTO tokens` row count — and they are the only source of metrics when
+the backend is sqlite or another embedded store with no exporter. Write-rate
+counters here also provide the natural signal for detecting anomalous
 token-insertion activity, which application-level metrics cannot currently see.
 
 ### 2. Distributed lock manager
@@ -183,28 +200,30 @@ Recommended:
   (the postgres locker already detects lease loss via `ErrLockLost`).
 - `auditor_locks_held` — gauge of currently held anchors.
 
-### 3. Standard Fabric network / approval path
+### 3. Endorser / approval path (standard Fabric network)
 
-Only the Fabric-X finality queue is instrumented. The standard Fabric network
-service path (request-approval / broadcast / finality) has no counters or
-latency histograms of its own; the ttx layer only times ordering via
+Only the Fabric-X finality queue is instrumented. The standard Fabric endorser
+path — `EndorserService` in `token/services/network/fabric/endorsement/provider.go`
+(`ReceiveTx`, `Endorse`, `CollectEndorsements`) and `RequestApprovalView` in
+`token/services/network/fabric/endorsement/fsc/initiator.go` — emits no
+domain-specific metrics. The ttx layer only times ordering via
 `ordering_duration_seconds`.
 
-Recommended: request-approval and broadcast counters, durations, and error
-counters for the Fabric network driver, mirroring the Fabric-X queue metrics.
+Recommended (per-operation semantic counters, not generic view timing — FSC
+already covers that):
 
-### 4. Validation / double-spend
+- `endorser_requests_total{operation, result}` — counter (operation =
+  receive_tx / endorse / collect_endorsements; result = success / failure).
+- `endorser_operation_duration_seconds{operation}` — histogram.
+- `approval_requests_total{result}` and `approval_request_duration_seconds`
+  for `RequestApprovalView`, labelled by `network`/`channel`/`namespace` like
+  the other lifecycle counters.
 
-Token-request validation (`token/services/...` validators) is not instrumented.
+Note: double-spend is enforced at commit time by Fabric / the token chaincode,
+not by the SDK validators, so it does not belong on this list as an SDK-level
+metric.
 
-Recommended:
-
-- `validation_invocations_total` and `validation_failures_total{reason}` —
-  counters.
-- `validation_duration_seconds` — histogram.
-- A dedicated double-spend / duplicate-detection counter.
-
-### 5. Transaction-level failure counter
+### 4. Transaction-level failure counter
 
 The lifecycle exposes `endorsed`, `audit_approved`, and `accepted` counters but
 no symmetric failure counter; failures are only visible indirectly through
@@ -214,7 +233,7 @@ Recommended: `transactions_failed_total{phase, reason}` with the same
 `network`/`channel`/`namespace` labels as the other lifecycle counters, so success
 and failure rates can be compared directly.
 
-### 6. Wallet / identity resolution
+### 5. Wallet / identity resolution
 
 Only cache fill levels are gauged (`cache_level`, `recipient_data_cache_level`).
 There are no counters for wallet lookups or signer/verifier resolution, so cache

--- a/docs/monitoring/grafana/README.md
+++ b/docs/monitoring/grafana/README.md
@@ -1,0 +1,45 @@
+# Grafana dashboard
+
+`token-sdk.json` is a Grafana dashboard for the Token SDK metrics catalogued in
+[../../metrics.md](../../metrics.md). It targets a Prometheus data source
+scraping the Fabric Smart Client metrics endpoint exposed by the application.
+
+## Import
+
+1. In Grafana, **Dashboards → New → Import**.
+2. Upload `token-sdk.json` (or paste its content).
+3. When prompted, select the Prometheus data source that scrapes your
+   FSC/Token-SDK metrics endpoint.
+
+## Variables
+
+The dashboard exposes four template variables, all multi-select with `All`
+default:
+
+- `network` / `channel` / `namespace` — filter to a specific TMS.
+- `method` — filter the driver-service panels to a specific method
+  (e.g. `Issue`, `Transfer`).
+
+## Panels
+
+| Row | Panels |
+|-----|--------|
+| Driver services (decorator layer) | Ops rate by service, error rate by service, per-method p95 duration |
+| Transaction lifecycle (ttx) | Endorsed / audit-approved / accepted rate, phase duration p95 |
+| Finality listener | Confirmed / deleted / hash-mismatch / retry-exhausted rate, `OnStatus` p50/p95 |
+| Versioned envelope sessions (ttx) | Sent/received by type, errors by reason, body size p95 |
+| Auditor service | Audit / append p95, lock conflicts, append errors, releases |
+| Token selection (sherdlock) | Selection p95, outcomes, unspent-token fetches, immediate retries p95 |
+| Certification + identity caches | Certified / errors / dropped rate, request p95, cache levels, pending buffer |
+| Fabric-X finality queue | Pending events gauge, drops + errors rate, processing p95 |
+
+## Caveats
+
+- Histogram quantiles use a 5-minute sliding window; tune via panel queries
+  if your scrape interval differs from the default.
+- The dashboard only renders panels for which the corresponding metrics are
+  emitted by the running application — services not enabled in your build
+  will simply show "No data".
+- Panels do not yet cover the metrics flagged as gaps in
+  [../../metrics.md#coverage-gaps-and-recommended-additions](../../metrics.md#coverage-gaps-and-recommended-additions);
+  add them once the underlying instrumentation lands.

--- a/docs/monitoring/grafana/token-sdk.json
+++ b/docs/monitoring/grafana/token-sdk.json
@@ -1,0 +1,403 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source scraping the Fabric Smart Client / Token SDK metrics endpoint.",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {"type": "grafana", "id": "grafana", "name": "Grafana", "version": "9.0.0"},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0"},
+    {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
+    {"type": "panel", "id": "stat", "name": "Stat", "version": ""}
+  ],
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "iteration": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Driver services (decorator layer)",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 101,
+      "title": "Operations rate (per second) by service",
+      "description": "Sum of *_service_operations_total rate across the filtered TMS, broken down by service.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 1},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "issue",    "expr": "sum(rate(issue_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",    "legendFormat": "issue"},
+        {"refId": "transfer", "expr": "sum(rate(transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))", "legendFormat": "transfer"},
+        {"refId": "tokens",   "expr": "sum(rate(tokens_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",   "legendFormat": "tokens"},
+        {"refId": "auditor",  "expr": "sum(rate(auditor_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",  "legendFormat": "auditor"},
+        {"refId": "upgrade",  "expr": "sum(rate(tokens_upgrade_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))", "legendFormat": "upgrade"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 102,
+      "title": "Error rate (per second) by service",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "issue",    "expr": "sum(rate(issue_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",    "legendFormat": "issue"},
+        {"refId": "transfer", "expr": "sum(rate(transfer_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))", "legendFormat": "transfer"},
+        {"refId": "tokens",   "expr": "sum(rate(tokens_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",   "legendFormat": "tokens"},
+        {"refId": "auditor",  "expr": "sum(rate(auditor_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))",  "legendFormat": "auditor"},
+        {"refId": "upgrade",  "expr": "sum(rate(tokens_upgrade_service_errors_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[$__rate_interval]))", "legendFormat": "upgrade"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 103,
+      "title": "Per-method duration (p95) — Transfer / Issue / Tokens / Auditor / Upgrade",
+      "description": "p95 over a 5m sliding window, summed across replicas, broken down by service.method.",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 9},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "issue",    "expr": "histogram_quantile(0.95, sum by (le, method) (rate(issue_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",    "legendFormat": "issue.{{method}}"},
+        {"refId": "transfer", "expr": "histogram_quantile(0.95, sum by (le, method) (rate(transfer_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))", "legendFormat": "transfer.{{method}}"},
+        {"refId": "tokens",   "expr": "histogram_quantile(0.95, sum by (le, method) (rate(tokens_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",   "legendFormat": "tokens.{{method}}"},
+        {"refId": "auditor",  "expr": "histogram_quantile(0.95, sum by (le, method) (rate(auditor_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))",  "legendFormat": "auditor.{{method}}"},
+        {"refId": "upgrade",  "expr": "histogram_quantile(0.95, sum by (le, method) (rate(tokens_upgrade_service_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\",method=~\"$method\"}[5m])))", "legendFormat": "upgrade.{{method}}"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 200,
+      "title": "Transaction lifecycle (ttx)",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 201,
+      "title": "Lifecycle counters (rate) — endorsed / audit_approved / accepted",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "e", "expr": "sum(rate(endorsed_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "endorsed"},
+        {"refId": "a", "expr": "sum(rate(audit_approved_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "audit_approved"},
+        {"refId": "c", "expr": "sum(rate(accepted_transactions{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "accepted"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 202,
+      "title": "Phase duration (p95) — endorsement / audit_approval / ordering",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "e", "expr": "histogram_quantile(0.95, sum by (le) (rate(endorsement_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))", "legendFormat": "endorsement p95"},
+        {"refId": "a", "expr": "histogram_quantile(0.95, sum by (le) (rate(audit_approval_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))", "legendFormat": "audit_approval p95"},
+        {"refId": "o", "expr": "histogram_quantile(0.95, sum by (le) (rate(ordering_duration_seconds_bucket{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))", "legendFormat": "ordering p95"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 300,
+      "title": "Finality listener",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 26},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 301,
+      "title": "Finality outcomes (rate)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 27},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "c", "expr": "rate(finality_listener_confirmed_total[$__rate_interval])", "legendFormat": "confirmed"},
+        {"refId": "d", "expr": "rate(finality_listener_deleted_total[$__rate_interval])", "legendFormat": "deleted"},
+        {"refId": "h", "expr": "rate(finality_listener_hash_mismatch_total[$__rate_interval])", "legendFormat": "hash_mismatch"},
+        {"refId": "r", "expr": "rate(finality_listener_retry_exhausted_total[$__rate_interval])", "legendFormat": "retry_exhausted"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 302,
+      "title": "OnStatus processing duration (p50 / p95)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 27},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "p50", "expr": "histogram_quantile(0.50, sum by (le) (rate(finality_listener_on_status_duration_seconds_bucket[5m])))", "legendFormat": "p50"},
+        {"refId": "p95", "expr": "histogram_quantile(0.95, sum by (le) (rate(finality_listener_on_status_duration_seconds_bucket[5m])))", "legendFormat": "p95"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 400,
+      "title": "Versioned envelope sessions (ttx)",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 35},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 401,
+      "title": "Envelopes sent / received (rate) by type",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 36},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "s", "expr": "sum by (type) (rate(ttx_envelope_sent_total[$__rate_interval]))", "legendFormat": "sent {{type}}"},
+        {"refId": "r", "expr": "sum by (type) (rate(ttx_envelope_received_total[$__rate_interval]))", "legendFormat": "recv {{type}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 402,
+      "title": "Envelope errors (rate) + body size p95 by type",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 36},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "err",  "expr": "sum by (error) (rate(ttx_envelope_errors_total[$__rate_interval]))", "legendFormat": "errors {{error}}"},
+        {"refId": "size", "expr": "histogram_quantile(0.95, sum by (le, type) (rate(ttx_envelope_body_bytes_bucket[5m])))", "legendFormat": "body p95 {{type}} (bytes)"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 500,
+      "title": "Auditor service",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 44},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 501,
+      "title": "Audit / Append duration (p95) + lock conflicts + append errors",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 45},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "ad", "expr": "histogram_quantile(0.95, sum by (le) (rate(auditor_audit_duration_seconds_bucket[5m])))", "legendFormat": "audit p95"},
+        {"refId": "ap", "expr": "histogram_quantile(0.95, sum by (le) (rate(auditor_append_duration_seconds_bucket[5m])))", "legendFormat": "append p95"},
+        {"refId": "lc", "expr": "rate(auditor_audit_lock_conflicts_total[$__rate_interval])", "legendFormat": "lock_conflicts/s"},
+        {"refId": "ae", "expr": "rate(auditor_append_errors_total[$__rate_interval])", "legendFormat": "append_errors/s"},
+        {"refId": "rl", "expr": "rate(auditor_releases_total[$__rate_interval])", "legendFormat": "releases/s"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 600,
+      "title": "Token selection (sherdlock)",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 53},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 601,
+      "title": "Selection duration (p95) + outcomes (rate)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 54},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "p95", "expr": "histogram_quantile(0.95, sum by (le) (rate(selection_duration_seconds_bucket[5m])))", "legendFormat": "duration p95"},
+        {"refId": "out", "expr": "sum by (outcome) (rate(selection_outcome_total[$__rate_interval]))", "legendFormat": "outcome={{outcome}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 602,
+      "title": "Unspent token fetches (rate) + immediate retries (p95)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 54},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "f", "expr": "sum by (fetcher_type) (rate(unspent_tokens_invocations[$__rate_interval]))", "legendFormat": "fetch {{fetcher_type}}/s"},
+        {"refId": "r", "expr": "histogram_quantile(0.95, sum by (le) (rate(selection_immediate_retries_bucket[5m])))", "legendFormat": "retries p95"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 700,
+      "title": "Certification + identity caches",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 62},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 701,
+      "title": "Certification — certified / errors / dropped (rate) + request p95",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 63},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "c", "expr": "sum(rate(certified_tokens{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "certified/s"},
+        {"refId": "e", "expr": "sum(rate(certification_errors_total{channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "errors/s"},
+        {"refId": "d", "expr": "sum(rate(certification_dropped_tokens_total{channel=~\"$channel\",namespace=~\"$namespace\"}[$__rate_interval]))", "legendFormat": "dropped/s"},
+        {"refId": "p", "expr": "histogram_quantile(0.95, sum by (le) (rate(certification_request_duration_seconds_bucket{channel=~\"$channel\",namespace=~\"$namespace\"}[5m])))", "legendFormat": "request p95 (s)"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 702,
+      "title": "Cache fill levels + certification buffer (gauges)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 63},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "ic", "expr": "cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}", "legendFormat": "idemix cache_level"},
+        {"refId": "rc", "expr": "recipient_data_cache_level{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}", "legendFormat": "recipient_data_cache_level"},
+        {"refId": "pt", "expr": "certification_pending_tokens{channel=~\"$channel\",namespace=~\"$namespace\"}", "legendFormat": "certification_pending"}
+      ]
+    },
+    {
+      "type": "row",
+      "id": 800,
+      "title": "Fabric-X finality queue",
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 71},
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 801,
+      "title": "Pending events (gauge)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 6, "x": 0, "y": 72},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "options": {"reduceOptions": {"calcs": ["lastNotNull"]}},
+      "targets": [
+        {"refId": "p", "expr": "finality_queue_pending_events", "legendFormat": "pending"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 802,
+      "title": "Enqueue drops + processing errors (rate)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 9, "x": 6, "y": 72},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "d", "expr": "rate(finality_queue_enqueue_drops_total[$__rate_interval])", "legendFormat": "drops/s"},
+        {"refId": "e", "expr": "rate(finality_queue_processing_errors_total[$__rate_interval])", "legendFormat": "errors/s"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 803,
+      "title": "Processing duration (p95)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "gridPos": {"h": 6, "w": 9, "x": 15, "y": 72},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "options": {"legend": {"showLegend": true, "placement": "bottom"}},
+      "targets": [
+        {"refId": "p", "expr": "histogram_quantile(0.95, sum by (le) (rate(finality_queue_processing_duration_seconds_bucket[5m])))", "legendFormat": "p95"}
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["fabric-token-sdk", "token-sdk", "hyperledger"],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "label": "Prometheus",
+        "query": "prometheus",
+        "refresh": 1,
+        "hide": 0
+      },
+      {
+        "name": "network",
+        "type": "query",
+        "label": "Network",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(transfer_service_operations_total, network)",
+        "query": {"query": "label_values(transfer_service_operations_total, network)", "refId": "v"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "refresh": 2
+      },
+      {
+        "name": "channel",
+        "type": "query",
+        "label": "Channel",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(transfer_service_operations_total{network=~\"$network\"}, channel)",
+        "query": {"query": "label_values(transfer_service_operations_total{network=~\"$network\"}, channel)", "refId": "v"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "refresh": 2
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "label": "Namespace",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\"}, namespace)",
+        "query": {"query": "label_values(transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\"}, namespace)", "refId": "v"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "refresh": 2
+      },
+      {
+        "name": "method",
+        "type": "query",
+        "label": "Driver method",
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)",
+        "query": {"query": "label_values(transfer_service_operations_total{network=~\"$network\",channel=~\"$channel\",namespace=~\"$namespace\"}, method)", "refId": "v"},
+        "includeAll": true,
+        "multi": true,
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "refresh": 2
+      }
+    ]
+  },
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Fabric Token SDK — Overview",
+  "uid": "fabric-token-sdk-overview",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
Closes #1745 

Adds `docs/metrics.md`, a complete reference of the 50 metrics the SDK emits (driver services, ttx lifecycle, finality, envelope sessions, auditor, selection, certification, identity caches, Fabric-X queue), each with type, labels, and description. Linked from the monitoring guide.
  
  Also adds a coverage-gap section ranking the uninstrumented layers — storage, the auditor lock manager, the standard Fabric network path, validation, a transaction-failure counter, and wallet resolution — with concrete suggested metrics for follow-up.
