### PR TITLE
fix(boolpolicy): bound recursive-descent depth and input length to prevent stack exhaustion

### DIFF
--- a/token/services/identity/boolpolicy/parser.go
+++ b/token/services/identity/boolpolicy/parser.go
@@ -25,6 +25,19 @@ import (
 	"unicode"
 )
 
+const (
+	// maxPolicyLen is the maximum byte length accepted by Parse.
+	// Policies longer than 4 KB cannot represent a sensible real-world
+	// expression and are almost certainly an attack or a bug.
+	maxPolicyLen = 4 * 1024
+
+	// maxParseDepth is the maximum parenthesis nesting depth allowed by the
+	// recursive-descent parser.  Each open parenthesis adds one frame to the
+	// Go call stack; capping at 64 prevents goroutine stack exhaustion from
+	// attacker-supplied deeply-nested expressions.
+	maxParseDepth = 64
+)
+
 // ---------------------------------------------------------------------------
 // AST nodes
 // ---------------------------------------------------------------------------
@@ -169,14 +182,24 @@ type parser struct {
 
 // Parse parses a boolean expression string and returns the root AST node.
 // It returns an error for any lexical or syntactic problems.
+//
+// Parse enforces two hard limits to prevent resource exhaustion:
+//   - input longer than maxPolicyLen bytes is rejected immediately.
+//   - parenthesis nesting deeper than maxParseDepth levels is rejected;
+//     this bounds the Go call-stack depth of the recursive descent and
+//     prevents goroutine stack exhaustion from attacker-supplied input.
 func Parse(input string) (Node, error) {
+	if len(input) > maxPolicyLen {
+		return nil, fmt.Errorf("policy expression exceeds maximum length of %d bytes (got %d)", maxPolicyLen, len(input))
+	}
+
 	p := &parser{lex: newLexer(input)}
 	p.advance() // prime the lookahead
 	if p.err != nil {
 		return nil, p.err
 	}
 
-	node := p.parseOr()
+	node := p.parseOr(0)
 	if p.err != nil {
 		return nil, p.err
 	}
@@ -196,11 +219,11 @@ func (p *parser) advance() {
 
 // parseOr handles: and_expr ( 'OR' and_expr )*
 // OR is left-associative and lower precedence than AND.
-func (p *parser) parseOr() Node {
-	left := p.parseAnd()
+func (p *parser) parseOr(depth int) Node {
+	left := p.parseAnd(depth)
 	for p.err == nil && p.current.kind == tokOr {
 		p.advance()
-		right := p.parseAnd()
+		right := p.parseAnd(depth)
 		left = &OrNode{Left: left, Right: right}
 	}
 
@@ -209,11 +232,11 @@ func (p *parser) parseOr() Node {
 
 // parseAnd handles: primary ( 'AND' primary )*
 // AND is left-associative and higher precedence than OR.
-func (p *parser) parseAnd() Node {
-	left := p.parsePrimary()
+func (p *parser) parseAnd(depth int) Node {
+	left := p.parsePrimary(depth)
 	for p.err == nil && p.current.kind == tokAnd {
 		p.advance()
-		right := p.parsePrimary()
+		right := p.parsePrimary(depth)
 		left = &AndNode{Left: left, Right: right}
 	}
 
@@ -221,7 +244,7 @@ func (p *parser) parseAnd() Node {
 }
 
 // parsePrimary handles: '$' digits | '(' expr ')'
-func (p *parser) parsePrimary() Node {
+func (p *parser) parsePrimary(depth int) Node {
 	if p.err != nil {
 		return nil
 	}
@@ -233,8 +256,13 @@ func (p *parser) parsePrimary() Node {
 		return node
 
 	case tokLParen:
+		if depth >= maxParseDepth {
+			p.err = fmt.Errorf("policy expression exceeds maximum nesting depth of %d", maxParseDepth)
+
+			return nil
+		}
 		p.advance() // consume '('
-		node := p.parseOr()
+		node := p.parseOr(depth + 1)
 		if p.err != nil {
 			return nil
 		}

--- a/token/services/identity/boolpolicy/parser_test.go
+++ b/token/services/identity/boolpolicy/parser_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package boolpolicy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -259,4 +260,59 @@ func TestErrorMissingOperand(t *testing.T) {
 func TestErrorUnexpectedCharacter(t *testing.T) {
 	_, err := Parse("$0 & $1")
 	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// Security: resource-exhaustion guards
+// ---------------------------------------------------------------------------
+
+func TestErrorInputTooLong(t *testing.T) {
+	// Build a string that is exactly one byte over the limit.
+	// Its content is irrelevant; we just need length > maxPolicyLen.
+	long := make([]byte, maxPolicyLen+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	_, err := Parse(string(long))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum length")
+}
+
+func TestErrorNestingTooDeep(t *testing.T) {
+	// Build a policy with maxParseDepth+1 open parentheses, e.g.
+	// "(((... $0 ...)))" — one level deeper than the allowed limit.
+	depth := maxParseDepth + 1
+	policy := ""
+	var policySb285 strings.Builder
+	for range depth {
+		policySb285.WriteString("(")
+	}
+	policy += policySb285.String()
+	policy += "$0"
+	var policySb289 strings.Builder
+	for range depth {
+		policySb289.WriteString(")")
+	}
+	policy += policySb289.String()
+	_, err := Parse(policy)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum nesting depth")
+}
+
+func TestNestingAtLimitIsAllowed(t *testing.T) {
+	// A policy nested exactly at maxParseDepth must succeed.
+	policy := ""
+	var policySb300 strings.Builder
+	for range maxParseDepth {
+		policySb300.WriteString("(")
+	}
+	policy += policySb300.String()
+	policy += "$0"
+	var policySb304 strings.Builder
+	for range maxParseDepth {
+		policySb304.WriteString(")")
+	}
+	policy += policySb304.String()
+	_, err := Parse(policy)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Problem

`boolpolicy/parser.go` had no defence against attacker-supplied input:

- **No input-length cap** — `Parse` passed arbitrarily long strings directly to the lexer.
- **No depth limit** — `parsePrimary` called `parseOr` on every `(` token with no counter,
  allowing unbounded mutual recursion (`parsePrimary → parseOr → parseAnd → parsePrimary → …`).

A policy string with N nested parentheses produces ~3 N Go stack frames. At ~100 000 levels the
Go runtime emits `runtime: goroutine stack exceeds 1000000000-byte limit` and aborts the process
via `runtime.throw` — **not** a `panic`, so no `defer/recover` wrapper can intercept it. Both
production drivers (`fabtoken` and `zkatdlog`) register the `boolpolicy` deserializer on the
`Owner` field path, meaning a single malicious transfer transaction is sufficient to crash the
chaincode container.

## Solution

Two complementary guards added entirely within `parser.go`; no public API or wire-format change.

### 1 — Input-length cap (`maxPolicyLen = 4096`)

```go
// Parse, first line of the function body
if len(input) > maxPolicyLen {
    return nil, fmt.Errorf("policy expression exceeds maximum length of %d bytes (got %d)", maxPolicyLen, len(input))
}
```

Stops the attack before the lexer is created. 4 KB is generous for any legitimate policy.

### 2 — Nesting depth cap (`maxParseDepth = 64`)

`parseOr`, `parseAnd`, and `parsePrimary` each receive a `depth int` parameter.  
`depth` is passed **unchanged** through `OR`/`AND` chaining (no new call per infix token) and
incremented by exactly **one** when descending into a parenthesised sub-expression:

```go
case tokLParen:
    if depth >= maxParseDepth {
        p.err = fmt.Errorf("policy expression exceeds maximum nesting depth of %d", maxParseDepth)
        return nil
    }
    p.advance()
    node := p.parseOr(depth + 1)
```

At the limit the Go call-stack depth is bounded to ~3 × 64 = ~192 frames — negligible.

## Files changed

| File | Change |
|------|--------|
| `token/services/identity/boolpolicy/parser.go` | Add `maxPolicyLen`/`maxParseDepth` constants; guard in `Parse`; thread `depth` through recursive methods |
| `token/services/identity/boolpolicy/parser_test.go` | Three new security regression tests |

## Testing

Three new tests in `parser_test.go` (all in the same `boolpolicy` package so the unexported
constants are accessible):

| Test | Assertion |
|------|-----------|
| `TestErrorInputTooLong` | A `maxPolicyLen+1`-byte string is rejected with "exceeds maximum length" |
| `TestErrorNestingTooDeep` | `maxParseDepth+1` nested parentheses are rejected with "exceeds maximum nesting depth" |
| `TestNestingAtLimitIsAllowed` | Exactly `maxParseDepth` nested parentheses are accepted (fence-post check) |

Full package test run — all 74 tests pass:

```
ok  github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy  2.171s
```

## Backwards compatibility

- **Wire format**: unchanged — `PolicyIdentity` serialization is not touched.
- **Public API**: `Parse(string) (Node, error)` signature is unchanged; callers that previously
  passed oversized or over-nested input will now receive an error rather than crashing.
- **Limits**: 4 KB / depth 64 are deliberately conservative. Real-world policies in the existing
  test suite are well under 100 bytes and 3 levels deep.

## Checklist

- [x] Signed-off (`git commit -s`)
- [x] `make checks` passes
- [x] `make unit-tests` passes
- [x] No new exported symbols; no wire-format change
- [x] Security regression tests added
