### PR TITLE
perf(fabtoken): cache verifier deserialization in transfer validation

### DIFF
--- a/token/core/fabtoken/v1/validator/validator_test.go
+++ b/token/core/fabtoken/v1/validator/validator_test.go
@@ -477,6 +477,33 @@ func TestTransferSignatureValidate(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed deserializing issuer")
 	})
 
+	t.Run("SameOwnerCachesVerifier", func(t *testing.T) {
+		deserializer := &mock.Deserializer{}
+		sigProvider := &mock.SignatureProvider{}
+		ta := &actions.TransferAction{
+			Inputs: []*actions.TransferActionInput{
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+				{Input: &actions.Output{Owner: []byte("owner1")}},
+			},
+			Outputs: []*actions.Output{
+				{Owner: []byte("owner2")},
+			},
+		}
+		deserializer.GetOwnerVerifierReturns(&mock.Verifier{}, nil)
+		sigProvider.HasBeenSignedByReturns([]byte("sig"), nil)
+		c := &validator.Context{
+			TransferAction:    ta,
+			Deserializer:      deserializer,
+			SignatureProvider: sigProvider,
+			Logger:            logger,
+			PP:                pp,
+		}
+		err := validator.TransferSignatureValidate(ctx, c)
+		require.NoError(t, err)
+		assert.Equal(t, 1, deserializer.GetOwnerVerifierCallCount(), "GetOwnerVerifier should be called only once for repeated same owner")
+	})
+
 	t.Run("RedeemIssuerSignatureError", func(t *testing.T) {
 		deserializer := &mock.Deserializer{}
 		sigProvider := &mock.SignatureProvider{}

--- a/token/core/fabtoken/v1/validator/validator_transfer.go
+++ b/token/core/fabtoken/v1/validator/validator_transfer.go
@@ -31,16 +31,23 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 		return errors.Errorf("invalid number of token inputs, expected at least 1")
 	}
 
+	verifierCache := make(map[string]driver.Verifier)
 	var inputToken []*actions.Output
-	for _, in := range ctx.TransferAction.Inputs {
+	for i, in := range ctx.TransferAction.Inputs {
 		tok := in.Input
 
 		inputToken = append(inputToken, tok)
 		owner := tok.GetOwner()
 		ctx.Logger.Debugf("check sender [%s]", driver.Identity(owner).UniqueID())
-		verifier, err := ctx.Deserializer.GetOwnerVerifier(c, owner)
-		if err != nil {
-			return errors.Wrapf(err, "failed deserializing owner [%v][%s]", tok, driver.Identity(owner).UniqueID())
+		ownerKey := string(owner)
+		verifier, cached := verifierCache[ownerKey]
+		if !cached {
+			var err error
+			verifier, err = ctx.Deserializer.GetOwnerVerifier(c, owner)
+			if err != nil {
+				return errors.Wrapf(err, "failed deserializing owner [%d][%v][%s]", i, in, driver.Identity(owner).UniqueID())
+			}
+			verifierCache[ownerKey] = verifier
 		}
 		ctx.Logger.Debugf("signature verification [%v][%s]", tok, driver.Identity(owner).UniqueID())
 


### PR DESCRIPTION
Cherry-picked commits from #1589 by @Rama542.

This PR includes:
- Cache verifier deserialization to improve performance when same owner appears multiple times in transfer inputs
- Fix path handling in regression tests (use `path.Join` instead of `filepath.Join` for embed.FS)

See original PR #1589 for full context and discussion.