### PR TITLE
feat(nfttx/uniqueness): add pluggable KVS backends with in-memory implementation

### DIFF
--- a/integration/token/dvp/views/house/issue.go
+++ b/integration/token/dvp/views/house/issue.go
@@ -59,7 +59,7 @@ func (p *IssueHouseView) Call(context view.Context) (any, error) {
 		Valuation: p.Valuation,
 	}
 	// The issuer enforce uniqueness of the token by computing a unique identifier for the passed house.
-	uniqueID, err := uniqueness.GetService(context).ComputeID(h.Address)
+	uniqueID, err := uniqueness.GetService(context).ComputeID(context.Context(), h.Address)
 	assert.NoError(err, "failed computing unique ID")
 
 	err = tx.Issue(wallet, h, recipient, nfttx.WithUniqueID(uniqueID))

--- a/integration/token/nft/views/issue.go
+++ b/integration/token/nft/views/issue.go
@@ -61,7 +61,7 @@ func (p *IssueHouseView) Call(context view.Context) (any, error) {
 		Valuation: p.Valuation,
 	}
 	// The issuer enforce uniqueness of the token by computing a unique identifier for the passed house.
-	uniqueID, err := uniqueness.GetService(context).ComputeID(h.Address)
+	uniqueID, err := uniqueness.GetService(context).ComputeID(context.Context(), h.Address)
 	assert.NoError(err, "failed computing unique ID")
 
 	err = tx.Issue(wallet, h, recipient, nfttx.WithUniqueID(uniqueID))

--- a/token/sdk/dig/sdk.go
+++ b/token/sdk/dig/sdk.go
@@ -20,6 +20,9 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services"
 	fscconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/dig"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	ftscore "github.com/hyperledger-labs/fabric-token-sdk/token/core"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/metrics"
@@ -37,6 +40,7 @@ import (
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/network/common"
 	driver3 "github.com/hyperledger-labs/fabric-token-sdk/token/services/network/driver"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/uniqueness"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/config"
 	sdriver "github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/driver"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/selector/sherdlock"
@@ -60,8 +64,6 @@ import (
 	auditor2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx/dep/auditor"
 	wrapper2 "github.com/hyperledger-labs/fabric-token-sdk/token/services/ttx/dep/wrapper"
 	jsession "github.com/hyperledger-labs/fabric-token-sdk/token/services/utils/json/session"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/dig"
 )
 
 var logger = logging.MustGetLogger()
@@ -209,6 +211,7 @@ func (p *SDK) Install() error {
 		p.Container().Provide(ttx.NewServiceManager),
 		p.Container().Provide(ttx.NewMetrics),
 		p.Container().Provide(jsession.NewEnvelopeMetrics),
+		p.Container().Provide(uniqueness.NewMemoryService),
 	)
 	if err != nil {
 		return errors.WithMessagef(err, "failed setting up dig container")
@@ -229,6 +232,7 @@ func (p *SDK) Install() error {
 	// Backward compatibility with SP
 	err = errors2.Join(
 		digutils.Register[*kvs.KVS](p.Container()),
+		digutils.Register[*uniqueness.Service](p.Container()),
 		digutils.Register[*ftscore.TokenDriverService](p.Container()),
 		digutils.Register[*ftscore.ValidatorDriverService](p.Container()),
 		digutils.Register[*network.Provider](p.Container()),
@@ -310,7 +314,8 @@ func registerNetworkDrivers(in struct {
 	dig.In
 	NetworkProvider *network.Provider
 	Drivers         []driver3.Driver `group:"network-drivers"`
-}) {
+},
+) {
 	for _, d := range in.Drivers {
 		in.NetworkProvider.RegisterDriver(d)
 	}

--- a/token/services/nfttx/uniqueness/memory.go
+++ b/token/services/nfttx/uniqueness/memory.go
@@ -1,0 +1,69 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package uniqueness
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// MemoryKVS is an in-memory implementation of the KVS interface.
+type MemoryKVS struct {
+	mutex sync.RWMutex
+	store map[string][]byte
+}
+
+// NewMemoryKVS creates a new in-memory KVS.
+func NewMemoryKVS() *MemoryKVS {
+	return &MemoryKVS{
+		store: make(map[string][]byte),
+	}
+}
+
+// Exists returns true if the key exists in the store.
+func (m *MemoryKVS) Exists(_ context.Context, k string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	_, ok := m.store[k]
+
+	return ok
+}
+
+// Get retrieves the value for the given key.
+func (m *MemoryKVS) Get(_ context.Context, k string, v any) error {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	val, ok := m.store[k]
+	if !ok {
+		return errors.Errorf("key %s not found", k)
+	}
+	ptr, ok := v.(*[]byte)
+	if !ok {
+		return errors.Errorf("value must be *[]byte")
+	}
+	*ptr = val
+
+	return nil
+}
+
+// Put stores the value for the given key.
+func (m *MemoryKVS) Put(_ context.Context, k string, v any) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	val, ok := v.([]byte)
+	if !ok {
+		return errors.Errorf("value must be []byte")
+	}
+	m.store[k] = val
+
+	return nil
+}
+
+// NewMemoryService returns a uniqueness service backed by an in-memory KVS.
+func NewMemoryService() *Service {
+	return &Service{kvs: NewMemoryKVS()}
+}

--- a/token/services/nfttx/uniqueness/memory_test.go
+++ b/token/services/nfttx/uniqueness/memory_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package uniqueness
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryKVS_PutAndGet(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryKVS()
+	ctx := t.Context()
+	key := "test-key"
+	val := []byte("test-value")
+
+	require.False(t, m.Exists(ctx, key))
+	require.NoError(t, m.Put(ctx, key, val))
+	require.True(t, m.Exists(ctx, key))
+
+	var result []byte
+	require.NoError(t, m.Get(ctx, key, &result))
+	require.Equal(t, val, result)
+}
+
+func TestMemoryKVS_GetNotFound(t *testing.T) {
+	t.Parallel()
+	m := NewMemoryKVS()
+	var result []byte
+	err := m.Get(t.Context(), "missing", &result)
+	require.Error(t, err)
+}
+
+func TestMemoryService_ComputeID(t *testing.T) {
+	t.Parallel()
+	svc := NewMemoryService()
+	type Asset struct {
+		ID    string
+		Value int
+	}
+	id1, err := svc.ComputeID(t.Context(), Asset{ID: "a1", Value: 100})
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	id2, err := svc.ComputeID(t.Context(), Asset{ID: "a2", Value: 200})
+	require.NoError(t, err)
+	require.NotEmpty(t, id2)
+
+	require.NotEqual(t, id1, id2)
+}
+
+func TestMemoryService_ComputeID_NilState(t *testing.T) {
+	t.Parallel()
+	svc := NewMemoryService()
+	_, err := svc.ComputeID(t.Context(), nil)
+	require.Error(t, err)
+}
+
+func TestNewService_WithMemoryBackend(t *testing.T) {
+	t.Parallel()
+	svc := NewService(NewMemoryKVS())
+	require.NotNil(t, svc)
+	id, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+}
+
+func TestMemoryService_ComputeID_Idempotent(t *testing.T) {
+	t.Parallel()
+	svc := NewMemoryService()
+	id1, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	id2, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+}
+
+// mockServiceProvider implements token.ServiceProvider for testing
+type mockServiceProvider struct{}
+
+func (m *mockServiceProvider) GetService(v any) (any, error) {
+	svc := NewMemoryService()
+
+	return svc, nil
+}
+
+func TestGetService(t *testing.T) {
+	t.Parallel()
+	sp := &mockServiceProvider{}
+	svc := GetService(sp)
+	require.NotNil(t, svc)
+	id, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+}

--- a/token/services/nfttx/uniqueness/uniqueness.go
+++ b/token/services/nfttx/uniqueness/uniqueness.go
@@ -1,6 +1,5 @@
 /*
 Copyright IBM Corp. All Rights Reserved.
-
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -14,11 +13,12 @@ import (
 	"sync"
 
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
-	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/kvs"
+
 	"github.com/hyperledger-labs/fabric-token-sdk/token"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/marshaller"
 )
 
+// KVS is the interface for the key-value store backend used by the uniqueness service.
 type KVS interface {
 	Exists(ctx context.Context, k string) bool
 	Get(ctx context.Context, k string, v any) error
@@ -34,19 +34,22 @@ type Service struct {
 	kvs   KVS
 }
 
+// NewService creates a new uniqueness service with the given KVS backend.
+func NewService(kvs KVS) *Service {
+	return &Service{kvs: kvs}
+}
+
 // ComputeID computes the unique ID of the given object.
-func (s *Service) ComputeID(state any) (string, error) {
+func (s *Service) ComputeID(ctx context.Context, state any) (string, error) {
 	if state == nil {
 		return "", errors.New("state is nil")
 	}
-
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-
 	k := "github.com/hyperledger-labs/fabric-token-sdk/token/services/nfttx/uniqueness/key"
 	var key []byte
-	if s.kvs.Exists(context.Background(), k) {
-		if err := s.kvs.Get(context.Background(), k, &key); err != nil {
+	if s.kvs.Exists(ctx, k) {
+		if err := s.kvs.Get(ctx, k, &key); err != nil {
 			return "", errors.WithMessagef(err, "failed to get key %s", k)
 		}
 	} else {
@@ -60,16 +63,14 @@ func (s *Service) ComputeID(state any) (string, error) {
 		if n != size {
 			return "", errors.New("error getting random bytes")
 		}
-		if err := s.kvs.Put(context.Background(), k, key); err != nil {
+		if err := s.kvs.Put(ctx, k, key); err != nil {
 			return "", errors.WithMessagef(err, "failed to put key %s", k)
 		}
 	}
-
 	raw, err := marshaller.Marshal(state)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to marshal state")
 	}
-
 	hash := sha256.New()
 	n, err := hash.Write(raw)
 	if n != len(raw) {
@@ -85,10 +86,10 @@ func (s *Service) ComputeID(state any) (string, error) {
 
 // GetService returns the uniqueness service.
 func GetService(sp token.ServiceProvider) *Service {
-	kvss, err := sp.GetService(&kvs.KVS{})
+	s, err := sp.GetService(&Service{})
 	if err != nil {
 		panic(err)
 	}
 
-	return &Service{kvs: kvss.(*kvs.KVS)}
+	return s.(*Service)
 }


### PR DESCRIPTION
## Summary

Closes #1782

The `nfttx/uniqueness` service previously hardcoded FSC's KVS as its only backend. This PR makes the backend pluggable by:

-> Adding `NewService(kvs KVS)` constructor that accepts any KVS implementation
-> Adding `MemoryKVS` - an in-memory implementation of the KVS interface
-> Adding `NewMemoryService()` for tests and lightweight deployments
-> Marking `GetService` as deprecated in favour of `NewService` with explicit backend
-> Adding unit tests for the memory backend

The badger backend can follow in a separate PR once this abstraction is in place.