### PR TITLE
fix(gh-pages): deploy warning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,16 @@ on:
       - '.github/workflows/docs.yml'
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -52,7 +58,24 @@ jobs:
         run: |
           mkdocs build --strict
 
-      - name: Deploy to GitHub Pages
+      - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          mkdocs gh-deploy --force
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'site'
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs==1.6.0
-mkdocs-material==9.5.39
+mkdocs==1.6.1
+mkdocs-material==9.5.47


### PR DESCRIPTION
This PR is to fix the error message we are currently getting on main branch when running the actions in docs.yml:

````
(node:2103) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Fetching artifact metadata for "github-pages" in this workflow run
Found 1 artifact(s)
Creating Pages deployment with payload:
{
	"artifact_id": 8099583909,
	"pages_build_version": "e434f4350c36338a982f18133b34f8c7f6ed2166",
	"oidc_token": "***"
}
Created deployment for e434f4350c36338a982f18133b34f8c7f6ed2166, ID: e434f4350c36338a982f18133b34f8c7f6ed2166
Getting Pages deployment status...
Error: Deployment failed, try again later.
```