### PR TITLE
fix(tokendb): make StoreToken idempotent with ON CONFLICT DO NOTHING

### DIFF
--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -1317,6 +1317,7 @@ func (t *TokenTransaction) StoreToken(ctx context.Context, tr driver.TokenRecord
 	query, args := q.InsertInto(t.table.Tokens).
 		Fields("tx_id", "idx", "issuer_raw", "owner_raw", "owner_type", "owner_identity", "owner_wallet_id", "ledger", "ledger_type", "ledger_metadata", "token_type", "quantity", "amount", "stored_at", "owner", "auditor", "issuer").
 		Row(tr.TxID, tr.Index, tr.IssuerRaw, tr.OwnerRaw, tr.OwnerType, tr.OwnerIdentity, tr.OwnerWalletID, tr.Ledger, tr.LedgerFormat, tr.LedgerMetadata, tr.Type, tr.Quantity, tr.Amount, time.Now().UTC(), tr.Owner, tr.Auditor, tr.Issuer).
+		OnConflictDoNothing().
 		Format()
 	logging.Debug(logger, query, args)
 	if _, err := t.tx.ExecContext(ctx, query, args...); err != nil {
@@ -1339,6 +1340,7 @@ func (t *TokenTransaction) StoreToken(ctx context.Context, tr driver.TokenRecord
 	query, args = q.InsertInto(t.table.Ownership).
 		Fields("tx_id", "idx", "wallet_id").
 		Rows(rows).
+		OnConflictDoNothing().
 		Format()
 	logging.Debug(logger, query, args)
 


### PR DESCRIPTION
Fixes #1795.

`StoreToken` commits the token and ownership rows in its own transaction. When a caller retries the surrounding flow after a downstream failure (e.g. a later audit or finality step that runs after the token rows are already committed), `StoreToken` re-inserts the same `(tx_id, idx)` and hits the primary-key unique violation (SQLSTATE 23505), aborting the caller.

This adds `ON CONFLICT DO NOTHING` to the token and ownership inserts so re-storing an already-recorded output is a no-op and the retry succeeds. A token output is content-addressed by `(tx_id, idx)`, so keeping the first stored row is safe.

The `OnConflictDoNothing()` builder is already used elsewhere in this package (e.g. the atomic upsert in `WalletStore.StoreIdentity`, #1662), so this follows the existing pattern.
