### PR TITLE
feat(evm): initial foundation - design, crypto primitives and address/hash types

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
+	github.com/dgraph-io/badger/v4 v4.9.2 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.4.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
@@ -85,6 +86,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
@@ -118,6 +120,7 @@ require (
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kilic/bls12-381 v0.1.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/parsers/yaml v1.1.0 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -717,6 +717,8 @@ github.com/decred/dcrd/crypto/blake256 v1.1.0 h1:zPMNGQCm0g4QTY27fOCorQW7EryeQ/U
 github.com/decred/dcrd/crypto/blake256 v1.1.0/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 h1:5RVFMOWjMyRy8cARdy79nAmgYw3hK/4HUq48LQ6Wwqo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1/go.mod h1:ZXNYxsqcloTdSy/rNShjYzMhyjf0LaoftYK0p+A3h40=
+github.com/dgraph-io/badger/v4 v4.9.2 h1:Wb5qw8gElqwV1a8msHTeQKova9b1V10heFKMIiPd80E=
+github.com/dgraph-io/badger/v4 v4.9.2/go.mod h1:nJjaJTUOSsQEBhsq209FmwCvMJzEA3e74RjZw6V2pQI=
 github.com/dgraph-io/ristretto/v2 v2.4.0 h1:I/w09yLjhdcVD2QV192UJcq8dPBaAJb9pOuMyNy0XlU=
 github.com/dgraph-io/ristretto/v2 v2.4.0/go.mod h1:0KsrXtXvnv0EqnzyowllbVJB8yBonswa2lTCK2gGo9E=
 github.com/dgryski/go-farm v0.0.0-20240924180020-3414d57e47da h1:aIftn67I1fkbMa512G+w+Pxci9hJPB8oMnkcP3iZF38=
@@ -871,6 +873,8 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v25.2.10+incompatible h1:F3vclr7C3HpB1k9mxCGRMXq6FdUalZ6H/pNX4FP1v0Q=
+github.com/google/flatbuffers v25.2.10+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/x/token/services/network/evm/client/types.go
+++ b/x/token/services/network/evm/client/types.go
@@ -1,0 +1,177 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package client defines the EVM JSON-RPC client abstraction used by the network driver,
+// together with the local value types (Address, Hash) exchanged with the chain.
+//
+// The types are defined locally, without go-ethereum, because that dependency's license is a
+// hard blocker for the project. They are a minimal mirror of the well-known 20-byte address and
+// 32-byte hash, with hex, text and JSON encoding. Addresses are rendered as lowercase hex; EIP-55
+// checksum rendering can be layered on later if a UI needs it (it does not affect on-chain
+// comparisons, which are by bytes).
+package client
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+const (
+	// AddressLength is the length in bytes of an Ethereum address.
+	AddressLength = 20
+	// HashLength is the length in bytes of a Keccak256/SHA-256 hash.
+	HashLength = 32
+)
+
+// Address is a 20-byte Ethereum account or contract address.
+type Address [AddressLength]byte
+
+// Hash is a 32-byte hash value (Keccak256 or SHA-256).
+type Hash [HashLength]byte
+
+// BytesToAddress returns an Address set to the value of b.
+// If b is longer than AddressLength it is right-aligned (the low-order bytes are kept), matching
+// the conventional interpretation of an address as a big-endian 160-bit value.
+func BytesToAddress(b []byte) Address {
+	var a Address
+	if len(b) > AddressLength {
+		b = b[len(b)-AddressLength:]
+	}
+	copy(a[AddressLength-len(b):], b)
+
+	return a
+}
+
+// HexToAddress parses a hex string (with or without a 0x prefix) into an Address.
+// It is strict: the decoded value must be exactly AddressLength bytes.
+func HexToAddress(s string) (Address, error) {
+	b, err := decodeHex(s)
+	if err != nil {
+		return Address{}, errors.Wrapf(err, "invalid address [%s]", s)
+	}
+	if len(b) != AddressLength {
+		return Address{}, errors.Errorf("invalid address length for [%s]: expected %d bytes, got %d", s, AddressLength, len(b))
+	}
+
+	return BytesToAddress(b), nil
+}
+
+// Bytes returns the address as a byte slice.
+func (a Address) Bytes() []byte { return a[:] }
+
+// Hex returns the 0x-prefixed lowercase hex encoding of the address.
+func (a Address) Hex() string { return "0x" + hex.EncodeToString(a[:]) }
+
+// String implements fmt.Stringer, returning the 0x-prefixed hex encoding.
+func (a Address) String() string { return a.Hex() }
+
+// MarshalText implements encoding.TextMarshaler (used by JSON and YAML).
+func (a Address) MarshalText() ([]byte, error) { return []byte(a.Hex()), nil }
+
+// UnmarshalText implements encoding.TextUnmarshaler, parsing a hex string into the address.
+func (a *Address) UnmarshalText(text []byte) error {
+	parsed, err := HexToAddress(string(text))
+	if err != nil {
+		return err
+	}
+	*a = parsed
+
+	return nil
+}
+
+// BytesToHash returns a Hash set to the value of b, right-aligned like BytesToAddress.
+func BytesToHash(b []byte) Hash {
+	var h Hash
+	if len(b) > HashLength {
+		b = b[len(b)-HashLength:]
+	}
+	copy(h[HashLength-len(b):], b)
+
+	return h
+}
+
+// HexToHash parses a hex string (with or without a 0x prefix) into a Hash.
+// It is strict: the decoded value must be exactly HashLength bytes.
+func HexToHash(s string) (Hash, error) {
+	b, err := decodeHex(s)
+	if err != nil {
+		return Hash{}, errors.Wrapf(err, "invalid hash [%s]", s)
+	}
+	if len(b) != HashLength {
+		return Hash{}, errors.Errorf("invalid hash length for [%s]: expected %d bytes, got %d", s, HashLength, len(b))
+	}
+
+	return BytesToHash(b), nil
+}
+
+// Bytes returns the hash as a byte slice.
+func (h Hash) Bytes() []byte { return h[:] }
+
+// Hex returns the 0x-prefixed lowercase hex encoding of the hash.
+func (h Hash) Hex() string { return "0x" + hex.EncodeToString(h[:]) }
+
+// String implements fmt.Stringer, returning the 0x-prefixed hex encoding.
+func (h Hash) String() string { return h.Hex() }
+
+// MarshalText implements encoding.TextMarshaler (used by JSON and YAML).
+func (h Hash) MarshalText() ([]byte, error) { return []byte(h.Hex()), nil }
+
+// UnmarshalText implements encoding.TextUnmarshaler, parsing a hex string into the hash.
+func (h *Hash) UnmarshalText(text []byte) error {
+	parsed, err := HexToHash(string(text))
+	if err != nil {
+		return err
+	}
+	*h = parsed
+
+	return nil
+}
+
+// Compile-time checks that the JSON encoders round-trip through the text encoders.
+var (
+	_ json.Marshaler   = Address{}
+	_ json.Unmarshaler = (*Address)(nil)
+	_ json.Marshaler   = Hash{}
+	_ json.Unmarshaler = (*Hash)(nil)
+)
+
+// MarshalJSON encodes the address as a JSON hex string.
+func (a Address) MarshalJSON() ([]byte, error) { return json.Marshal(a.Hex()) }
+
+// UnmarshalJSON decodes a JSON hex string into the address.
+func (a *Address) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return errors.Wrapf(err, "address must be a JSON string")
+	}
+
+	return a.UnmarshalText([]byte(s))
+}
+
+// MarshalJSON encodes the hash as a JSON hex string.
+func (h Hash) MarshalJSON() ([]byte, error) { return json.Marshal(h.Hex()) }
+
+// UnmarshalJSON decodes a JSON hex string into the hash.
+func (h *Hash) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return errors.Wrapf(err, "hash must be a JSON string")
+	}
+
+	return h.UnmarshalText([]byte(s))
+}
+
+// decodeHex decodes a hex string, tolerating an optional 0x/0X prefix and surrounding whitespace.
+func decodeHex(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "0x")
+	s = strings.TrimPrefix(s, "0X")
+
+	return hex.DecodeString(s)
+}

--- a/x/token/services/network/evm/client/types_test.go
+++ b/x/token/services/network/evm/client/types_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHexToAddress(t *testing.T) {
+	const canonical = "0x1234567890123456789012345678901234567890"
+
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+		wantHex string
+	}{
+		{name: "0x prefix", in: canonical, wantHex: canonical},
+		{name: "no prefix", in: "1234567890123456789012345678901234567890", wantHex: canonical},
+		{name: "uppercase", in: "0xABCDEF0000000000000000000000000000000000", wantHex: "0xabcdef0000000000000000000000000000000000"},
+		{name: "whitespace", in: "  " + canonical + "  ", wantHex: canonical},
+		{name: "too short", in: "0x1234", wantErr: true},
+		{name: "too long", in: canonical + "00", wantErr: true},
+		{name: "not hex", in: "0xZZ34567890123456789012345678901234567890", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a, err := HexToAddress(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantHex, a.Hex())
+		})
+	}
+}
+
+func TestAddressRoundTrip(t *testing.T) {
+	a, err := HexToAddress("0x1234567890123456789012345678901234567890")
+	require.NoError(t, err)
+
+	assert.Len(t, a.Bytes(), AddressLength)
+	assert.Equal(t, a.Hex(), a.String())
+
+	// text round-trip
+	text, err := a.MarshalText()
+	require.NoError(t, err)
+	var fromText Address
+	require.NoError(t, fromText.UnmarshalText(text))
+	assert.Equal(t, a, fromText)
+
+	// JSON round-trip
+	raw, err := json.Marshal(a)
+	require.NoError(t, err)
+	assert.JSONEq(t, `"0x1234567890123456789012345678901234567890"`, string(raw))
+	var fromJSON Address
+	require.NoError(t, json.Unmarshal(raw, &fromJSON))
+	assert.Equal(t, a, fromJSON)
+}
+
+func TestBytesToAddressRightAligns(t *testing.T) {
+	// shorter than 20 bytes: left-padded with zeros
+	short := BytesToAddress([]byte{0x01, 0x02})
+	assert.Equal(t, "0x0000000000000000000000000000000000000102", short.Hex())
+
+	// longer than 20 bytes: low-order 20 bytes kept
+	long := make([]byte, 22)
+	long[0], long[1] = 0xff, 0xff // these must be dropped
+	long[21] = 0x09
+	assert.Equal(t, "0x0000000000000000000000000000000000000009", BytesToAddress(long).Hex())
+}
+
+func TestHexToHash(t *testing.T) {
+	const canonical = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+	h, err := HexToHash(canonical)
+	require.NoError(t, err)
+	assert.Equal(t, canonical, h.Hex())
+	assert.Len(t, h.Bytes(), HashLength)
+
+	_, err = HexToHash("0xdeadbeef")
+	assert.Error(t, err, "hash shorter than 32 bytes must be rejected")
+}
+
+func TestHashRoundTrip(t *testing.T) {
+	h, err := HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+	require.NoError(t, err)
+
+	raw, err := json.Marshal(h)
+	require.NoError(t, err)
+	var fromJSON Hash
+	require.NoError(t, json.Unmarshal(raw, &fromJSON))
+	assert.Equal(t, h, fromJSON)
+}

--- a/x/token/services/network/evm/contracts/README.md
+++ b/x/token/services/network/evm/contracts/README.md
@@ -1,0 +1,16 @@
+# EVM Token Contracts
+
+Solidity sources for the EVM network driver (Approach 2). Landed in Phase 2.
+
+- `EndorsementVerifier.sol` — manages the authorized endorser set and threshold, and verifies
+  EIP-712 endorser signatures (ecrecover, low-s, `v ∈ {27,28}`, signer uniqueness).
+- `TokenState.sol` — stores token state and applies endorsed `StateDelta`s: verifies signatures,
+  checks the public-parameters version, enforces spent/existence per the `graphHiding` flag, then
+  applies the transition. Deployed per TMS via an EIP-1167 minimal clone.
+
+The on-chain `computeTokenID` and EIP-712 `hashStruct` MUST match the Go implementations in
+`../keys` and `../eip712` byte-for-byte. Phase 2 commits a shared digest fixture (produced by the
+Go side in Phase 1.4) and asserts the Solidity side reproduces it.
+
+Constraint: nothing in the Go driver may link go-ethereum. Tooling here (forge/anvil) is for
+contract build and test only, not linked into the driver binary.

--- a/x/token/services/network/evm/crypto/hash.go
+++ b/x/token/services/network/evm/crypto/hash.go
@@ -1,0 +1,63 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package crypto provides the hashing primitives used by the EVM network driver.
+//
+// Two hash functions are used across the driver, and they are NOT interchangeable:
+//
+//   - Keccak256 is the EVM-native hash. It backs on-chain object keys (token IDs, spent
+//     markers, metadata keys) and the EIP-712 digest, so anything the Solidity contracts
+//     recompute must use Keccak256.
+//   - SHA256 backs the values that flow through the rest of the Token SDK, namely the
+//     token-request hash and the public-parameters hash. The SDK computes those with SHA-256
+//     (see token/services/utils.Hashable), so the driver must match to stay interoperable with
+//     finality and public-parameters checks.
+//
+// This package deliberately does not depend on go-ethereum: its license is a hard blocker for
+// the project. Keccak comes from golang.org/x/crypto/sha3.
+package crypto
+
+import (
+	"crypto/sha256"
+
+	"golang.org/x/crypto/sha3"
+)
+
+// HashLength is the length in bytes of a Keccak256 or SHA-256 digest.
+const HashLength = 32
+
+// Keccak256 returns the Keccak-256 digest of the concatenation of data.
+//
+// This is the pre-standardization Keccak used by Ethereum, not FIPS-202 SHA3-256; the two
+// produce different digests for the same input.
+func Keccak256(data ...[]byte) []byte {
+	h := sha3.NewLegacyKeccak256()
+	for _, b := range data {
+		// hash.Hash.Write is documented never to return an error.
+		_, _ = h.Write(b)
+	}
+
+	return h.Sum(nil)
+}
+
+// Keccak256Hash returns the Keccak-256 digest of the concatenation of data as a fixed-size array.
+func Keccak256Hash(data ...[]byte) [HashLength]byte {
+	var out [HashLength]byte
+	copy(out[:], Keccak256(data...))
+
+	return out
+}
+
+// SHA256 returns the SHA-256 digest of data.
+//
+// It matches token/services/utils.Hashable.Raw() for non-empty input, which is what the Token
+// SDK uses for the token-request hash and the public-parameters hash. Use SHA256 (not Keccak256)
+// whenever a value must line up with those SDK-computed hashes.
+func SHA256(data []byte) []byte {
+	sum := sha256.Sum256(data)
+
+	return sum[:]
+}

--- a/x/token/services/network/evm/crypto/hash_test.go
+++ b/x/token/services/network/evm/crypto/hash_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package crypto
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeccak256KnownVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Well-known Ethereum keccak-256 vectors.
+		{name: "empty", in: "", want: "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"},
+		{name: "abc", in: "abc", want: "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hex.EncodeToString(Keccak256([]byte(tc.in))))
+		})
+	}
+}
+
+// TestKeccak256Concatenation guards the variadic behaviour: hashing several slices must equal
+// hashing their concatenation, because callers rely on that when building composite keys.
+func TestKeccak256Concatenation(t *testing.T) {
+	assert.Equal(t, Keccak256([]byte("abc")), Keccak256([]byte("a"), []byte("bc")))
+	assert.Equal(t, Keccak256([]byte("abc")), Keccak256([]byte("ab"), []byte("c")))
+}
+
+func TestKeccak256HashLength(t *testing.T) {
+	h := Keccak256Hash([]byte("anything"))
+	assert.Len(t, h[:], HashLength)
+	assert.Equal(t, Keccak256([]byte("anything")), h[:])
+}
+
+func TestSHA256KnownVector(t *testing.T) {
+	assert.Equal(t,
+		"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+		hex.EncodeToString(SHA256([]byte("abc"))),
+	)
+}
+
+// TestSHA256MatchesHashable is the parity guard: the driver's SHA256 must equal the SDK's
+// Hashable.Raw() for non-empty input, otherwise the token-request and public-parameters hashes
+// the driver writes on-chain would not match what the rest of the SDK computes and compares.
+func TestSHA256MatchesHashable(t *testing.T) {
+	for _, in := range [][]byte{[]byte("abc"), []byte("public-parameters"), []byte("a token request")} {
+		require.Equal(t, []byte(utils.Hashable(in).Raw()), SHA256(in))
+	}
+}

--- a/x/token/services/network/evm/depguard_test.go
+++ b/x/token/services/network/evm/depguard_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// forbiddenDependency is the module that must never enter the EVM driver's build graph.
+// Its license (LGPL) is a hard blocker for the project, so all Ethereum primitives (hashing,
+// addresses, signing, RLP) are provided locally or by permissively-licensed libraries.
+const forbiddenDependency = "github.com/ethereum/go-ethereum"
+
+// TestNoGoEthereumDependency fails if go-ethereum appears anywhere in the transitive dependencies
+// of the EVM driver packages. It is intentionally a build-graph guard rather than a unit test: it
+// catches an accidental import the moment it lands, in CI, across every current and future file.
+func TestNoGoEthereumDependency(t *testing.T) {
+	cmd := exec.Command("go", "list", "-deps", "./...")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("skipping: could not run 'go list -deps' (%v): %s", err, out)
+	}
+	for _, dep := range strings.Split(string(out), "\n") {
+		require.NotContains(t, dep, forbiddenDependency,
+			"go-ethereum must not be linked (license blocker); found it in the build graph")
+	}
+}

--- a/x/token/services/network/evm/doc.go
+++ b/x/token/services/network/evm/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package evm implements an Ethereum/EVM network driver for the Token SDK.
+//
+// It follows Approach 2 (pre-order execution with FSC endorsers): FSC nodes validate token
+// requests off-chain in Go, sign the resulting state transition with secp256k1 keys (EIP-712),
+// and an on-chain contract verifies the endorser signatures plus spent/existence constraints
+// before applying the transition. See eth_network_driver_design.md for the full design and
+// eth_network_driver_implementation_plan.md for the build sequence.
+//
+// The package is organized into focused sub-packages:
+//
+//	client      EVM JSON-RPC client abstraction and the local Address/Hash value types
+//	crypto      Keccak256 and SHA-256 primitives (SHA-256 matches the SDK's Hashable)
+//	keys        the KeyTranslator that derives on-chain object keys (token IDs, etc.)
+//	statedelta  the StateDelta type and the translator from validated actions to a StateDelta
+//	eip712      the EIP-712 domain, type hashing, digest and secp256k1 signer/verifier
+//	endorsement the endorsement service provider, initiator and responder views
+//	finality    transaction finality tracking over the EVM node/gateway
+//	pp          the public-parameters version keeper
+//	contracts   the Solidity sources (EndorsementVerifier, TokenState) and deploy scripts
+//
+// Constraint: this driver must not link go-ethereum, whose license is a hard blocker for the
+// project. All Ethereum primitives (hashing, addresses, signing, RLP) are provided locally or by
+// permissively-licensed libraries. depguard_test.go enforces this.
+package evm

--- a/x/token/services/network/evm/eip712/doc.go
+++ b/x/token/services/network/evm/eip712/doc.go
@@ -1,0 +1,14 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package eip712 implements the EIP-712 signing envelope for endorser signatures over a StateDelta.
+//
+// It provides the domain separator (bound to chainId and the TokenState contract address), the
+// StateDelta type hashing, the final digest, and the secp256k1 signer/verifier. The digest and
+// type hashing use Keccak256 and must match the Solidity contract's recomputation exactly.
+// Endorsers recompute the digest from their own validated StateDelta and never blind-sign an
+// initiator-supplied digest. Hashing lands in Phase 1.4; the signer in Phase 3/4.
+package eip712

--- a/x/token/services/network/evm/endorsement/doc.go
+++ b/x/token/services/network/evm/endorsement/doc.go
@@ -1,0 +1,15 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package endorsement implements the EVM endorsement flow: collecting EIP-712 endorser signatures
+// over a StateDelta before a transaction is submitted on-chain.
+//
+// It mirrors token/services/network/fabric/endorsement/fsc: a lazy service provider keyed by
+// TMSID, an initiator view that collects endorsements from FSC identities, and a responder view
+// that validates the request, translates it to a StateDelta, and signs it. Endorsers are bound to
+// both an FSC view.Identity (for routing) and an Ethereum address (for on-chain recovery); the
+// identity registry lives here. Implemented in Phase 4.
+package endorsement

--- a/x/token/services/network/evm/finality/doc.go
+++ b/x/token/services/network/evm/finality/doc.go
@@ -1,0 +1,14 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package finality tracks EVM transaction finality and notifies registered listeners.
+//
+// The baseline determines finality from receipts read at the "finalized" block tag, resolving an
+// anchor to its Ethereum transaction via the indexed StateCommitted event; the fabric-x-evm
+// gateway's TransactionByHash().isPending lifecycle is layered on as an efficiency signal where
+// available. It reuses the backend-agnostic pieces from token/services/network/fabricx/finality
+// (the event queue and OnlyOnceListener). Implemented in Phase 5/6.
+package finality

--- a/x/token/services/network/evm/keys/doc.go
+++ b/x/token/services/network/evm/keys/doc.go
@@ -1,0 +1,14 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package keys implements the EVM KeyTranslator: the single source of truth for deriving on-chain
+// object keys (token IDs, spent markers, metadata keys) from token-request concepts.
+//
+// It is the EVM analog of token/services/network/common/rws/keys.Translator. The derivations here
+// must be reproduced exactly by the Solidity TokenState contract, so the initiator, every
+// endorser and the contract agree byte-for-byte on every key. Keys use Keccak256 over abi.encode
+// with fixed per-class prefixes for domain separation. Implemented in Phase 1.3.
+package keys

--- a/x/token/services/network/evm/pp/doc.go
+++ b/x/token/services/network/evm/pp/doc.go
@@ -1,0 +1,14 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package pp keeps track of the public-parameters version for each TMS.
+//
+// It is the EVM analog of token/services/network/fabricx/pp: a per-TMS counter, synced from the
+// TokenState contract's on-chain publicParamsVersion, that endorsers use to refuse signing a
+// StateDelta validated against stale parameters. The version follows the same convention as the
+// FabricX VersionKeeper (the first update initializes, subsequent updates increment). Implemented
+// in Phase 5.
+package pp

--- a/x/token/services/network/evm/statedelta/doc.go
+++ b/x/token/services/network/evm/statedelta/doc.go
@@ -1,0 +1,16 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package statedelta defines the StateDelta type and the translator that turns validated token
+// actions into a StateDelta.
+//
+// A StateDelta is the EVM backend artifact, analogous to Fabric's RWSet: it carries the anchor, a
+// single spentRefs list (token IDs for graph-revealing drivers, serial numbers for graph-hiding
+// ones, disambiguated by the contract's graphHiding flag), the new outputs, metadata, and the
+// SHA-256 token-request and public-parameters hashes with the public-parameters version. The
+// translator (Phase 1.3/3) mirrors token/services/network/common/rws/translator and must produce
+// byte-identical deltas across endorsers.
+package statedelta


### PR DESCRIPTION

First slice of the EVM network driver (Approach 2). This locks in the design we hammered out on #1701 and adds the basic crypto layer everything else will build on. No actual driver logic yet.

## What's included
- Updated design doc with the decisions we settled on: single-list StateDelta with a contract-side graphHiding flag, tokenID-only spend refs (since the EVM contract is stateful, we don't need to bind the token hash into the key like Fabric does), SHA-256 for request/public-params hashes, and quorum governance once the deployer seeds the initial state.
- Crypto helpers: keccak256 (via x/crypto/sha3) and SHA-256. The SHA-256 one matches the SDK's token-request hash so finality lines up later.
- Local Address (20B) and Hash (32B) types with hex/text/JSON encoding. No go-ethereum dependency, plus a build test that fails if it ever sneaks in (license issue for us).
- Basic package scaffolding under x/token/services/network/evm.
- Small go.sum fix in the integration module (missing badger entry) so the build works again.

## Not in this PR
StateDelta types, key derivation, EIP-712, and driver wiring are coming in follow-up PRs.