### PR TITLE
fix(zkatdlog): enforce point-at-infinity check in IPA validation

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
@@ -81,10 +81,10 @@ func (ipa *IPA) Validate(curve mathlib.CurveID) error {
 	if ipa.R == nil {
 		return errors.New("invalid IPA proof: nil R")
 	}
-	if err := math.CheckZrElements(ipa.L, curve, uint64(len(ipa.L))); err != nil {
+	if err := math.CheckElements(ipa.L, curve, uint64(len(ipa.L))); err != nil {
 		return errors.Wrapf(err, "invalid IPA proof: invalid L elements")
 	}
-	if err := math.CheckZrElements(ipa.R, curve, uint64(len(ipa.R))); err != nil {
+	if err := math.CheckElements(ipa.R, curve, uint64(len(ipa.R))); err != nil {
 		return errors.Wrapf(err, "invalid IPA proof: invalid R elements")
 	}
 


### PR DESCRIPTION
closes #1760

## Description

This PR fixes a high-severity validation bypass bug in the Bulletproof IPA (Inner Product Argument) verifier. 

The `IPA.Validate()` function was incorrectly using `math.CheckZrElements` to validate the `L` and `R` commitments, which are slices of `*mathlib.G1`. While `*mathlib.G1` satisfies the `BaseElement` interface expected by `CheckZrElements`, `CheckZrElements` only validates the `CurveID()` and **does not check for the point-at-infinity (`IsInfinity()`)**.

This missing check could potentially allow a malicious prover to include identity-point commitments and bypass intended mathematical validation checks. 

This PR replaces the usage of `math.CheckZrElements` with `math.CheckElements` for the `L` and `R` vectors, which properly delegates to `CheckElement` and enforces the `IsInfinity()` check on every point.

## Changes Made
- Modified `token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go`
- Swapped `math.CheckZrElements` with `math.CheckElements` when validating `ipa.L` and `ipa.R`.

## Testing
Verified that existing unit tests in `token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/` pass successfully with `go test .`

Let me know if this looks good
Thanks 🙏 