### PR TITLE
enable CI on feature branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "feature/evm-network-driver", "feature/zkat-snark-driver" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "feature/evm-network-driver", "feature/zkat-snark-driver" ]
   schedule:
     - cron: '39 22 * * 5'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - feature/evm-network-driver
+      - feature/zkat-snark-driver
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -12,6 +14,8 @@ on:
   pull_request:
     branches:
       - main
+      - feature/evm-network-driver
+      - feature/zkat-snark-driver
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/md_links.yml
+++ b/.github/workflows/md_links.yml
@@ -2,9 +2,9 @@ name: Check Markdown links
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
 
 jobs:
   check-links:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
   workflow_dispatch:
     inputs:
       fsc-version:
@@ -91,6 +91,7 @@ jobs:
 
   itest:
     needs: checks
+    if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This PR updates all GitHub workflow files to support the feature branches: feature/evm-network-driver and feature/zkat-snark-driver.

The integration tests will be executed only when the target branch is `main` though.