### PR TITLE
Implements token lock cleanup for orphan transactions

### DIFF
--- a/token/services/storage/db/sql/common/tokenlock.go
+++ b/token/services/storage/db/sql/common/tokenlock.go
@@ -107,7 +107,7 @@ func (db *TokenLockStore) Close() error {
 
 func IsExpiredToken(tokenRequests, tokenLocks common3.Table, leaseExpiry time.Duration) cond.Condition {
 	return cond.Or(
-		cond.FieldIn(tokenRequests.Field("status"), driver.Deleted),
+		cond.FieldIn(tokenRequests.Field("status"), driver.Deleted, driver.Orphan),
 		cond.OlderThan(tokenLocks.Field("created_at"), leaseExpiry),
 	)
 }

--- a/token/services/storage/db/sql/postgres/tokenlock.go
+++ b/token/services/storage/db/sql/postgres/tokenlock.go
@@ -67,19 +67,24 @@ func (db *TokenLockStore) Cleanup(ctx context.Context, leaseExpiry time.Duration
 	if err := db.logStaleLocks(ctx, leaseExpiry); err != nil {
 		db.Logger.Warnf("Could not log stale locks: %v", err)
 	}
-	tokenLocks, _ := q.Table(db.Table.TokenLocks), q.Table(db.Table.Requests)
+	tokenLocks, tokenRequests := q.Table(db.Table.TokenLocks), q.Table(db.Table.Requests)
 
-	query, args := common3.NewBuilder().
-		WriteString("DELETE FROM ").
-		WriteConditionSerializable(tokenLocks, db.ci).
-		WriteString(" WHERE ").
-		WriteConditionSerializable(cond.OlderThan(tokenLocks.Field("created_at"), leaseExpiry), db.ci).
-		WriteString(" OR ").
-		WriteString(
-			fmt.Sprintf("EXISTS (SELECT 1 FROM %s WHERE %s.tx_id = %s.consumer_tx_id AND %s.status IN (%d))",
-				db.Table.Requests, db.Table.Requests, db.Table.TokenLocks, db.Table.Requests, driver.Deleted,
-			)). // TODO: Implement EXIST condition
-		Build()
+	existsDeletedOrOrphan := cond.Exists(
+		q.Select().
+			Fields(common3.FieldName("1")).
+			From(tokenRequests).
+			Where(cond.And(
+				cond.Cmp(tokenRequests.Field("tx_id"), "=", tokenLocks.Field("consumer_tx_id")),
+				cond.FieldIn(tokenRequests.Field("status"), driver.Deleted, driver.Orphan),
+			)),
+	)
+
+	query, args := q.DeleteFrom(db.Table.TokenLocks).
+		Where(cond.Or(
+			cond.OlderThan(tokenLocks.Field("created_at"), leaseExpiry),
+			existsDeletedOrOrphan,
+		)).
+		Format(db.ci)
 
 	db.Logger.Debug(query)
 	_, err := db.WriteDB.ExecContext(ctx, query, args...)

--- a/token/services/storage/db/sql/postgres/tokenlock_test.go
+++ b/token/services/storage/db/sql/postgres/tokenlock_test.go
@@ -65,16 +65,17 @@ func TestCleanup(t *testing.T) {
 		consumerTxID, tokenID.TxId, tokenID.Index, *status, createdAt, timeNow,
 	}
 	mockDB.
-		ExpectQuery("SELECT TOKEN_LOCKS.consumer_tx_id, TOKEN_LOCKS.tx_id, TOKEN_LOCKS.idx, REQUESTS.status, TOKEN_LOCKS.created_at, NOW\\(\\) AS now " +
-			"FROM TOKEN_LOCKS LEFT JOIN REQUESTS ON TOKEN_LOCKS.consumer_tx_id = REQUESTS.tx_id " +
-			"WHERE \\(\\(\\(REQUESTS.status = \\$1\\)\\)\\) OR \\(TOKEN_LOCKS.created_at < NOW\\(\\) - INTERVAL '1 seconds'\\)").
-		WithArgs(input).
+		ExpectQuery("SELECT TOKEN_LOCKS.consumer_tx_id, TOKEN_LOCKS.tx_id, TOKEN_LOCKS.idx, REQUESTS.status, TOKEN_LOCKS.created_at, NOW\\(\\) AS now "+
+			"FROM TOKEN_LOCKS LEFT JOIN REQUESTS ON TOKEN_LOCKS.consumer_tx_id = REQUESTS.tx_id "+
+			"WHERE \\(\\(\\(REQUESTS.status = \\$1\\)\\) OR \\(\\(REQUESTS.status = \\$2\\)\\)\\) OR \\(TOKEN_LOCKS.created_at < NOW\\(\\) - INTERVAL '1 seconds'\\)").
+		WithArgs(driver.Deleted, driver.Orphan).
 		WillReturnRows(mockDB.NewRows([]string{"consumer_tx_id", "tx_id", "idx", "status", "created_at", "now"}).AddRow(output...))
 
-	mockDB.ExpectExec("DELETE FROM TOKEN_LOCKS WHERE " +
-		"TOKEN_LOCKS.created_at < NOW\\(\\) - INTERVAL '1 seconds'" +
-		" OR " +
-		"EXISTS \\(SELECT 1 FROM REQUESTS WHERE REQUESTS.tx_id = TOKEN_LOCKS.consumer_tx_id AND  REQUESTS.status IN \\(3\\)").
+	mockDB.ExpectExec("DELETE FROM TOKEN_LOCKS WHERE "+
+		"\\(TOKEN_LOCKS\\.created_at < NOW\\(\\) - INTERVAL '1 seconds'\\)"+
+		" OR "+
+		"\\(EXISTS \\(SELECT 1 FROM REQUESTS WHERE \\(REQUESTS\\.tx_id = TOKEN_LOCKS\\.consumer_tx_id\\) AND \\(\\(\\(REQUESTS\\.status = \\$1\\)\\) OR \\(\\(REQUESTS\\.status = \\$2\\)\\)\\)\\)\\)").
+		WithArgs(driver.Deleted, driver.Orphan).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err = mockTokenLockStorePostgress(db).Cleanup(t.Context(), time.Second)
@@ -89,4 +90,43 @@ func TestLock(t *testing.T) {
 
 func TestUnlockByTxID(t *testing.T) {
 	common3.TestUnlockByTxID(t, mockTokenLockStore)
+}
+
+func TestCleanupOrphan(t *testing.T) {
+	RegisterTestingT(t)
+	db, mockDB, err := sqlmock.New()
+	Expect(err).ToNot(HaveOccurred())
+
+	input := driver.Orphan
+
+	consumerTxID := "orphan-tx-1234"
+	tokenID := token.ID{TxId: "5678", Index: 5}
+	status := &input
+	createdAt := time.Date(2025, time.June, 8, 10, 0, 0, 0, time.UTC)
+
+	var timeNow time.Time
+	output := []driver2.Value{
+		consumerTxID, tokenID.TxId, tokenID.Index, *status, createdAt, timeNow,
+	}
+
+	// Expect the SELECT query for logging - now includes both Deleted and Orphan
+	mockDB.
+		ExpectQuery("SELECT TOKEN_LOCKS.consumer_tx_id, TOKEN_LOCKS.tx_id, TOKEN_LOCKS.idx, REQUESTS.status, TOKEN_LOCKS.created_at, NOW\\(\\) AS now "+
+			"FROM TOKEN_LOCKS LEFT JOIN REQUESTS ON TOKEN_LOCKS.consumer_tx_id = REQUESTS.tx_id "+
+			"WHERE \\(\\(\\(REQUESTS.status = \\$1\\)\\) OR \\(\\(REQUESTS.status = \\$2\\)\\)\\) OR \\(TOKEN_LOCKS.created_at < NOW\\(\\) - INTERVAL '1 seconds'\\)").
+		WithArgs(driver.Deleted, driver.Orphan).
+		WillReturnRows(mockDB.NewRows([]string{"consumer_tx_id", "tx_id", "idx", "status", "created_at", "now"}).AddRow(output...))
+
+	// Expect the DELETE query with both Deleted (3) and Orphan (4) statuses
+	mockDB.ExpectExec("DELETE FROM TOKEN_LOCKS WHERE "+
+		"\\(TOKEN_LOCKS\\.created_at < NOW\\(\\) - INTERVAL '1 seconds'\\)"+
+		" OR "+
+		"\\(EXISTS \\(SELECT 1 FROM REQUESTS WHERE \\(REQUESTS\\.tx_id = TOKEN_LOCKS\\.consumer_tx_id\\) AND \\(\\(\\(REQUESTS\\.status = \\$1\\)\\) OR \\(\\(REQUESTS\\.status = \\$2\\)\\)\\)\\)\\)").
+		WithArgs(driver.Deleted, driver.Orphan).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err = mockTokenLockStorePostgress(db).Cleanup(t.Context(), time.Second)
+
+	Expect(mockDB.ExpectationsWereMet()).To(Succeed())
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/token/services/storage/db/sql/query/cond/condition_test.go
+++ b/token/services/storage/db/sql/query/cond/condition_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	localPostgres "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/postgres"
+	q "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query"
 	common3 "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/common"
 	cond2 "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/cond"
 	common2 "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/common"
@@ -82,6 +83,16 @@ var testMatrix = []testCase{
 		condition:      cond2.BetweenBytes("pkey", []byte("start"), []byte("end")),
 		expectedQuery:  "(pkey >= $0) AND (pkey < $1)",
 		expectedParams: []common3.Param{[]byte("start"), []byte("end")},
+	},
+	{
+		condition: cond2.Exists(
+			q.Select().
+				Fields(common3.FieldName("1")).
+				From(common3.NewTable("requests")).
+				Where(cond2.Eq("status", 3)),
+		),
+		expectedQuery:  "EXISTS (SELECT 1 FROM requests WHERE status = $0)",
+		expectedParams: []common3.Param{3},
 	},
 }
 

--- a/token/services/storage/db/sql/query/cond/exists.go
+++ b/token/services/storage/db/sql/query/cond/exists.go
@@ -1,0 +1,31 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cond
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/common"
+)
+
+// subquery is the interface satisfied by a SELECT query that can write itself into a builder.
+type subquery interface {
+	FormatTo(common.CondInterpreter, common.Builder)
+}
+
+type existsCond struct {
+	subquery subquery
+}
+
+// Exists creates an EXISTS (SELECT ...) condition wrapping the given subquery.
+func Exists(sq subquery) Condition {
+	return &existsCond{subquery: sq}
+}
+
+func (e *existsCond) WriteString(ci common.CondInterpreter, sb common.Builder) {
+	sb.WriteString("EXISTS (")
+	e.subquery.FormatTo(ci, sb)
+	sb.WriteRune(')')
+}

--- a/token/services/storage/db/sql/sqlite/tokenlock_test.go
+++ b/token/services/storage/db/sql/sqlite/tokenlock_test.go
@@ -45,9 +45,22 @@ func TestIsStale(t *testing.T) {
 		"FROM TokenLocks AS tl " +
 		"LEFT JOIN Requests AS tr " +
 		"ON tl.tx_id = tr.tx_id " +
-		"WHERE (tr.status = $1) OR (tl.created_at < datetime('now', '-5 seconds'))" +
+		"WHERE ((tr.status) IN (($1), ($2))) OR (tl.created_at < datetime('now', '-5 seconds'))" +
 		")"))
-	Expect(args).To(ConsistOf(driver.Deleted))
+	Expect(args).To(ConsistOf(driver.Deleted, driver.Orphan))
+}
+
+func TestIsStaleOrphan(t *testing.T) {
+	RegisterTestingT(t)
+
+	query, args := q.DeleteFrom("TokenLocks").
+		Where(IsStale("TokenLocks", "Requests", 10*time.Second)).
+		Format(NewConditionInterpreter())
+
+	// Verify the query includes both Deleted (3) and Orphan (4) statuses using IN syntax
+	Expect(query).To(ContainSubstring("(tr.status) IN"))
+	Expect(query).To(ContainSubstring("datetime('now', '-10 seconds')"))
+	Expect(args).To(ConsistOf(driver.Deleted, driver.Orphan))
 }
 
 func TestLock(t *testing.T) {


### PR DESCRIPTION
Addresses issue: https://github.com/hyperledger-labs/fabric-token-sdk/issues/1797