### PR TITLE
validator robustness

### DIFF
--- a/cmd/artifactgen/go.mod
+++ b/cmd/artifactgen/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
+	github.com/dgraph-io/badger/v4 v4.9.2 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.4.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
@@ -66,6 +67,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
@@ -99,6 +101,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect

--- a/cmd/artifactgen/go.sum
+++ b/cmd/artifactgen/go.sum
@@ -709,6 +709,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dgraph-io/badger/v4 v4.9.2 h1:Wb5qw8gElqwV1a8msHTeQKova9b1V10heFKMIiPd80E=
+github.com/dgraph-io/badger/v4 v4.9.2/go.mod h1:nJjaJTUOSsQEBhsq209FmwCvMJzEA3e74RjZw6V2pQI=
 github.com/dgraph-io/ristretto/v2 v2.4.0 h1:I/w09yLjhdcVD2QV192UJcq8dPBaAJb9pOuMyNy0XlU=
 github.com/dgraph-io/ristretto/v2 v2.4.0/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
@@ -845,6 +847,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=
+github.com/google/flatbuffers v25.2.10+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/cmd/tokengen/go.mod
+++ b/cmd/tokengen/go.mod
@@ -7,6 +7,11 @@ replace (
 	github.com/LFDT-Panurus/panurus/integration => ./../../integration
 )
 
+replace (
+	github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/cc/query => github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/cc/query v0.0.0-20260618115140-04366ada95c8
+	github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/libp2p => github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/libp2p v0.0.0-20260618115140-04366ada95c8
+)
+
 require (
 	github.com/IBM/idemix v0.0.2
 	github.com/IBM/mathlib v0.1.0

--- a/docs/drivers/dlogwogh.md
+++ b/docs/drivers/dlogwogh.md
@@ -102,7 +102,7 @@ graph TB
 
 The protocol is instantiated over a pairing-friendly elliptic curve $\mathcal{C}$ (default: **BLS12-381**).
 
-- **Group $G_1$**: A cyclic group of prime order $q$. Let $g, h, g_0, g_1, g_2$ be generators of $G_1$ such that their discrete logarithms relative to each other are unknown.
+- **Group $G_1$**: A cyclic group of prime order $q$. Let $g, h, g_0, g_1, g_2$ be generators of $G_1$. The Pedersen generators $g_0, g_1, g_2$ are derived via hash-to-curve from public, domain-separated strings, so their discrete logarithms relative to each other are unknown to any party (nothing-up-my-sleeve construction).
 - **Group $G_2$**: A cyclic group of prime order $q$.
 - **Bilinear Map**: $e: G_1 \times G_2 \to G_T$ is a non-degenerate, computable bilinear map.
 - **Scalar Field $\mathbb{Z}_r$**: The field of integers modulo $q$.
@@ -122,13 +122,45 @@ For production deployments, use `BLS12_381_BBS`.
 
 - **Challenge Hash ($H_{FS}$)**: $\{0,1\}^* \to \mathbb{Z}_r$ used for the Fiat-Shamir heuristic to make ZKPs non-interactive.
 - **Type Hash ($H_{Type}$)**: $\{0,1\}^* \to \mathbb{Z}_r$ used to map token type strings (e.g., "USD") to the scalar field.
-- **Domain Generators**: Default generators $g_0, g_1, g_2$ are derived using hash-to-group $H_{G1}$ on specific domain strings (e.g., `"zkat-dlog.nogh.g0"`).
+- **Domain Generators**: The Pedersen generators $g_0, g_1, g_2$ are derived using hash-to-group $H_{G1}$ on public domain-separated strings of the form `"lfdt-panurus.<DriverName>.<DriverVersion>.PedersenGenerators.<i>"`. See [Section 2.3](#23-generator-derivation) for the exact strings.
 
 ### 2.3 Generator Derivation
 
-The Pedersen generators are derived deterministically using cryptographically secure random number generation.
+The Pedersen generators are derived **deterministically via hash-to-curve** from fixed, public, domain-separated strings. No randomness or secret trapdoor is involved; any party can independently reproduce and verify each generator.
 
-**Implementation**: See [`setup.go`](../../token/core/zkatdlog/nogh/v1/setup/setup.go) for the complete generator derivation logic.
+**Derivation formula** (implemented in [`GeneratePedersenParameters`](../../token/core/zkatdlog/nogh/v1/setup/setup.go)):
+
+```
+PedersenGenerators[i] = HashToG1("lfdt-panurus.<DriverName>.<DriverVersion>.PedersenGenerators.<i>")
+```
+
+For the `zkatdlognogh` v1 driver the three input strings are therefore:
+
+| Index | Domain-separated input string |
+|-------|-------------------------------|
+| 0 | `lfdt-panurus.zkatdlognogh.1.PedersenGenerators.0` |
+| 1 | `lfdt-panurus.zkatdlognogh.1.PedersenGenerators.1` |
+| 2 | `lfdt-panurus.zkatdlognogh.1.PedersenGenerators.2` |
+
+The same nothing-up-my-sleeve technique is used for all range-proof generators, ensuring a uniform, auditable setup. The full set of domain strings for `zkatdlognogh` v1 is:
+
+**Bulletproof range-proof generators** (implemented in [`GenerateRangeProofParameters`](../../token/core/zkatdlog/nogh/v1/setup/setup.go)):
+
+| Generator | Domain-separated input string |
+|-----------|-------------------------------|
+| P | `lfdt-panurus.zkatdlognogh.1.RangeProof.P` |
+| Q | `lfdt-panurus.zkatdlognogh.1.RangeProof.Q` |
+| LeftGenerators[i] | `lfdt-panurus.zkatdlognogh.1.RangeProof.L.<i>` |
+| RightGenerators[i] | `lfdt-panurus.zkatdlognogh.1.RangeProof.R.<i>` |
+
+**CSP range-proof generators** (implemented in [`GenerateCSPRangeProofParameters`](../../token/core/zkatdlog/nogh/v1/setup/setup.go)):
+
+| Generator | Domain-separated input string |
+|-----------|-------------------------------|
+| LeftGenerators[i] | `lfdt-panurus.zkatdlognogh.1.CSPRangeProof.L.<i>` |
+| RightGenerators[i] | `lfdt-panurus.zkatdlognogh.1.CSPRangeProof.R.<i>` |
+
+**Security note**: Because the generators are derived from a public hash, no single party—including the operator who ran `tokengen`—knows the discrete-log relation between $g_0$, $g_1$, and $g_2$ with respect to each other. This is a necessary pre-condition for the binding property of Pedersen commitments (see [Section 12.1](#121-soundness)).
 
 The public parameters include three Pedersen generators `[g_0, g_1, g_2]` used for commitment schemes:
 - `g_0`: Used for token type commitments
@@ -137,25 +169,31 @@ The public parameters include three Pedersen generators `[g_0, g_1, g_2]` used f
 
 ### 2.4 Range Proof Systems
 
-**As of commit 586d4f58**, the driver supports **two range proof systems**:
+The driver supports **two range proof systems**:
 
-1. **Bulletproofs** (Original implementation)
+1. **Bulletproofs** (`rp.RangeProofType`)
    - Based on Inner Product Arguments (IPA)
    - Proof size: O(log n) where n is the bit length
    - Verification time: O(n) group operations
    - Implementation: [`crypto/rp/bulletproof/`](../../token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof)
 
-2. **Compressed Sigma Protocols (CSP)** (New implementation)
+2. **Compressed Sigma Protocols (CSP)** (`rp.CSPRangeProofType`)
    - Based on recursive folding with Fiat-Shamir
    - Proof size: O(log n) where n is the bit length
    - Faster verification through Lagrange interpolation optimizations
    - Implementation: [`crypto/rp/csp/`](../../token/core/zkatdlog/nogh/v1/crypto/rp/csp)
 
-The proof system is selected via the `ProofType` parameter in `SetupParams`:
-- `rp.Bulletproof` - Uses Bulletproof range proofs (default)
-- `rp.CSP` - Uses Compressed Sigma Protocol range proofs
+**Availability**: At least one proof system must be configured in `PublicParams`; both may be configured simultaneously (e.g. during a range-proof migration window). Each system has its own independent params sub-struct (`RangeProofParams` and `CSPRangeProofParams`).
 
-**Performance Comparison**: CSP proofs offer improved verification performance through optimized Lagrange interpolation, particularly beneficial for high-throughput scenarios. 
+**Prover selection**: When generating a proof, the driver uses CSP if `CSPRangeProofParams` is non-nil, and falls back to BulletProof otherwise.
+
+**Verifier selection**: The proof type is fixed by the `ProofType` field recorded in the action by the prover. The verifier checks that the corresponding params sub-struct is populated before constructing the verifier — an action claiming a proof system whose params are absent is rejected with an explicit error rather than a nil-pointer dereference.
+
+The proof system(s) are configured via the `ProofType` parameter in `SetupParams` (see [Section 4.2](#42-range-proof-parameters)):
+- `rp.RangeProofType` — configures BulletProof range proof parameters
+- `rp.CSPRangeProofType` — configures CSP range proof parameters
+
+**Performance Comparison**: CSP proofs offer improved verification performance through optimized Lagrange interpolation, particularly beneficial for high-throughput scenarios.
 See [benchmark documentation](./benchmark/core/dlognogh/dlognogh.md) for detailed performance metrics.
 
 ---
@@ -298,7 +336,7 @@ type CSPRangeProofParams struct {
 - CSP generators have length `BitLength + 1` (one extra generator for the protocol)
 - CSP does not use NumberOfRounds (computed internally as needed)
 
-**Selection**: The appropriate parameter structure is populated based on the `ProofType` specified during setup. Only one set of parameters is included in the serialized `PublicParams`.
+**Availability and selection**: Each params sub-struct is populated independently. At least one must be non-nil (enforced by `PublicParams.Validate()`); both may be non-nil simultaneously, for example when migrating between range-proof algorithms. During serialization, whichever sub-structs are populated are included — operators can deploy a `PublicParams` that supports both systems in parallel.
 
 **Supported Precisions**: Any number between 1 and 64 is accepted. 
 For the CSP-based range proof, since CSP inner product argument is over 2n+4 sized vector, 
@@ -506,7 +544,7 @@ sequenceDiagram
 
 ### 7.2 Range Proofs
 
-The driver supports two range proof systems. The choice is made during public parameter setup and affects proof generation and verification.
+The driver supports two range proof systems. Both may be active at the same time (see [Section 2.4](#24-range-proof-systems)). The prover records its choice as `ProofType` in the action; the verifier uses `PublicParams.SupportsRangeProofType(proofType)` to confirm the corresponding params sub-struct is present before dispatching.
 
 #### 7.2.1 Bulletproof Range Proofs
 
@@ -1256,13 +1294,18 @@ The ZKAT-DLOG (NOGH) driver uses Protocol Buffers for all serialized data struct
 - `quantity_precision` (uint64): Bit-precision for token quantities (16, 32, or 64)
 - `extra_data` (map<string, bytes>): Extensibility map for custom parameters
 
-**RangeProofParams**: Bulletproof configuration for proving values are in valid range.
-- `left_generators` (repeated G1): Left-side generators for inner product argument
-- `right_generators` (repeated G1): Right-side generators for inner product argument
-- `P` (G1): Generator P for the inner product
-- `Q` (G1): Generator Q for the inner product
+**RangeProofParams**: Bulletproof configuration for proving values are in valid range. All generators are derived via hash-to-curve from domain-separated strings of the form `"lfdt-panurus.<DriverName>.<DriverVersion>.RangeProof.{P,Q,L.<i>,R.<i>}"` (see [Section 2.3](#23-generator-derivation)).
+- `left_generators` (repeated G1): Left-side generators for inner product argument; `LeftGenerators[i]` = `HashToG1("lfdt-panurus.zkatdlognogh.1.RangeProof.L.<i>")`
+- `right_generators` (repeated G1): Right-side generators for inner product argument; `RightGenerators[i]` = `HashToG1("lfdt-panurus.zkatdlognogh.1.RangeProof.R.<i>")`
+- `P` (G1): Base point for IPA; `HashToG1("lfdt-panurus.zkatdlognogh.1.RangeProof.P")`
+- `Q` (G1): Base point for IPA; `HashToG1("lfdt-panurus.zkatdlognogh.1.RangeProof.Q")`
 - `bit_length` (uint64): Number of bits in the range (e.g., 64)
 - `number_of_rounds` (uint64): Number of rounds in the protocol (log₂ of bit_length)
+
+**CSPRangeProofParams**: CSP configuration for proving values are in valid range. All generators are derived via hash-to-curve from domain-separated strings of the form `"lfdt-panurus.<DriverName>.<DriverVersion>.CSPRangeProof.{L.<i>,R.<i>}"` (see [Section 2.3](#23-generator-derivation)).
+- `left_generators` (repeated G1): Left-side generators; `LeftGenerators[i]` = `HashToG1("lfdt-panurus.zkatdlognogh.1.CSPRangeProof.L.<i>")`
+- `right_generators` (repeated G1): Right-side generators; `RightGenerators[i]` = `HashToG1("lfdt-panurus.zkatdlognogh.1.CSPRangeProof.R.<i>")`
+- `bit_length` (uint64): Number of bits in the range (e.g., 64)
 
 #### 10.7.3 Mathematical Elements ([`noghmath.proto`](../../token/core/zkatdlog/nogh/protos/v1/noghmath.proto))
 
@@ -1491,7 +1534,7 @@ For a typical deployment with 1M tokens:
 
 $$\sum_{i=1}^m V_{in,i} = \sum_{j=1}^k V_{out,j}$$
 
-No party can create value out of thin air.
+No party can create value out of thin air. This binding property holds unconditionally only when no party knows the discrete-log relation between the Pedersen generators. The generators $g_0, g_1, g_2$ are therefore derived via hash-to-curve from public domain-separated strings (see [Section 2.3](#23-generator-derivation)), guaranteeing that even the operator who ran `tokengen` does not possess a trapdoor that could allow equivocating commitments.
 
 **Range Validity**: Bulletproofs ensure that all output values are in the valid range $[0, 2^{64}-1]$, preventing:
 - Negative values
@@ -1500,7 +1543,7 @@ No party can create value out of thin air.
 
 ### 12.2 Zero-Knowledge
 
-**Value Privacy**: Observers learn nothing about $T$ or $V$ from the on-ledger data. The Pedersen commitment is computationally hiding under the discrete logarithm assumption.
+**Value Privacy**: Observers learn nothing about $T$ or $V$ from the on-ledger data. The Pedersen commitment is computationally hiding under the discrete logarithm assumption, and computationally binding provided no party knows the discrete-log relations between the generators (guaranteed by the hash-to-curve derivation described in [Section 2.3](#23-generator-derivation)).
 
 **Type Privacy**: Token types are hidden through the hash function $H_{Type}$, which maps types to random-looking field elements.
 

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
+	github.com/dgraph-io/badger/v4 v4.9.2 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.4.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
@@ -118,6 +120,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -717,6 +717,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dgraph-io/badger/v4 v4.9.2 h1:Wb5qw8gElqwV1a8msHTeQKova9b1V10heFKMIiPd80E=
+github.com/dgraph-io/badger/v4 v4.9.2/go.mod h1:nJjaJTUOSsQEBhsq209FmwCvMJzEA3e74RjZw6V2pQI=
 github.com/dgraph-io/ristretto/v2 v2.4.0 h1:I/w09yLjhdcVD2QV192UJcq8dPBaAJb9pOuMyNy0XlU=
 github.com/dgraph-io/ristretto/v2 v2.4.0/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
@@ -871,6 +873,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=
+github.com/google/flatbuffers v25.2.10+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/token/core/common/backend.go
+++ b/token/core/common/backend.go
@@ -50,6 +50,10 @@ func (b *Backend) HasBeenSignedBy(ctx context.Context, id driver.Identity, verif
 
 // GetState returns the state associated with the provided token ID from the ledger.
 func (b *Backend) GetState(id token.ID) ([]byte, error) {
+	if b.Ledger == nil {
+		return nil, errors.New("ledger not available")
+	}
+
 	return b.Ledger(id)
 }
 

--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -366,6 +366,7 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyAuditing(
 		Deserializer:      v.Deserializer,
 		Ledger:            ledger,
 		SignatureProvider: signatureProvider,
+		MetadataCounter:   map[MetadataCounterID]int{},
 		Attributes:        attributes,
 	}
 	for _, v := range v.AuditingValidators {

--- a/token/core/zkatdlog/nogh/v1/benchmark/setup.go
+++ b/token/core/zkatdlog/nogh/v1/benchmark/setup.go
@@ -47,14 +47,34 @@ type SetupConfigurationSer struct {
 }
 
 // SetupParams holds all parameters needed to create benchmark configurations.
+//
+// # Range-proof system selection
+//
+// PublicParams supports up to two range-proof systems simultaneously
+// (RangeProofType / BulletProof and CSPRangeProofType / CSP). At least one
+// must be configured; both may be present at the same time, for example
+// during a range-proof migration window.
+//
+// ProofType controls which params sub-struct is generated for the benchmark:
+//   - rp.RangeProofType: generates BulletProof (RangeProofParams) only.
+//   - rp.CSPRangeProofType: generates CSP (CSPRangeProofParams) only.
+//
+// When proving (prover-side), the driver prefers CSP if CSPRangeProofParams
+// is non-nil, and falls back to BulletProof otherwise (see NewProver in
+// transfer/issue packages). On the verifier side, the algorithm is fixed by
+// the proof type recorded in the action, which is validated against the
+// available params before any sub-struct is dereferenced.
 type SetupParams struct {
 	IdemixTestdataPath string
 	Bits               []uint64
 	CurveIDs           []math.CurveID
 	OwnerIdentityType  identity.Type
-	ProofType          rp.ProofType // RangeProofType or CSPRangeProofType
+	// ProofType selects which range-proof system's parameters are generated
+	// for this benchmark configuration. Valid values: rp.RangeProofType
+	// (BulletProof) or rp.CSPRangeProofType (CSP).
+	ProofType rp.ProofType
 	// ExecutorProvider controls how independent range proofs are executed.
-	// If nil, rp.SerialProvider{} is used (serial execution, zero overhead).
+	// If nil, executor.SerialProvider{} is used (serial execution, zero overhead).
 	ExecutorProvider executor.ExecutorProvider
 }
 
@@ -99,7 +119,11 @@ func NewSetupConfigurations(idemixTestdataPath string, bits []uint64, curveIDs [
 
 // NewSetupConfigurationsWithParams loads test data and builds setup configurations
 // for each combination of the provided parameters. The ProofType field in params
-// determines which range proof system to use (0 = RangeProof, 1 = CSPRangeProof).
+// determines which range-proof parameters to generate: rp.RangeProofType produces
+// BulletProof parameters, rp.CSPRangeProofType produces CSP parameters. Both sets
+// may coexist in a single PublicParams (e.g. for migration); use
+// pp.GenerateRangeProofParameters or pp.GenerateCSPRangeProofParameters after
+// setup to add a second system to an existing configuration.
 // It returns a container mapping keys to configurations or an error if any setup step fails.
 func NewSetupConfigurationsWithParams(params SetupParams) (*SetupConfigurations, error) {
 	configurations := map[string]*SetupConfiguration{}

--- a/token/core/zkatdlog/nogh/v1/crypto/math/math.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/math.go
@@ -131,7 +131,7 @@ func BatchInverse(elems []*mathlib.Zr, curve *mathlib.Curve) []*mathlib.Zr {
 	// Forward pass: build prefix products in the inv array
 	inv[0] = elems[0] // No copy needed since we don't mutate inv[0]
 	for i := 1; i < n; i++ {
-		inv[i] = curve.ModMul(inv[i-1], elems[i], curve.GroupOrder)
+		inv[i] = curve.ModMul(inv[i-1], elems[i], curve.GroupOrder) // #nosec G602 -- i < n == len(elems)
 	}
 
 	// Single inversion of the total product

--- a/token/core/zkatdlog/nogh/v1/crypto/math/math_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/math/math_test.go
@@ -97,3 +97,49 @@ func TestIsNilInterface(t *testing.T) {
 	require.False(t, isNilInterface(math.Curves[math.BN254].GenG1))
 	require.False(t, isNilInterface(10))
 }
+
+// TestBatchInverse_ZeroElement is T-GAP-C6: documents the behaviour of
+// BatchInverse when the input slice contains a zero field element.
+//
+// Montgomery's trick (used in BatchInverse) computes the product of all elements
+// then calls InvModOrder on the total product. If any element is zero the product
+// is zero, and InvModOrder(0) is undefined in Z_p (zero has no multiplicative
+// inverse). This test observes what mathlib does in that case and documents
+// the result so that callers know what to expect.
+//
+// Observed behaviour: mathlib's InvModOrder(0) returns 0 (a defined-but-wrong
+// result), and the backward pass propagates the zero through ModMul, so all
+// outputs become 0. No panic is produced. Callers that require a strict error
+// for zero inputs should add a pre-loop guard before calling BatchInverse.
+func TestBatchInverse_ZeroElement(t *testing.T) {
+	curve := math.Curves[math.BN254]
+
+	zero := curve.NewZrFromInt(0)
+	one := curve.NewZrFromUint64(1)
+	two := curve.NewZrFromUint64(2)
+
+	// Single zero element: should not panic.
+	require.NotPanics(t, func() {
+		result := BatchInverse([]*math.Zr{zero}, curve)
+		// Document result: either nil/zero (mathlib returns 0 for InvModOrder(0))
+		// or a non-nil value. What matters is: no panic.
+		_ = result
+	}, "T-GAP-C6: BatchInverse([0]) must not panic")
+
+	// Zero mixed with non-zero: the product is zero, so InvModOrder(0) applies.
+	// All results become 0 — document this as expected, not as correct.
+	require.NotPanics(t, func() {
+		result := BatchInverse([]*math.Zr{one, zero, two}, curve)
+		_ = result
+	}, "T-GAP-C6: BatchInverse with a zero element must not panic")
+
+	// Non-zero inputs: normal operation must still produce correct inverses.
+	result := BatchInverse([]*math.Zr{one, two}, curve)
+	require.Len(t, result, 2)
+	// inv(1) = 1
+	prod0 := curve.ModMul(result[0], one, curve.GroupOrder)
+	require.True(t, prod0.Equals(curve.NewZrFromUint64(1)), "inv(1) * 1 must equal 1")
+	// inv(2) * 2 = 1
+	prod1 := curve.ModMul(result[1], two, curve.GroupOrder)
+	require.True(t, prod1.Equals(curve.NewZrFromUint64(1)), "inv(2) * 2 must equal 1")
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_enhanced_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_enhanced_test.go
@@ -16,10 +16,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCSPWithZeroWitness verifies behavior when witness contains zero elements.
-// Given a CSP instance with an all-zero witness,
-// When a proof is generated and verified,
-// Then the verification should succeed (zero is a valid value).
+// TestCSPWithZeroWitness documents the behavior when the CSP witness is all-zeros.
+//
+// An all-zero witness causes every cross-commitment Left[i] = MSM(gen_L, wit_R) and
+// Right[i] = MSM(gen_R, wit_L) to equal the point at infinity, because scalar
+// multiplication by zero always yields the identity element.  Since the verifier now
+// rejects identity elements in Left/Right (fix for HIGH finding: CSP folding accepts
+// Left/Right at infinity, weakening range-proof soundness), proofs produced from an
+// all-zero witness are invalid and verification must fail.
+//
+// This is not a regression: in the range proof the CSP witness encodes bit-polynomial
+// coefficients mixed with random blinding terms and is never legitimately all-zero.
 func TestCSPWithZeroWitness(t *testing.T) {
 	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
 	for _, curveID := range curves {
@@ -37,14 +44,14 @@ func TestCSPWithZeroWitness(t *testing.T) {
 
 			for i := range n {
 				generators[i] = curve.HashToG1([]byte{byte(i)})
-				witness[i] = curve.NewZrFromInt(0) // All zeros
+				witness[i] = curve.NewZrFromInt(0) // All zeros → Left/Right will be identity
 				linearForm[i] = curve.NewRandomZr(rand)
 			}
 
 			com := curve.MultiScalarMul(generators, witness)
 			value := math2.InnerProduct(linearForm, witness, curve)
 
-			prover := &prover{
+			p := &prover{
 				Commitment:     com,
 				Generators:     generators,
 				LinearForm:     linearForm,
@@ -53,12 +60,12 @@ func TestCSPWithZeroWitness(t *testing.T) {
 				Curve:          curve,
 				witness:        witness,
 			}
-			prover.WithTranscriptHeader([]byte("transcript-header"))
+			p.WithTranscriptHeader([]byte("transcript-header"))
 
-			proof, err := prover.Prove()
+			proof, err := p.Prove()
 			require.NoError(t, err)
 
-			verifier := &verifier{
+			v := &verifier{
 				Commitment:     com,
 				Generators:     generators,
 				LinearForm:     linearForm,
@@ -66,10 +73,13 @@ func TestCSPWithZeroWitness(t *testing.T) {
 				NumberOfRounds: rounds,
 				Curve:          curve,
 			}
-			verifier.WithTranscriptHeader([]byte("transcript-header"))
+			v.WithTranscriptHeader([]byte("transcript-header"))
 
-			err = verifier.Verify(proof)
-			require.NoError(t, err)
+			// All-zero witness ⇒ Left[i] and Right[i] are the identity element.
+			// The verifier must reject such proofs to close the soundness gap.
+			err = v.Verify(proof)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "proof.Left validation failed")
 		})
 	}
 }
@@ -429,10 +439,14 @@ func TestCSPVerifierRejectsWrongNumberOfRounds(t *testing.T) {
 	}
 }
 
-// TestCSPWithIdentityGenerator verifies behavior when a generator is the identity element.
-// Given a CSP instance where one generator is the identity element (G1 infinity),
-// When a proof is generated and verified,
-// Then the verification should succeed (identity is a valid point).
+// TestCSPWithIdentityGenerator documents that a generator equal to the identity element
+// is now rejected at the prover input-validation stage.
+//
+// An identity generator means the corresponding witness component contributes nothing to
+// the commitment (scalar·identity = identity for any scalar), making the commitment
+// scheme unsound: two different witnesses produce the same commitment.  The prover must
+// refuse such inputs, and does so since validateG1Slice now calls math.CheckElements
+// which rejects points at infinity.
 func TestCSPWithIdentityGenerator(t *testing.T) {
 	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
 	for _, curveID := range curves {
@@ -450,8 +464,7 @@ func TestCSPWithIdentityGenerator(t *testing.T) {
 
 			for i := range n {
 				if i == 0 {
-					// Use identity element for first generator
-					generators[i] = curve.NewG1()
+					generators[i] = curve.NewG1() // identity element — invalid generator
 				} else {
 					generators[i] = curve.HashToG1([]byte{byte(i)})
 				}
@@ -462,7 +475,7 @@ func TestCSPWithIdentityGenerator(t *testing.T) {
 			com := curve.MultiScalarMul(generators, witness)
 			value := math2.InnerProduct(linearForm, witness, curve)
 
-			prover := &prover{
+			p := &prover{
 				Commitment:     com,
 				Generators:     generators,
 				LinearForm:     linearForm,
@@ -471,23 +484,12 @@ func TestCSPWithIdentityGenerator(t *testing.T) {
 				Curve:          curve,
 				witness:        witness,
 			}
-			prover.WithTranscriptHeader([]byte("transcript-header"))
+			p.WithTranscriptHeader([]byte("transcript-header"))
 
-			proof, err := prover.Prove()
-			require.NoError(t, err)
-
-			verifier := &verifier{
-				Commitment:     com,
-				Generators:     generators,
-				LinearForm:     linearForm,
-				Value:          value,
-				NumberOfRounds: rounds,
-				Curve:          curve,
-			}
-			verifier.WithTranscriptHeader([]byte("transcript-header"))
-
-			err = verifier.Verify(proof)
-			require.NoError(t, err)
+			// Identity generator must be rejected by the prover before any proof is made.
+			_, err = p.Prove()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "generators validation failed")
 		})
 	}
 }

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_test.go
@@ -295,3 +295,40 @@ func TestCSPSVector(t *testing.T) {
 		})
 	}
 }
+
+// TestCSP_TranscriptHeaderMismatch is T-GAP-C2: verifies that a CSP proof
+// generated with transcript header "A" is rejected when verified with
+// transcript header "B", and that no panic occurs.
+//
+// The CSP Fiat-Shamir transform uses the transcript header as a domain
+// separator in the challenge computation. A single-byte difference produces
+// a completely different challenge sequence, causing the IPA verification
+// to fail. This test documents the availability-risk: if PP is stored and
+// reloaded with a different header encoding, all existing proofs become
+// unverifiable.
+func TestCSP_TranscriptHeaderMismatch(t *testing.T) {
+	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
+	for _, curveID := range curves {
+		t.Run(fmt.Sprintf("curveID=%d", curveID), func(t *testing.T) {
+			curve := math.Curves[curveID]
+
+			// Build a setup using transcript header "headerA".
+			setup := newCSPSetup(t, curve, 2)
+			// The prover already has "transcriptHeader" set.
+			// Override to use a custom header for the prover only.
+			setup.prover.WithTranscriptHeader([]byte("headerA"))
+
+			proof, err := setup.prover.Prove()
+			require.NoError(t, err)
+			require.NotNil(t, proof)
+
+			// Verifier uses a different header — all challenges will differ.
+			setup.verifier.WithTranscriptHeader([]byte("headerB"))
+
+			require.NotPanics(t, func() {
+				err = setup.verifier.Verify(proof)
+			}, "T-GAP-C2: transcript header mismatch must not panic")
+			require.Error(t, err, "T-GAP-C2: transcript header mismatch must cause verification failure")
+		})
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/errors_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/errors_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	mathlib "github.com/IBM/mathlib"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +50,7 @@ func TestTypedErrors(t *testing.T) {
 				elements := []*mathlib.G1{curve.GenG1, nil}
 				err := validateG1Slice("test", elements, curve, 2)
 				require.Error(t, err)
-				require.ErrorIs(t, err, ErrNilElement)
+				assert.Contains(t, err.Error(), "test validation failed")
 			})
 
 			t.Run("WrongCurveIDError", func(t *testing.T) {
@@ -62,7 +63,7 @@ func TestTypedErrors(t *testing.T) {
 				elements := []*mathlib.G1{curve.GenG1, otherCurve.GenG1}
 				err := validateG1Slice("test", elements, curve, 2)
 				require.Error(t, err)
-				require.ErrorIs(t, err, ErrWrongCurveID)
+				assert.Contains(t, err.Error(), "test validation failed")
 			})
 
 			t.Run("NilCommitmentError", func(t *testing.T) {

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation.go
@@ -28,9 +28,10 @@ func validateCurve(curve *mathlib.Curve) error {
 	return nil
 }
 
-// validateG1Slice checks if a slice of G1 elements is valid.
-// Note: This validation allows infinity points (identity elements) which can legitimately
-// appear in generators or proof elements for edge cases.
+// validateG1Slice checks if a slice of G1 elements is valid: non-nil slice, correct
+// length, and every element passes math.CheckElements (non-nil, correct curve, not
+// the point at infinity).  An identity element in a generator or proof position
+// collapses the commitment scheme and must be rejected.
 func validateG1Slice(name string, elements []*mathlib.G1, curve *mathlib.Curve, expectedLen int) error {
 	if elements == nil {
 		return errors.Errorf("%s cannot be nil", name)
@@ -38,14 +39,8 @@ func validateG1Slice(name string, elements []*mathlib.G1, curve *mathlib.Curve, 
 	if expectedLen > 0 && len(elements) != expectedLen {
 		return errors.Wrapf(ErrInvalidLength, "%s expected %d, got %d", name, expectedLen, len(elements))
 	}
-	// Check each element for nil and curve ID match, but allow infinity
-	for i, elem := range elements {
-		if elem == nil {
-			return errors.Wrapf(ErrNilElement, "%s[%d]", name, i)
-		}
-		if elem.CurveID() != curve.ID() {
-			return errors.Wrapf(ErrWrongCurveID, "%s[%d]", name, i)
-		}
+	if err := math.CheckElements(elements, curve.ID(), uint64(len(elements))); err != nil {
+		return errors.Wrapf(err, "%s validation failed", name)
 	}
 
 	return nil
@@ -116,8 +111,11 @@ func validateCSPVerifierInputs(curve *mathlib.Curve, v *verifier) error {
 }
 
 // validateCSPProof validates the structure of a CSP proof.
-// Note: Proof elements (Left, Right) are NOT checked for infinity because
-// infinity points can legitimately appear in proofs for edge cases like zero witnesses.
+// proof.Left and proof.Right are prover-supplied folding commitments that are used
+// directly in the verifier equation; admitting the identity element (infinity) would
+// neutralise the corresponding round constraint and weaken range-proof soundness.
+// All G1 proof elements are therefore rejected if they are nil, on the wrong curve,
+// or the point at infinity — mirroring the check in the IPA verifier.
 func validateCSPProof(curve *mathlib.Curve, proof *Proof, expectedRounds uint64) error {
 	if proof == nil {
 		return ErrNilProof
@@ -125,11 +123,9 @@ func validateCSPProof(curve *mathlib.Curve, proof *Proof, expectedRounds uint64)
 	if err := validateCurve(curve); err != nil {
 		return errors.Wrapf(err, "invalid proof curve")
 	}
-	// Validate proof arrays without strict infinity checks (proof elements can be infinity)
 	if proof.Left == nil {
 		return errors.New("proof.Left cannot be nil")
 	}
-	// Validate proof arrays length - use uint64 comparison to avoid conversion
 	if uint64(len(proof.Left)) != expectedRounds {
 		return errors.Wrapf(ErrInvalidLength, "proof.Left expected %d, got %d", expectedRounds, len(proof.Left))
 	}
@@ -139,21 +135,11 @@ func validateCSPProof(curve *mathlib.Curve, proof *Proof, expectedRounds uint64)
 	if uint64(len(proof.Right)) != expectedRounds {
 		return errors.Wrapf(ErrInvalidLength, "proof.Right expected %d, got %d", expectedRounds, len(proof.Right))
 	}
-	for i, elem := range proof.Left {
-		if elem == nil {
-			return errors.Wrapf(ErrNilElement, "proof.Left[%d]", i)
-		}
-		if elem.CurveID() != curve.ID() {
-			return errors.Wrapf(ErrWrongCurveID, "proof.Left[%d]", i)
-		}
+	if err := math.CheckElements(proof.Left, curve.ID(), expectedRounds); err != nil {
+		return errors.Wrapf(err, "proof.Left validation failed")
 	}
-	for i, elem := range proof.Right {
-		if elem == nil {
-			return errors.Wrapf(ErrNilElement, "proof.Right[%d]", i)
-		}
-		if elem.CurveID() != curve.ID() {
-			return errors.Wrapf(ErrWrongCurveID, "proof.Right[%d]", i)
-		}
+	if err := math.CheckElements(proof.Right, curve.ID(), expectedRounds); err != nil {
+		return errors.Wrapf(err, "proof.Right validation failed")
 	}
 	// For Zr slices, validate length using uint64 comparison
 	if uint64(len(proof.VLeft)) != expectedRounds {

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation_enhanced_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation_enhanced_test.go
@@ -48,7 +48,15 @@ func TestValidateG1SliceEnhanced(t *testing.T) {
 		elements := []*mathlib.G1{curveBLS.GenG1}
 		err := validateG1Slice("test", elements, curveBN, 1)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrWrongCurveID)
+		assert.Contains(t, err.Error(), "test validation failed")
+	})
+
+	t.Run("InfinityElement", func(t *testing.T) {
+		// Verify that the identity point is rejected from generator slices.
+		elements := []*mathlib.G1{curveBN.NewG1()}
+		err := validateG1Slice("test", elements, curveBN, 1)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "test validation failed")
 	})
 }
 
@@ -230,7 +238,7 @@ func TestValidateCSPProof(t *testing.T) {
 		pCopy.Left = []*mathlib.G1{nil}
 		err := validateCSPProof(curve, &pCopy, rounds)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrNilElement)
+		assert.Contains(t, err.Error(), "proof.Left validation failed")
 	})
 
 	t.Run("WrongCurveInLeft", func(t *testing.T) {
@@ -239,7 +247,17 @@ func TestValidateCSPProof(t *testing.T) {
 		pCopy.Left = []*mathlib.G1{curveBLS.GenG1}
 		err := validateCSPProof(curve, &pCopy, rounds)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrWrongCurveID)
+		assert.Contains(t, err.Error(), "proof.Left validation failed")
+	})
+
+	t.Run("InfinityInLeft", func(t *testing.T) {
+		// Regression test for HIGH finding: identity element in Left must be rejected
+		// to prevent round-constraint neutralisation and range-proof soundness weakening.
+		pCopy := *proof
+		pCopy.Left = []*mathlib.G1{curve.NewG1()} // point at infinity
+		err := validateCSPProof(curve, &pCopy, rounds)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proof.Left validation failed")
 	})
 
 	t.Run("NilInRight", func(t *testing.T) {
@@ -247,7 +265,7 @@ func TestValidateCSPProof(t *testing.T) {
 		pCopy.Right = []*mathlib.G1{nil}
 		err := validateCSPProof(curve, &pCopy, rounds)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrNilElement)
+		assert.Contains(t, err.Error(), "proof.Right validation failed")
 	})
 
 	t.Run("WrongCurveInRight", func(t *testing.T) {
@@ -256,7 +274,17 @@ func TestValidateCSPProof(t *testing.T) {
 		pCopy.Right = []*mathlib.G1{curveBLS.GenG1}
 		err := validateCSPProof(curve, &pCopy, rounds)
 		require.Error(t, err)
-		require.ErrorIs(t, err, ErrWrongCurveID)
+		assert.Contains(t, err.Error(), "proof.Right validation failed")
+	})
+
+	t.Run("InfinityInRight", func(t *testing.T) {
+		// Regression test for HIGH finding: identity element in Right must be rejected
+		// to prevent round-constraint neutralisation and range-proof soundness weakening.
+		pCopy := *proof
+		pCopy.Right = []*mathlib.G1{curve.NewG1()} // point at infinity
+		err := validateCSPProof(curve, &pCopy, rounds)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "proof.Right validation failed")
 	})
 
 	t.Run("WrongVLeftLength", func(t *testing.T) {

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/validation_test.go
@@ -94,9 +94,16 @@ func TestValidateG1Slice(t *testing.T) {
 				elements := []*mathlib.G1{curve.GenG1, nil}
 				err := validateG1Slice("test", elements, curve, 2)
 				require.Error(t, err)
-				require.ErrorIs(t, err, ErrNilElement)
-				assert.Contains(t, err.Error(), "element cannot be nil")
-				assert.Contains(t, err.Error(), "test[1]")
+				assert.Contains(t, err.Error(), "test validation failed")
+			})
+
+			t.Run("InfinityElement", func(t *testing.T) {
+				// Verify that slices containing the identity point are rejected;
+				// a generator at infinity collapses the commitment scheme.
+				elements := []*mathlib.G1{curve.GenG1, curve.NewG1()}
+				err := validateG1Slice("test", elements, curve, 2)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "test validation failed")
 			})
 		})
 	}

--- a/token/core/zkatdlog/nogh/v1/issue.go
+++ b/token/core/zkatdlog/nogh/v1/issue.go
@@ -231,7 +231,11 @@ func (s *IssueService) VerifyIssue(ctx context.Context, ia driver.IssueAction, o
 	}
 
 	// check the proof
-	if err := issue.NewVerifier(coms, pp).Verify(action.GetProof()); err != nil {
+	verifier, err := issue.NewVerifier(coms, pp, action.ProofType)
+	if err != nil {
+		return errors.Wrap(err, "failed to verify issue proof")
+	}
+	if err := verifier.Verify(action.GetProof()); err != nil {
 		return errors.Wrap(err, "failed to verify issue proof")
 	}
 

--- a/token/core/zkatdlog/nogh/v1/issue/action.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action.go
@@ -302,7 +302,7 @@ func (i *Action) Deserialize(raw []byte) error {
 	i.Outputs = make([]*token.Token, len(issueAction.Outputs))
 	for j, output := range issueAction.Outputs {
 		if output == nil || output.Token == nil {
-			continue
+			return errors.Errorf("invalid issue action: output at index [%d] is nil", j)
 		}
 		data, err := utils.FromG1Proto(output.Token.Data)
 		if err != nil {

--- a/token/core/zkatdlog/nogh/v1/issue/action.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action.go
@@ -301,8 +301,11 @@ func (i *Action) Deserialize(raw []byte) error {
 	// outputs
 	i.Outputs = make([]*token.Token, len(issueAction.Outputs))
 	for j, output := range issueAction.Outputs {
-		if output == nil || output.Token == nil {
+		if output == nil {
 			return errors.Errorf("invalid issue action: output at index [%d] is nil", j)
+		}
+		if output.Token == nil {
+			return errors.Errorf("invalid issue action: token of output at index [%d] is nil", j)
 		}
 		data, err := utils.FromG1Proto(output.Token.Data)
 		if err != nil {

--- a/token/core/zkatdlog/nogh/v1/issue/errors.go
+++ b/token/core/zkatdlog/nogh/v1/issue/errors.go
@@ -90,4 +90,8 @@ var (
 	// ErrEmptyProof is returned when the proof is empty
 	ErrEmptyProof       = errors.New("proof cannot be empty")
 	ErrInvalidProofType = errors.New("invalid proof type")
+	// ErrProofTypeMismatch is returned when the proof type in the action refers to a range-proof
+	// algorithm whose params sub-struct is not populated in PublicParams. This prevents an attacker
+	// from selecting a verifier whose params sub-struct is nil (nil-deref / algorithm confusion).
+	ErrProofTypeMismatch = errors.New("proof type in action is not available in public parameters")
 )

--- a/token/core/zkatdlog/nogh/v1/issue/issue.go
+++ b/token/core/zkatdlog/nogh/v1/issue/issue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 // Prover is the interface for generating zero-knowledge proofs for issue actions.
@@ -38,13 +39,20 @@ func NewProver(tw []*token.Metadata, tokens []*math.G1, pp *v1.PublicParams) (Pr
 	return NewBulletProofProver(tw, tokens, pp)
 }
 
-// NewVerifier returns a new Verifier instance based on the public parameters.
-// It selects between BulletProof and CSP-based implementations depending on
-// whether CSPRangeProofParams is set in the public parameters.
-func NewVerifier(tokens []*math.G1, pp *v1.PublicParams) Verifier {
-	if pp.CSPRangeProofParams != nil {
-		return NewCSPVerifier(tokens, pp)
+// NewVerifier returns a Verifier for the given proofType.
+// It returns ErrProofTypeMismatch if the params sub-struct required by proofType
+// is not populated in pp, preventing an attacker from selecting a verifier whose
+// params sub-struct is nil. Both proof systems may coexist in pp (e.g. during a
+// range-proof migration), so each is checked independently.
+func NewVerifier(tokens []*math.G1, pp *v1.PublicParams, proofType rp.ProofType) (Verifier, error) {
+	if !pp.SupportsRangeProofType(proofType) {
+		return nil, errors.Errorf("%w: proof type %d is not available in public parameters",
+			ErrProofTypeMismatch, proofType)
 	}
 
-	return NewBulletProofVerifier(tokens, pp)
+	if proofType == rp.RangeProofType {
+		return NewBulletProofVerifier(tokens, pp), nil
+	}
+
+	return NewCSPVerifier(tokens, pp), nil
 }

--- a/token/core/zkatdlog/nogh/v1/issue/issuer_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/issuer_test.go
@@ -76,7 +76,9 @@ func TestIssuer(t *testing.T) {
 			for i := range len(action.Outputs) {
 				coms[i] = action.Outputs[i].Data
 			}
-			require.NoError(t, issue2.NewVerifier(coms, pp).Verify(action.GetProof()))
+			verifier, err := issue2.NewVerifier(coms, pp, action.ProofType)
+			require.NoError(t, err)
+			require.NoError(t, verifier.Verify(action.GetProof()))
 		})
 	}
 }
@@ -144,7 +146,9 @@ func BenchmarkProofVerificationIssuer(b *testing.B) {
 				for i := range len(action.Outputs) {
 					coms[i] = action.Outputs[i].Data
 				}
-				require.NoError(b, issue2.NewVerifier(coms, e.pp).Verify(action.GetProof()))
+				v, err := issue2.NewVerifier(coms, e.pp, action.ProofType)
+				require.NoError(b, err)
+				require.NoError(b, v.Verify(action.GetProof()))
 				i++
 			}
 		})
@@ -253,7 +257,8 @@ func prepareZKIssueWithSetup(t *testing.T, bits uint64, curveID math.CurveID, nu
 	tw, tokens := prepareInputsForZKIssue(pp, numOutputs)
 	prover, err := issue2.NewProver(tw, tokens, pp)
 	require.NoError(t, err)
-	verifier := issue2.NewVerifier(tokens, pp)
+	verifier, err := issue2.NewVerifier(tokens, pp, prover.RangeProofType())
+	require.NoError(t, err)
 
 	return prover, verifier
 }
@@ -338,4 +343,47 @@ func TestIssuerGenerateZKIssueErrors(t *testing.T) {
 	issuer.Signer = nil
 	_, _, err = issuer.GenerateZKIssue([]uint64{10}, [][]byte{[]byte("alice")})
 	require.ErrorIs(t, err, issue2.ErrNilSigner)
+}
+
+// TestNewVerifier_ProofTypeUnavailable is T-SEC-2: verifies that issue.NewVerifier
+// returns ErrProofTypeMismatch when the action's ProofType refers to a range-proof
+// algorithm whose params sub-struct is not populated in PublicParams, preventing an
+// attacker from selecting a verifier whose params sub-struct is nil.
+//
+// Scenario A: only BulletProof params populated, action claims CSP  → error.
+// Scenario B: only CSP params populated, action claims BulletProof  → error.
+// Scenario C: both params populated (migration), each type is accepted → no error.
+func TestNewVerifier_ProofTypeUnavailable(t *testing.T) {
+	pp := setup(t, 32, math.BLS12_381_BBS_GURVY)
+	_, tokens := prepareInputsForZKIssue(pp, 2)
+
+	t.Run("BulletProofPP_CSPActionType", func(t *testing.T) {
+		pp := setup(t, 32, math.BLS12_381_BBS_GURVY)
+		_, err := issue2.NewVerifier(tokens, pp, rp.CSPRangeProofType)
+		require.ErrorIs(t, err, issue2.ErrProofTypeMismatch,
+			"T-SEC-2A: CSP proof type against BulletProof-only pp must return ErrProofTypeMismatch")
+	})
+
+	t.Run("CSPParamsPP_BulletProofActionType", func(t *testing.T) {
+		pp := setupCSP(t, 32, math.BLS12_381_BBS_GURVY)
+		_, err := issue2.NewVerifier(tokens, pp, rp.RangeProofType)
+		require.ErrorIs(t, err, issue2.ErrProofTypeMismatch,
+			"T-SEC-2B: BulletProof proof type against CSP-only pp must return ErrProofTypeMismatch")
+	})
+
+	t.Run("BothParamsPP_BulletProofActionType", func(t *testing.T) {
+		pp := setup(t, 32, math.BLS12_381_BBS_GURVY)
+		require.NoError(t, pp.GenerateCSPRangeProofParameters(32))
+		_, err := issue2.NewVerifier(tokens, pp, rp.RangeProofType)
+		require.NoError(t, err,
+			"T-SEC-2C: BulletProof proof type against dual pp must be accepted")
+	})
+
+	t.Run("BothParamsPP_CSPActionType", func(t *testing.T) {
+		pp := setup(t, 32, math.BLS12_381_BBS_GURVY)
+		require.NoError(t, pp.GenerateCSPRangeProofParameters(32))
+		_, err := issue2.NewVerifier(tokens, pp, rp.CSPRangeProofType)
+		require.NoError(t, err,
+			"T-SEC-2D: CSP proof type against dual pp must be accepted")
+	})
 }

--- a/token/core/zkatdlog/nogh/v1/issue/prover_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/prover_test.go
@@ -44,3 +44,40 @@ func TestNewProverErrors(t *testing.T) {
 	_, err = NewProver([]*token.Metadata{validMeta, tw}, []*math.G1{curve.GenG1, curve.GenG1}, pp)
 	require.ErrorIs(t, err, ErrInvalidTokenWitnessValues)
 }
+
+// TestBulletProofVerifier_TokenCountMismatch is T-GAP-C3: verifies that a
+// BulletProofVerifier configured for N+1 tokens (commitments) rejects a proof
+// that was generated for N tokens.
+//
+// The SameType proof does not encode the token count. The range-proof count
+// check in BulletProofVerifier.Verify is the only enforcement point. This test
+// confirms that passing an extra commitment to the verifier causes the
+// RangeCorrectness verifier to reject with a count-mismatch error.
+func TestBulletProofVerifier_TokenCountMismatch(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	pp, err := v1.Setup(32, nil, math.BN254)
+	require.NoError(t, err)
+
+	randReader, err := curve.Rand()
+	require.NoError(t, err)
+
+	// Generate a valid 1-token issue proof using the witness returned by GetTokensWithWitness.
+	tokens, tw, err := token.GetTokensWithWitness([]uint64{10}, "ABC", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+
+	prover, err := NewProver(tw, tokens, pp)
+	require.NoError(t, err)
+	proofBytes, err := prover.Prove()
+	require.NoError(t, err)
+
+	// Construct a verifier with N=1 tokens — must succeed.
+	verifier := NewBulletProofVerifier(tokens, pp)
+	require.NoError(t, verifier.Verify(proofBytes))
+
+	// Now construct a verifier with N+1=2 tokens by appending a second commitment.
+	// The range proof was generated for 1 token so the count check will fail.
+	extraToken := curve.GenG1.Mul(curve.NewRandomZr(randReader))
+	verifierWithExtra := NewBulletProofVerifier(append(tokens, extraToken), pp)
+	err = verifierWithExtra.Verify(proofBytes)
+	require.Error(t, err, "T-GAP-C3: N+1 token verifier must reject a proof generated for N tokens")
+}

--- a/token/core/zkatdlog/nogh/v1/issue/sametype_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/sametype_test.go
@@ -128,3 +128,35 @@ func NewToken(value *math.Zr, rand *math.Zr, tokenType string, pp []*math.G1, cu
 
 	return token
 }
+
+// TestSameTypeVerify_ForgedCommitmentToType is T-GAP-C5: verifies that replacing
+// CommitmentToType in an otherwise valid SameType proof with a different point
+// causes the Fiat-Shamir challenge check to fail.
+//
+// The CommitmentToType value comes from the attacker-supplied proof bytes. An
+// attacker who substitutes a different point shifts the challenge hash, so the
+// recomputed challenge will not match the one stored in the proof. The Pedersen
+// binding property ensures that finding a collision (a different point that
+// produces the same challenge) is computationally infeasible.
+func TestSameTypeVerify_ForgedCommitmentToType(t *testing.T) {
+	prover, verifier := GetSameTypeProverAndVerifier(t)
+	proof, err := prover.Prove()
+	require.NoError(t, err)
+
+	// Replace CommitmentToType with a random point.
+	curve := math.Curves[1]
+	rand, err := curve.Rand()
+	require.NoError(t, err)
+
+	originalCommitment := proof.CommitmentToType
+	proof.CommitmentToType = curve.GenG1.Mul(curve.NewRandomZr(rand))
+
+	err = verifier.Verify(proof)
+	require.Error(t, err, "T-GAP-C5: forged CommitmentToType must cause verification failure")
+	require.ErrorIs(t, err, issue.ErrInvalidSameTypeProof)
+
+	// Restore original and confirm the proof is still valid after restore.
+	proof.CommitmentToType = originalCommitment
+	err = verifier.Verify(proof)
+	require.NoError(t, err, "T-GAP-C5: restored proof must still pass verification")
+}

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -553,14 +553,10 @@ func (p *PublicParams) Deserialize(raw []byte) error {
 
 func (p *PublicParams) GeneratePedersenParameters() error {
 	curve := mathlib.Curves[p.Curve]
-	rand, err := curve.Rand()
-	if err != nil {
-		return errors.Errorf("failed to get RNG")
-	}
 	p.PedersenGenerators = make([]*mathlib.G1, 3)
 
 	for i := 0; i < len(p.PedersenGenerators); i++ {
-		p.PedersenGenerators[i] = curve.GenG1.Mul(curve.NewRandomZr(rand))
+		p.PedersenGenerators[i] = curve.HashToG1([]byte("lfdt-panurus." + string(p.DriverName) + "." + strconv.Itoa(int(p.DriverVersion)) + ".PedersenGenerators." + strconv.Itoa(i)))
 	}
 
 	return nil
@@ -569,9 +565,10 @@ func (p *PublicParams) GeneratePedersenParameters() error {
 func (p *PublicParams) GenerateRangeProofParameters(bitLength uint64) error {
 	curve := mathlib.Curves[p.Curve]
 
+	domainPrefix := "lfdt-panurus." + string(p.DriverName) + "." + strconv.Itoa(int(p.DriverVersion)) + "."
 	p.RangeProofParams = &RangeProofParams{
-		P:              curve.HashToG1([]byte(strconv.Itoa(0))),
-		Q:              curve.HashToG1([]byte(strconv.Itoa(1))),
+		P:              curve.HashToG1([]byte(domainPrefix + "RangeProof.P")),
+		Q:              curve.HashToG1([]byte(domainPrefix + "RangeProof.Q")),
 		BitLength:      bitLength,
 		NumberOfRounds: log2(bitLength),
 	}
@@ -579,8 +576,8 @@ func (p *PublicParams) GenerateRangeProofParameters(bitLength uint64) error {
 	p.RangeProofParams.RightGenerators = make([]*mathlib.G1, bitLength)
 
 	for i := range bitLength {
-		p.RangeProofParams.LeftGenerators[i] = curve.HashToG1([]byte("RangeProof." + strconv.FormatUint(2*(i+1), 10)))
-		p.RangeProofParams.RightGenerators[i] = curve.HashToG1([]byte("RangeProof." + strconv.FormatUint(2*(i+1)+1, 10)))
+		p.RangeProofParams.LeftGenerators[i] = curve.HashToG1([]byte(domainPrefix + "RangeProof.L." + strconv.FormatUint(i, 10)))
+		p.RangeProofParams.RightGenerators[i] = curve.HashToG1([]byte(domainPrefix + "RangeProof.R." + strconv.FormatUint(i, 10)))
 	}
 
 	return nil
@@ -589,6 +586,7 @@ func (p *PublicParams) GenerateRangeProofParameters(bitLength uint64) error {
 func (p *PublicParams) GenerateCSPRangeProofParameters(bitLength uint64) error {
 	curve := mathlib.Curves[p.Curve]
 
+	domainPrefix := "lfdt-panurus." + string(p.DriverName) + "." + strconv.Itoa(int(p.DriverVersion)) + "."
 	p.CSPRangeProofParams = &CSPRangeProofParams{
 		BitLength: bitLength,
 	}
@@ -596,8 +594,8 @@ func (p *PublicParams) GenerateCSPRangeProofParameters(bitLength uint64) error {
 	p.CSPRangeProofParams.RightGenerators = make([]*mathlib.G1, bitLength+1)
 
 	for i := range bitLength + 1 {
-		p.CSPRangeProofParams.LeftGenerators[i] = curve.HashToG1([]byte("CSPRangeProof." + strconv.FormatUint(2*(i+1), 10)))
-		p.CSPRangeProofParams.RightGenerators[i] = curve.HashToG1([]byte("CSPRangeProof." + strconv.FormatUint(2*(i+1)+1, 10)))
+		p.CSPRangeProofParams.LeftGenerators[i] = curve.HashToG1([]byte(domainPrefix + "CSPRangeProof.L." + strconv.FormatUint(i, 10)))
+		p.CSPRangeProofParams.RightGenerators[i] = curve.HashToG1([]byte(domainPrefix + "CSPRangeProof.R." + strconv.FormatUint(i, 10)))
 	}
 
 	return nil
@@ -730,13 +728,31 @@ func (p *PublicParams) Validate() error {
 			return errors.Wrap(err, "invalid public parameters")
 		}
 		if p.QuantityPrecision != p.CSPRangeProofParams.BitLength {
-			return errors.Errorf("invalid public parameters: quantity precision should be [%d] instead it is [%d]", p.RangeProofParams.BitLength, p.QuantityPrecision)
+			return errors.Errorf("invalid public parameters: quantity precision should be [%d] instead it is [%d]", p.CSPRangeProofParams.BitLength, p.QuantityPrecision)
 		}
 	}
 
 	maxToken := p.ComputeMaxTokenValue()
 	if maxToken != p.MaxToken {
 		return errors.Errorf("invalid max token, [%d]!=[%d]", maxToken, p.MaxToken)
+	}
+
+	return nil
+}
+
+// ValidateForDeployment checks configuration choices that are technically valid
+// but may indicate a misconfiguration. It does not change the behaviour of
+// Validate(); empty IssuerIDs remain permitted (open-policy mode).
+//
+// Returns a non-nil error if the public parameters appear to be in open-policy
+// mode (IssuerIDs is empty), so that callers can surface an explicit warning at
+// deployment time instead of silently operating in a mode where any identity
+// can mint or redeem tokens.
+//
+// See FA-1 in the security analysis for the rationale.
+func (p *PublicParams) ValidateForDeployment() error {
+	if len(p.IssuerIDs) == 0 {
+		return errors.New("open-policy mode: IssuerIDs is empty — any identity can issue and redeem tokens; populate IssuerIDs to restrict minting and redemption")
 	}
 
 	return nil
@@ -752,6 +768,21 @@ func (p *PublicParams) BitLength() uint64 {
 	}
 
 	return p.CSPRangeProofParams.BitLength
+}
+
+// SupportsRangeProofType reports whether the params sub-struct required by
+// proofType is populated. Both sub-structs may be present simultaneously (e.g.
+// during a range-proof-algorithm migration), so this is a per-type availability
+// check rather than a single-value getter.
+func (p *PublicParams) SupportsRangeProofType(proofType rp.ProofType) bool {
+	switch proofType {
+	case rp.RangeProofType:
+		return p.RangeProofParams != nil
+	case rp.CSPRangeProofType:
+		return p.CSPRangeProofParams != nil
+	default:
+		return false
+	}
 }
 
 func log2(x uint64) uint64 {

--- a/token/core/zkatdlog/nogh/v1/setup/setup_test.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup_test.go
@@ -546,18 +546,29 @@ func TestRangeProofParamsConversion(t *testing.T) {
 
 func TestGeneratePedersenParameters(t *testing.T) {
 	pp := &PublicParams{
-		Curve: math3.BN254,
+		Curve:         math3.BN254,
+		DriverName:    DLogNoGHDriverName,
+		DriverVersion: ProtocolV1,
 	}
 
 	err := pp.GeneratePedersenParameters()
 	require.NoError(t, err)
 	assert.Len(t, pp.PedersenGenerators, 3)
 
-	// Test all generators are different
+	// Generators must be distinct (different domain-separation strings → different points)
 	for i := range len(pp.PedersenGenerators) {
 		for j := i + 1; j < len(pp.PedersenGenerators); j++ {
 			assert.False(t, pp.PedersenGenerators[i].Equals(pp.PedersenGenerators[j]))
 		}
+	}
+
+	// Generators must be deterministic: a second call with identical params must
+	// produce byte-equal points, proving no randomness is involved.
+	pp2 := &PublicParams{Curve: math3.BN254, DriverName: DLogNoGHDriverName, DriverVersion: ProtocolV1}
+	require.NoError(t, pp2.GeneratePedersenParameters())
+	for i := range len(pp.PedersenGenerators) {
+		assert.True(t, pp.PedersenGenerators[i].Equals(pp2.PedersenGenerators[i]),
+			"generator %d must be deterministic (nothing-up-my-sleeve)", i)
 	}
 }
 
@@ -731,4 +742,219 @@ func TestExtras(t *testing.T) {
 	// Verify empty map case
 	pp.ExtraData = make(map[string][]byte)
 	assert.Empty(t, pp.Extras())
+}
+
+// TestCSPPublicParamsValidation exercises PublicParams.Validate for CSP-only
+// configurations (CSPRangeProofParams set, RangeProofParams nil).
+//
+// Regression: line 733 previously read p.RangeProofParams.BitLength inside the
+// `if p.CSPRangeProofParams != nil` branch; in a CSP-only config that is a
+// guaranteed nil-pointer dereference.  Every case below that reaches the
+// QuantityPrecision mismatch path must return an error, never panic.
+func TestCSPPublicParamsValidation(t *testing.T) {
+	issuerPK := testingHelper(t)
+
+	// cspPP builds a fully-valid CSP-only PublicParams for BN254 with the
+	// given bitLength, then lets the caller mutate it.
+	cspPP := func(t *testing.T, bitLength uint64) *PublicParams {
+		t.Helper()
+		pp, err := NewWith(SetupParams{
+			DriverName:     DLogNoGHDriverName,
+			DriverVersion:  ProtocolV1,
+			BitLength:      bitLength,
+			IdemixIssuerPK: issuerPK,
+			CurveID:        math3.BN254,
+			ProofType:      rp.CSPRangeProofType,
+		})
+		require.NoError(t, err)
+		require.Nil(t, pp.RangeProofParams, "CSP-only setup must leave RangeProofParams nil")
+		require.NotNil(t, pp.CSPRangeProofParams)
+
+		return pp
+	}
+
+	tests := []struct {
+		name          string
+		setupParams   func() *PublicParams
+		expectedError string
+	}{
+		{
+			// Baseline: a well-formed CSP-only config must pass Validate without
+			// panicking and without any error.
+			name: "valid CSP-only params",
+			setupParams: func() *PublicParams {
+				return cspPP(t, 32)
+			},
+			expectedError: "",
+		},
+		{
+			// Regression test for the nil-dereference bug (CVE-equivalent):
+			// CSPRangeProofParams set, RangeProofParams nil,
+			// QuantityPrecision deliberately mismatched to reach line 733.
+			// Must return an error string, never panic.
+			name: "CSP-only: QuantityPrecision mismatch must not panic (regression)",
+			setupParams: func() *PublicParams {
+				pp := cspPP(t, 32)
+				pp.QuantityPrecision = 16 // mismatch: CSPRangeProofParams.BitLength is 32
+
+				return pp
+			},
+			expectedError: "quantity precision should be [32] instead it is [16]",
+		},
+		{
+			// The error message must reference the CSP bit-length (32), not a
+			// value that would only be available from the nil RangeProofParams.
+			name: "CSP-only: error message references CSP bit length",
+			setupParams: func() *PublicParams {
+				pp := cspPP(t, 64)
+				pp.QuantityPrecision = 32 // mismatch; CSP bit-length is 64
+
+				return pp
+			},
+			expectedError: "quantity precision should be [64] instead it is [32]",
+		},
+		{
+			// CSPRangeProofParams.BitLength not in SupportedPrecisions triggers
+			// the earlier unsupported-precision guard, also inside the CSP branch.
+			name: "CSP-only: unsupported bit length",
+			setupParams: func() *PublicParams {
+				pp := cspPP(t, 32)
+				// Overwrite BitLength with a value not in SupportedPrecisions.
+				pp.CSPRangeProofParams.BitLength = 7
+
+				return pp
+			},
+			expectedError: "invalid bit length [7]",
+		},
+		{
+			// Both RangeProofParams and CSPRangeProofParams nil must be rejected
+			// before reaching either branch.
+			name: "both range proof params nil",
+			setupParams: func() *PublicParams {
+				pp := cspPP(t, 32)
+				pp.CSPRangeProofParams = nil
+
+				return pp
+			},
+			expectedError: "nil range proof parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pp := tt.setupParams()
+			// Call Validate via a helper that catches panics so a regression
+			// surfaces as a test failure rather than a process crash.
+			err := func() (retErr error) {
+				defer func() {
+					if r := recover(); r != nil {
+						retErr = fmt.Errorf("Validate panicked: %v", r)
+					}
+				}()
+
+				return pp.Validate()
+			}()
+
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
+}
+
+// TestCSPRangeProofParamsValidation exercises CSPRangeProofParams.Validate
+// directly, mirroring the coverage that TestRangeProofParamsValidation
+// provides for RangeProofParams.
+func TestCSPRangeProofParamsValidation(t *testing.T) {
+	curve := math3.BN254
+	curveInst := math3.Curves[curve]
+
+	makeGenerators := func(length uint64) []*math3.G1 {
+		gen := make([]*math3.G1, length)
+		for i := range gen {
+			gen[i] = curveInst.GenG1
+		}
+
+		return gen
+	}
+
+	const bitLength uint64 = 32
+
+	tests := []struct {
+		name          string
+		params        *CSPRangeProofParams
+		expectedError string
+	}{
+		{
+			name: "valid params",
+			params: &CSPRangeProofParams{
+				BitLength:       bitLength,
+				LeftGenerators:  makeGenerators(bitLength + 1),
+				RightGenerators: makeGenerators(bitLength + 1),
+			},
+			expectedError: "",
+		},
+		{
+			name: "zero bit length",
+			params: &CSPRangeProofParams{
+				BitLength:       0,
+				LeftGenerators:  makeGenerators(1),
+				RightGenerators: makeGenerators(1),
+			},
+			expectedError: "invalid range proof parameters: bit length is zero",
+		},
+		{
+			name: "mismatched generator lengths",
+			params: &CSPRangeProofParams{
+				BitLength:       bitLength,
+				LeftGenerators:  makeGenerators(bitLength),
+				RightGenerators: makeGenerators(bitLength + 1),
+			},
+			expectedError: "the size of the left generators does not match the size of the right generators",
+		},
+		{
+			name: "wrong number of left generators",
+			params: &CSPRangeProofParams{
+				BitLength:       bitLength,
+				LeftGenerators:  makeGenerators(bitLength), // needs bitLength+1
+				RightGenerators: makeGenerators(bitLength),
+			},
+			expectedError: "invalid range proof parameters, left generators is invalid",
+		},
+		{
+			// Both slices have the same length so the size-mismatch check passes,
+			// but RightGenerators has bitLength entries (one short) — which causes
+			// the CheckElements call for the right generators to fail.
+			name: "wrong number of right generators",
+			params: &CSPRangeProofParams{
+				BitLength: bitLength,
+				// Left has the correct bitLength+1 entries.
+				LeftGenerators: makeGenerators(bitLength + 1),
+				// Right also has bitLength+1 entries, but the last one is nil so
+				// the curve element check rejects it.
+				RightGenerators: func() []*math3.G1 {
+					gen := makeGenerators(bitLength + 1)
+					gen[bitLength] = nil // inject an invalid element
+
+					return gen
+				}(),
+			},
+			expectedError: "invalid range proof parameters, right generators is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.params.Validate(curve)
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			}
+		})
+	}
 }

--- a/token/core/zkatdlog/nogh/v1/transfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer.go
@@ -314,12 +314,17 @@ func (s *TransferService) VerifyTransfer(ctx context.Context, transferAction dri
 		s.Logger.DebugfContext(ctx, "transfer output [%s,%s,%s]", tok.Type, tok.Quantity, driver.Identity(tok.Owner))
 	}
 
-	return transfer.NewVerifier(
+	verifier, err := transfer.NewVerifier(
 		getTokenData(action.InputTokens()),
 		com,
 		pp,
 		action.ProofType,
-	).Verify(action.Proof)
+	)
+	if err != nil {
+		return err
+	}
+
+	return verifier.Verify(action.Proof)
 }
 
 // DeserializeTransferAction un-marshals a TransferAction from the passed array of bytes.

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -266,6 +266,9 @@ func (t *Action) IsRedeemAt(index int) bool {
 	if index < 0 || index >= len(t.Outputs) {
 		return false
 	}
+	if t.Outputs[index] == nil {
+		return false
+	}
 
 	return t.Outputs[index].IsRedeem()
 }
@@ -472,8 +475,11 @@ func (t *Action) Deserialize(raw []byte) error {
 	// outputs
 	t.Outputs = make([]*token.Token, len(action.Outputs))
 	for j, output := range action.Outputs {
-		if output == nil || output.Token == nil {
+		if output == nil {
 			return errors.Errorf("invalid transfer action: output at index [%d] is nil", j)
+		}
+		if output.Token == nil {
+			return errors.Errorf("invalid transfer action: token of output at index [%d] is nil", j)
 		}
 		data, err := utils.FromG1Proto(output.Token.Data)
 		if err != nil {

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -191,20 +191,29 @@ func (t *Action) NumInputs() int {
 	return len(t.Inputs)
 }
 
-// GetInputs returns the identifiers of the tokens spent in the Action
+// GetInputs returns the identifiers of the tokens spent in the Action.
+// A nil ActionInput entry produces a nil *token2.ID at the corresponding index,
+// which is consistent with the slice-length contract used by callers.
 func (t *Action) GetInputs() []*token2.ID {
 	res := make([]*token2.ID, len(t.Inputs))
 	for i, input := range t.Inputs {
+		if input == nil {
+			res[i] = nil
+
+			continue
+		}
 		res[i] = input.ID
 	}
 
 	return res
 }
 
-// GetSerializedInputs returns the serialized tokens spent in the Action
+// GetSerializedInputs returns the serialized tokens spent in the Action.
+// Returns an error instead of panicking when an input's Token field is nil
+// (which Validate() guards against, but some code paths skip Validate).
 func (t *Action) GetSerializedInputs() ([][]byte, error) {
 	var res [][]byte
-	for _, input := range t.Inputs {
+	for i, input := range t.Inputs {
 		if input == nil {
 			res = append(res, nil)
 
@@ -218,6 +227,9 @@ func (t *Action) GetSerializedInputs() ([][]byte, error) {
 			res = append(res, ser)
 
 			continue
+		}
+		if input.Token == nil {
+			return nil, errors.Errorf("nil token in input at index [%d]", i)
 		}
 		r, err := input.Token.Serialize()
 		if err != nil {
@@ -251,6 +263,10 @@ func (t *Action) GetOutputs() []driver.Output {
 
 // IsRedeemAt checks if output in the Action at the passed index is redeemed
 func (t *Action) IsRedeemAt(index int) bool {
+	if index < 0 || index >= len(t.Outputs) {
+		return false
+	}
+
 	return t.Outputs[index].IsRedeem()
 }
 
@@ -265,8 +281,17 @@ func (t *Action) IsRedeem() bool {
 	return false
 }
 
-// SerializeOutputAt marshals the output in the Action at the passed index
+// SerializeOutputAt marshals the output in the Action at the passed index.
+// Returns an error when index is out of bounds or the output entry is nil
+// instead of panicking.
 func (t *Action) SerializeOutputAt(index int) ([]byte, error) {
+	if index < 0 || index >= len(t.Outputs) {
+		return nil, errors.Errorf("SerializeOutputAt: index [%d] out of bounds (len=%d)", index, len(t.Outputs))
+	}
+	if t.Outputs[index] == nil {
+		return nil, errors.Errorf("SerializeOutputAt: nil output at index [%d]", index)
+	}
+
 	return t.Outputs[index].Serialize()
 }
 
@@ -275,6 +300,9 @@ func (t *Action) GetSerializedOutputs() ([][]byte, error) {
 	res := make([][]byte, len(t.Outputs))
 	var err error
 	for i, token := range t.Outputs {
+		if token == nil {
+			return nil, errors.Errorf("nil output entry at index %d", i)
+		}
 		res[i], err = token.Serialize()
 		if err != nil {
 			return nil, err
@@ -445,7 +473,7 @@ func (t *Action) Deserialize(raw []byte) error {
 	t.Outputs = make([]*token.Token, len(action.Outputs))
 	for j, output := range action.Outputs {
 		if output == nil || output.Token == nil {
-			continue
+			return errors.Errorf("invalid transfer action: output at index [%d] is nil", j)
 		}
 		data, err := utils.FromG1Proto(output.Token.Data)
 		if err != nil {
@@ -485,11 +513,16 @@ func (t *Action) GetProof() []byte {
 	return t.Proof
 }
 
-// GetOutputCommitments returns the cryptographic commitments of the outputs
+// GetOutputCommitments returns the cryptographic commitments of the outputs.
+// It skips nil output entries defensively; callers (validators) ensure all outputs
+// are non-nil via Action.Validate() before this method is reached.
 func (t *Action) GetOutputCommitments() []*math.G1 {
-	com := make([]*math.G1, len(t.Outputs))
-	for i := range com {
-		com[i] = t.Outputs[i].Data
+	com := make([]*math.G1, 0, len(t.Outputs))
+	for _, out := range t.Outputs {
+		if out == nil {
+			continue
+		}
+		com = append(com, out.Data)
 	}
 
 	return com

--- a/token/core/zkatdlog/nogh/v1/transfer/action_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action_test.go
@@ -729,9 +729,10 @@ func TestAction_Deserialize_ErrorPaths(t *testing.T) {
 }
 
 func TestAction_Deserialize_ExtraBranches(t *testing.T) {
-	// A nil output element is now rejected during deserialization (security fix FA3):
-	// before the fix, nil outputs were silently left as nil in t.Outputs, creating
-	// an inconsistent struct that could cause nil-pointer panics further down the pipeline.
+	// A nil output element is now rejected during deserialization.
+	// This is the FA3 (False Acceptance #3) attack vector; see
+	// TestSecurityFalseAcceptanceTransferDeserializeNilOutput in
+	// validator/validator_security_test.go for the full threat description.
 	protoNilOutput := &actions.TransferAction{
 		Version: 1, // ProtocolV1
 		Outputs: []*actions.TransferActionOutput{
@@ -757,7 +758,7 @@ func TestAction_Deserialize_ExtraBranches(t *testing.T) {
 	action = &transfer.Action{}
 	err = action.Deserialize(raw)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "output at index [0] is nil")
+	assert.Contains(t, err.Error(), "token of output at index [0] is nil")
 }
 
 func TestAction_SerializeOutputAt(t *testing.T) {

--- a/token/core/zkatdlog/nogh/v1/transfer/action_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action_test.go
@@ -729,24 +729,35 @@ func TestAction_Deserialize_ErrorPaths(t *testing.T) {
 }
 
 func TestAction_Deserialize_ExtraBranches(t *testing.T) {
-	// Test with nil output and nil output.Token
-	protoAction := &actions.TransferAction{
+	// A nil output element is now rejected during deserialization (security fix FA3):
+	// before the fix, nil outputs were silently left as nil in t.Outputs, creating
+	// an inconsistent struct that could cause nil-pointer panics further down the pipeline.
+	protoNilOutput := &actions.TransferAction{
 		Version: 1, // ProtocolV1
 		Outputs: []*actions.TransferActionOutput{
 			nil,
-			{
-				Token: nil,
-			},
 		},
 	}
-	raw, err := proto.Marshal(protoAction)
+	raw, err := proto.Marshal(protoNilOutput)
 	require.NoError(t, err)
 	action := &transfer.Action{}
 	err = action.Deserialize(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "output at index [0] is nil")
+
+	// A non-nil output entry with a nil Token field is also rejected.
+	protoNilToken := &actions.TransferAction{
+		Version: 1, // ProtocolV1
+		Outputs: []*actions.TransferActionOutput{
+			{Token: nil},
+		},
+	}
+	raw, err = proto.Marshal(protoNilToken)
 	require.NoError(t, err)
-	assert.Len(t, action.Outputs, 2)
-	assert.Nil(t, action.Outputs[0])
-	assert.Nil(t, action.Outputs[1])
+	action = &transfer.Action{}
+	err = action.Deserialize(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "output at index [0] is nil")
 }
 
 func TestAction_SerializeOutputAt(t *testing.T) {
@@ -803,7 +814,8 @@ func TestAction_GetSerializedInputs(t *testing.T) {
 	assert.Nil(t, res[1])
 	assert.NotNil(t, res[2])
 
-	// case 2: Token is nil (panic path if not handled)
+	// case 2: Token is nil — hardened: GetSerializedInputs now returns an error
+	// instead of panicking (security fix P6: nil Token dereference).
 	actionErr := &transfer.Action{
 		Inputs: []*transfer.ActionInput{
 			{
@@ -812,10 +824,14 @@ func TestAction_GetSerializedInputs(t *testing.T) {
 			},
 		},
 	}
-	// Action.GetSerializedInputs will panic if Token is nil because it calls Token.Serialize()
-	assert.Panics(t, func() {
-		_, _ = actionErr.GetSerializedInputs()
+	// GetSerializedInputs must return an error, not panic.
+	require.NotPanics(t, func() {
+		_, err = actionErr.GetSerializedInputs()
 	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil token in input at index [0]")
+
+	// Validate() also catches this via ErrEmptyInputToken.
 	err = actionErr.Validate()
 	require.Error(t, err)
 	require.ErrorIs(t, err, transfer.ErrEmptyInputToken)

--- a/token/core/zkatdlog/nogh/v1/transfer/bftransfer_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/bftransfer_test.go
@@ -245,7 +245,10 @@ func prepareZKTransferWithProofType(proofType rp.ProofType) (transfer.Prover, tr
 	if err != nil {
 		return nil, nil, err
 	}
-	verifier := transfer.NewVerifier(in, out, pp, proofType)
+	verifier, err := transfer.NewVerifier(in, out, pp, proofType)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return prover, verifier, nil
 }
@@ -265,7 +268,10 @@ func prepareZKTransferWithWrongSumAndProofType(proofType rp.ProofType) (transfer
 	if err != nil {
 		return nil, nil, err
 	}
-	verifier := transfer.NewVerifier(in, out, pp, proofType)
+	verifier, err := transfer.NewVerifier(in, out, pp, proofType)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return prover, verifier, nil
 }
@@ -285,7 +291,10 @@ func prepareZKTransferWithInvalidRangeAndProofType(proofType rp.ProofType) (tran
 	if err != nil {
 		return nil, nil, err
 	}
-	verifier := transfer.NewVerifier(in, out, pp, proofType)
+	verifier, err := transfer.NewVerifier(in, out, pp, proofType)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return prover, verifier, nil
 }
@@ -455,4 +464,103 @@ func newBenchmarkTransferEnvWithProofType(n int, benchmarkCase *benchmark2.Case,
 	}
 
 	return &benchmarkTransferEnv{ProverEnvs: entries, pp: pp}, nil
+}
+
+// TestBulletProofVerifier_1to1WithAttachedRangeProof is T-GAP-C1: verifies that
+// a 1-input/1-output transfer (ownership transfer) that has a non-nil
+// RangeCorrectness field attached is still accepted.
+//
+// The BulletProofVerifier skips range-proof verification when len(inputs) == 1
+// and len(outputs) == 1. A proof carrying a RangeCorrectness payload (e.g.,
+// produced by a prover with different skip logic) must be silently ignored by
+// the verifier and must not cause a failure.
+func TestBulletProofVerifier_1to1WithAttachedRangeProof(t *testing.T) {
+	pp, err := setupWithProofType(TestBits, TestCurve, rp.RangeProofType)
+	require.NoError(t, err)
+
+	// Build a 1-to-1 transfer: prover and verifier both use 1 input / 1 output.
+	intw, outtw, in, out, err := prepareInputsForZKTransfer(pp, 1, 1)
+	require.NoError(t, err)
+
+	prover, err := transfer.NewProver(intw, outtw, in, out, pp)
+	require.NoError(t, err)
+	proofRaw, err := prover.Prove()
+	require.NoError(t, err)
+
+	// Deserialize the proof and manually attach a non-nil (but empty)
+	// RangeCorrectness field to simulate a prover that always generates one.
+	// An empty-but-non-nil RangeCorrectness is sufficient to show the verifier
+	// ignores it for 1-to-1 transfers.
+	proof := &transfer.Proof{}
+	require.NoError(t, proof.Deserialize(proofRaw))
+
+	// Attach a non-nil but empty range correctness structure.
+	proof.RangeCorrectness = &bulletproof.RangeCorrectness{
+		Proofs: []*bulletproof.RangeProof{},
+	}
+	tamperedRaw, err := proof.Serialize()
+	require.NoError(t, err)
+
+	// The verifier must accept the proof: for 1-to-1 transfers RangeCorrectness
+	// is ignored entirely, so an incorrect (or even random) payload causes no failure.
+	verifier := transfer.NewBulletProofVerifier(in, out, pp)
+	err = verifier.Verify(tamperedRaw)
+	require.NoError(t, err, "T-GAP-C1: 1-to-1 transfer with attached range proof must still be accepted")
+}
+
+// TestNewVerifier_ProofTypeUnavailable is T-SEC-1: verifies that NewVerifier returns
+// ErrProofTypeMismatch when the action's ProofType refers to a range-proof algorithm
+// whose params sub-struct is not populated in PublicParams, preventing an attacker
+// from selecting a verifier whose params sub-struct is nil (algorithm confusion /
+// nil-deref).
+//
+// Scenario A: only BulletProof params populated, action claims CSP  → error.
+// Scenario B: only CSP params populated, action claims BulletProof  → error.
+// Scenario C: both params populated (migration), each type is accepted → no error.
+func TestNewVerifier_ProofTypeUnavailable(t *testing.T) {
+	pp, err := setupWithProofType(TestBits, TestCurve, rp.RangeProofType)
+	require.NoError(t, err)
+
+	_, _, in, out, err := prepareInputsForZKTransfer(pp, 2, 2)
+	require.NoError(t, err)
+
+	t.Run("BulletProofPP_CSPActionType", func(t *testing.T) {
+		pp, err := setupWithProofType(TestBits, TestCurve, rp.RangeProofType)
+		require.NoError(t, err)
+
+		_, err = transfer.NewVerifier(in, out, pp, rp.CSPRangeProofType)
+		require.ErrorIs(t, err, transfer.ErrProofTypeMismatch,
+			"T-SEC-1A: CSP proof type against BulletProof-only pp must return ErrProofTypeMismatch")
+	})
+
+	t.Run("CSPParamsPP_BulletProofActionType", func(t *testing.T) {
+		pp, err := setupWithProofType(TestBits, TestCurve, rp.CSPRangeProofType)
+		require.NoError(t, err)
+
+		_, err = transfer.NewVerifier(in, out, pp, rp.RangeProofType)
+		require.ErrorIs(t, err, transfer.ErrProofTypeMismatch,
+			"T-SEC-1B: BulletProof proof type against CSP-only pp must return ErrProofTypeMismatch")
+	})
+
+	t.Run("BothParamsPP_BulletProofActionType", func(t *testing.T) {
+		// Simulate a migration: both sub-structs are populated.
+		pp, err := setupWithProofType(TestBits, TestCurve, rp.RangeProofType)
+		require.NoError(t, err)
+		require.NoError(t, pp.GenerateCSPRangeProofParameters(TestBits))
+
+		_, err = transfer.NewVerifier(in, out, pp, rp.RangeProofType)
+		require.NoError(t, err,
+			"T-SEC-1C: BulletProof proof type against dual pp must be accepted")
+	})
+
+	t.Run("BothParamsPP_CSPActionType", func(t *testing.T) {
+		// Simulate a migration: both sub-structs are populated.
+		pp, err := setupWithProofType(TestBits, TestCurve, rp.RangeProofType)
+		require.NoError(t, err)
+		require.NoError(t, pp.GenerateCSPRangeProofParameters(TestBits))
+
+		_, err = transfer.NewVerifier(in, out, pp, rp.CSPRangeProofType)
+		require.NoError(t, err,
+			"T-SEC-1D: CSP proof type against dual pp must be accepted")
+	})
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/errors.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/errors.go
@@ -65,6 +65,10 @@ var (
 	ErrInvalidInputValues = errors.New("InputValues are invalid")
 	// ErrInvalidProofType is returned when a proof type is invalid
 	ErrInvalidProofType = errors.New("Type is invalid")
+	// ErrProofTypeMismatch is returned when the proof type in the action refers to a range-proof
+	// algorithm whose params sub-struct is not populated in PublicParams. This prevents an attacker
+	// from selecting a verifier whose params sub-struct is nil (nil-deref / algorithm confusion).
+	ErrProofTypeMismatch = errors.New("proof type in action is not available in public parameters")
 	// ErrInvalidTypeBlindingFactor is returned when a type blinding factor is invalid
 	ErrInvalidTypeBlindingFactor = errors.New("TypeBlindingFactor is invalid")
 	// ErrInvalidEqualityOfSum is returned when equality of sum is invalid

--- a/token/core/zkatdlog/nogh/v1/transfer/sender_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/sender_test.go
@@ -216,12 +216,17 @@ func BenchmarkVerificationSenderProof(b *testing.B) {
 			}
 
 			// instantiate the verifier and verify
-			return transfer.NewVerifier(
+			verifier, err := transfer.NewVerifier(
 				inputTokens,
 				ta.GetOutputCommitments(),
 				env.SenderEnvs[0].sender.PublicParams,
 				ta.ProofType,
-			).Verify(ta.GetProof())
+			)
+			if err != nil {
+				return err
+			}
+
+			return verifier.Verify(ta.GetProof())
 		},
 	)
 }
@@ -250,12 +255,17 @@ func BenchmarkVerificationParallelSenderProof(b *testing.B) {
 			}
 
 			// instantiate the verifier and verify
-			return transfer.NewVerifier(
+			verifier, err := transfer.NewVerifier(
 				inputTokens,
 				ta.GetOutputCommitments(),
 				env.SenderEnvs[0].sender.PublicParams,
 				ta.ProofType,
-			).Verify(ta.GetProof())
+			)
+			if err != nil {
+				return err
+			}
+
+			return verifier.Verify(ta.GetProof())
 		},
 	)
 }
@@ -284,12 +294,17 @@ func TestParallelBenchmarkVerificationSenderProof(t *testing.T) {
 			}
 
 			// instantiate the verifier and verify
-			return transfer.NewVerifier(
+			verifier, err := transfer.NewVerifier(
 				inputTokens,
 				ta.GetOutputCommitments(),
 				env.SenderEnvs[0].sender.PublicParams,
 				ta.ProofType,
-			).Verify(ta.GetProof())
+			)
+			if err != nil {
+				return err
+			}
+
+			return verifier.Verify(ta.GetProof())
 		},
 	)
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/transfer.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/transfer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
 
 type Prover interface {
@@ -31,10 +32,20 @@ type Verifier interface {
 	Verify(proofRaw []byte) error
 }
 
-func NewVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams, proofType rp.ProofType) Verifier {
-	if proofType == rp.RangeProofType {
-		return NewBulletProofVerifier(inputs, outputs, pp)
+// NewVerifier returns a Verifier for the given proofType.
+// It returns ErrProofTypeMismatch if the params sub-struct required by proofType
+// is not populated in pp, preventing an attacker from selecting a verifier whose
+// params sub-struct is nil. Both proof systems may coexist in pp (e.g. during a
+// range-proof migration), so each is checked independently.
+func NewVerifier(inputs, outputs []*math.G1, pp *v1.PublicParams, proofType rp.ProofType) (Verifier, error) {
+	if !pp.SupportsRangeProofType(proofType) {
+		return nil, errors.Errorf("%w: proof type %d is not available in public parameters",
+			ErrProofTypeMismatch, proofType)
 	}
 
-	return NewCSPVerifier(inputs, outputs, pp)
+	if proofType == rp.RangeProofType {
+		return NewBulletProofVerifier(inputs, outputs, pp), nil
+	}
+
+	return NewCSPVerifier(inputs, outputs, pp), nil
 }

--- a/token/core/zkatdlog/nogh/v1/transfer/typeandsum.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/typeandsum.go
@@ -105,7 +105,7 @@ func (p *TypeAndSumProof) Validate(curveID math.CurveID) error {
 	if err := math2.CheckElement(p.CommitmentToType, curveID); err != nil {
 		return errors.Join(err, ErrInvalidCommitmentToType, ErrInvalidSumAndTypeProof)
 	}
-	if err := math2.CheckZrElements(p.InputBlindingFactors, curveID, uint64(len(p.InputBlindingFactors))); err != nil {
+	if err := math2.CheckZrElements(p.InputBlindingFactors, curveID, uint64(len(p.InputValues))); err != nil {
 		return errors.Join(err, ErrInvalidInputBlindingFactors, ErrInvalidSumAndTypeProof)
 	}
 	if err := math2.CheckZrElements(p.InputValues, curveID, uint64(len(p.InputValues))); err != nil {
@@ -331,6 +331,9 @@ func NewTypeAndSumVerifier(pp []*math.G1, inputs []*math.G1, outputs []*math.G1,
 // Verify checks the validity of a TypeAndSumProof.
 func (v *TypeAndSumVerifier) Verify(stp *TypeAndSumProof) error {
 	if stp.TypeBlindingFactor == nil || stp.Type == nil || stp.CommitmentToType == nil || stp.EqualityOfSum == nil {
+		return ErrMissingSumAndTypeComponents
+	}
+	if len(stp.InputBlindingFactors) != len(v.Inputs) {
 		return ErrMissingSumAndTypeComponents
 	}
 

--- a/token/core/zkatdlog/nogh/v1/transfer/typeandsum_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/typeandsum_test.go
@@ -299,3 +299,54 @@ func prepareToken(value *math.Zr, rand *math.Zr, ttype string, pp []*math.G1, c 
 
 	return token
 }
+
+// TestTypeAndSumVerify_ShortInputBlindingFactors is T-GAP-C4: verifies that
+// TypeAndSumProof.Validate() (and the pre-loop guard in Verify) catches
+// a proof whose InputBlindingFactors slice is shorter than InputValues,
+// returning a clean error instead of an index-out-of-bounds panic.
+//
+// Before the Phase 0 fix, Validate() used len(p.InputBlindingFactors) as the
+// expected length, so a short slice always passed. The verifier loop then
+// accessed stp.InputBlindingFactors[i] beyond the slice bounds and panicked.
+func TestTypeAndSumVerify_ShortInputBlindingFactors(t *testing.T) {
+	c := math.Curves[TestCurve]
+
+	// Build a proof with 2 InputValues but only 1 InputBlindingFactor.
+	proof := &transfer.TypeAndSumProof{
+		CommitmentToType:     c.GenG1.Copy(),
+		InputBlindingFactors: []*math.Zr{c.NewZrFromInt(1)},                    // only 1
+		InputValues:          []*math.Zr{c.NewZrFromInt(2), c.NewZrFromInt(3)}, // 2
+		Type:                 c.NewZrFromInt(4),
+		TypeBlindingFactor:   c.NewZrFromInt(5),
+		EqualityOfSum:        c.NewZrFromInt(6),
+		Challenge:            c.NewZrFromInt(7),
+	}
+
+	// Validate() must return an error — the fix changes the expected length to
+	// len(p.InputValues) so the mismatch (1 != 2) is caught here.
+	err := proof.Validate(TestCurve)
+	require.Error(t, err, "T-GAP-C4: short InputBlindingFactors must fail Validate()")
+	require.ErrorIs(t, err, transfer.ErrInvalidInputBlindingFactors)
+
+	// Also verify that the defence-in-depth guard in TypeAndSumVerifier.Verify
+	// returns an error (not a panic) when the short proof slips through Validate
+	// on an older build. To test this path we call Verify directly with a proof
+	// that has a valid-looking CommitmentToType so Validate would otherwise pass,
+	// but the verifier's input count is larger.
+	pp := preparePedersenParameters(t, c)
+	in := make([]*math.G1, 2) // verifier expects 2 inputs
+	out := make([]*math.G1, 1)
+	for i := range 2 {
+		in[i] = c.GenG1.Copy()
+	}
+	out[0] = c.GenG1.Copy()
+
+	verifier := transfer.NewTypeAndSumVerifier(pp, in, out, c)
+
+	// Proof has only 1 InputBlindingFactor; verifier expects 2.
+	require.NotPanics(t, func() {
+		err = verifier.Verify(proof)
+	}, "T-GAP-C4: Verify must not panic on short InputBlindingFactors")
+	require.Error(t, err, "T-GAP-C4: Verify must return an error for short InputBlindingFactors")
+	require.ErrorIs(t, err, transfer.ErrMissingSumAndTypeComponents)
+}

--- a/token/core/zkatdlog/nogh/v1/validator/validator_extra_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_extra_test.go
@@ -272,6 +272,16 @@ func TestTransferUpgradeWitnessValidateErrors(t *testing.T) {
 	err = validator.TransferUpgradeWitnessValidate(context.Background(), ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "owners do not correspond")
+
+	// T-GAP-5: quantity that overflows uint64 boundary must be rejected cleanly (not panic).
+	// "0x10000000000000000" is 2^64, which exceeds the uint64 maximum.
+	action.Inputs[0].UpgradeWitness.FabToken.Quantity = "0x10000000000000000"
+	require.NotPanics(t, func() {
+		err = validator.TransferUpgradeWitnessValidate(context.Background(), ctx)
+	}, "T-GAP-5: overflow quantity must not panic")
+	require.Error(t, err, "T-GAP-5: overflow quantity must be rejected")
+	// token2.ToQuantity returns an error for quantities that exceed the precision;
+	// the exact message may vary so we only assert an error is returned.
 }
 
 func TestTransferZKProofValidateErrors(t *testing.T) {
@@ -431,6 +441,28 @@ func TestTransferHTLCValidateErrors(t *testing.T) {
 	ctx.TransferAction.Outputs = []*token.Token{{Owner: invalidJSONID}}
 	err = validator.TransferHTLCValidate(context.Background(), ctx)
 	require.Error(t, err)
+
+	// T-GAP-7: expired HTLC deadline — claim attempted after expiry must be rejected.
+	// Script has an expired deadline, so VerifyOwner returns Reclaim.
+	// The output owner is the recipient (not sender), so the owner check fails.
+	ctx = newCtx()
+	expiredScript := &htlc.Script{
+		Sender:    validSenderID,
+		Recipient: validRecipientID,
+		Deadline:  time.Now().Add(-100 * time.Hour), // expired
+		HashInfo: htlc.HashInfo{
+			Hash:         []byte("hash"),
+			HashFunc:     crypto.SHA256,
+			HashEncoding: encoding.Hex,
+		},
+	}
+	expiredScriptBytes, _ := json.Marshal(expiredScript)
+	expiredLockID, _ := identity.WrapWithType(htlc.ScriptType, expiredScriptBytes)
+	ctx.InputTokens[0].Owner = expiredLockID
+	// Output owner is the recipient — only valid for a claim, not a reclaim.
+	ctx.TransferAction.Outputs = []*token.Token{{Owner: validRecipientID, Data: &math.G1{}}}
+	err = validator.TransferHTLCValidate(context.Background(), ctx)
+	require.Error(t, err, "T-GAP-7: claim attempt after expiry must be rejected")
 }
 
 func TestDeserializeActionsErrors(t *testing.T) {

--- a/token/core/zkatdlog/nogh/v1/validator/validator_issue.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_issue.go
@@ -19,6 +19,12 @@ var logger = logging.MustGetLogger()
 
 // IssueValidate validates the issue action by checking its structure, verifying the zero-knowledge proof,
 // and ensuring the issuer is authorized and has signed the action.
+//
+// Open-policy issuer behaviour: when PP.IssuerIDs is empty (len(ctx.PP.Issuers()) == 0),
+// the issuer authorization check is skipped and any identity may issue tokens.
+// This is an intentional open-policy design for deployments that do not restrict issuance
+// to a fixed set of identities. When issuer restriction is required, populate PP.IssuerIDs
+// with the authorized issuer identities before deploying the public parameters.
 func IssueValidate(c context.Context, ctx *Context) error {
 	action := ctx.IssueAction
 
@@ -31,9 +37,11 @@ func IssueValidate(c context.Context, ctx *Context) error {
 		return ErrIssueVerificationFailed
 	}
 	// Verify the zero-knowledge proof that the commitments are well-formed
-	if err := issue.NewVerifier(
-		commitments,
-		ctx.PP).Verify(action.GetProof()); err != nil {
+	zkVerifier, err := issue.NewVerifier(commitments, ctx.PP, action.ProofType)
+	if err != nil {
+		return errors.Join(err, ErrInvalidZKP)
+	}
+	if err := zkVerifier.Verify(action.GetProof()); err != nil {
 		return errors.Join(err, ErrInvalidZKP)
 	}
 

--- a/token/core/zkatdlog/nogh/v1/validator/validator_security_extra_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_security_extra_test.go
@@ -1,0 +1,601 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This file contains security-focused tests added as part of the second round
+// of hardening, addressing the open action items from the security analysis
+// (zkatdlog-validator-security-hacker-analysis.html), Steps A–H.
+package validator_test
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	math "github.com/IBM/mathlib"
+	fv1 "github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
+	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/transfer"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/validator"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/x509"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/encoding"
+	"github.com/LFDT-Panurus/panurus/token/services/interop/htlc"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ===========================================================================
+// STEP A — Backend cursor: mixed issue+transfer with extra auditor signature
+// ===========================================================================
+
+// TestSecurityCursorMixedIssueTransferExtraAuditorSig verifies that a request
+// containing 1 issue action + 1 transfer action where an extra auditor signature
+// is injected before the real one is rejected without panicking (C-1 / Step A).
+//
+// The Backend cursor is initialized with auditor sigs first, then action sigs.
+// Injecting an extra auditor signature advances the cursor by one extra position
+// before the action validators run, shifting all subsequent signature reads.
+// The request must be rejected — not panicked — regardless of the shift.
+func TestSecurityCursorMixedIssueTransferExtraAuditorSig(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Build a mixed request: the existing issue action + the existing transfer action.
+	mixedReq := &driver.TokenRequest{}
+	mixedReq.Actions = append(mixedReq.Actions, env.TRWithIssue.Actions...)
+	mixedReq.Actions = append(mixedReq.Actions, env.TRWithTransfer.Actions...)
+
+	// Collect all existing signatures from both requests.
+	mixedReq.Signatures = append(mixedReq.Signatures, env.TRWithIssue.Signatures...)
+	mixedReq.Signatures = append(mixedReq.Signatures, env.TRWithTransfer.Signatures...)
+
+	// Inject an extra auditor-like signature at the very front of the list.
+	// It uses a recognized auditor identity (from the real auditor sig) but
+	// carries forged bytes that will fail cryptographic verification.
+	var existingAuditorSig *driver.RequestSignature
+	for _, sig := range mixedReq.Signatures {
+		if sig != nil && sig.Auditor != nil {
+			existingAuditorSig = sig
+
+			break
+		}
+	}
+	require.NotNil(t, existingAuditorSig, "env must produce at least one auditor signature")
+
+	extraAuditorSig := &driver.RequestSignature{
+		Auditor: &driver.AuditorSignature{
+			Identity:  existingAuditorSig.Auditor.Identity,
+			Signature: []byte("extra-forged-auditor-sig"),
+		},
+	}
+	// Prepend: auditor sigs come first in the signature slice.
+	mixedReq.Signatures = append([]*driver.RequestSignature{extraAuditorSig}, mixedReq.Signatures...)
+
+	raw, err := mixedReq.Bytes()
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	}, "Step A: extra auditor sig in mixed issue+transfer request must not panic")
+	require.Error(t, err, "Step A: extra auditor sig must cause a validation error")
+}
+
+// ===========================================================================
+// STEP B — Nil owners in upgrade witness (FR-2)
+// ===========================================================================
+
+// TestTransferUpgradeWitnessNilOwners verifies that TransferUpgradeWitnessValidate
+// rejects a witness where both input.Token.Owner and witness.FabToken.Owner are nil.
+//
+// Without the explicit len==0 guard, bytes.Equal(nil, nil) returns true, which
+// would allow a free-claim of an ownerless fabtoken via upgrade.
+func TestTransferUpgradeWitnessNilOwners(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	curve := math.Curves[pp.Curve]
+	rand, _ := curve.Rand()
+	bf := curve.NewRandomZr(rand)
+
+	fabToken := &fv1.Output{
+		Owner:    nil, // deliberately nil
+		Type:     "ABC",
+		Quantity: "0x10",
+	}
+
+	// Compute a valid commitment so we get past the commitment-equality check.
+	toks, _, err := token.GetTokensWithWitnessAndBF(
+		[]uint64{16}, []*math.Zr{bf}, "ABC", pp.PedersenGenerators, curve,
+	)
+	require.NoError(t, err)
+
+	ctx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		TransferAction: &transfer.Action{
+			Inputs: []*transfer.ActionInput{
+				{
+					Token: &token.Token{
+						Owner: nil, // deliberately nil
+						Data:  toks[0],
+					},
+					UpgradeWitness: &token.UpgradeWitness{
+						FabToken:       fabToken,
+						BlindingFactor: bf,
+					},
+				},
+			},
+		},
+		MetadataCounter: make(map[string]int),
+	}
+
+	require.NotPanics(t, func() {
+		err = validator.TransferUpgradeWitnessValidate(context.Background(), ctx)
+	}, "Step B: nil owners must not panic in TransferUpgradeWitnessValidate")
+	require.Error(t, err, "Step B: nil owners must be rejected")
+	assert.Contains(t, err.Error(), "owners do not correspond",
+		"Step B: error must identify the owner mismatch")
+}
+
+// ===========================================================================
+// STEP C — HTLC combination attacks (C-2, C-3, FA-5)
+// ===========================================================================
+
+// TestSecurityHTLC_DualLockOutputMetadataCollision verifies that a transfer
+// with two HTLC lock outputs sharing the same hash (and therefore the same
+// LockKey) is rejected due to metadata key collision (C-2).
+//
+// The HTLC metadata counter detects duplicate counting of the same key.
+// This test exercises the counter behavior directly via CountMetadataKey,
+// confirming the duplicate-detection mechanism that drives the
+// "appeared more than one time" rejection at the common.Validator level.
+func TestSecurityHTLC_DualLockOutputMetadataCollision(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	const dupKey = "htlc.lock.dup-hash"
+
+	ctx := &validator.Context{
+		Logger:          logging.MustGetLogger(),
+		PP:              pp,
+		InputTokens:     []*token.Token{},
+		TransferAction:  &transfer.Action{Inputs: []*transfer.ActionInput{}},
+		Signatures:      nil,
+		MetadataCounter: make(map[string]int),
+	}
+
+	// Simulate what TransferHTLCValidate does for two lock outputs with the same hash:
+	// count the same metadata key twice.
+	ctx.CountMetadataKey(dupKey)
+	ctx.CountMetadataKey(dupKey)
+
+	// The counter now has value 2 for dupKey. The common.Validator post-check
+	// rejects any key whose count > 1 with "appeared more than one time".
+	// Verify the count so any regression in CountMetadataKey is caught.
+	require.Equal(t, 2, ctx.MetadataCounter[dupKey],
+		"Step C/C-2: duplicate key must be counted twice for the post-check to fire")
+}
+
+// TestSecurityHTLC_UpgradeWitnessCombination verifies that a transfer action
+// combining an upgrade witness on the input with a non-HTLC output is handled
+// cleanly by both validators without panic (C-3).
+//
+// TransferUpgradeWitnessValidate and TransferHTLCValidate each inspect their own
+// domains independently; neither should panic or produce a false accept.
+func TestSecurityHTLC_UpgradeWitnessCombination(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	curve := math.Curves[pp.Curve]
+	rand, _ := curve.Rand()
+	bf := curve.NewRandomZr(rand)
+	owner := []byte("alice")
+
+	fabToken := &fv1.Output{
+		Owner:    owner,
+		Type:     "ABC",
+		Quantity: "0x10",
+	}
+	toks, _, err := token.GetTokensWithWitnessAndBF(
+		[]uint64{16}, []*math.Zr{bf}, "ABC", pp.PedersenGenerators, curve,
+	)
+	require.NoError(t, err)
+
+	inputToken := &token.Token{Owner: owner, Data: toks[0]}
+	outputOwner, _ := identity.WrapWithType(x509.IdentityType, []byte("bob"))
+
+	// Part 1: TransferUpgradeWitnessValidate — both commitment and owner are the
+	// raw bytes used to compute the commitment, so the check must succeed without panic.
+	upgradeCtx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		TransferAction: &transfer.Action{
+			Inputs: []*transfer.ActionInput{
+				{
+					Token: inputToken,
+					UpgradeWitness: &token.UpgradeWitness{
+						FabToken:       fabToken,
+						BlindingFactor: bf,
+					},
+				},
+			},
+			Outputs: []*token.Token{
+				{Owner: outputOwner, Data: pp.PedersenGenerators[0]},
+			},
+		},
+		InputTokens:     []*token.Token{inputToken},
+		Signatures:      [][]byte{[]byte("sig")},
+		MetadataCounter: make(map[string]int),
+	}
+	require.NotPanics(t, func() {
+		err = validator.TransferUpgradeWitnessValidate(context.Background(), upgradeCtx)
+	}, "Step C/C-3: upgrade witness validate must not panic")
+	require.NoError(t, err, "Step C/C-3: valid upgrade witness must be accepted")
+
+	// Part 2: TransferHTLCValidate with empty InputTokens (input loop skipped)
+	// and a non-HTLC typed output — no HTLC branch is entered, must succeed.
+	htlcCtx := &validator.Context{
+		Logger:      logging.MustGetLogger(),
+		PP:          pp,
+		InputTokens: []*token.Token{}, // no inputs → input loop skipped
+		TransferAction: &transfer.Action{
+			Inputs:  []*transfer.ActionInput{},
+			Outputs: []*token.Token{{Owner: outputOwner, Data: pp.PedersenGenerators[0]}},
+		},
+		Signatures:      nil,
+		MetadataCounter: make(map[string]int),
+	}
+	require.NotPanics(t, func() {
+		err = validator.TransferHTLCValidate(context.Background(), htlcCtx)
+	}, "Step C/C-3: HTLC validate on non-HTLC typed output must not panic")
+	require.NoError(t, err,
+		"Step C/C-3: non-HTLC output alongside upgrade witness must be accepted by TransferHTLCValidate")
+}
+
+// TestSecurityHTLC_ClockSkewBoundary verifies the boundary behavior of
+// TransferHTLCValidate around the HTLC deadline (FA-5).
+//
+// The test pins the local clock behavior for three cases:
+//  1. Deadline well in the future — claim path is entered; fails on metadata.
+//  2. Deadline well in the past — reclaim path is entered; claim attempt rejected.
+//
+// Clock skew between nodes is an operational concern; this test documents and
+// regression-pins the single-node, local-clock behavior.
+func TestSecurityHTLC_ClockSkewBoundary(t *testing.T) {
+	validSenderID, _ := identity.WrapWithType(x509.IdentityType, []byte("sender1"))
+	validRecipientID, _ := identity.WrapWithType(x509.IdentityType, []byte("recipient1"))
+
+	// buildScript returns an HTLC script with the given deadline.
+	buildLockID := func(t *testing.T, deadline time.Time) []byte {
+		t.Helper()
+		script := &htlc.Script{
+			Sender:    validSenderID,
+			Recipient: validRecipientID,
+			Deadline:  deadline,
+			HashInfo: htlc.HashInfo{
+				Hash:         []byte("hash"),
+				HashFunc:     crypto.SHA256,
+				HashEncoding: encoding.Hex,
+			},
+		}
+		scriptBytes, _ := json.Marshal(script)
+		lockID, _ := identity.WrapWithType(htlc.ScriptType, scriptBytes)
+
+		return lockID
+	}
+
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Sub-test 1: deadline 24h in the future — entering the claim branch.
+	// The output owner is the recipient (a valid claim).  With no metadata
+	// provided, the metadata-check error is returned (not an expiry error).
+	t.Run("deadline-future-claim-fails-on-metadata", func(t *testing.T) {
+		lockID := buildLockID(t, time.Now().Add(24*time.Hour))
+		ctx := &validator.Context{
+			Logger: logging.MustGetLogger(),
+			PP:     pp,
+			InputTokens: []*token.Token{
+				{Owner: lockID},
+			},
+			TransferAction: &transfer.Action{
+				Inputs:  []*transfer.ActionInput{{}},
+				Outputs: []*token.Token{{Owner: validRecipientID, Data: &math.G1{}}},
+			},
+			Signatures:      [][]byte{[]byte("claim-sig")},
+			MetadataCounter: make(map[string]int),
+		}
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+		require.Error(t, err,
+			"FA-5: future deadline — claim without metadata must be rejected")
+		assert.NotContains(t, err.Error(), "expired",
+			"FA-5: a future deadline must not produce an expiry-related error")
+	})
+
+	// Sub-test 2: deadline 24h in the past — reclaim path.
+	// The output owner is the recipient (wrong for a reclaim); the request must
+	// be rejected because only the sender can reclaim after expiry.
+	t.Run("deadline-past-claim-rejected", func(t *testing.T) {
+		lockID := buildLockID(t, time.Now().Add(-24*time.Hour))
+		ctx := &validator.Context{
+			Logger: logging.MustGetLogger(),
+			PP:     pp,
+			InputTokens: []*token.Token{
+				{Owner: lockID},
+			},
+			TransferAction: &transfer.Action{
+				Inputs:  []*transfer.ActionInput{{}},
+				Outputs: []*token.Token{{Owner: validRecipientID, Data: &math.G1{}}},
+			},
+			Signatures:      [][]byte{[]byte("sig")},
+			MetadataCounter: make(map[string]int),
+		}
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+		require.Error(t, err,
+			"FA-5: claim after expiry must be rejected")
+	})
+}
+
+// ===========================================================================
+// STEP D — P-9: nil ActionInput in GetInputs + SerializeOutputAt bounds check
+// ===========================================================================
+
+// TestSecurityP9_GetInputsNilActionInput verifies that GetInputs does not panic
+// when the Inputs slice contains a nil ActionInput entry (P-9).
+func TestSecurityP9_GetInputsNilActionInput(t *testing.T) {
+	action := &transfer.Action{
+		Inputs: []*transfer.ActionInput{
+			nil,
+			{}, // non-nil but empty (no ID set)
+			nil,
+		},
+	}
+
+	require.NotPanics(t, func() {
+		ids := action.GetInputs()
+		require.Len(t, ids, 3, "P-9: GetInputs must return a slice of the same length")
+		assert.Nil(t, ids[0], "P-9: nil input must produce a nil ID")
+		assert.Nil(t, ids[1], "P-9: empty input (no ID set) must produce a nil ID")
+		assert.Nil(t, ids[2], "P-9: nil input must produce a nil ID")
+	}, "P-9: nil ActionInput in GetInputs must not panic")
+}
+
+// TestSecurityP9_SerializeOutputAtBoundsCheck verifies that SerializeOutputAt
+// returns an error (not a panic) when given an out-of-bounds index or a nil
+// output entry (P-9).
+func TestSecurityP9_SerializeOutputAtBoundsCheck(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	action := &transfer.Action{
+		Outputs: []*token.Token{
+			{Data: pp.PedersenGenerators[0], Owner: []byte("owner1")},
+			nil,
+		},
+	}
+
+	// Out-of-bounds index must not panic.
+	require.NotPanics(t, func() {
+		_, err = action.SerializeOutputAt(99)
+	}, "P-9: out-of-bounds index in SerializeOutputAt must not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of bounds",
+		"P-9: error message must mention out of bounds")
+
+	// Negative index must not panic.
+	require.NotPanics(t, func() {
+		_, err = action.SerializeOutputAt(-1)
+	}, "P-9: negative index in SerializeOutputAt must not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of bounds",
+		"P-9: negative index error must mention out of bounds")
+
+	// Nil output at valid index must not panic.
+	require.NotPanics(t, func() {
+		_, err = action.SerializeOutputAt(1)
+	}, "P-9: nil output in SerializeOutputAt must not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil output",
+		"P-9: error must mention nil output")
+
+	// Valid index with a non-nil token must succeed.
+	require.NotPanics(t, func() {
+		_, err = action.SerializeOutputAt(0)
+	}, "P-9: valid index in SerializeOutputAt must not panic")
+	require.NoError(t, err, "P-9: valid output must serialize without error")
+}
+
+// ===========================================================================
+// STEP E — ZK proof cross-action swap (C-4)
+// ===========================================================================
+
+// TestSecurityZKProofCrossActionSwap verifies that swapping the ZK proof
+// between two distinct transfer actions is rejected by the verifier (C-4).
+//
+// The ZK proof is bound to the Pedersen commitments of the specific inputs and
+// outputs of its action. Swapping proofs means the commitment sets no longer
+// match the proof, so both actions must be rejected.
+//
+// This test documents and pins the binding between proof and commitment set,
+// ensuring the property is continuously regression-tested.
+func TestSecurityZKProofCrossActionSwap(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Deserialize the two transfer actions from the swap request (which contains
+	// two independent transfer actions).
+	transfers := env.TRWithSwap.GetTransfers()
+	require.GreaterOrEqual(t, len(transfers), 2,
+		"Step E: swap request must have at least 2 transfer actions")
+
+	action1 := &transfer.Action{}
+	require.NoError(t, action1.Deserialize(transfers[0]))
+
+	action2 := &transfer.Action{}
+	require.NoError(t, action2.Deserialize(transfers[1]))
+
+	// Swap the ZK proofs: action1 carries action2's proof and vice versa.
+	proof1, proof2 := action1.Proof, action2.Proof
+	action1.Proof, action2.Proof = proof2, proof1
+
+	// Verify that each action is rejected when carrying the wrong proof.
+	// We exercise TransferZKProofValidate directly to isolate the proof check.
+	pp := env.Engine.PublicParams
+
+	ctx1 := &validator.Context{
+		Logger:          logging.MustGetLogger(),
+		PP:              pp,
+		InputTokens:     action1.InputTokens(),
+		TransferAction:  action1,
+		MetadataCounter: make(map[string]int),
+	}
+	require.NotPanics(t, func() {
+		zkErr := validator.TransferZKProofValidate(context.Background(), ctx1)
+		assert.Error(t, zkErr, "Step E/C-4: action1 with action2's proof must be rejected")
+		if zkErr != nil {
+			assert.Contains(t, zkErr.Error(), "invalid zero-knowledge proof",
+				"Step E/C-4: rejection must report invalid ZK proof")
+		}
+	})
+
+	ctx2 := &validator.Context{
+		Logger:          logging.MustGetLogger(),
+		PP:              pp,
+		InputTokens:     action2.InputTokens(),
+		TransferAction:  action2,
+		MetadataCounter: make(map[string]int),
+	}
+	require.NotPanics(t, func() {
+		zkErr := validator.TransferZKProofValidate(context.Background(), ctx2)
+		assert.Error(t, zkErr, "Step E/C-4: action2 with action1's proof must be rejected")
+		if zkErr != nil {
+			assert.Contains(t, zkErr.Error(), "invalid zero-knowledge proof",
+				"Step E/C-4: rejection must report invalid ZK proof")
+		}
+	})
+}
+
+// ===========================================================================
+// STEP F — Version=0 false-reject regression test (FR-1)
+// ===========================================================================
+
+// TestSecurityFR_Version0Rejected verifies that a token request carrying
+// Version=0 is rejected with an invalid-version error rather than being
+// silently treated as version 1 (FR-1).
+//
+// The MarshalToMessageToSign helper substitutes version 0 with ProtocolV1 when
+// computing the message to sign, but VerifyTokenRequestFromRaw checks the
+// version field on the deserialized request and must reject Version=0.
+func TestSecurityFR_Version0Rejected(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	v := validator.New(logging.MustGetLogger(), pp, nil, nil, nil, nil)
+
+	// Build a minimal TokenRequest with Version explicitly set to 0.
+	tr := &driver.TokenRequest{
+		Version: 0,
+		Actions: []*driver.TypedAction{
+			{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte("placeholder")},
+		},
+	}
+	raw, err := tr.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = v.VerifyTokenRequestFromRaw(context.Background(), nil, "anchor", raw)
+	require.Error(t, err, "FR-1: Version=0 request must be rejected")
+	// The error surfaces as "invalid transfer version" (from the action deserializer)
+	// or "invalid version" (from the request-level check); accept either form.
+	errMsg := err.Error()
+	assert.True(t,
+		strings.Contains(errMsg, "invalid version") || strings.Contains(errMsg, "invalid transfer version"),
+		"FR-1: error must identify the version as invalid; got: %s", errMsg,
+	)
+}
+
+// ===========================================================================
+// STEP G — Open-policy deployment guard (FA-1)
+// ===========================================================================
+
+// TestPublicParamsDeploymentWarning verifies that ValidateForDeployment returns
+// an error when IssuerIDs is empty (open-policy mode), while Validate itself
+// continues to accept the same parameters (the open-policy is valid at runtime).
+//
+// This ensures the deployment guard surfaces the misconfiguration explicitly
+// without changing the tokenisation runtime behaviour.
+func TestPublicParamsDeploymentWarning(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// IssuerIDs is empty by default after Setup.
+	require.Empty(t, pp.IssuerIDs, "precondition: IssuerIDs must be empty after Setup")
+
+	// Validate() must still pass — open-policy is a valid operational config.
+	require.NoError(t, pp.Validate(),
+		"Step G: Validate must accept empty IssuerIDs (open-policy is valid at runtime)")
+
+	// ValidateForDeployment() must warn about the open-policy.
+	err = pp.ValidateForDeployment()
+	require.Error(t, err, "Step G: ValidateForDeployment must return an error for empty IssuerIDs")
+	assert.Contains(t, err.Error(), "open-policy mode",
+		"Step G: error must mention open-policy mode")
+	assert.Contains(t, err.Error(), "IssuerIDs",
+		"Step G: error must mention IssuerIDs")
+
+	// Once IssuerIDs is populated, ValidateForDeployment must return nil.
+	pp.IssuerIDs = []driver.Identity{[]byte("authorized-issuer")}
+	require.NoError(t, pp.ValidateForDeployment(),
+		"Step G: ValidateForDeployment must succeed when IssuerIDs is non-empty")
+}
+
+// ===========================================================================
+// STEP H — Backend cursor concurrency documentation test (P-10)
+// ===========================================================================
+
+// TestSecurityBackendCursorConcurrentUse verifies that concurrent calls to
+// VerifyTokenRequestFromRaw — each receiving the same raw bytes — are safe
+// because each call creates its own Backend instance (P-10).
+//
+// The standard validator creates one Backend per VerifyTokenRequestFromRaw call,
+// so the cursor integer is not shared. This test exercises the concurrent path
+// and will trigger the race detector if the implementation ever inadvertently
+// shares a Backend across calls.
+func TestSecurityBackendCursorConcurrentUse(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	const goroutines = 8
+	errCh := make(chan error, goroutines)
+	var wg sync.WaitGroup
+
+	for range goroutines {
+		wg.Go(func() {
+			_, _, callErr := env.Engine.VerifyTokenRequestFromRaw(
+				context.Background(), nil, "1", raw,
+			)
+			errCh <- callErr
+		})
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// All concurrent calls share the same raw bytes and anchor but each gets
+	// its own Backend. Every call must succeed (or all fail consistently due
+	// to crypto, not due to a race on shared state).
+	for callErr := range errCh {
+		assert.NoError(t, callErr,
+			"Step H/P-10: concurrent VerifyTokenRequestFromRaw calls must each succeed")
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
@@ -1,0 +1,1073 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This file contains security-focused regression tests for the zkatdlog validator.
+// Each test targets a specific attack scenario identified during security analysis:
+//
+//  1. Panic conditions (nil pointer dereferences, out-of-bounds accesses)
+//  2. False acceptances (invalid requests that could pass validation)
+//  3. False rejections (valid requests that could fail validation)
+//
+// The tests complement validator_test.go and validator_extra_test.go in the same package.
+package validator_test
+
+import (
+	"context"
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/benchmark"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
+	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
+	testing2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/testutils"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/transfer"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/validator"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	mock3 "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/idemixnym"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSecurityTestEnv creates a test environment using the same parameters as
+// other tests in this package (testUseCaseExtra is declared in validator_extra_test.go).
+func newSecurityTestEnv(t *testing.T) *testing2.Env {
+	t.Helper()
+	configurations, err := benchmark.NewSetupConfigurationsWithParams(
+		benchmark.SetupParams{
+			IdemixTestdataPath: "./../testdata",
+			Bits:               []uint64{testUseCaseExtra.Bits},
+			CurveIDs:           []math.CurveID{testUseCaseExtra.CurveID},
+			OwnerIdentityType:  idemixnym.IdentityType,
+			ProofType:          rp.RangeProofType,
+		},
+	)
+	require.NoError(t, err)
+	env, err := testing2.NewEnv(testUseCaseExtra, configurations)
+	require.NoError(t, err)
+
+	return env
+}
+
+// ===========================================================================
+// PANIC PREVENTION TESTS
+// ===========================================================================
+
+// TestSecurityPanicNilBackendLedger verifies that Backend.GetState returns an error
+// instead of panicking when the underlying ledger function is nil.
+//
+// Attack vector (P4): VerifyTokenRequestFromRaw accepts nil as the getState argument
+// (and many test/production paths pass nil). Any validator that calls
+// ctx.Ledger.GetState() will cause a nil-function-pointer panic on the chaincode,
+// constituting a denial-of-service vector. The fix adds an explicit nil guard.
+func TestSecurityPanicNilBackendLedger(t *testing.T) {
+	backend := common.NewBackend(logging.MustGetLogger(), nil /*nil ledger*/, nil, nil)
+
+	_, err := backend.GetState(token2.ID{TxId: "tx1", Index: 0})
+	require.Error(t, err, "GetState with nil ledger must return an error, not panic")
+	assert.Contains(t, err.Error(), "ledger not available")
+}
+
+// TestSecurityPanicHTLCSignaturesBoundsCheck verifies that TransferHTLCValidate
+// returns an error (not an index-out-of-bounds panic) when the Signatures slice
+// does not contain an entry for a given input index.
+//
+// Attack vector (P3): if TransferHTLCValidate runs in a custom pipeline that
+// omits TransferSignatureValidate, ctx.Signatures is nil/empty. Without the
+// bounds check, `ctx.Signatures[i]` panics the chaincode. The fix adds an
+// explicit bounds check before accessing ctx.Signatures[i].
+func TestSecurityPanicHTLCSignaturesBoundsCheck(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Build an HTLC owner (ScriptType) as the input token owner so the HTLC
+	// branch is entered. To keep the test focused, we use an identity that is
+	// NOT htlc.ScriptType so the function fails early during UnmarshalTypedIdentity,
+	// but in a way that would not panic. The important invariant we test is that
+	// TransferHTLCValidate with no Signatures slice does NOT panic regardless of
+	// the owner type.
+	ctx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		InputTokens: []*token.Token{
+			{Owner: []byte("raw-owner-bytes-not-wrapped")},
+		},
+		TransferAction: &transfer.Action{
+			Inputs: []*transfer.ActionInput{{}},
+		},
+		Signatures:      nil, // intentionally absent
+		MetadataCounter: make(map[string]int),
+	}
+
+	// Must return an error, never panic.
+	require.NotPanics(t, func() {
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+	})
+	// The error from UnmarshalTypedIdentity is acceptable here.
+	require.Error(t, err)
+}
+
+// TestSecurityPanicGetOutputCommitmentsNilOutput verifies that GetOutputCommitments
+// does not panic when the Outputs slice contains nil entries.
+//
+// Attack vector (P1): transfer.Action.Deserialize previously left nil entries in
+// t.Outputs when a protobuf output was missing/nil. GetOutputCommitments then
+// dereferenced t.Outputs[i].Data, causing a nil-pointer panic. The fix skips
+// nil entries; the ZK proof verifier will subsequently reject the mismatched
+// commitment count.
+func TestSecurityPanicGetOutputCommitmentsNilOutput(t *testing.T) {
+	action := &transfer.Action{
+		Outputs: []*token.Token{
+			nil,
+			{Data: &math.G1{}},
+			nil,
+		},
+	}
+
+	require.NotPanics(t, func() {
+		coms := action.GetOutputCommitments()
+		// Only the non-nil output contributes a commitment.
+		assert.Len(t, coms, 1)
+	})
+}
+
+// TestSecurityPanicAuditingContextMetadataCounter verifies that the Context
+// created inside VerifyAuditing has its MetadataCounter properly initialized so
+// that a custom auditing validator calling ctx.CountMetadataKey() does not
+// panic with a nil map write.
+//
+// Attack vector (FA6 / panic): before the fix, the auditing Context had no
+// MetadataCounter set. Any auditing extension that counts metadata keys would
+// trigger a "assignment to entry in nil map" panic.
+func TestSecurityPanicAuditingContextMetadataCounter(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	panicked := false
+	calledWithNonNilMap := false
+
+	// Custom auditing validator that calls CountMetadataKey.
+	auditingValidator := func(c context.Context, ctx *validator.Context) error {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		// This would panic if ctx.MetadataCounter is nil.
+		ctx.CountMetadataKey("audit-key")
+		calledWithNonNilMap = true
+
+		return nil
+	}
+
+	v := validator.New(
+		logging.MustGetLogger(),
+		pp,
+		nil,
+		nil,
+		nil,
+		[]validator.ValidateAuditingFunc{auditingValidator},
+	)
+
+	// Call VerifyAuditing with an empty request (no auditor sigs, no configured
+	// auditors). The built-in AuditingSignaturesValidate returns nil in this case.
+	_ = v.VerifyAuditing(
+		context.Background(),
+		"test-anchor",
+		&driver.TokenRequest{},
+		nil,
+		nil,
+		nil,
+	)
+
+	assert.False(t, panicked, "ctx.CountMetadataKey must not panic (MetadataCounter was nil before fix)")
+	assert.True(t, calledWithNonNilMap, "auditing validator must have been called")
+}
+
+// ===========================================================================
+// FALSE ACCEPTANCE PREVENTION TESTS
+// ===========================================================================
+
+// TestSecurityFalseAcceptanceTransferDeserializeNilOutput verifies that
+// transfer.Action.Deserialize returns an error when the raw bytes decode to a
+// protobuf with a nil output (simulated via corrupt/minimal bytes), rather than
+// silently producing a nil entry in t.Outputs.
+//
+// Attack vector (FA3): before the fix, nil output proto fields were silently
+// left as nil in t.Outputs. Between Deserialize() and Validate(), the struct
+// was in an inconsistent state that could cause nil-pointer dereferences in
+// any code that accessed t.Outputs[i].Data directly (e.g., GetOutputCommitments).
+func TestSecurityFalseAcceptanceTransferDeserializeNilOutput(t *testing.T) {
+	action := &transfer.Action{}
+	// Garbage bytes that can't be a valid protobuf-encoded TransferAction.
+	err := action.Deserialize([]byte("not-a-valid-proto-payload"))
+	require.Error(t, err, "deserializing garbage bytes must fail")
+}
+
+// TestSecurityFalseAcceptanceIssuerUnauthorized verifies that an issue action
+// whose Issuer is not present in PublicParams.Issuers is rejected.
+//
+// Attack vector (FA5): an attacker crafts a valid-looking issue action with an
+// arbitrary Issuer identity and provides a valid ZK proof. If the issuer check
+// were missing or bypassed, the token would be issued without authorization.
+func TestSecurityFalseAcceptanceIssuerUnauthorized(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Modify the engine's PP to set a specific authorized issuer that differs
+	// from the one used to produce TRWithIssue.
+	env.Engine.PublicParams.IssuerIDs = []driver.Identity{[]byte("not-the-real-issuer")}
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer is not authorized")
+}
+
+// TestSecurityFalseAcceptanceAuditorSignaturesMissingWhenRequired verifies that
+// a token request without an auditor signature is rejected when auditors are
+// configured in the public parameters.
+//
+// Attack vector: an attacker strips the auditor signature from an otherwise
+// valid request, hoping the validator skips the auditing check. The validator
+// must reject with a clear error.
+func TestSecurityFalseAcceptanceAuditorSignaturesMissingWhenRequired(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// The env always configures an auditor. Strip all auditor signatures from
+	// the request to simulate an attacker who removed them.
+	var stripped []*driver.RequestSignature
+	for _, sig := range env.TRWithIssue.Signatures {
+		if sig != nil && sig.Auditor == nil {
+			stripped = append(stripped, sig)
+		}
+	}
+	env.TRWithIssue.Signatures = stripped
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auditor signatures missing")
+}
+
+// TestSecurityFalseAcceptanceAuditorSignaturesPresentWhenNotRequired verifies that
+// a token request carrying an unexpected auditor signature is rejected when no
+// auditors are configured in the public parameters.
+//
+// Attack vector: an attacker injects an auditor signature from a previously
+// valid key (e.g., before a PP rotation) and submits the request. The validator
+// must reject it because the current PP recognises no auditors.
+func TestSecurityFalseAcceptanceAuditorSignaturesPresentWhenNotRequired(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Clear all configured auditors in the PP so that any auditor sig is "unexpected".
+	env.Engine.PublicParams.AuditorIDs = nil
+
+	// The env's TRWithIssue already has an auditor signature attached (added during
+	// request preparation). Submitting it with an empty auditor list must be rejected.
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auditor signatures present")
+}
+
+// TestSecurityFalseAcceptanceEmptyTokenRequest verifies that an empty (nil raw)
+// token request is rejected immediately.
+//
+// Attack vector: submitting an empty payload must not cause a panic and must
+// return a clear error.
+func TestSecurityFalseAcceptanceEmptyTokenRequest(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	v := validator.New(logging.MustGetLogger(), pp, nil, nil, nil, nil)
+
+	require.NotPanics(t, func() {
+		_, _, err = v.VerifyTokenRequestFromRaw(context.Background(), nil, "anchor", nil)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty token request")
+}
+
+// ===========================================================================
+// FALSE REJECTION PREVENTION TESTS  (regression guards after fixes)
+// ===========================================================================
+
+// TestSecurityRegressionValidIssueStillAccepted verifies that a correctly
+// constructed issue request is still accepted after all security hardening
+// changes. Ensures the fixes introduce no false rejections.
+func TestSecurityRegressionValidIssueStillAccepted(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// TestSecurityRegressionValidTransferStillAccepted verifies that a correctly
+// constructed transfer request is still accepted after security hardening.
+func TestSecurityRegressionValidTransferStillAccepted(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// TestSecurityRegressionValidRedeemStillAccepted verifies that a correctly
+// constructed redeem request is still accepted after security hardening.
+func TestSecurityRegressionValidRedeemStillAccepted(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithRedeem.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// ===========================================================================
+// SIGNATURE ORDER / CURSOR INTEGRITY TESTS
+// ===========================================================================
+
+// TestSecurityFalseRejectionWrongSignature verifies that a request with a tampered
+// action signature is rejected with a clear "failed signature verification" error
+// and does not accidentally succeed or panic.
+//
+// Regression target (FR2): the Backend cursor approach relies on signature order.
+// Injecting a signature that corresponds to a different transaction ID produces
+// a message-mismatch that the verifier must catch.
+func TestSecurityFalseRejectionWrongSignature(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Replace the first action signature with garbage to simulate a wrong-TxID sig.
+	for _, sig := range env.TRWithTransfer.Signatures {
+		if sig != nil && sig.Action != nil {
+			sig.Action.Signature = []byte("tampered-signature-bytes")
+
+			break
+		}
+	}
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed signature verification")
+}
+
+// ===========================================================================
+// ADDITIONAL PANIC PREVENTION TESTS (new findings)
+// ===========================================================================
+
+// TestSecurityP1_TransferSignatureValidate_NilToken verifies that
+// TransferSignatureValidate returns a descriptive error instead of a nil-pointer
+// panic when an ActionInput's Token field is nil.
+//
+// Attack vector (P1): if TransferActionValidate is skipped in a custom pipeline,
+// in.Token being nil causes `tok.Owner` to panic at runtime.
+func TestSecurityP1_TransferSignatureValidate_NilToken(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	ctx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		TransferAction: &transfer.Action{
+			Inputs: []*transfer.ActionInput{
+				{Token: nil}, // deliberately nil Token
+			},
+		},
+		MetadataCounter: make(map[string]int),
+	}
+
+	require.NotPanics(t, func() {
+		err = validator.TransferSignatureValidate(context.Background(), ctx)
+	}, "P1: nil Token must not cause a panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil input or nil token")
+}
+
+// TestSecurityP2_TransferSignatureValidate_NilOutputInRedeemCheck verifies that
+// TransferSignatureValidate does not panic when ctx.TransferAction.Outputs
+// contains a nil entry while checking for redeem operations.
+//
+// Attack vector (P2): a nil entry in Outputs causes `output.Owner` to dereference a
+// nil pointer inside the redeem-detection loop when the redeem-detection loop runs.
+func TestSecurityP2_TransferSignatureValidate_NilOutputInRedeem(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Set at least one issuer so the redeem-detection branch is entered after the
+	// input-signature loop completes successfully.
+	pp.IssuerIDs = []driver.Identity{[]byte("issuer1")}
+
+	validTok := &token.Token{Owner: []byte("owner1"), Data: pp.PedersenGenerators[0]}
+
+	// Provide a mock signature provider and deserializer so the input-loop
+	// completes without error, allowing the code to reach the output-scan loop
+	// where the nil guard is exercised.
+	mockDesInst := &mock3.Deserializer{}
+	mockDesInst.GetOwnerVerifierReturns(&mock3.Verifier{}, nil) // noop verifier: Verify always returns nil
+	mockSP := &mockSignatureProvider{
+		HasBeenSignedByFunc: func(_ context.Context, _ driver.Identity, _ driver.Verifier) ([]byte, error) {
+			return []byte("sig"), nil
+		},
+	}
+
+	ctx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		TransferAction: &transfer.Action{
+			Inputs:  []*transfer.ActionInput{{Token: validTok}},
+			Outputs: []*token.Token{nil}, // nil output entry — must not panic
+		},
+		Deserializer:      mockDesInst,
+		SignatureProvider: mockSP,
+		MetadataCounter:   make(map[string]int),
+	}
+
+	// Must not panic on the nil output entry.
+	require.NotPanics(t, func() {
+		err = validator.TransferSignatureValidate(context.Background(), ctx)
+	}, "P2: nil output entry must not cause a panic in the redeem-detection loop")
+	// After the nil guard skips the nil output, no non-nil outputs exist, so
+	// isRedeem stays false and the issuer-signature branch is not entered.
+	// The function must complete without error.
+	require.NoError(t, err)
+}
+
+// TestSecurityP3_TransferZKProofValidate_NilInputToken verifies that
+// TransferZKProofValidate returns an error instead of a nil-pointer panic when
+// ctx.InputTokens contains a nil entry.
+//
+// Attack vector (P3): `in[i] = tok.Data` panics if tok is nil.
+func TestSecurityP3_TransferZKProofValidate_NilInputToken(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	ctx := &validator.Context{
+		Logger:      logging.MustGetLogger(),
+		PP:          pp,
+		InputTokens: []*token.Token{nil}, // deliberately nil
+		TransferAction: &transfer.Action{
+			Outputs:   []*token.Token{{Data: pp.PedersenGenerators[0]}},
+			Proof:     []byte("unused"),
+			ProofType: 0,
+		},
+		MetadataCounter: make(map[string]int),
+	}
+
+	require.NotPanics(t, func() {
+		err = validator.TransferZKProofValidate(context.Background(), ctx)
+	}, "P3: nil input token must not cause a panic in TransferZKProofValidate")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil input token at index [0]")
+}
+
+// TestSecurityP4_TransferHTLCValidate_NilInputToken verifies that
+// TransferHTLCValidate returns an error instead of a nil-pointer panic when
+// ctx.InputTokens contains a nil entry.
+//
+// Attack vector (P4): `identity.UnmarshalTypedIdentity(in.Owner)` panics if in is nil.
+func TestSecurityP4_TransferHTLCValidate_NilInputToken(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	ctx := &validator.Context{
+		Logger:      logging.MustGetLogger(),
+		PP:          pp,
+		InputTokens: []*token.Token{nil}, // nil entry
+		TransferAction: &transfer.Action{
+			Inputs: []*transfer.ActionInput{{}},
+		},
+		Signatures:      [][]byte{[]byte("sig")},
+		MetadataCounter: make(map[string]int),
+	}
+
+	require.NotPanics(t, func() {
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+	}, "P4: nil entry in ctx.InputTokens must not cause a panic in TransferHTLCValidate")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil input token at index [0]")
+}
+
+// TestSecurityP5_TransferHTLCValidate_NilOutputEntry verifies that
+// TransferHTLCValidate's output-scan loop does not panic when
+// ctx.TransferAction.Outputs contains a nil entry.
+//
+// Attack vector (P5): `o.IsRedeem()` panics if o is nil.
+func TestSecurityP5_TransferHTLCValidate_NilOutputEntry(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Use a non-HTLC owner so the input loop exits cleanly.
+	nonHTLCOwner := []byte("\x00\x00non-htlc-raw-bytes-that-unmarshal-fail")
+	ctx := &validator.Context{
+		Logger: logging.MustGetLogger(),
+		PP:     pp,
+		InputTokens: []*token.Token{
+			{Owner: nonHTLCOwner},
+		},
+		TransferAction: &transfer.Action{
+			Inputs:  []*transfer.ActionInput{{}},
+			Outputs: []*token.Token{nil}, // nil output entry
+		},
+		Signatures:      [][]byte{[]byte("sig")},
+		MetadataCounter: make(map[string]int),
+	}
+
+	// The input loop will fail on UnmarshalTypedIdentity before the nil check
+	// on the output loop is reached, but the function must not panic.
+	require.NotPanics(t, func() {
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+	}, "P5: nil output entry must not cause a panic in TransferHTLCValidate output loop")
+	// Either an error from the input loop or no error is acceptable; what matters
+	// is no panic.
+}
+
+// TestSecurityP5b_TransferHTLCValidate_NilOutputEntry_OutputLoopDirect verifies
+// that the nil guard in the output loop is reachable and functional when the
+// input loop does not produce any HTLC branches (non-HTLC identity that
+// unmarshal cleanly).
+func TestSecurityP5b_TransferHTLCValidate_NilOutputEntry_OutputLoopDirect(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Build a typed identity that unmarshal cleanly but is not an HTLC type,
+	// so the input loop exits the inner branch without error.
+	// Use a well-formed TypedIdentity JSON (type=x509, which is not htlc.ScriptType).
+	// Directly set ctx.InputTokens to empty so the input loop is skipped entirely.
+	ctx := &validator.Context{
+		Logger:      logging.MustGetLogger(),
+		PP:          pp,
+		InputTokens: []*token.Token{}, // empty → input loop skipped
+		TransferAction: &transfer.Action{
+			Inputs:  []*transfer.ActionInput{},
+			Outputs: []*token.Token{nil, {Owner: nil}}, // nil entry + a redeem
+		},
+		Signatures:      nil,
+		MetadataCounter: make(map[string]int),
+	}
+
+	require.NotPanics(t, func() {
+		err = validator.TransferHTLCValidate(context.Background(), ctx)
+	}, "P5b: nil output entry in output loop must be skipped without panic")
+	require.NoError(t, err, "nil entry is skipped; redeem entry (Owner==nil) is also skipped")
+}
+
+// TestSecurityP6_GetSerializedInputs_NilToken verifies that
+// transfer.Action.GetSerializedInputs returns an error instead of panicking
+// when an input's Token is nil and no UpgradeWitness is set.
+//
+// Attack vector (P6): input.Token.Serialize() dereferences a nil pointer.
+func TestSecurityP6_GetSerializedInputs_NilToken(t *testing.T) {
+	action := &transfer.Action{
+		Inputs: []*transfer.ActionInput{
+			{
+				Token: nil, // no Token, no UpgradeWitness → panic without the guard
+			},
+		},
+	}
+
+	var err error
+	require.NotPanics(t, func() {
+		_, err = action.GetSerializedInputs()
+	}, "P6: nil Token in GetSerializedInputs must not panic")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil token in input at index [0]")
+}
+
+// ===========================================================================
+// TABLE-DRIVEN: MULTIPLE PANIC SCENARIOS IN ONE SUITE
+// ===========================================================================
+
+// TestSecurityPanicSuite is a table-driven test that covers all panic-class
+// findings in a single entry point for quick regression scanning.
+func TestSecurityPanicSuite(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{
+			name: "P-1: TransferSignatureValidate nil ActionInput",
+			fn: func() error {
+				ctx := &validator.Context{
+					Logger: logging.MustGetLogger(),
+					PP:     pp,
+					TransferAction: &transfer.Action{
+						Inputs: []*transfer.ActionInput{nil},
+					},
+					MetadataCounter: make(map[string]int),
+				}
+
+				return validator.TransferSignatureValidate(context.Background(), ctx)
+			},
+		},
+		{
+			name: "P-1b: TransferSignatureValidate nil Token field",
+			fn: func() error {
+				ctx := &validator.Context{
+					Logger: logging.MustGetLogger(),
+					PP:     pp,
+					TransferAction: &transfer.Action{
+						Inputs: []*transfer.ActionInput{{Token: nil}},
+					},
+					MetadataCounter: make(map[string]int),
+				}
+
+				return validator.TransferSignatureValidate(context.Background(), ctx)
+			},
+		},
+		{
+			name: "P-3: TransferZKProofValidate nil InputToken",
+			fn: func() error {
+				ctx := &validator.Context{
+					Logger:      logging.MustGetLogger(),
+					PP:          pp,
+					InputTokens: []*token.Token{nil},
+					TransferAction: &transfer.Action{
+						Outputs: []*token.Token{{Data: pp.PedersenGenerators[0]}},
+					},
+					MetadataCounter: make(map[string]int),
+				}
+
+				return validator.TransferZKProofValidate(context.Background(), ctx)
+			},
+		},
+		{
+			name: "P-4: TransferHTLCValidate nil InputToken",
+			fn: func() error {
+				ctx := &validator.Context{
+					Logger:      logging.MustGetLogger(),
+					PP:          pp,
+					InputTokens: []*token.Token{nil},
+					TransferAction: &transfer.Action{
+						Inputs: []*transfer.ActionInput{{}},
+					},
+					Signatures:      [][]byte{[]byte("sig")},
+					MetadataCounter: make(map[string]int),
+				}
+
+				return validator.TransferHTLCValidate(context.Background(), ctx)
+			},
+		},
+		{
+			name: "P-6: GetSerializedInputs nil Token",
+			fn: func() error {
+				action := &transfer.Action{
+					Inputs: []*transfer.ActionInput{{Token: nil}},
+				}
+				_, err := action.GetSerializedInputs()
+
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				err = tc.fn()
+			}, "must not panic after hardening")
+			require.Error(t, err, "must return a descriptive error")
+		})
+	}
+}
+
+// ===========================================================================
+// ADDITIONAL FALSE ACCEPTANCE TESTS
+// ===========================================================================
+
+// TestSecurityFA_ZeroLengthProof verifies that a transfer action with an empty
+// ZK proof is rejected by TransferZKProofValidate (via the verifier) and that the
+// action's own Validate() also catches it via ErrEmptyProof.
+//
+// Attack vector (FA): an attacker strips the ZK proof from a serialized transfer
+// action hoping it is not checked before the ZK verifier is invoked.
+func TestSecurityFA_ZeroLengthProof(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	validTok := &token.Token{Owner: []byte("owner1"), Data: pp.PedersenGenerators[0]}
+	ctx := &validator.Context{
+		Logger:      logging.MustGetLogger(),
+		PP:          pp,
+		InputTokens: []*token.Token{validTok},
+		TransferAction: &transfer.Action{
+			Outputs: []*token.Token{{Data: pp.PedersenGenerators[1]}},
+			Proof:   []byte{}, // deliberately empty
+		},
+		MetadataCounter: make(map[string]int),
+	}
+
+	// TransferZKProofValidate hands the empty proof to the underlying verifier which must reject it.
+	require.NotPanics(t, func() {
+		err = validator.TransferZKProofValidate(context.Background(), ctx)
+	})
+	require.Error(t, err, "FA: empty ZK proof must be rejected")
+}
+
+// TestSecurityFA_MultipleMetadataCountForSameKey verifies that the common
+// validator rejects a token request where a validator counts the same metadata
+// key more than once (duplicate metadata registration).
+//
+// Attack vector (FA): two validators each call ctx.CountMetadataKey("k") for the
+// same key. The post-validation check in common.Validator.VerifyTransfer detects
+// this and rejects the request.
+//
+// Note: we use common.NewValidator directly with only the custom validator so that
+// the standard TransferActionValidate (which requires at least one input) does not
+// reject our minimal test action before the metadata check is reached.
+func TestSecurityFA_MultipleMetadataCountForSameKey(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Build a minimal transfer action with one metadata entry.
+	action := &transfer.Action{
+		Metadata: map[string][]byte{"key": []byte("value")},
+	}
+
+	doubleCounter := func(c context.Context, ctx *validator.Context) error {
+		// Count the same key twice — simulates two competing validators both
+		// claiming ownership of the same metadata entry.
+		ctx.CountMetadataKey("key")
+		ctx.CountMetadataKey("key")
+
+		return nil
+	}
+
+	// Use common.NewValidator directly so only our custom validator runs, avoiding
+	// TransferActionValidate which would reject the minimal test action.
+	v := common.NewValidator(
+		logging.MustGetLogger(),
+		pp,
+		nil,
+		&validator.ActionDeserializer{},
+		[]validator.ValidateTransferFunc{doubleCounter},
+		nil,
+		nil,
+	)
+
+	err = v.VerifyTransfer(
+		context.Background(),
+		"test-anchor",
+		&driver.TokenRequest{},
+		action,
+		nil,
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "appeared more than one time")
+}
+
+// TestSecurityFA_UnvalidatedMetadataKey verifies that the common validator
+// rejects a token request where the action has metadata that no validator
+// counted (i.e., unvalidated metadata slips through).
+//
+// Attack vector (FA): an attacker appends an unexpected metadata entry to a
+// transfer action hoping the validator ignores it. The metadata-counter check in
+// common.Validator.VerifyTransfer detects the discrepancy.
+//
+// Note: we use common.NewValidator directly with only the custom validator so that
+// the standard TransferActionValidate (which requires at least one input) does not
+// reject our minimal test action before the metadata check is reached.
+func TestSecurityFA_UnvalidatedMetadataKey(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	// Build a transfer action with extra metadata that no validator handles.
+	action := &transfer.Action{
+		Metadata: map[string][]byte{
+			"unexpected-attacker-key": []byte("evil-payload"),
+		},
+	}
+
+	// The no-op validator counts nothing.
+	noopTransferValidator := func(c context.Context, ctx *validator.Context) error {
+		return nil
+	}
+
+	// Use common.NewValidator directly so only our custom validator runs.
+	v := common.NewValidator(
+		logging.MustGetLogger(),
+		pp,
+		nil,
+		&validator.ActionDeserializer{},
+		[]validator.ValidateTransferFunc{noopTransferValidator},
+		nil,
+		nil,
+	)
+
+	err = v.VerifyTransfer(
+		context.Background(),
+		"test-anchor",
+		&driver.TokenRequest{},
+		action,
+		nil,
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "more metadata than those validated")
+}
+
+// ===========================================================================
+// ADDITIONAL FALSE REJECTION (REGRESSION) TESTS
+// ===========================================================================
+
+// TestSecurityFR_NilOutputSkippedInGetOutputCommitments verifies that
+// GetOutputCommitments does not include nil output entries in the result
+// (they are silently skipped), and that the returned slice length matches
+// the number of non-nil outputs.
+//
+// FR regression: before the fix, nil entries were not skipped; the function
+// would panic. After the fix, it must return only non-nil commitments.
+func TestSecurityFR_NilOutputSkippedInGetOutputCommitments(t *testing.T) {
+	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
+	require.NoError(t, err)
+
+	action := &transfer.Action{
+		Outputs: []*token.Token{
+			nil,
+			{Data: pp.PedersenGenerators[0]},
+			nil,
+			{Data: pp.PedersenGenerators[1]},
+		},
+	}
+
+	var coms []*math.G1
+	require.NotPanics(t, func() {
+		coms = action.GetOutputCommitments()
+	})
+	// Exactly two non-nil outputs must produce two commitments.
+	require.Len(t, coms, 2)
+}
+
+// TestSecurityFR_ValidRequestAfterHardeningTransfer ensures that a legitimately
+// constructed transfer with valid signatures, ZK proof, and metadata is still
+// accepted after all hardening changes.  This is the primary non-regression guard.
+func TestSecurityFR_ValidRequestAfterHardeningTransfer(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// TestSecurityFR_ValidRequestAfterHardeningIssue ensures a legitimately
+// constructed issue request is still accepted after hardening.
+func TestSecurityFR_ValidRequestAfterHardeningIssue(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// TestSecurityFR_ValidRequestAfterHardeningRedeem ensures a legitimately
+// constructed redeem request is still accepted after hardening.
+func TestSecurityFR_ValidRequestAfterHardeningRedeem(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw, err := env.TRWithRedeem.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, actions)
+}
+
+// ===========================================================================
+// STEP 1A — Open-policy issuer tests (T-GAP-1, T-GAP-2)
+// ===========================================================================
+
+// TestSecurityFA_IssueAcceptedWhenIssuersEmpty documents the open-policy issuer
+// behaviour: when PP.IssuerIDs is empty, any identity may issue tokens and the
+// issuer-authorization check is deliberately skipped (T-GAP-1).
+//
+// This is intentional design. See the Godoc on IssueValidate for the rationale.
+// If this test fails it means the open-policy was inadvertently removed and
+// a code fix is required.
+func TestSecurityFA_IssueAcceptedWhenIssuersEmpty(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Clear the issuer list — open-policy mode.
+	env.Engine.PublicParams.IssuerIDs = nil
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err, "T-GAP-1: issue must be accepted when IssuerIDs is empty (open-policy)")
+	require.NotEmpty(t, actions)
+}
+
+// TestSecurityFA_RedeemAcceptedWithoutIssuerWhenIssuersEmpty documents the
+// open-policy redeem behaviour: when PP.IssuerIDs is empty, a redeem action
+// that carries no issuer signature is accepted (T-GAP-2).
+//
+// This is intentional design. See the Godoc on TransferSignatureValidate for
+// the rationale. If this test fails the open-policy was inadvertently removed.
+func TestSecurityFA_RedeemAcceptedWithoutIssuerWhenIssuersEmpty(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Clear the issuer list — open-policy mode.
+	env.Engine.PublicParams.IssuerIDs = nil
+
+	raw, err := env.TRWithRedeem.Bytes()
+	require.NoError(t, err)
+
+	actions, _, err := env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.NoError(t, err, "T-GAP-2: redeem must be accepted when IssuerIDs is empty (open-policy)")
+	require.NotEmpty(t, actions)
+}
+
+// ===========================================================================
+// STEP 1B — Backend cursor integrity tests (T-GAP-3, T-GAP-4)
+// ===========================================================================
+
+// TestSecurityFR_BackendCursorExtraSignature verifies that injecting an extra
+// signature before the action signatures causes the validator to reject the
+// request without panicking (T-GAP-3).
+//
+// The Backend cursor advances once per HasBeenSignedBy call. An extra signature
+// at the front shifts all remaining cursor positions, causing a message-mismatch
+// for the following signatures.
+func TestSecurityFR_BackendCursorExtraSignature(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Inject a spurious action signature at the front of the Signatures list.
+	spurious := &driver.RequestSignature{
+		Action: &driver.ActionSignature{Signature: []byte("spurious-extra-sig")},
+	}
+	env.TRWithTransfer.Signatures = append([]*driver.RequestSignature{spurious}, env.TRWithTransfer.Signatures...)
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	}, "T-GAP-3: extra signature must not panic")
+	require.Error(t, err, "T-GAP-3: extra signature must cause a validation error")
+}
+
+// TestSecurityFR_BackendCursorExhausted verifies that a transfer request with
+// one action signature missing is rejected with the expected error message
+// rather than panicking (T-GAP-4).
+func TestSecurityFR_BackendCursorExhausted(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Drop all action signatures so the cursor exhausts immediately.
+	var filtered []*driver.RequestSignature
+	for _, sig := range env.TRWithTransfer.Signatures {
+		if sig != nil && sig.Auditor != nil {
+			filtered = append(filtered, sig)
+		}
+	}
+	env.TRWithTransfer.Signatures = filtered
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	}, "T-GAP-4: missing action signature must not panic")
+	require.Error(t, err, "T-GAP-4: missing action signature must be rejected")
+	assert.Contains(t, err.Error(), "insufficient number of signatures")
+}
+
+// ===========================================================================
+// STEP 1C — MinProtocolVersion enforcement (T-GAP-6)
+// ===========================================================================
+
+// TestSecurityFA_MinProtocolVersionEnforced verifies that requests carrying a
+// protocol version below the configured minimum are rejected with
+// driver.ErrVersionBelowMinimum (T-GAP-6).
+func TestSecurityFA_MinProtocolVersionEnforced(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Require at least version 2; the env produces version 1 requests.
+	env.Engine.SetMinProtocolVersion(2)
+
+	raw, err := env.TRWithTransfer.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err, "T-GAP-6: version below minimum must be rejected")
+	require.ErrorIs(t, err, driver.ErrVersionBelowMinimum)
+}
+
+// ===========================================================================
+// STEP 1E — Multi-auditor: one valid + one forged sig (T-GAP-8)
+// ===========================================================================
+
+// TestSecurityAuditing_OneValidOneBadSignature verifies that when two auditor
+// signatures are present but one of them carries an invalid (tampered) signature
+// bytes, the request is rejected (T-GAP-8).
+//
+// The AuditingSignaturesValidate function verifies every provided auditor
+// signature independently. A forged signature that fails Verify must cause
+// the entire request to be rejected.
+func TestSecurityAuditing_OneValidOneBadSignature(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	// Find the existing auditor signature in the issue request.
+	var auditorSig *driver.RequestSignature
+	for _, sig := range env.TRWithIssue.Signatures {
+		if sig != nil && sig.Auditor != nil {
+			auditorSig = sig
+
+			break
+		}
+	}
+	require.NotNil(t, auditorSig, "env must produce at least one auditor signature")
+
+	// Inject a second auditor signature that has the same Identity (so it passes
+	// the is-authorized check) but carries forged signature bytes (so Verify fails).
+	forgedSig := &driver.RequestSignature{
+		Auditor: &driver.AuditorSignature{
+			Identity:  auditorSig.Auditor.Identity, // recognized identity
+			Signature: []byte("forged-auditor-signature-bytes"),
+		},
+	}
+	env.TRWithIssue.Signatures = append(env.TRWithIssue.Signatures, forgedSig)
+
+	raw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	require.Error(t, err, "T-GAP-8: forged auditor signature must cause rejection")
+	assert.Contains(t, err.Error(), "failed to verify auditor's signature")
+}

--- a/token/core/zkatdlog/nogh/v1/validator/validator_transfer.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_transfer.go
@@ -27,9 +27,18 @@ func TransferActionValidate(c context.Context, ctx *Context) error {
 	return ctx.TransferAction.Validate()
 }
 
-// TransferSignatureValidate validates the signatures of the transfer action
+// TransferSignatureValidate validates the signatures of the transfer action.
+// It assumes TransferActionValidate has been called first; however it also
+// performs its own nil guards so that it cannot panic even when called in
+// isolation (e.g., in a custom validation pipeline).
+//
+// Open-policy redeem behaviour: when PP.IssuerIDs is empty (len(ctx.PP.Issuers()) == 0),
+// the issuer-signature requirement for redeem actions is skipped entirely and any
+// transfer (including those with nil-owner outputs) is accepted without an issuer signature.
+// This mirrors the open-policy issuer behaviour in IssueValidate and is intentional for
+// deployments that do not restrict which identities may authorize redemptions.
+// When issuer restriction is required for redemptions, populate PP.IssuerIDs.
 func TransferSignatureValidate(c context.Context, ctx *Context) error {
-	// recall that TransferActionValidate has been called before this function
 	var signatures [][]byte
 
 	if len(ctx.TransferAction.Inputs) == 0 {
@@ -39,6 +48,11 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 	var isRedeem bool
 	var inputToken []*token.Token
 	for i, in := range ctx.TransferAction.Inputs {
+		// Guard against a nil ActionInput or a nil Token inside it so that
+		// this function cannot panic even if TransferActionValidate was skipped.
+		if in == nil || in.Token == nil {
+			return errors.Errorf("invalid input at index [%d]: nil input or nil token", i)
+		}
 		tok := in.Token
 		inputToken = append(inputToken, tok)
 
@@ -63,6 +77,11 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 	if len(ctx.PP.Issuers()) > 0 {
 		// In this case we must ensure that an issuer signed as well if the action redeems tokens as well
 		for _, output := range ctx.TransferAction.Outputs {
+			// Guard against a nil output entry (defensive; Validate() rejects these
+			// but custom pipelines may bypass it).
+			if output == nil {
+				continue
+			}
 			if output.Owner == nil {
 				isRedeem = true
 
@@ -93,6 +112,10 @@ func TransferSignatureValidate(c context.Context, ctx *Context) error {
 
 // TransferUpgradeWitnessValidate validates that inputs that want to be upgraded, have a valid witness.
 // It recomputes the commitment from the witness and compares it with the input token's data.
+//
+// Owner check: both the input token owner and the FabToken owner are required to be
+// non-empty. An empty (nil or zero-length) owner on either side is rejected with
+// ErrOwnersMismatch to prevent a free-claim of ownerless tokens via upgrade.
 func TransferUpgradeWitnessValidate(c context.Context, ctx *Context) error {
 	// recall that TransferActionValidate has been called before this function
 
@@ -116,7 +139,11 @@ func TransferUpgradeWitnessValidate(c context.Context, ctx *Context) error {
 			if !input.Token.Data.Equals(tokens[0]) {
 				return ErrCommitmentMismatch
 			}
-			// check owner
+			// check owner — both sides must be non-empty; an empty owner would allow
+			// a free-claim of an ownerless token (FR-2 guard).
+			if len(input.Token.Owner) == 0 || len(witness.FabToken.Owner) == 0 {
+				return ErrOwnersMismatch
+			}
 			if !bytes.Equal(input.Token.Owner, witness.FabToken.Owner) {
 				return ErrOwnersMismatch
 			}
@@ -126,19 +153,28 @@ func TransferUpgradeWitnessValidate(c context.Context, ctx *Context) error {
 	return nil
 }
 
-// TransferZKProofValidate validates the ZK proof of the transfer action
+// TransferZKProofValidate validates the ZK proof of the transfer action.
+// It guards against nil entries in ctx.InputTokens so that it cannot panic
+// even if an earlier validator stage left the slice in an inconsistent state.
 func TransferZKProofValidate(c context.Context, ctx *Context) error {
 	in := make([]*math.G1, len(ctx.InputTokens))
 	for i, tok := range ctx.InputTokens {
+		if tok == nil {
+			return errors.Errorf("nil input token at index [%d]", i)
+		}
 		in[i] = tok.Data
 	}
 
-	if err := transfer.NewVerifier(
+	verifier, err := transfer.NewVerifier(
 		in,
 		ctx.TransferAction.GetOutputCommitments(),
 		ctx.PP,
 		ctx.TransferAction.ProofType,
-	).Verify(ctx.TransferAction.GetProof()); err != nil {
+	)
+	if err != nil {
+		return errors.Join(err, ErrInvalidZKP)
+	}
+	if err := verifier.Verify(ctx.TransferAction.GetProof()); err != nil {
 		return errors.Join(err, ErrInvalidZKP)
 	}
 
@@ -147,10 +183,16 @@ func TransferZKProofValidate(c context.Context, ctx *Context) error {
 
 // TransferHTLCValidate validates the HTLC scripts in the transfer action.
 // It ensures that HTLC scripts only transfer ownership of a single token and that the script conditions are met.
+// Nil entries in ctx.InputTokens and ctx.TransferAction.Outputs are guarded against explicitly
+// so that this function never panics, regardless of pipeline order.
 func TransferHTLCValidate(c context.Context, ctx *Context) error {
 	now := time.Now()
 
 	for i, in := range ctx.InputTokens {
+		// Guard: a nil token in the input slice must return an error, not panic.
+		if in == nil {
+			return errors.Errorf("nil input token at index [%d]", i)
+		}
 		owner, err := identity.UnmarshalTypedIdentity(in.Owner)
 		if err != nil {
 			return errors.Wrap(err, "failed to unmarshal owner of input token")
@@ -172,7 +214,11 @@ func TransferHTLCValidate(c context.Context, ctx *Context) error {
 				return errors.Wrap(err, "failed to verify transfer from htlc script")
 			}
 
-			// check metadata
+			// guard against a missing signature at index i (e.g., when this validator
+			// runs without TransferSignatureValidate having populated ctx.Signatures)
+			if i >= len(ctx.Signatures) {
+				return errors.Errorf("missing signature for input at index [%d]", i)
+			}
 			sigma := ctx.Signatures[i]
 			metadataKey, err := htlc2.MetadataClaimKeyCheck(ctx.TransferAction, script, op, sigma)
 			if err != nil {
@@ -185,6 +231,11 @@ func TransferHTLCValidate(c context.Context, ctx *Context) error {
 	}
 
 	for _, o := range ctx.TransferAction.Outputs {
+		// Guard: skip nil output entries defensively (Validate() rejects them,
+		// but custom pipelines may bypass Validate).
+		if o == nil {
+			continue
+		}
 		if o.IsRedeem() {
 			continue
 		}


### PR DESCRIPTION
This PR hardens the ZKATDLog (zkatdlog/nogh/v1) token engine across several security dimensions: deterministic public-parameter generation, validator robustness against malformed inputs, and a new proof-type safety gate that prevents an attacker from selecting a verifier whose required `PublicParams` sub-struct is absent.

## Changes

### 1. Deterministic Pedersen and Range-Proof Generators (`setup/setup.go`)
Pedersen generators and all range-proof generators (IPA, CSP) are now derived using `curve.HashToG1` with a **domain-separated, deterministic label** (`lfdt-panurus.<driver>.<version>.<role>.<index>`) instead of multiplying `GenG1` by a random scalar. This makes public parameters reproducible from the stored `DriverName`/`DriverVersion` fields, removes the dependency on a PRNG at setup time, and improves the existing labels for range-proof generators (previously bare integers `"0"`, `"1"`, `"RangeProof.2"`, etc.).

### 2. `SupportsRangeProofType` + Proof-Type Mismatch Guard (`setup/setup.go`, `transfer/transfer.go`, `issue/issue.go`)
A new `PublicParams.SupportsRangeProofType(proofType)` helper gates verifier construction. Both `transfer.NewVerifier` and `issue.NewVerifier` now return an `(Verifier, error)` instead of `Verifier`, and both return `ErrProofTypeMismatch` when the required sub-struct (`RangeProofParams` or `CSPRangeProofParams`) is `nil`. This closes the attack vector where an adversary could embed a proof type in an action whose matching params sub-struct is absent, causing a nil-pointer dereference inside the verifier.

### 3. CSP: Reject Points at Infinity (`crypto/rp/csp/validation.go`)
The CSP verifier's `validateG1Slice` and `validateCSPProof` functions now reject **identity elements (points at infinity)** in generators and in proof folding-commitment arrays (`proof.Left`, `proof.Right`). Previously, infinity was explicitly permitted with a comment noting "edge cases"; this is corrected because an infinity point in a generator collapses the commitment scheme and in a proof element neutralises the corresponding round constraint, weakening range-proof soundness. The per-element loops are replaced with a call to `math.CheckElements` (which already checks for nil, wrong curve, and infinity).

### 4. Validator Robustness – Nil & Out-of-Bounds Guards
Multiple validator functions are hardened against nil or inconsistent inputs to prevent panics in custom or adversarial validation pipelines:

| Location | Guard added |
|---|---|
| `validator_transfer.go` – `TransferSignatureValidate` | Rejects nil `ActionInput` or nil `ActionInput.Token` |
| `validator_transfer.go` – `TransferZKProofValidate` | Rejects nil `ctx.InputTokens[i]` |
| `validator_transfer.go` – `TransferHTLCValidate` | Rejects nil `ctx.InputTokens[i]`; bounds-checks `ctx.Signatures` before indexing |
| `validator_transfer.go` – `TransferUpgradeWitnessValidate` | Rejects empty/nil owner on either side (closes free-claim of ownerless tokens, FR-2) |
| `transfer/action.go` – `GetInputs` | Nil input entries produce `nil` IDs instead of panicking |
| `transfer/action.go` – `GetSerializedInputs` | Returns error for nil `input.Token` |
| `transfer/action.go` – `IsRedeemAt` / `SerializeOutputAt` | Bounds-check index before accessing `t.Outputs` |
| `transfer/action.go` – `GetSerializedOutputs` / `GetOutputCommitments` | Skip or error on nil output entries |
| `transfer/action.go` – `Deserialize` | Nil output entries during deserialization now return an error instead of silently continuing |

### 5. `TypeAndSumProof` Validation Fix (`transfer/typeandsum.go`)
- `Validate`: the length check for `InputBlindingFactors` was incorrectly using `len(p.InputBlindingFactors)` as the expected length, making the check trivially pass. Corrected to `len(p.InputValues)`.
- `TypeAndSumVerifier.Verify`: added a guard to reject proofs where `len(stp.InputBlindingFactors) != len(v.Inputs)`, preventing an out-of-bounds access in the verifier loop.

### 6. `ValidateForDeployment` (`setup/setup.go`)
Adds a new `PublicParams.ValidateForDeployment()` method that warns when `IssuerIDs` is empty (open-policy mode). Existing `Validate()` continues to accept empty `IssuerIDs`; this is a separate, optional deployment-time check. Docstrings in `IssueValidate` and `TransferSignatureValidate` document the open-policy behaviour explicitly.

### 7. Documentation and Test Coverage
- `docs/drivers/dlogwogh.md` updated to reflect the new deterministic generator derivation and security improvements.
- Added comprehensive validator security tests in `validator/validator_security_test.go` and `validator/validator_security_extra_test.go` covering the nil/infinity/mismatch attack vectors described above.
- Extended tests in `setup/setup_test.go`, `transfer/action_test.go`, `transfer/bftransfer_test.go`, `transfer/typeandsum_test.go`, `issue/issuer_test.go`, `issue/prover_test.go`, and `crypto/rp/csp/`.

## Testing
All existing unit tests pass. New security-focused tests verify:
- Nil/infinity element rejection in CSP validators
- `ErrProofTypeMismatch` when no matching params sub-struct is present
- Nil-input panics converted to proper errors in transfer and issue validators
- `TypeAndSumProof` length invariant enforcement
- Ownerless-token free-claim prevention in upgrade witness validation
