### PR TITLE
feat(identity/x509): make PKCS11 SessionCacheSize configurable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hyperledger-labs/fabric-smart-client v0.12.1
 	github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0
-	github.com/hyperledger/fabric-lib-go v1.1.3
+	github.com/hyperledger/fabric-lib-go v1.1.4
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
 	github.com/hyperledger/fabric-x-common v0.2.4
 	github.com/jackc/pgx/v5 v5.9.2
@@ -144,7 +144,7 @@ require (
 	github.com/libp2p/go-yamux/v5 v5.0.1 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
-	github.com/miekg/pkcs11 v1.1.1 // indirect
+	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -988,8 +988,8 @@ github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0 h1:NB/QO2t4R5f6Nz/oREqZeaE4
 github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0/go.mod h1:c3zA3gOL/V53a0v1TGgHe8nifeH6daG/UrmJs79I9pI=
 github.com/hyperledger/fabric-config v0.3.0 h1:FS5/dc9GAniljP6RYxQRG92AaiBVoN2vTvtOvnWqeQs=
 github.com/hyperledger/fabric-config v0.3.0/go.mod h1:kSevTn78K83Suc++JsEo7Nt1tYIPqDajW+ORz3OhWlg=
-github.com/hyperledger/fabric-lib-go v1.1.3 h1:alvgtBlbm373P3BLIxdHKVT4I64mORDwQy49uTWdkI4=
-github.com/hyperledger/fabric-lib-go v1.1.3/go.mod h1:zwnGaLwmQ/usgC6Xbzh8jCnOniViRHSsg7WYErxbr30=
+github.com/hyperledger/fabric-lib-go v1.1.4 h1:9koRVvyPa/QjzTCSLbpRuvMPQF+wk8FhhHI/wgnssyc=
+github.com/hyperledger/fabric-lib-go v1.1.4/go.mod h1:MgRyDb/2fbfkruUAPaethrQfdnWXHDDcrRpOjybWPTE=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
 github.com/hyperledger/fabric-x-common v0.2.4 h1:HUhppbbQ35Zw4v/TrjPQ6kYvu3kBrqop1lVlfmWHZF0=
@@ -1142,8 +1142,8 @@ github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
-github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.2 h1:/VxmeAX5qU6Q3EwafypogwWbYryHFmF2RpkJmw3m4MQ=
+github.com/miekg/pkcs11 v1.1.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mikioh/tcp v0.0.0-20190314235350-803a9b46060c h1:bzE/A84HN25pxAuk9Eej1Kz9OUelF97nAc82bDquQI8=
 github.com/mikioh/tcp v0.0.0-20190314235350-803a9b46060c/go.mod h1:0SQS9kMwD2VsyFEB++InYyBJroV/FRmBgcydeSUcJms=
 github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b h1:z78hV3sbSMAUoyUMM0I83AUIT6Hu17AWfgjzIbtrYFc=

--- a/token/services/identity/x509/crypto/config.go
+++ b/token/services/identity/x509/crypto/config.go
@@ -60,13 +60,14 @@ type PKCS11 struct {
 	Hash     string `yaml:"Hash"`
 
 	// PKCS11 options
-	Library        string         `yaml:"Library"`
-	Label          string         `yaml:"Label"`
-	Pin            string         `yaml:"Pin"`
-	SoftwareVerify bool           `yaml:"SoftwareVerify,omitempty"`
-	Immutable      bool           `yaml:"Immutable,omitempty"`
-	AltID          string         `yaml:"AltId,omitempty"`
-	KeyIDs         []KeyIDMapping `mapstructure:"KeyIds"           yaml:"KeyIds,omitempty"`
+	Library          string         `yaml:"Library"`
+	Label            string         `yaml:"Label"`
+	Pin              string         `yaml:"Pin"`
+	SoftwareVerify   bool           `yaml:"SoftwareVerify,omitempty"`
+	Immutable        bool           `yaml:"Immutable,omitempty"`
+	AltID            string         `yaml:"AltId,omitempty"`
+	KeyIDs           []KeyIDMapping `mapstructure:"KeyIds"             yaml:"KeyIds,omitempty"`
+	SessionCacheSize uint           `yaml:"SessionCacheSize,omitempty"`
 }
 
 type KeyIDMapping struct {
@@ -94,14 +95,15 @@ func ToBCCSPOpts(boxed any) (*BCCSP, error) {
 
 func ToPKCS11OptsOpts(o *PKCS11) *pkcs11.PKCS11Opts {
 	res := &pkcs11.PKCS11Opts{
-		Security:       o.Security,
-		Hash:           o.Hash,
-		Library:        o.Library,
-		Label:          o.Label,
-		Pin:            o.Pin,
-		SoftwareVerify: o.SoftwareVerify,
-		Immutable:      o.Immutable,
-		AltID:          o.AltID,
+		Security:         o.Security,
+		Hash:             o.Hash,
+		Library:          o.Library,
+		Label:            o.Label,
+		Pin:              o.Pin,
+		SoftwareVerify:   o.SoftwareVerify,
+		Immutable:        o.Immutable,
+		AltID:            o.AltID,
+		SessionCacheSize: o.SessionCacheSize,
 	}
 	for _, d := range o.KeyIDs {
 		res.KeyIDs = append(res.KeyIDs, pkcs11.KeyIDMapping{

--- a/token/services/identity/x509/crypto/pkcs11/disabled.go
+++ b/token/services/identity/x509/crypto/pkcs11/disabled.go
@@ -23,13 +23,14 @@ type PKCS11Opts struct {
 	Hash     string `yaml:"Hash"`
 
 	// PKCS11 options
-	Library        string         `yaml:"Library"`
-	Label          string         `yaml:"Label"`
-	Pin            string         `yaml:"Pin"`
-	SoftwareVerify bool           `yaml:"SoftwareVerify,omitempty"`
-	Immutable      bool           `yaml:"Immutable,omitempty"`
-	AltID          string         `yaml:"AltId,omitempty"`
-	KeyIDs         []KeyIDMapping `mapstructure:"KeyIds"           yaml:"KeyIds,omitempty"`
+	Library          string         `yaml:"Library"`
+	Label            string         `yaml:"Label"`
+	Pin              string         `yaml:"Pin"`
+	SoftwareVerify   bool           `yaml:"SoftwareVerify,omitempty"`
+	Immutable        bool           `yaml:"Immutable,omitempty"`
+	AltID            string         `yaml:"AltId,omitempty"`
+	KeyIDs           []KeyIDMapping `mapstructure:"KeyIds"             yaml:"KeyIds,omitempty"`
+	SessionCacheSize uint           `yaml:"SessionCacheSize,omitempty"`
 }
 
 func NewProvider(opts any, ks bccsp.KeyStore, mapper func(ski []byte) []byte) (bccsp.BCCSP, error) {


### PR DESCRIPTION
Fixes #1822.

The x509 identity PKCS11 config exposed the standard PKCS11 options but not the session cache size, so `ToPKCS11OptsOpts` always left it at fabric-lib-go's hardcoded default of 10. On nodes that drive a large, concurrent PKCS11/HSM signing workload, that pins the session pool and serializes signing under load, with no config knob to raise it.

fabric-lib-go v1.1.4 exposes `SessionCacheSize` on `bccsp/pkcs11.PKCS11Opts` (#49), so this:

- bumps fabric-lib-go v1.1.3 → v1.1.4 (pulls miekg/pkcs11 v1.1.1 → v1.1.2 as an indirect);
- adds a `SessionCacheSize` field to the x509 crypto `PKCS11` config and to the `!pkcs11` build-tag stub so both build variants compile;
- passes it into `PKCS11Opts` in `ToPKCS11OptsOpts`.

Backward compatible: omitting the field leaves it zero, which fabric-lib-go maps to its default cache size of 10. Verified `go build ./token/...` and `go build -tags pkcs11 ./token/...` both pass.
