### PR TITLE
Add benchmarks for Quantity operations

### DIFF
--- a/docs/drivers/benchmark/benchmark.md
+++ b/docs/drivers/benchmark/benchmark.md
@@ -24,3 +24,6 @@
 
 ### Node Level Benchmarks
 - [Token Validation Service Benchmark](token_validation_service_benchmark.md)
+
+### Foundational Types
+- `Quantity` operations (`token/token/quantity_test.go`) — micro-benchmarks for `BigQuantity`/`UInt64Quantity` `Add`, `Sub`, `Cmp`, and `ToQuantity` parsing. Run with `go test -run='^$' -bench=. -benchmem ./token/token/`

--- a/token/token/quantity_test.go
+++ b/token/token/quantity_test.go
@@ -405,6 +405,81 @@ func TestUInt64Quantity_Clone(t *testing.T) {
 	assert.Equal(t, "100", clone.Decimal())
 }
 
+// Package-level sinks prevent the compiler from optimizing away the
+// benchmarked, side-effect-free calls (dead-code elimination).
+var (
+	benchResult token.Quantity
+	benchErr    error
+	benchCmp    int
+)
+
+func BenchmarkBigQuantity_Add(b *testing.B) {
+	q := token.NewZeroQuantity(128)
+	one := token.NewOneQuantity(128)
+	b.ResetTimer()
+	for b.Loop() {
+		benchResult, benchErr = q.Add(one)
+	}
+	require.NoError(b, benchErr)
+}
+
+func BenchmarkBigQuantity_Sub(b *testing.B) {
+	q, err := token.ToQuantity("1000000000", 128)
+	require.NoError(b, err)
+	one := token.NewOneQuantity(128)
+	b.ResetTimer()
+	for b.Loop() {
+		benchResult, benchErr = q.Sub(one)
+	}
+	require.NoError(b, benchErr)
+}
+
+func BenchmarkBigQuantity_Cmp(b *testing.B) {
+	q := token.NewZeroQuantity(128)
+	one := token.NewOneQuantity(128)
+	b.ResetTimer()
+	for b.Loop() {
+		benchCmp = q.Cmp(one)
+	}
+}
+
+func BenchmarkUInt64Quantity_Add(b *testing.B) {
+	q := token.NewZeroQuantity(64)
+	one := token.NewOneQuantity(64)
+	b.ResetTimer()
+	for b.Loop() {
+		benchResult, benchErr = q.Add(one)
+	}
+	require.NoError(b, benchErr)
+}
+
+func BenchmarkUInt64Quantity_Sub(b *testing.B) {
+	q, err := token.ToQuantity("1000000000", 64)
+	require.NoError(b, err)
+	one := token.NewOneQuantity(64)
+	b.ResetTimer()
+	for b.Loop() {
+		benchResult, benchErr = q.Sub(one)
+	}
+	require.NoError(b, benchErr)
+}
+
+func BenchmarkUInt64Quantity_Cmp(b *testing.B) {
+	q := token.NewZeroQuantity(64)
+	one := token.NewOneQuantity(64)
+	b.ResetTimer()
+	for b.Loop() {
+		benchCmp = q.Cmp(one)
+	}
+}
+
+func BenchmarkToQuantity(b *testing.B) {
+	for b.Loop() {
+		benchResult, benchErr = token.ToQuantity("0x1234567890abcdef", 64)
+	}
+	require.NoError(b, benchErr)
+}
+
 func ToHex(q uint64) string {
 	return "0x" + strconv.FormatUint(q, 16)
 }


### PR DESCRIPTION
## Summary
- Add benchmarks for `BigQuantity` and `UInt64Quantity` operations (`Add`, `Sub`, `Cmp`)
- Add benchmark for `ToQuantity` parsing

Continues the work from #1477 (closed), rebased on latest `main` with review comments addressed:
- Assert on errors instead of ignoring them (`require.NoError`)
- Move setup out of the timed loop and call `b.ResetTimer()` so only the target op is measured
- Store side-effect-free results in package-level sinks to prevent dead-code elimination

Resolves #1819
