### PR TITLE
add pluggable backend support with in-memory backend

### DIFF
--- a/token/services/nfttx/uniqueness/uniqueness.go
+++ b/token/services/nfttx/uniqueness/uniqueness.go
@@ -11,27 +11,107 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"reflect"
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+	platformkvs "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/marshaller"
 )
 
-type KVS interface {
+type Backend interface {
 	Exists(ctx context.Context, k string) bool
 	Get(ctx context.Context, k string, v any) error
 	Put(ctx context.Context, k string, key any) error
 }
 
+// ServiceOption configures the uniqueness service.
+type ServiceOption func(*Service)
+
+// WithBackend configures the uniqueness service to use a custom backend.
+func WithBackend(kvs Backend) ServiceOption {
+	if kvs == nil {
+		panic("backend is nil")
+	}
+
+	return func(s *Service) {
+		s.kvs = kvs
+	}
+}
+
+// NewService returns a new uniqueness service backed by the passed backend.
+func NewService(kvs Backend) *Service {
+	if kvs == nil {
+		panic("backend is nil")
+	}
+
+	return &Service{kvs: kvs}
+}
+
+// InMemoryBackend is an in-memory uniqueness backend.
+type InMemoryBackend struct {
+	lock  sync.RWMutex
+	store map[string]any
+}
+
+// NewInMemoryBackend returns a new in-memory uniqueness backend.
+func NewInMemoryBackend() Backend {
+	return &InMemoryBackend{
+		store: map[string]any{},
+	}
+}
+
+func (b *InMemoryBackend) Exists(_ context.Context, k string) bool {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	_, ok := b.store[k]
+	return ok
+}
+
+func (b *InMemoryBackend) Get(_ context.Context, k string, v any) error {
+	b.lock.RLock()
+	value, ok := b.store[k]
+	b.lock.RUnlock()
+
+	if !ok {
+		return errors.WithMessagef(errors.New("key not found"), "key %s", k)
+	}
+
+	if v == nil {
+		return errors.New("value must be a non-nil pointer")
+	}
+
+	target := reflect.ValueOf(v)
+	if target.Kind() != reflect.Ptr || target.IsNil() {
+		return errors.New("value must be a non-nil pointer")
+	}
+
+	valueVal := reflect.ValueOf(value)
+	if !valueVal.Type().AssignableTo(target.Elem().Type()) {
+		return errors.WithMessagef(errors.New("type mismatch"), "cannot assign %T to %T", value, v)
+	}
+
+	target.Elem().Set(valueVal)
+	return nil
+}
+
+func (b *InMemoryBackend) Put(_ context.Context, k string, key any) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	b.store[k] = key
+	return nil
+}
+
 // Service is a uniqueness service.
 // The service computes a unique id for a given object by hashing the object's json representation together with a random salt.
 // The random salt is used to avoid dictionary attacks.
-// The random salt is stored in the KVS and is generated on the first call to the service.
+// The random salt is stored in the backend and is generated on the first call to the service.
 type Service struct {
 	mutex sync.Mutex
-	kvs   KVS
+	kvs   Backend
 }
 
 // ComputeID computes the unique ID of the given object.
@@ -50,8 +130,7 @@ func (s *Service) ComputeID(state any) (string, error) {
 			return "", errors.WithMessagef(err, "failed to get key %s", k)
 		}
 	} else {
-		// sample a random 32 bytes key and store it
-		size := 32
+		const size = 32
 		key = make([]byte, size)
 		n, err := rand.Read(key)
 		if err != nil {
@@ -71,24 +150,41 @@ func (s *Service) ComputeID(state any) (string, error) {
 	}
 
 	hash := sha256.New()
-	n, err := hash.Write(raw)
-	if n != len(raw) {
-		return "", errors.New("error writing to hash")
+	n, err := hash.Write(key)
+	if n != len(key) {
+		return "", errors.New("error writing key to hash")
 	}
 	if err != nil {
-		return "", errors.Wrapf(err, "error writing to hash")
+		return "", errors.Wrapf(err, "error writing key to hash")
 	}
-	digest := hash.Sum(nil)
 
+	n, err = hash.Write(raw)
+	if n != len(raw) {
+		return "", errors.New("error writing raw state to hash")
+	}
+	if err != nil {
+		return "", errors.Wrapf(err, "error writing raw state to hash")
+	}
+
+	digest := hash.Sum(nil)
 	return base64.StdEncoding.EncodeToString(digest), nil
 }
 
 // GetService returns the uniqueness service.
-func GetService(sp token.ServiceProvider) *Service {
-	kvss, err := sp.GetService(&kvs.KVS{})
-	if err != nil {
-		panic(err)
+func GetService(sp token.ServiceProvider, opts ...ServiceOption) *Service {
+	service := &Service{}
+	for _, opt := range opts {
+		opt(service)
 	}
 
-	return &Service{kvs: kvss.(*kvs.KVS)}
+	if service.kvs == nil {
+		kvss, err := sp.GetService(&platformkvs.KVS{})
+		if err != nil {
+			panic(err)
+		}
+
+		service.kvs = kvss.(*platformkvs.KVS)
+	}
+
+	return service
 }

--- a/token/services/nfttx/uniqueness/uniqueness_test.go
+++ b/token/services/nfttx/uniqueness/uniqueness_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package uniqueness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInMemoryBackend(t *testing.T) {
+	backend := NewInMemoryBackend()
+	svc := NewService(backend)
+
+	id1, err := svc.ComputeID(map[string]string{"address": "1"})
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	id2, err := svc.ComputeID(map[string]string{"address": "1"})
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+
+	id3, err := svc.ComputeID(map[string]string{"address": "2"})
+	require.NoError(t, err)
+	require.NotEmpty(t, id3)
+	require.NotEqual(t, id1, id3)
+}
+
+func TestGetServiceWithBackendOption(t *testing.T) {
+	svc := GetService(nil, WithBackend(NewInMemoryBackend()))
+	require.NotNil(t, svc)
+
+	id, err := svc.ComputeID("payload")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+}


### PR DESCRIPTION
The NFT uniqueness service was hardcoded to use FSC KVS, preventing alternative backends. I introduced a pluggable backend abstraction and added an in-memory backend implementation so the service can be reused with multiple storage backends.


-Introduces a generic Backend abstraction for the NFT uniqueness service
-Keeps existing default FSC KVS behavior
-Fixes hashing to include the stored random salt
-Adds unit tests for backend use and ID stability