### PR TITLE
test(tokens): add baseline SQL benchmarks for TokenStore queries

### DIFF
--- a/token/services/storage/db/sql/common/tokens_bench_test_util.go
+++ b/token/services/storage/db/sql/common/tokens_bench_test_util.go
@@ -1,0 +1,112 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package common
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/benchmark"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/db/driver"
+	tokentype "github.com/hyperledger-labs/fabric-token-sdk/token/token"
+)
+
+func SeedBenchTokens(b *testing.B, store *TokenStore, n int) {
+	b.Helper()
+	ctx := context.Background()
+	for i := range n {
+		rec := driver.TokenRecord{
+			TxID:           fmt.Sprintf("tx%d", i),
+			Index:          0,
+			OwnerRaw:       []byte("wallet0"),
+			OwnerType:      "idemix",
+			OwnerIdentity:  []byte("wallet0"),
+			OwnerWalletID:  "wallet0",
+			Ledger:         []byte("ledger"),
+			LedgerMetadata: []byte("meta"),
+			Quantity:       "0x64",
+			Type:           tokentype.Type("GOLD"),
+		}
+		if err := store.StoreToken(ctx, rec, []string{"wallet0"}); err != nil {
+			b.Fatalf("seed failed at i=%d: %v", i, err)
+		}
+	}
+}
+
+func RunTokenStoreBenchmarks(b *testing.B, store *TokenStore) {
+	b.Helper()
+	b.Run("UnspentTokensIterator", func(b *testing.B) {
+		SeedBenchTokens(b, store, 1000)
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *TokenStore { return store },
+			func(s *TokenStore) error {
+				it, err := s.UnspentTokensIterator(context.Background())
+				if err != nil {
+					return err
+				}
+				defer it.Close()
+				for {
+					tok, err := it.Next()
+					if err != nil {
+						return err
+					}
+					if tok == nil {
+						break
+					}
+				}
+
+				return nil
+			},
+		)
+		result.Print()
+	})
+
+	b.Run("Balance", func(b *testing.B) {
+		SeedBenchTokens(b, store, 1000)
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *TokenStore { return store },
+			func(s *TokenStore) error {
+				_, err := s.Balance(context.Background(), "wallet0", tokentype.Type("GOLD"))
+
+				return err
+			},
+		)
+		result.Print()
+	})
+
+	b.Run("UnspentTokensIteratorBy", func(b *testing.B) {
+		SeedBenchTokens(b, store, 1000)
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *TokenStore { return store },
+			func(s *TokenStore) error {
+				it, err := s.UnspentTokensIteratorBy(context.Background(), "wallet0", tokentype.Type("GOLD"))
+				if err != nil {
+					return err
+				}
+				defer it.Close()
+				for {
+					tok, err := it.Next()
+					if err != nil {
+						return err
+					}
+					if tok == nil {
+						break
+					}
+				}
+
+				return nil
+			},
+		)
+		result.Print()
+	})
+}

--- a/token/services/storage/db/sql/postgres/tokens_bench_test.go
+++ b/token/services/storage/db/sql/postgres/tokens_bench_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package postgres
+
+import (
+	"database/sql"
+	"testing"
+
+	fscpostgres "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	sqlcommon "github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/db/sql/common"
+)
+
+func openBenchTokenStore(b *testing.B) (*sqlcommon.TokenStore, func()) {
+	b.Helper()
+	cfg := fscpostgres.DefaultConfig(fscpostgres.WithDBName("bench-tokens"))
+	terminate, _, err := fscpostgres.StartPostgres(b.Context(), cfg, nil)
+	if err != nil {
+		b.Skipf("postgres not available: %v", err)
+	}
+	b.Cleanup(terminate)
+
+	db, err := sql.Open("pgx", cfg.DataSource())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tables, err := sqlcommon.GetTableNames("")
+	if err != nil {
+		b.Fatal(err)
+	}
+	store, err := sqlcommon.NewTokenStoreWithNotifier(db, db, tables, NewConditionInterpreter(), nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := store.CreateSchema(); err != nil {
+		b.Fatal(err)
+	}
+
+	return store, func() { _ = db.Close() }
+}
+
+func BenchmarkTokenStore(b *testing.B) {
+	store, cleanup := openBenchTokenStore(b)
+	defer cleanup()
+	sqlcommon.RunTokenStoreBenchmarks(b, store)
+}

--- a/token/services/storage/db/sql/sqlite/tokens_bench_test.go
+++ b/token/services/storage/db/sql/sqlite/tokens_bench_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	sqlcommon "github.com/hyperledger-labs/fabric-token-sdk/token/services/storage/db/sql/common"
+)
+
+func openBenchTokenStore(b *testing.B) (*sqlcommon.TokenStore, func()) {
+	b.Helper()
+	dir := b.TempDir()
+	dsn := fmt.Sprintf("file:%s/bench.sqlite?_pragma=busy_timeout(20000)", dir)
+	readDB, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	writeDB, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		b.Fatal(err)
+	}
+	tables, err := sqlcommon.GetTableNames("")
+	if err != nil {
+		b.Fatal(err)
+	}
+	store, err := sqlcommon.NewTokenStoreWithNotifier(readDB, writeDB, tables, NewConditionInterpreter(), nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := store.CreateSchema(); err != nil {
+		b.Fatal(err)
+	}
+
+	return store, func() {
+		_ = readDB.Close()
+		_ = writeDB.Close()
+	}
+}
+
+func BenchmarkTokenStore(b *testing.B) {
+	store, cleanup := openBenchTokenStore(b)
+	defer cleanup()
+	sqlcommon.RunTokenStoreBenchmarks(b, store)
+}


### PR DESCRIPTION
Closes #1784

## Summary
Adds baseline benchmarks for `TokenStore` SQL queries across **SQLite** and **PostgreSQL** backends to establish performance metrics before introducing prepared statements.

The prepared statement implementation will follow in a subsequent PR once these baselines are in place as a reference.

## Benchmarks covered
-> `BenchmarkUnspentTokensIterator` - iterates all unspent tokens (1000 seeded)
-> `BenchmarkBalance` - queries balance for a wallet + token type
-> `BenchmarkUnspentTokensIteratorBy` - filters unspent tokens by wallet + token type

## How to run

**SQLite:**
```bash
go test -bench=. -benchtime=5s ./token/services/storage/db/sql/sqlite/...
```

**PostgreSQL** (requires Docker):
```bash
go test -bench=. -benchtime=5s ./token/services/storage/db/sql/postgres/...
```

## Baseline results (SQLite, 4 workers, 1000 tokens, 5s)

| Query | Throughput | P50 | P99 | Allocs/op |
|---|---|---|---|---|
| UnspentTokensIterator | 27,600/s | 135µs | 334µs | 127 |
| Balance | 57,910/s | 61µs | 307µs | 117 |
| UnspentTokensIteratorBy | 21,320/s | 179µs | 395µs | 145 |