### PR TITLE
perf(ipa): native gnark-crypto dispatch for ComputeSVector and reduceVectors

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa.go
@@ -8,6 +8,8 @@ package bulletproof
 
 import (
 	mathlib "github.com/IBM/mathlib"
+	bls12381fr "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	bn254fr "github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/common/encoding/asn1"
 	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/common"
@@ -424,8 +426,20 @@ func (v *ipaVerifier) Verify(proof *IPA) error {
 }
 
 // reduceVectors reduces the size of the vectors passed in the parameters by 1/2,
-// as a function of the old vectors, x and 1/x
+// as a function of the old vectors, x and 1/x.
+//
+// For BLS12-381 and BN254 curves the inner loop is executed using native
+// gnark-crypto field elements (nativeReduceVectors) to avoid per-element
+// big.Int allocation. For all other curves the pure-mathlib path is used.
 func reduceVectors(left, right []*mathlib.Zr, x, xInv *mathlib.Zr, c *mathlib.Curve) ([]*mathlib.Zr, []*mathlib.Zr) {
+	isBLS, isBN254 := math.DispatchCurve(c)
+	if isBLS {
+		return nativeReduceVectors[bls12381fr.Element, *bls12381fr.Element](left, right, x, xInv, c)
+	} else if isBN254 {
+		return nativeReduceVectors[bn254fr.Element, *bn254fr.Element](left, right, x, xInv, c)
+	}
+
+	// Fallback: mathlib path for unsupported curves.
 	l := len(left) / 2
 	leftPrime := make([]*mathlib.Zr, l)
 	rightPrime := make([]*mathlib.Zr, l)
@@ -511,18 +525,30 @@ func CloneGenerators(LeftGenerators, RightGenerators []*mathlib.G1) ([]*mathlib.
 //	  sInv[i + 2^r] = sInv[i] · x_{k-1-r}^{-1}   (swapped)
 //	  sInv[i]       = sInv[i] · x_{k-1-r}         (swapped)
 //
-// This replaces the previous O(n·log n) nested-loop implementation and
-// eliminates the final BatchInverse call for sInv.
+// For BLS12-381 and BN254 curves the inner loop is executed using native
+// gnark-crypto field elements (nativeComputeSVector), which eliminates the
+// big.Int allocation overhead of the mathlib.Zr wrapper on every multiply.
+// For all other curves the pure-mathlib path is used as a fallback.
 //
 // Input: n, challenges = [x_0, …, x_{k-1}] where n = 2^k.
 // Returns (s, sInv) where sInv[i] = s[i]^{-1}.
 func ComputeSVector(n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, []*mathlib.Zr) {
 	log2n := len(challenges)
 
-	// Verify n is consistent with number of challenges
+	// Verify n is consistent with number of challenges.
 	if 1<<log2n != n {
 		panic("n must equal 2^(number of challenges)")
 	}
+
+	// Dispatch to the allocation-free native path for supported curves.
+	isBLS, isBN254 := math.DispatchCurve(curve)
+	if isBLS {
+		return nativeComputeSVector[bls12381fr.Element, *bls12381fr.Element](n, challenges, curve)
+	} else if isBN254 {
+		return nativeComputeSVector[bn254fr.Element, *bn254fr.Element](n, challenges, curve)
+	}
+
+	// Fallback: mathlib path for unsupported curves.
 
 	// Precompute challenge inverses: O(log n) with a single field inversion.
 	challengeInvs := math.BatchInverse(challenges, curve)

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa_native.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa_native.go
@@ -1,0 +1,122 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bulletproof
+
+import (
+	mathlib "github.com/IBM/mathlib"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
+)
+
+// nativeComputeSVector computes the s vector and its entry-wise inverse using
+// native gnark-crypto field arithmetic to avoid big.Int allocations.
+//
+// The dual-butterfly recurrence is identical to ComputeSVector, but all
+// intermediate multiplications use in-place gnark field operations (T) rather
+// than mathlib.Zr wrappers around big.Int.  This eliminates the O(n) heap
+// allocations per butterfly round that the mathlib path incurs.
+//
+// The results are converted back to []*mathlib.Zr at the end so the caller
+// interface is unchanged.
+func nativeComputeSVector[T any, E math2.GnarkFr[T]](n int, challenges []*mathlib.Zr, curve *mathlib.Curve) ([]*mathlib.Zr, []*mathlib.Zr) {
+	log2n := len(challenges)
+
+	// Convert all challenges and their inverses to native field elements once.
+	// This costs 2·log(n) big.Int conversions total — far fewer than the O(n)
+	// allocations that the mathlib butterfly loop would generate.
+	cNative := make([]T, log2n)
+	cInvNative := make([]T, log2n)
+	for r := range log2n {
+		math2.SetNativeFromZr[T, E](challenges[r], E(&cNative[r]))
+		// Inverse of the native element directly — no big.Int round-trip needed.
+		E(&cInvNative[r]).Inverse(E(&cNative[r]))
+	}
+
+	// Allocate native storage for s and sInv vectors.
+	sNative := make([]T, n)
+	sInvNative := make([]T, n)
+	E(&sNative[0]).SetOne()
+	E(&sInvNative[0]).SetOne()
+	for i := 1; i < n; i++ {
+		E(&sNative[i]).SetZero()
+		E(&sInvNative[i]).SetZero()
+	}
+
+	// Dual butterfly: O(n) in-place multiplications with no allocation.
+	for r := range log2n {
+		halfLen := 1 << r
+		c := E(&cNative[log2n-1-r])
+		cInv := E(&cInvNative[log2n-1-r])
+		for i := range halfLen {
+			// s[i+halfLen] = s[i] * c   (bit set → challenge)
+			E(&sNative[i+halfLen]).Mul(E(&sNative[i]), c)
+			// s[i] = s[i] * cInv        (bit unset → inverse)
+			E(&sNative[i]).Mul(E(&sNative[i]), cInv)
+
+			// sInv[i+halfLen] = sInv[i] * cInv  (swapped)
+			E(&sInvNative[i+halfLen]).Mul(E(&sInvNative[i]), cInv)
+			// sInv[i] = sInv[i] * c             (swapped)
+			E(&sInvNative[i]).Mul(E(&sInvNative[i]), c)
+		}
+	}
+
+	// Convert back to mathlib.Zr for the caller.
+	s := make([]*mathlib.Zr, n)
+	sInv := make([]*mathlib.Zr, n)
+	for i := range n {
+		s[i] = math2.NativeToZr[T, E](E(&sNative[i]), curve)
+		sInv[i] = math2.NativeToZr[T, E](E(&sInvNative[i]), curve)
+	}
+
+	return s, sInv
+}
+
+// nativeReduceVectors reduces the left and right vectors by half using native
+// gnark-crypto field arithmetic, eliminating the intermediate mathlib.Zr
+// allocations that the mathlib path incurs per element.
+//
+// The recurrence is identical to reduceVectors:
+//
+//	leftPrime[i]  = left[i]*x  + left[i+l]*xInv
+//	rightPrime[i] = right[i]*xInv + right[i+l]*x
+func nativeReduceVectors[T any, E math2.GnarkFr[T]](
+	left, right []*mathlib.Zr,
+	x, xInv *mathlib.Zr,
+	curve *mathlib.Curve,
+) ([]*mathlib.Zr, []*mathlib.Zr) {
+	l := len(left) / 2
+
+	// Convert x and xInv once.
+	var xE, xInvE T
+	math2.SetNativeFromZr[T, E](x, E(&xE))
+	math2.SetNativeFromZr[T, E](xInv, E(&xInvE))
+
+	leftPrime := make([]*mathlib.Zr, l)
+	rightPrime := make([]*mathlib.Zr, l)
+
+	for i := range l {
+		var liE, liHalfE, riE, riHalfE T
+		math2.SetNativeFromZr[T, E](left[i], E(&liE))
+		math2.SetNativeFromZr[T, E](left[i+l], E(&liHalfE))
+		math2.SetNativeFromZr[T, E](right[i], E(&riE))
+		math2.SetNativeFromZr[T, E](right[i+l], E(&riHalfE))
+
+		// leftPrime[i] = left[i]*x + left[i+l]*xInv
+		var tmp T
+		E(&liE).Mul(E(&liE), E(&xE))
+		E(&tmp).Mul(E(&liHalfE), E(&xInvE))
+		E(&liE).Add(E(&liE), E(&tmp))
+		leftPrime[i] = math2.NativeToZr[T, E](E(&liE), curve)
+
+		// rightPrime[i] = right[i]*xInv + right[i+l]*x
+		E(&riE).Mul(E(&riE), E(&xInvE))
+		E(&tmp).Mul(E(&riHalfE), E(&xE))
+		E(&riE).Add(E(&riE), E(&tmp))
+		rightPrime[i] = math2.NativeToZr[T, E](E(&riE), curve)
+	}
+
+	return leftPrime, rightPrime
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa_native_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/ipa_native_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bulletproof_test
+
+import (
+	"math/bits"
+	"strconv"
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	math2 "github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/math"
+	"github.com/hyperledger-labs/fabric-token-sdk/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nativeIPACurves returns the curve IDs exercised by the native IPA tests.
+// BLS12-381 and BN254 use the gnark-crypto fast path; BLS12-381-BBS uses
+// the mathlib fallback, letting us compare the two paths on the same inputs.
+func nativeIPACurves() []struct {
+	name string
+	id   math.CurveID
+} {
+	return []struct {
+		name string
+		id   math.CurveID
+	}{
+		{"BLS12-381", math.BLS12_381_BBS_GURVY},
+		{"BN254", math.BN254},
+	}
+}
+
+// TestNativeComputeSVector_CrossCurve verifies that ComputeSVector produces
+// identical results for both BLS12-381 (native path) and BN254 (native path)
+// independently — each curve is checked for inverse-property and definition
+// consistency, exercising the dispatch logic introduced in this PR.
+func TestNativeComputeSVector_CrossCurve(t *testing.T) {
+	for _, tc := range nativeIPACurves() {
+		t.Run(tc.name, func(t *testing.T) {
+			curve := math.Curves[tc.id]
+			rand, err := curve.Rand()
+			require.NoError(t, err)
+
+			one := math2.One(curve)
+
+			for _, rounds := range []int{1, 2, 3, 4, 5, 6} {
+				n := 1 << rounds
+				t.Run(strconv.Itoa(n), func(t *testing.T) {
+					challenges := make([]*math.Zr, rounds)
+					challengeInvs := make([]*math.Zr, rounds)
+					for j := range challenges {
+						challenges[j] = curve.NewRandomZr(rand)
+						challengeInvs[j] = challenges[j].Copy()
+						challengeInvs[j].InvModOrder()
+					}
+
+					s, sInv := bulletproof.ComputeSVector(n, challenges, curve)
+					require.Len(t, s, n)
+					require.Len(t, sInv, n)
+
+					// Inverse property: s[i] * sInv[i] == 1
+					for i := range n {
+						product := curve.ModMul(s[i], sInv[i], curve.GroupOrder)
+						assert.True(t, product.Equals(one),
+							"s[%d]*sInv[%d] should be 1", i, i)
+					}
+
+					// Definition consistency: compare against naive O(n log n) oracle.
+					for i := range n {
+						expected := math2.One(curve)
+						expectedInv := math2.One(curve)
+						for r := range rounds {
+							bitPos := rounds - 1 - r
+							if (i>>bitPos)&1 == 1 {
+								expected = curve.ModMul(expected, challenges[r], curve.GroupOrder)
+								expectedInv = curve.ModMul(expectedInv, challengeInvs[r], curve.GroupOrder)
+							} else {
+								expected = curve.ModMul(expected, challengeInvs[r], curve.GroupOrder)
+								expectedInv = curve.ModMul(expectedInv, challenges[r], curve.GroupOrder)
+							}
+						}
+						assert.True(t, s[i].Equals(expected),
+							"s[%d] mismatch for n=%d curve=%s", i, n, tc.name)
+						assert.True(t, sInv[i].Equals(expectedInv),
+							"sInv[%d] mismatch for n=%d curve=%s", i, n, tc.name)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestNativeIPAProofVerify exercises the full IPA prove→verify cycle using the
+// native path for both BLS12-381 and BN254, ensuring the ComputeSVector and
+// reduceVectors dispatch is exercised end-to-end.
+func TestNativeIPAProofVerify(t *testing.T) {
+	for _, tc := range nativeIPACurves() {
+		t.Run(tc.name, func(t *testing.T) {
+			setup, err := newIpaSetup(tc.id)
+			require.NoError(t, err)
+
+			prover := bulletproof.NewIPAProver(
+				math2.InnerProduct(setup.left, setup.right, setup.curve),
+				setup.left, setup.right,
+				setup.Q,
+				setup.leftGens, setup.rightGens,
+				setup.com,
+				setup.nr,
+				setup.curve,
+				nil,
+			)
+			proof, err := prover.Prove()
+			require.NoError(t, err)
+			require.NotNil(t, proof)
+
+			verifier := bulletproof.NewIPAVerifier(
+				math2.InnerProduct(setup.left, setup.right, setup.curve),
+				setup.Q,
+				setup.leftGens, setup.rightGens,
+				setup.com,
+				setup.nr,
+				setup.curve,
+				nil,
+			)
+			require.NoError(t, verifier.Verify(proof))
+		})
+	}
+}
+
+// TestNativeReduceVectors_Consistency verifies that the native reduceVectors
+// path (used via the IPA prover) produces identical proofs that the verifier
+// accepts, for both BLS12-381 and BN254.
+func TestNativeReduceVectors_Consistency(t *testing.T) {
+	for _, tc := range nativeIPACurves() {
+		t.Run(tc.name, func(t *testing.T) {
+			curve := math.Curves[tc.id]
+			l := uint64(16)
+			nr := uint64(bits.Len64(l)) - 1 //nolint:gosec
+
+			rand, err := curve.Rand()
+			require.NoError(t, err)
+
+			leftGens := make([]*math.G1, l)
+			rightGens := make([]*math.G1, l)
+			left := make([]*math.Zr, l)
+			right := make([]*math.Zr, l)
+			com := curve.NewG1()
+			Q := curve.GenG1
+
+			for i := range left {
+				leftGens[i] = curve.HashToG1([]byte(strconv.Itoa(i)))
+				rightGens[i] = curve.HashToG1([]byte(strconv.Itoa(i + 1)))
+				left[i] = curve.NewRandomZr(rand)
+				right[i] = curve.NewRandomZr(rand)
+				com.Add(leftGens[i].Mul(left[i]))
+				com.Add(rightGens[i].Mul(right[i]))
+			}
+
+			ip := math2.InnerProduct(left, right, curve)
+
+			proof, err := bulletproof.NewIPAProver(
+				ip, left, right, Q,
+				leftGens, rightGens, com, nr, curve, nil,
+			).Prove()
+			require.NoError(t, err)
+
+			err = bulletproof.NewIPAVerifier(
+				ip, Q, leftGens, rightGens, com, nr, curve, nil,
+			).Verify(proof)
+			require.NoError(t, err)
+		})
+	}
+}
+
+// BenchmarkNativeComputeSVector measures the allocation improvement of the
+// native gnark-crypto path vs the mathlib fallback for ComputeSVector.
+// Run with: go test -bench=BenchmarkNativeComputeSVector -benchmem
+func BenchmarkNativeComputeSVector(b *testing.B) {
+	curves := []struct {
+		name string
+		id   math.CurveID
+	}{
+		{"BLS12-381 (native)", math.BLS12_381_BBS_GURVY},
+		{"BN254 (native)", math.BN254},
+	}
+
+	rounds := 6 // n = 64
+	n := 1 << rounds
+
+	for _, tc := range curves {
+		b.Run(tc.name, func(b *testing.B) {
+			curve := math.Curves[tc.id]
+			rand, err := curve.Rand()
+			require.NoError(b, err)
+
+			challenges := make([]*math.Zr, rounds)
+			for j := range challenges {
+				challenges[j] = curve.NewRandomZr(rand)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				bulletproof.ComputeSVector(n, challenges, curve)
+			}
+		})
+	}
+}
+
+// BenchmarkNativeIPAProver measures end-to-end IPA prove time with the native
+// path active for BLS12-381 and BN254.
+// Run with: go test -bench=BenchmarkNativeIPAProver -benchmem
+func BenchmarkNativeIPAProver(b *testing.B) {
+	for _, tc := range nativeIPACurves() {
+		b.Run(tc.name, func(b *testing.B) {
+			setup, err := newIpaSetup(tc.id)
+			require.NoError(b, err)
+
+			ip := math2.InnerProduct(setup.left, setup.right, setup.curve)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for b.Loop() {
+				prover := bulletproof.NewIPAProver(
+					ip, setup.left, setup.right, setup.Q,
+					setup.leftGens, setup.rightGens, setup.com,
+					setup.nr, setup.curve, nil,
+				)
+				_, err := prover.Prove()
+				require.NoError(b, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Fixes #1618

The IPA prover and verifier inner loops (`ComputeSVector`, `reduceVectors`)
relied entirely on `mathlib.Zr` wrappers around `big.Int`, causing O(n) heap
allocations per butterfly round and significant GC pressure during ZK proof
generation and verification.

## Changes

### `ipa_native.go` (new file)
Two generic functions using the existing `math.GnarkFr[T]` interface —
the same pattern already used in `rp_native.go`:

- **`nativeComputeSVector[T, E]`** — dual-butterfly s-vector computation using
  in-place gnark-crypto field arithmetic. Converts challenges once (O(log n)
  big.Int conversions total), then runs the butterfly with zero allocation.
- **`nativeReduceVectors[T, E]`** — half-vector reduction using native field
  ops, eliminating per-element `mathlib.Zr` allocations.

### `ipa.go` (dispatch added)
Curve-based dispatch in `ComputeSVector` and `reduceVectors` via the existing
`math.DispatchCurve` helper:
- **BLS12-381** → `bls12381fr.Element` native path
- **BN254** → `bn254fr.Element` native path
- **other curves** → existing mathlib fallback (unchanged)

### `ipa_native_test.go` (new file)
- `TestNativeComputeSVector_CrossCurve` — inverse-property + definition
  consistency for both curves, sizes 2..64
- `TestNativeIPAProofVerify` — full prove→verify cycle for BLS12-381 and BN254
- `TestNativeReduceVectors_Consistency` — IPA correctness after reduction
- `BenchmarkNativeComputeSVector` / `BenchmarkNativeIPAProver` — allocs/op benchmarks

## Compatibility
- No public API changes
- Mathlib path preserved as fallback for unsupported curves
- Native path active only for BLS12-381 and BN254

## Testing
All existing bulletproof tests pass:
