### PR TITLE
perf(ttxdb): batch transaction records into a single multi-row INSERT

### DIFF
--- a/token/services/storage/ttxdb/store.go
+++ b/token/services/storage/ttxdb/store.go
@@ -271,8 +271,8 @@ func (d *StoreService) AppendTransactionRecord(ctx context.Context, req *token.R
 
 		return errors.WithMessagef(err, "append token request for txid [%s] failed", record.Anchor)
 	}
-	for _, tx := range txs {
-		if err := w.AddTransaction(ctx, tx); err != nil {
+	if len(txs) > 0 {
+		if err := w.AddTransaction(ctx, txs...); err != nil {
 			w.Rollback()
 
 			return errors.WithMessagef(err, "append transactions for txid [%s] failed", record.Anchor)


### PR DESCRIPTION
Fixes #1810.

`AppendTransactionRecord` looped over the parsed transaction records and called `AddTransaction` once per record, issuing N single-row INSERTs inside the store transaction. `AddTransaction` is variadic and its SQL implementation already builds a single multi-row `INSERT ... VALUES (..),(..)`, so this passes all records in one call to collapse the per-tx writes (typically the transfer leg plus the change-back-to-sender leg) into one round-trip.

Guarded with `len(txs) > 0` so a transaction that parses into zero records does not emit an empty INSERT.

No behavior change: the same rows are written in the same store transaction, just in one statement instead of N.
