### PR TITLE
feat(nfttx/uniqueness): add badger-based KVS backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/IBM/idemix/bccsp/types v0.0.0-20260501050258-bb91d87b1252
 	github.com/IBM/mathlib v0.1.0
 	github.com/consensys/gnark-crypto v0.20.1
+	github.com/dgraph-io/badger/v4 v4.9.2
 	github.com/dgraph-io/ristretto/v2 v2.4.0
 	github.com/go-co-op/gocron/v2 v2.21.2
 	github.com/go-viper/mapstructure/v2 v2.5.0
@@ -67,6 +68,7 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
@@ -78,6 +80,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect
 	github.com/knadh/koanf/providers/env/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgraph-io/badger/v4 v4.9.2 h1:Wb5qw8gElqwV1a8msHTeQKova9b1V10heFKMIiPd80E=
+github.com/dgraph-io/badger/v4 v4.9.2/go.mod h1:nJjaJTUOSsQEBhsq209FmwCvMJzEA3e74RjZw6V2pQI=
 github.com/dgraph-io/ristretto/v2 v2.4.0 h1:I/w09yLjhdcVD2QV192UJcq8dPBaAJb9pOuMyNy0XlU=
 github.com/dgraph-io/ristretto/v2 v2.4.0/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
@@ -807,6 +809,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=
+github.com/google/flatbuffers v25.2.10+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/token/services/nfttx/uniqueness/badger.go
+++ b/token/services/nfttx/uniqueness/badger.go
@@ -1,0 +1,127 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package uniqueness
+
+import (
+	"context"
+	"os"
+
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+var logger = logging.MustGetLogger()
+
+// BadgerKVS is a badger-backed implementation of the KVS interface.
+type BadgerKVS struct {
+	db *badger.DB
+}
+
+// NewBadgerKVS creates a new badger-backed KVS at the given path.
+// If path is empty, an in-memory badger instance is used. If path is non-empty,
+// it must point to an existing directory; otherwise the call fails fast with a
+// clear error rather than surfacing badger's lower-level open failure.
+func NewBadgerKVS(path string) (*BadgerKVS, error) {
+	opts := badger.DefaultOptions(path)
+	if path == "" {
+		opts = opts.WithInMemory(true)
+	} else {
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "badger path %q is not accessible", path)
+		}
+		if !info.IsDir() {
+			return nil, errors.Errorf("badger path %q exists but is not a directory", path)
+		}
+	}
+	opts = opts.WithLogger(nil)
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open badger db")
+	}
+
+	return &BadgerKVS{db: db}, nil
+}
+
+// Close closes the underlying badger db.
+func (b *BadgerKVS) Close() error {
+	return b.db.Close()
+}
+
+// Exists returns true if the key exists in the store.
+//
+// BadgerDB transactions are goroutine-safe via MVCC, so no external locking is
+// required around Exists/Get/Put.
+//
+// The KVS interface forces Exists to return bool with no error, so any error
+// other than ErrKeyNotFound (e.g. txn conflict, corruption) is logged here
+// rather than silently swallowed - callers will see Exists return false, but
+// the underlying failure will be visible in the logs for diagnosis.
+func (b *BadgerKVS) Exists(_ context.Context, k string) bool {
+	err := b.db.View(func(txn *badger.Txn) error {
+		_, err := txn.Get([]byte(k))
+
+		return err
+	})
+	if err == nil {
+		return true
+	}
+	if !errors.Is(err, badger.ErrKeyNotFound) {
+		logger.Warnf("badger Exists(%q) returned unexpected error: %v", k, err)
+	}
+
+	return false
+}
+
+// Get retrieves the value for the given key.
+func (b *BadgerKVS) Get(_ context.Context, k string, v any) error {
+	ptr, ok := v.(*[]byte)
+	if !ok {
+		return errors.Errorf("value must be *[]byte")
+	}
+
+	return b.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(k))
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				// Wrap (not Errorf) so callers can still errors.Is(err, badger.ErrKeyNotFound).
+				return errors.Wrapf(err, "key %s not found", k)
+			}
+
+			return err
+		}
+
+		return item.Value(func(val []byte) error {
+			*ptr = append([]byte{}, val...)
+
+			return nil
+		})
+	})
+}
+
+// Put stores the value for the given key.
+func (b *BadgerKVS) Put(_ context.Context, k string, v any) error {
+	val, ok := v.([]byte)
+	if !ok {
+		return errors.Errorf("value must be []byte")
+	}
+
+	return b.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(k), val)
+	})
+}
+
+// NewBadgerService returns a uniqueness service backed by a badger KVS at the given path.
+// If path is empty, an in-memory badger instance is used.
+func NewBadgerService(path string) (*Service, error) {
+	kvs, err := NewBadgerKVS(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Service{kvs: kvs}, nil
+}

--- a/token/services/nfttx/uniqueness/badger_test.go
+++ b/token/services/nfttx/uniqueness/badger_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+package uniqueness
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestBadgerKVS(t *testing.T) *BadgerKVS {
+	t.Helper()
+	kvs, err := NewBadgerKVS("")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, kvs.Close())
+	})
+
+	return kvs
+}
+
+func TestBadgerKVS_PutAndGet(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+	ctx := t.Context()
+	key := "test-key"
+	val := []byte("test-value")
+
+	require.False(t, b.Exists(ctx, key))
+	require.NoError(t, b.Put(ctx, key, val))
+	require.True(t, b.Exists(ctx, key))
+
+	var result []byte
+	require.NoError(t, b.Get(ctx, key, &result))
+	require.Equal(t, val, result)
+}
+
+func TestBadgerKVS_GetNotFound(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+	var result []byte
+	err := b.Get(t.Context(), "missing", &result)
+	require.Error(t, err)
+}
+
+func TestBadgerKVS_PutInvalidValue(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+	err := b.Put(t.Context(), "key", "not-bytes")
+	require.Error(t, err)
+}
+
+func TestBadgerKVS_GetInvalidPointer(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+	require.NoError(t, b.Put(t.Context(), "key", []byte("val")))
+	var wrong string
+	err := b.Get(t.Context(), "key", &wrong)
+	require.Error(t, err)
+}
+
+func TestNewBadgerKVS_InMemory(t *testing.T) {
+	t.Parallel()
+	kvs, err := NewBadgerKVS("")
+	require.NoError(t, err)
+	require.NotNil(t, kvs)
+	defer func() { require.NoError(t, kvs.Close()) }()
+}
+
+func TestNewBadgerKVS_OnDisk(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	kvs, err := NewBadgerKVS(dir)
+	require.NoError(t, err)
+	require.NotNil(t, kvs)
+	defer func() { require.NoError(t, kvs.Close()) }()
+
+	require.NoError(t, kvs.Put(t.Context(), "k", []byte("v")))
+	var result []byte
+	require.NoError(t, kvs.Get(t.Context(), "k", &result))
+	require.Equal(t, []byte("v"), result)
+}
+
+func TestNewBadgerService(t *testing.T) {
+	t.Parallel()
+	svc, err := NewBadgerService("")
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	id, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	require.NotEmpty(t, id)
+}
+
+func TestBadgerService_ComputeID_Idempotent(t *testing.T) {
+	t.Parallel()
+	svc, err := NewBadgerService("")
+	require.NoError(t, err)
+
+	id1, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	id2, err := svc.ComputeID(t.Context(), "test-state")
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+}
+
+func TestBadgerService_ComputeID_DistinctStates(t *testing.T) {
+	t.Parallel()
+	svc, err := NewBadgerService("")
+	require.NoError(t, err)
+
+	type Asset struct {
+		ID    string
+		Value int
+	}
+
+	id1, err := svc.ComputeID(t.Context(), Asset{ID: "a1", Value: 100})
+	require.NoError(t, err)
+	require.NotEmpty(t, id1)
+
+	id2, err := svc.ComputeID(t.Context(), Asset{ID: "a2", Value: 200})
+	require.NoError(t, err)
+	require.NotEmpty(t, id2)
+
+	require.NotEqual(t, id1, id2)
+}
+
+func TestBadgerKVS_GetNotFound_PreservesErrKeyNotFound(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+
+	var result []byte
+	err := b.Get(t.Context(), "missing", &result)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, badger.ErrKeyNotFound),
+		"expected error to wrap badger.ErrKeyNotFound, got: %v", err)
+}
+
+func TestNewBadgerKVS_NonExistentPath(t *testing.T) {
+	t.Parallel()
+	kvs, err := NewBadgerKVS("/nonexistent/path/that/should/not/exist")
+	require.Error(t, err)
+	require.Nil(t, kvs)
+}
+
+func TestNewBadgerKVS_PathIsFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	file := dir + "/not-a-dir"
+	require.NoError(t, writeEmptyFile(file))
+
+	kvs, err := NewBadgerKVS(file)
+	require.Error(t, err)
+	require.Nil(t, kvs)
+}
+
+func TestBadgerKVS_ConcurrentReadsAndWrites(t *testing.T) {
+	t.Parallel()
+	b := newTestBadgerKVS(t)
+	ctx := t.Context()
+
+	const workers = 32
+	const opsPerWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := range workers {
+		go func(w int) {
+			defer wg.Done()
+			// Use assert (not require) inside goroutines: require.* calls
+			// t.FailNow, which is only safe on the goroutine running the test.
+			// assert.* records the failure and lets the goroutine return cleanly.
+			for i := range opsPerWorker {
+				key := fmt.Sprintf("worker-%d-key-%d", w, i)
+				val := fmt.Appendf(nil, "worker-%d-val-%d", w, i)
+
+				assert.NoError(t, b.Put(ctx, key, val))
+				assert.True(t, b.Exists(ctx, key))
+
+				var got []byte
+				assert.NoError(t, b.Get(ctx, key, &got))
+				assert.Equal(t, val, got)
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	for w := range workers {
+		for i := range opsPerWorker {
+			require.True(t, b.Exists(ctx, fmt.Sprintf("worker-%d-key-%d", w, i)))
+		}
+	}
+}
+
+func writeEmptyFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}


### PR DESCRIPTION
Closes #1783

## Summary

Adds a badger-backed implementation of the `KVS` interface for the pluggable uniqueness service, following the same interface established in #1782 (in-memory implementation).

## Changes

-> Adding `BadgerKVS` implementing `Exists`, `Get`, `Put`
-> Adding `NewBadgerKVS` supporting both on-disk and in-memory badger instances
-> Adding `NewBadgerService` constructor for tests and lightweight deployments
-> Adding `github.com/dgraph-io/badger/v4` as a new dependency
-> Unit tests with 85.7% coverage

## Testing
Verified with `-count=3`, all tests pass consistently.