### PR TITLE
feat(zkatsnark): add spend and output circuits

### DIFF
--- a/x/token/core/zkatsnark/circuit/output.go
+++ b/x/token/core/zkatsnark/circuit/output.go
@@ -1,0 +1,75 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package circuit
+
+import (
+    "github.com/consensys/gnark/frontend"
+    "github.com/consensys/gnark/std/algebra/native/twistededwards"
+
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
+)
+
+// OutputCircuit proves that a newly created output token is well-formed.
+//
+// It enforces three constraint groups:
+//   1. CommitmentOut == MiMC(Value, TokenType, Randomness)
+//   2. (ValueCommitOutX, ValueCommitOutY) == Value·V + RCV·R
+//   3. Value ∈ [1, 2^MaxBits)
+type OutputCircuit struct{
+	// Public inputs
+	CommitmentOut frontend.Variable `gnark:"public"`
+	ValueCommitOutX frontend.Variable `gnark:"public"`
+	ValueCommitOutY frontend.Variable `gnark:"public"`
+	TokenType frontend.Variable `gnark:"public"`
+	
+	// Private inputs
+	Value frontend.Variable
+	Randomness frontend.Variable
+	RCV frontend.Variable
+
+	// Compile-time parameter
+    // MaxBits is the bit-width of the value range constraint.
+	MaxBits int
+}
+
+func(c *OutputCircuit) Define(api frontend.API) error {
+	maxBits := c.MaxBits
+	if maxBits <= 0 {
+		maxBits = params.DefaultMaxBits
+	}
+
+	// ── Constraint Group 1: Commitment Integrity ────────────────────────────
+	commitment, err := gadgets.HashCircuit(api, c.Value, c.TokenType, c.Randomness)
+	if err != nil {
+        return err
+    }
+    api.AssertIsEqual(commitment, c.CommitmentOut)
+
+    // ── Constraint Group 2: Value Commitment Integrity ──────────────────────
+	genV := twistededwards.Point{X: jubjub.V.X, Y: jubjub.V.Y}
+    genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
+
+	cv, err := gadgets.ValueCommitCircuit(api, c.Value, c.RCV, genV, genR)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(cv.X, c.ValueCommitOutX)
+	api.AssertIsEqual(cv.Y, c.ValueCommitOutY)
+
+	// ── Constraint Group 3: Range Check ────────────────────────────────────
+    // api.ToBinary(v, n) decomposes v into n bit variables and adds constraints:
+    //   (a) each bit ∈ {0, 1}
+    //   (b) v == Σ bit_i * 2^i
+    // The bit decomposition implicitly constrains 0 <= v < 2^maxBits.
+    // api.AssertIsDifferent(v, 0) additionally enforces v != 0.
+    // Combined: 1 <= v < 2^maxBits.
+	_ = api.ToBinary(c.Value, maxBits)
+    api.AssertIsDifferent(c.Value, 0)
+
+	return nil
+}

--- a/x/token/core/zkatsnark/circuit/output.go
+++ b/x/token/core/zkatsnark/circuit/output.go
@@ -68,6 +68,12 @@ func(c *OutputCircuit) Define(api frontend.API) error {
     // The bit decomposition implicitly constrains 0 <= v < 2^maxBits.
     // api.AssertIsDifferent(v, 0) additionally enforces v != 0.
     // Combined: 1 <= v < 2^maxBits.
+
+	// Why this approach is better than other approaches:
+	// ToBinary(v, maxBits) directly converts the value into bits and enforces that each bit is either 0 or 1
+	// while also constraining the value to be the sum of the individual bits multiplied by 2^i.
+	// An alternative such as AssertIsLessOrEqual(v, 2^maxBits-1) is a general purpose comparator, and even after converting
+	// the value to bits, it has to kepp running the comparison checks, bit by bit, which can require extra machinery.
 	_ = api.ToBinary(c.Value, maxBits)
     api.AssertIsDifferent(c.Value, 0)
 

--- a/x/token/core/zkatsnark/circuit/output.go
+++ b/x/token/core/zkatsnark/circuit/output.go
@@ -6,38 +6,38 @@ SPDX-License-Identifier: Apache-2.0
 package circuit
 
 import (
-    "github.com/consensys/gnark/frontend"
-    "github.com/consensys/gnark/std/algebra/native/twistededwards"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/native/twistededwards"
 
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
 )
 
 // OutputCircuit proves that a newly created output token is well-formed.
 //
 // It enforces three constraint groups:
-//   1. CommitmentOut == MiMC(Value, TokenType, Randomness)
-//   2. (ValueCommitOutX, ValueCommitOutY) == Value·V + RCV·R
-//   3. Value ∈ [1, 2^MaxBits)
-type OutputCircuit struct{
+//  1. CommitmentOut == MiMC(Value, TokenType, Randomness)
+//  2. (ValueCommitOutX, ValueCommitOutY) == Value·V + RCV·R
+//  3. Value ∈ [1, 2^MaxBits)
+type OutputCircuit struct {
 	// Public inputs
-	CommitmentOut frontend.Variable `gnark:"public"`
+	CommitmentOut   frontend.Variable `gnark:"public"`
 	ValueCommitOutX frontend.Variable `gnark:"public"`
 	ValueCommitOutY frontend.Variable `gnark:"public"`
-	TokenType frontend.Variable `gnark:"public"`
-	
+	TokenType       frontend.Variable `gnark:"public"`
+
 	// Private inputs
-	Value frontend.Variable
+	Value      frontend.Variable
 	Randomness frontend.Variable
-	RCV frontend.Variable
+	RCV        frontend.Variable
 
 	// Compile-time parameter
-    // MaxBits is the bit-width of the value range constraint.
+	// MaxBits is the bit-width of the value range constraint.
 	MaxBits int
 }
 
-func(c *OutputCircuit) Define(api frontend.API) error {
+func (c *OutputCircuit) Define(api frontend.API) error {
 	maxBits := c.MaxBits
 	if maxBits <= 0 {
 		maxBits = params.DefaultMaxBits
@@ -46,13 +46,13 @@ func(c *OutputCircuit) Define(api frontend.API) error {
 	// ── Constraint Group 1: Commitment Integrity ────────────────────────────
 	commitment, err := gadgets.HashCircuit(api, c.Value, c.TokenType, c.Randomness)
 	if err != nil {
-        return err
-    }
-    api.AssertIsEqual(commitment, c.CommitmentOut)
+		return err
+	}
+	api.AssertIsEqual(commitment, c.CommitmentOut)
 
-    // ── Constraint Group 2: Value Commitment Integrity ──────────────────────
+	// ── Constraint Group 2: Value Commitment Integrity ──────────────────────
 	genV := twistededwards.Point{X: jubjub.V.X, Y: jubjub.V.Y}
-    genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
+	genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
 
 	cv, err := gadgets.ValueCommitCircuit(api, c.Value, c.RCV, genV, genR)
 	if err != nil {
@@ -62,12 +62,12 @@ func(c *OutputCircuit) Define(api frontend.API) error {
 	api.AssertIsEqual(cv.Y, c.ValueCommitOutY)
 
 	// ── Constraint Group 3: Range Check ────────────────────────────────────
-    // api.ToBinary(v, n) decomposes v into n bit variables and adds constraints:
-    //   (a) each bit ∈ {0, 1}
-    //   (b) v == Σ bit_i * 2^i
-    // The bit decomposition implicitly constrains 0 <= v < 2^maxBits.
-    // api.AssertIsDifferent(v, 0) additionally enforces v != 0.
-    // Combined: 1 <= v < 2^maxBits.
+	// api.ToBinary(v, n) decomposes v into n bit variables and adds constraints:
+	//   (a) each bit ∈ {0, 1}
+	//   (b) v == Σ bit_i * 2^i
+	// The bit decomposition implicitly constrains 0 <= v < 2^maxBits.
+	// api.AssertIsDifferent(v, 0) additionally enforces v != 0.
+	// Combined: 1 <= v < 2^maxBits.
 
 	// Why this approach is better than other approaches:
 	// ToBinary(v, maxBits) directly converts the value into bits and enforces that each bit is either 0 or 1
@@ -75,7 +75,7 @@ func(c *OutputCircuit) Define(api frontend.API) error {
 	// An alternative such as AssertIsLessOrEqual(v, 2^maxBits-1) is a general purpose comparator, and even after converting
 	// the value to bits, it has to kepp running the comparison checks, bit by bit, which can require extra machinery.
 	_ = api.ToBinary(c.Value, maxBits)
-    api.AssertIsDifferent(c.Value, 0)
+	api.AssertIsDifferent(c.Value, 0)
 
 	return nil
 }

--- a/x/token/core/zkatsnark/circuit/output_test.go
+++ b/x/token/core/zkatsnark/circuit/output_test.go
@@ -6,238 +6,250 @@ SPDX-License-Identifier: Apache-2.0
 package circuit_test
 
 import (
-    "fmt"
-    "math/big"
-    "sync"
-    "testing"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
 
-    "github.com/consensys/gnark-crypto/ecc"
-    "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-    "github.com/consensys/gnark/backend/groth16"
-    "github.com/consensys/gnark/constraint"
-    "github.com/consensys/gnark/frontend"
-    "github.com/consensys/gnark/frontend/cs/r1cs"
-    "github.com/stretchr/testify/require"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/stretchr/testify/require"
 
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
 )
- 
+
 var (
-    outputCS   constraint.ConstraintSystem
-    outputPK   groth16.ProvingKey
-    outputVK   groth16.VerifyingKey
-    outputOnce sync.Once
+	outputCS   constraint.ConstraintSystem
+	outputPK   groth16.ProvingKey
+	outputVK   groth16.VerifyingKey
+	outputOnce sync.Once
 )
 
 func setupOutput(t *testing.T) {
-    t.Helper()
-    outputOnce.Do(func() {
-        var err error
-        outputCS, err = frontend.Compile(
-            ecc.BLS12_381.ScalarField(),
-            r1cs.NewBuilder,
-            // MaxBits MUST be set here — it is baked into the circuit permanently.
-            &circuit.OutputCircuit{MaxBits: params.DefaultMaxBits},
-        )
-        if err != nil {
-            panic(fmt.Sprintf("OutputCircuit compilation failed: %v", err))
-        }
-        fmt.Printf("OutputCircuit: %d constraints\n", outputCS.GetNbConstraints())
+	t.Helper()
+	outputOnce.Do(func() {
+		var err error
+		outputCS, err = frontend.Compile(
+			ecc.BLS12_381.ScalarField(),
+			r1cs.NewBuilder,
+			// MaxBits MUST be set here — it is baked into the circuit permanently.
+			&circuit.OutputCircuit{MaxBits: params.DefaultMaxBits},
+		)
+		if err != nil {
+			panic(fmt.Sprintf("OutputCircuit compilation failed: %v", err))
+		}
+		fmt.Printf("OutputCircuit: %d constraints\n", outputCS.GetNbConstraints())
 
-        outputPK, outputVK, err = groth16.Setup(outputCS)
-        if err != nil {
-            panic(fmt.Sprintf("OutputCircuit groth16.Setup failed: %v", err))
-        }
-    })
+		outputPK, outputVK, err = groth16.Setup(outputCS)
+		if err != nil {
+			panic(fmt.Sprintf("OutputCircuit groth16.Setup failed: %v", err))
+		}
+	})
 }
 
 type outputInputs struct {
-    value      uint64
-    tokenType  fr.Element
-    randomness fr.Element
-    rcv        fr.Element
+	value      uint64
+	tokenType  fr.Element
+	randomness fr.Element
+	rcv        fr.Element
 }
 
-func newRandomOutputInputs() outputInputs {
-    var tokenType, randomness, rcv fr.Element
-    tokenType.SetBytes([]byte("USD"))
-    randomness.SetRandom()
-    rcv.SetRandom()
-    return outputInputs{value: 250, tokenType: tokenType, randomness: randomness, rcv: rcv}
+func newRandomOutputInputs(t *testing.T) outputInputs {
+	t.Helper()
+	var tokenType, randomness, rcv fr.Element
+	tokenType.SetBytes([]byte("USD"))
+	_, err := randomness.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv.SetRandom()
+	require.NoError(t, err)
+
+	return outputInputs{value: 250, tokenType: tokenType, randomness: randomness, rcv: rcv}
 }
 
 func buildOutputAssignment(t *testing.T, inp outputInputs) *circuit.OutputCircuit {
-    t.Helper()
-    var vField fr.Element
-    vField.SetUint64(inp.value)
+	t.Helper()
+	var vField fr.Element
+	vField.SetUint64(inp.value)
 
-    cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
-    require.NoError(t, err)
+	cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
+	require.NoError(t, err)
 
-    cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
-    require.NoError(t, err)
+	cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
+	require.NoError(t, err)
 
-    return &circuit.OutputCircuit{
-        CommitmentOut:   cm,
-        ValueCommitOutX: cv.X,
-        ValueCommitOutY: cv.Y,
-        TokenType:       inp.tokenType,
-        Value:           vField,
-        Randomness:      inp.randomness,
-        RCV:             inp.rcv,
-        MaxBits:         params.DefaultMaxBits,
-    }
+	return &circuit.OutputCircuit{
+		CommitmentOut:   cm,
+		ValueCommitOutX: cv.X,
+		ValueCommitOutY: cv.Y,
+		TokenType:       inp.tokenType,
+		Value:           vField,
+		Randomness:      inp.randomness,
+		RCV:             inp.rcv,
+		MaxBits:         params.DefaultMaxBits,
+	}
 }
 
 func TestOutputCircuitValidWitness(t *testing.T) {
 	setupOutput(t)
 
-	inp := newRandomOutputInputs()
+	inp := newRandomOutputInputs(t)
 	assignment := buildOutputAssignment(t, inp)
 
 	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	require.NoError(t, err)
 
-    proof, err := groth16.Prove(outputCS, outputPK, witness)
-    require.NoError(t, err, "groth16.Prove failed for a valid OutputCircuit witness")
+	proof, err := groth16.Prove(outputCS, outputPK, witness)
+	require.NoError(t, err, "groth16.Prove failed for a valid OutputCircuit witness")
 
-    publicWitness, err := witness.Public()
-    require.NoError(t, err)
+	publicWitness, err := witness.Public()
+	require.NoError(t, err)
 
-    err = groth16.Verify(proof, outputVK, publicWitness)
-    require.NoError(t, err, "groth16.Verify failed for a valid OutputCircuit proof")
+	err = groth16.Verify(proof, outputVK, publicWitness)
+	require.NoError(t, err, "groth16.Verify failed for a valid OutputCircuit proof")
 }
 
 func TestOutputCircuitInvalid_WrongValue(t *testing.T) {
-    setupOutput(t)
-    inp := newRandomOutputInputs()
-    assignment := buildOutputAssignment(t, inp)
+	setupOutput(t)
+	inp := newRandomOutputInputs(t)
+	assignment := buildOutputAssignment(t, inp)
 
-    var wrongValue fr.Element
-    wrongValue.SetUint64(inp.value + 500)
-    assignment.Value = wrongValue
+	var wrongValue fr.Element
+	wrongValue.SetUint64(inp.value + 500)
+	assignment.Value = wrongValue
 
-    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.Error(t, outputCS.IsSolved(witness), "must reject wrong Value")
+	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.Error(t, outputCS.IsSolved(witness), "must reject wrong Value")
 }
 
 func TestOutputCircuitInvalid_WrongRandomness(t *testing.T) {
-    setupOutput(t)
-    inp := newRandomOutputInputs()
-    assignment := buildOutputAssignment(t, inp)
+	setupOutput(t)
+	inp := newRandomOutputInputs(t)
+	assignment := buildOutputAssignment(t, inp)
 
-    var wrongR fr.Element
-    wrongR.SetRandom()
-    assignment.Randomness = wrongR
+	var wrongR fr.Element
+	_, err := wrongR.SetRandom()
+	require.NoError(t, err)
+	assignment.Randomness = wrongR
 
-    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.Error(t, outputCS.IsSolved(witness), "must reject wrong Randomness")
+	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.Error(t, outputCS.IsSolved(witness), "must reject wrong Randomness")
 }
 
 func TestOutputCircuitInvalid_WrongValueCommit(t *testing.T) {
-    setupOutput(t)
-    inp := newRandomOutputInputs()
-    assignment := buildOutputAssignment(t, inp)
+	setupOutput(t)
+	inp := newRandomOutputInputs(t)
+	assignment := buildOutputAssignment(t, inp)
 
-    var fakeRCV fr.Element
-    fakeRCV.SetRandom()
-    fakeCV, _ := jubjub.ValueCommit(inp.value+100, fakeRCV)
-    assignment.ValueCommitOutX = fakeCV.X
-    assignment.ValueCommitOutY = fakeCV.Y
+	var fakeRCV fr.Element
+	_, err := fakeRCV.SetRandom()
+	require.NoError(t, err)
+	fakeCV, _ := jubjub.ValueCommit(inp.value+100, fakeRCV)
+	assignment.ValueCommitOutX = fakeCV.X
+	assignment.ValueCommitOutY = fakeCV.Y
 
-    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.Error(t, outputCS.IsSolved(witness), "must reject wrong ValueCommit")
+	witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.Error(t, outputCS.IsSolved(witness), "must reject wrong ValueCommit")
 }
 
 // TestOutputCircuitInvalid_ZeroValue is the critical range test.
 // Zero-value tokens would allow creating tokens from nothing.
 // This test verifies the range constraint actually fires for v=0.
 func TestOutputCircuitInvalid_ZeroValue(t *testing.T) {
-    setupOutput(t)
+	setupOutput(t)
 
-    var tokenType, randomness, rcv fr.Element
-    tokenType.SetBytes([]byte("USD"))
-    randomness.SetRandom()
-    rcv.SetRandom()
+	var tokenType, randomness, rcv fr.Element
+	tokenType.SetBytes([]byte("USD"))
+	_, err := randomness.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv.SetRandom()
+	require.NoError(t, err)
 
-    var zeroField fr.Element
-    zeroField.SetUint64(0)
+	var zeroField fr.Element
+	zeroField.SetUint64(0)
 
-    // Compute a VALID commitment for v=0 so the commitment constraint passes.
-    // This isolates the range check as the only failing constraint.
-    // If we used a wrong commitment, the test would pass for the wrong reason.
-    cm, err := mimc.Hash(zeroField, tokenType, randomness)
-    require.NoError(t, err)
+	// Compute a VALID commitment for v=0 so the commitment constraint passes.
+	// This isolates the range check as the only failing constraint.
+	// If we used a wrong commitment, the test would pass for the wrong reason.
+	cm, err := mimc.Hash(zeroField, tokenType, randomness)
+	require.NoError(t, err)
 
-    cv, err := jubjub.ValueCommit(0, rcv)
-    require.NoError(t, err)
+	cv, err := jubjub.ValueCommit(0, rcv)
+	require.NoError(t, err)
 
-    assignment := &circuit.OutputCircuit{
-        CommitmentOut:   cm,
-        ValueCommitOutX: cv.X,
-        ValueCommitOutY: cv.Y,
-        TokenType:       tokenType,
-        Value:           zeroField, // ← the invalid field
-        Randomness:      randomness,
-        RCV:             rcv,
-        MaxBits:         params.DefaultMaxBits,
-    }
+	assignment := &circuit.OutputCircuit{
+		CommitmentOut:   cm,
+		ValueCommitOutX: cv.X,
+		ValueCommitOutY: cv.Y,
+		TokenType:       tokenType,
+		Value:           zeroField, // ← the invalid field
+		Randomness:      randomness,
+		RCV:             rcv,
+		MaxBits:         params.DefaultMaxBits,
+	}
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    err = outputCS.IsSolved(witness)
-    require.Error(t, err,
-        "CRITICAL: OutputCircuit accepted Value=0 — zero-value tokens are possible, "+
-            "check that api.AssertIsDifferent(c.Value, 0) is in Define")
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err,
+		"CRITICAL: OutputCircuit accepted Value=0 — zero-value tokens are possible, "+
+			"check that api.AssertIsDifferent(c.Value, 0) is in Define")
 }
 
 // TestOutputCircuitInvalid_OverflowValue verifies values >= 2^MaxBits are rejected.
 // An overflow value could be used to wrap around and represent a much smaller amount,
 // breaking conservation accounting.
 func TestOutputCircuitInvalid_OverflowValue(t *testing.T) {
-    setupOutput(t)
+	setupOutput(t)
 
-    // Construct a field element equal to 2^MaxBits.
-    // This is a valid BLS12-381 field element but exceeds the MaxBits limit.
-    var overflowValue fr.Element
-    var b big.Int
-    b.SetBit(&b, params.DefaultMaxBits, 1) // 2^64
-    overflowValue.SetBigInt(&b)
+	// Construct a field element equal to 2^MaxBits.
+	// This is a valid BLS12-381 field element but exceeds the MaxBits limit.
+	var overflowValue fr.Element
+	var b big.Int
+	b.SetBit(&b, params.DefaultMaxBits, 1) // 2^64
+	overflowValue.SetBigInt(&b)
 
-    var tokenType, randomness, rcv fr.Element
-    tokenType.SetBytes([]byte("USD"))
-    randomness.SetRandom()
-    rcv.SetRandom()
+	var tokenType, randomness, rcv fr.Element
+	tokenType.SetBytes([]byte("USD"))
+	_, err := randomness.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv.SetRandom()
+	require.NoError(t, err)
 
-    // Compute a consistent commitment so only the range check fires.
-    cm, err := mimc.Hash(overflowValue, tokenType, randomness)
-    require.NoError(t, err)
+	// Compute a consistent commitment so only the range check fires.
+	cm, err := mimc.Hash(overflowValue, tokenType, randomness)
+	require.NoError(t, err)
 
-    // We cannot call jubjub.ValueCommit with a field element value > uint64 max.
-    // Use a placeholder for the value commitment — the range check should fire first.
-    var fakeCVX, fakeCVY fr.Element
-    fakeCVX.SetRandom()
-    fakeCVY.SetRandom()
+	// We cannot call jubjub.ValueCommit with a field element value > uint64 max.
+	// Use a placeholder for the value commitment — the range check should fire first.
+	var fakeCVX, fakeCVY fr.Element
+	_, err = fakeCVX.SetRandom()
+	require.NoError(t, err)
+	_, err = fakeCVY.SetRandom()
+	require.NoError(t, err)
 
-    assignment := &circuit.OutputCircuit{
-        CommitmentOut:   cm,
-        ValueCommitOutX: fakeCVX,
-        ValueCommitOutY: fakeCVY,
-        TokenType:       tokenType,
-        Value:           overflowValue,
-        Randomness:      randomness,
-        RCV:             rcv,
-        MaxBits:         params.DefaultMaxBits,
-    }
+	assignment := &circuit.OutputCircuit{
+		CommitmentOut:   cm,
+		ValueCommitOutX: fakeCVX,
+		ValueCommitOutY: fakeCVY,
+		TokenType:       tokenType,
+		Value:           overflowValue,
+		Randomness:      randomness,
+		RCV:             rcv,
+		MaxBits:         params.DefaultMaxBits,
+	}
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    err = outputCS.IsSolved(witness)
-    require.Error(t, err,
-        "OutputCircuit must reject values >= 2^MaxBits — overflow attack possible if not")
+	err = outputCS.IsSolved(witness)
+	require.Error(t, err,
+		"OutputCircuit must reject values >= 2^MaxBits — overflow attack possible if not")
 }

--- a/x/token/core/zkatsnark/circuit/output_test.go
+++ b/x/token/core/zkatsnark/circuit/output_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package circuit_test
+
+import (
+    "fmt"
+    "math/big"
+    "sync"
+    "testing"
+
+    "github.com/consensys/gnark-crypto/ecc"
+    "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+    "github.com/consensys/gnark/backend/groth16"
+    "github.com/consensys/gnark/constraint"
+    "github.com/consensys/gnark/frontend"
+    "github.com/consensys/gnark/frontend/cs/r1cs"
+    "github.com/stretchr/testify/require"
+
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params"
+)
+ 
+var (
+    outputCS   constraint.ConstraintSystem
+    outputPK   groth16.ProvingKey
+    outputVK   groth16.VerifyingKey
+    outputOnce sync.Once
+)
+
+func setupOutput(t *testing.T) {
+    t.Helper()
+    outputOnce.Do(func() {
+        var err error
+        outputCS, err = frontend.Compile(
+            ecc.BLS12_381.ScalarField(),
+            r1cs.NewBuilder,
+            // MaxBits MUST be set here — it is baked into the circuit permanently.
+            &circuit.OutputCircuit{MaxBits: params.DefaultMaxBits},
+        )
+        if err != nil {
+            panic(fmt.Sprintf("OutputCircuit compilation failed: %v", err))
+        }
+        fmt.Printf("OutputCircuit: %d constraints\n", outputCS.GetNbConstraints())
+
+        outputPK, outputVK, err = groth16.Setup(outputCS)
+        if err != nil {
+            panic(fmt.Sprintf("OutputCircuit groth16.Setup failed: %v", err))
+        }
+    })
+}
+
+type outputInputs struct {
+    value      uint64
+    tokenType  fr.Element
+    randomness fr.Element
+    rcv        fr.Element
+}
+
+func newRandomOutputInputs() outputInputs {
+    var tokenType, randomness, rcv fr.Element
+    tokenType.SetBytes([]byte("USD"))
+    randomness.SetRandom()
+    rcv.SetRandom()
+    return outputInputs{value: 250, tokenType: tokenType, randomness: randomness, rcv: rcv}
+}
+
+func buildOutputAssignment(t *testing.T, inp outputInputs) *circuit.OutputCircuit {
+    t.Helper()
+    var vField fr.Element
+    vField.SetUint64(inp.value)
+
+    cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
+    require.NoError(t, err)
+
+    cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
+    require.NoError(t, err)
+
+    return &circuit.OutputCircuit{
+        CommitmentOut:   cm,
+        ValueCommitOutX: cv.X,
+        ValueCommitOutY: cv.Y,
+        TokenType:       inp.tokenType,
+        Value:           vField,
+        Randomness:      inp.randomness,
+        RCV:             inp.rcv,
+        MaxBits:         params.DefaultMaxBits,
+    }
+}
+
+func TestOutputCircuitValidWitness(t *testing.T) {
+	setupOutput(t)
+
+	inp := newRandomOutputInputs()
+	assignment := buildOutputAssignment(t, inp)
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    proof, err := groth16.Prove(outputCS, outputPK, witness)
+    require.NoError(t, err, "groth16.Prove failed for a valid OutputCircuit witness")
+
+    publicWitness, err := witness.Public()
+    require.NoError(t, err)
+
+    err = groth16.Verify(proof, outputVK, publicWitness)
+    require.NoError(t, err, "groth16.Verify failed for a valid OutputCircuit proof")
+}
+
+func TestOutputCircuitInvalid_WrongValue(t *testing.T) {
+    setupOutput(t)
+    inp := newRandomOutputInputs()
+    assignment := buildOutputAssignment(t, inp)
+
+    var wrongValue fr.Element
+    wrongValue.SetUint64(inp.value + 500)
+    assignment.Value = wrongValue
+
+    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.Error(t, outputCS.IsSolved(witness), "must reject wrong Value")
+}
+
+func TestOutputCircuitInvalid_WrongRandomness(t *testing.T) {
+    setupOutput(t)
+    inp := newRandomOutputInputs()
+    assignment := buildOutputAssignment(t, inp)
+
+    var wrongR fr.Element
+    wrongR.SetRandom()
+    assignment.Randomness = wrongR
+
+    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.Error(t, outputCS.IsSolved(witness), "must reject wrong Randomness")
+}
+
+func TestOutputCircuitInvalid_WrongValueCommit(t *testing.T) {
+    setupOutput(t)
+    inp := newRandomOutputInputs()
+    assignment := buildOutputAssignment(t, inp)
+
+    var fakeRCV fr.Element
+    fakeRCV.SetRandom()
+    fakeCV, _ := jubjub.ValueCommit(inp.value+100, fakeRCV)
+    assignment.ValueCommitOutX = fakeCV.X
+    assignment.ValueCommitOutY = fakeCV.Y
+
+    witness, _ := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.Error(t, outputCS.IsSolved(witness), "must reject wrong ValueCommit")
+}
+
+// TestOutputCircuitInvalid_ZeroValue is the critical range test.
+// Zero-value tokens would allow creating tokens from nothing.
+// This test verifies the range constraint actually fires for v=0.
+func TestOutputCircuitInvalid_ZeroValue(t *testing.T) {
+    setupOutput(t)
+
+    var tokenType, randomness, rcv fr.Element
+    tokenType.SetBytes([]byte("USD"))
+    randomness.SetRandom()
+    rcv.SetRandom()
+
+    var zeroField fr.Element
+    zeroField.SetUint64(0)
+
+    // Compute a VALID commitment for v=0 so the commitment constraint passes.
+    // This isolates the range check as the only failing constraint.
+    // If we used a wrong commitment, the test would pass for the wrong reason.
+    cm, err := mimc.Hash(zeroField, tokenType, randomness)
+    require.NoError(t, err)
+
+    cv, err := jubjub.ValueCommit(0, rcv)
+    require.NoError(t, err)
+
+    assignment := &circuit.OutputCircuit{
+        CommitmentOut:   cm,
+        ValueCommitOutX: cv.X,
+        ValueCommitOutY: cv.Y,
+        TokenType:       tokenType,
+        Value:           zeroField, // ← the invalid field
+        Randomness:      randomness,
+        RCV:             rcv,
+        MaxBits:         params.DefaultMaxBits,
+    }
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    err = outputCS.IsSolved(witness)
+    require.Error(t, err,
+        "CRITICAL: OutputCircuit accepted Value=0 — zero-value tokens are possible, "+
+            "check that api.AssertIsDifferent(c.Value, 0) is in Define")
+}
+
+// TestOutputCircuitInvalid_OverflowValue verifies values >= 2^MaxBits are rejected.
+// An overflow value could be used to wrap around and represent a much smaller amount,
+// breaking conservation accounting.
+func TestOutputCircuitInvalid_OverflowValue(t *testing.T) {
+    setupOutput(t)
+
+    // Construct a field element equal to 2^MaxBits.
+    // This is a valid BLS12-381 field element but exceeds the MaxBits limit.
+    var overflowValue fr.Element
+    var b big.Int
+    b.SetBit(&b, params.DefaultMaxBits, 1) // 2^64
+    overflowValue.SetBigInt(&b)
+
+    var tokenType, randomness, rcv fr.Element
+    tokenType.SetBytes([]byte("USD"))
+    randomness.SetRandom()
+    rcv.SetRandom()
+
+    // Compute a consistent commitment so only the range check fires.
+    cm, err := mimc.Hash(overflowValue, tokenType, randomness)
+    require.NoError(t, err)
+
+    // We cannot call jubjub.ValueCommit with a field element value > uint64 max.
+    // Use a placeholder for the value commitment — the range check should fire first.
+    var fakeCVX, fakeCVY fr.Element
+    fakeCVX.SetRandom()
+    fakeCVY.SetRandom()
+
+    assignment := &circuit.OutputCircuit{
+        CommitmentOut:   cm,
+        ValueCommitOutX: fakeCVX,
+        ValueCommitOutY: fakeCVY,
+        TokenType:       tokenType,
+        Value:           overflowValue,
+        Randomness:      randomness,
+        RCV:             rcv,
+        MaxBits:         params.DefaultMaxBits,
+    }
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    err = outputCS.IsSolved(witness)
+    require.Error(t, err,
+        "OutputCircuit must reject values >= 2^MaxBits — overflow attack possible if not")
+}

--- a/x/token/core/zkatsnark/circuit/spend.go
+++ b/x/token/core/zkatsnark/circuit/spend.go
@@ -6,11 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 package circuit
 
 import (
-    "github.com/consensys/gnark/frontend"
-    "github.com/consensys/gnark/std/algebra/native/twistededwards"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/std/algebra/native/twistededwards"
 
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
 )
 
 // SpendCircuit proves that the prover knows a valid opening of a commitment
@@ -18,39 +18,39 @@ import (
 // formed from the same value.
 type SpendCircuit struct {
 	// Public inputs
-	CommitmentIn frontend.Variable `gnark:",public"`
+	CommitmentIn   frontend.Variable `gnark:",public"`
 	ValueCommitInX frontend.Variable `gnark:",public"`
 	ValueCommitInY frontend.Variable `gnark:",public"`
-	TokenType frontend.Variable `gnark:",public"`
-	
+	TokenType      frontend.Variable `gnark:",public"`
+
 	// Private inputs
-	Value frontend.Variable
+	Value      frontend.Variable
 	Randomness frontend.Variable
-	RCV frontend.Variable
+	RCV        frontend.Variable
 }
 
 // Define encodes the SpendCircuit constraints into the R1CS.
 // Called exactly once during frontend.Compile; not called at prove time.
-func(c *SpendCircuit) Define(api frontend.API) error {
+func (c *SpendCircuit) Define(api frontend.API) error {
 	// ── Constraint Group 1: Commitment Integrity ────────────────────────────
-    // Enforce: CommitmentIn == MiMC(Value, TokenType, Randomness)
+	// Enforce: CommitmentIn == MiMC(Value, TokenType, Randomness)
 
 	// The three inputs to MiMC correspond exactly to the three arguments of
-    // mimc.Hash in the native wallet code: (value, tokenType, randomness).
-    // The order must be identical between native and circuit code.
+	// mimc.Hash in the native wallet code: (value, tokenType, randomness).
+	// The order must be identical between native and circuit code.
 	commitment, err := gadgets.HashCircuit(api, c.Value, c.TokenType, c.Randomness)
 	if err != nil {
-        return err
-    }
-    api.AssertIsEqual(commitment, c.CommitmentIn)
+		return err
+	}
+	api.AssertIsEqual(commitment, c.CommitmentIn)
 
 	// ── Constraint Group 2: Value Commitment Integrity ──────────────────────
-    // Enforce: (ValueCommitInX, ValueCommitInY) == Value·V + RCV·R over Jubjub
+	// Enforce: (ValueCommitInX, ValueCommitInY) == Value·V + RCV·R over Jubjub
 
 	// gadgets.ValueCommitCircuit is the in-circuit counterpart of jubjub.ValueCommit.
-    // Consistency between native and circuit is enforced by TestValueCommitCrossConsistency.
+	// Consistency between native and circuit is enforced by TestValueCommitCrossConsistency.
 	genV := twistededwards.Point{X: jubjub.V.X, Y: jubjub.V.Y}
-    genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
+	genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
 
 	cv, err := gadgets.ValueCommitCircuit(api, c.Value, c.RCV, genV, genR)
 	if err != nil {

--- a/x/token/core/zkatsnark/circuit/spend.go
+++ b/x/token/core/zkatsnark/circuit/spend.go
@@ -1,0 +1,63 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package circuit
+
+import (
+    "github.com/consensys/gnark/frontend"
+    "github.com/consensys/gnark/std/algebra/native/twistededwards"
+
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+)
+
+// SpendCircuit proves that the prover knows a valid opening of a commitment
+// recorded on the ledger, and that the published value commitment is correctly
+// formed from the same value.
+type SpendCircuit struct {
+	// Public inputs
+	CommitmentIn frontend.Variable `gnark:",public"`
+	ValueCommitInX frontend.Variable `gnark:",public"`
+	ValueCommitInY frontend.Variable `gnark:",public"`
+	TokenType frontend.Variable `gnark:",public"`
+	
+	// Private inputs
+	Value frontend.Variable
+	Randomness frontend.Variable
+	RCV frontend.Variable
+}
+
+// Define encodes the SpendCircuit constraints into the R1CS.
+// Called exactly once during frontend.Compile; not called at prove time.
+func(c *SpendCircuit) Define(api frontend.API) error {
+	// ── Constraint Group 1: Commitment Integrity ────────────────────────────
+    // Enforce: CommitmentIn == MiMC(Value, TokenType, Randomness)
+
+	// The three inputs to MiMC correspond exactly to the three arguments of
+    // mimc.Hash in the native wallet code: (value, tokenType, randomness).
+    // The order must be identical between native and circuit code.
+	commitment, err := gadgets.HashCircuit(api, c.Value, c.TokenType, c.Randomness)
+	if err != nil {
+        return err
+    }
+    api.AssertIsEqual(commitment, c.CommitmentIn)
+
+	// ── Constraint Group 2: Value Commitment Integrity ──────────────────────
+    // Enforce: (ValueCommitInX, ValueCommitInY) == Value·V + RCV·R over Jubjub
+
+	// gadgets.ValueCommitCircuit is the in-circuit counterpart of jubjub.ValueCommit.
+    // Consistency between native and circuit is enforced by TestValueCommitCrossConsistency.
+	genV := twistededwards.Point{X: jubjub.V.X, Y: jubjub.V.Y}
+    genR := twistededwards.Point{X: jubjub.R.X, Y: jubjub.R.Y}
+
+	cv, err := gadgets.ValueCommitCircuit(api, c.Value, c.RCV, genV, genR)
+	if err != nil {
+		return err
+	}
+	api.AssertIsEqual(cv.X, c.ValueCommitInX)
+	api.AssertIsEqual(cv.Y, c.ValueCommitInY)
+
+	return nil
+}

--- a/x/token/core/zkatsnark/circuit/spend_test.go
+++ b/x/token/core/zkatsnark/circuit/spend_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package circuit_test
+
+import (
+    "fmt"
+    "sync"
+    "testing"
+
+    "github.com/consensys/gnark-crypto/ecc"
+    "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+    "github.com/consensys/gnark/backend/groth16"
+    "github.com/consensys/gnark/constraint"
+    "github.com/consensys/gnark/frontend"
+    "github.com/consensys/gnark/frontend/cs/r1cs"
+    "github.com/stretchr/testify/require"
+
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
+)
+
+// ── Package-level setup — compiled once for all spend tests ──────────────────
+
+var (
+    spendCS   constraint.ConstraintSystem
+    spendPK   groth16.ProvingKey
+    spendVK   groth16.VerifyingKey
+    spendOnce sync.Once
+)
+
+func setupSpend(t *testing.T) {
+    t.Helper()
+    spendOnce.Do(func() {
+        var err error
+        spendCS, err = frontend.Compile(
+            ecc.BLS12_381.ScalarField(),
+            r1cs.NewBuilder,
+            &circuit.SpendCircuit{},
+        )
+        if err != nil {
+            panic(fmt.Sprintf("SpendCircuit compilation failed: %v", err))
+        }
+        
+        fmt.Printf("SpendCircuit: %d constraints\n", spendCS.GetNbConstraints())
+
+        spendPK, spendVK, err = groth16.Setup(spendCS)
+        if err != nil {
+            panic(fmt.Sprintf("SpendCircuit groth16.Setup failed: %v", err))
+        }
+    })
+}
+
+type spendInputs struct {
+	value uint64
+	tokenType fr.Element
+	randomness fr.Element
+	rcv fr.Element
+}
+
+func newRandomSpendInputs() spendInputs {
+	var tokenType, randomness, rcv fr.Element
+	tokenType.SetBytes([]byte("USD"))
+	randomness.SetRandom()
+	rcv.SetRandom()
+
+	return spendInputs{
+        value:      100,
+        tokenType:  tokenType,
+        randomness: randomness,
+        rcv:        rcv,
+    }
+}
+
+func buildSpendAssignment(t *testing.T, inp spendInputs) *circuit.SpendCircuit {
+	t.Helper()
+
+    // Encode value as a field element — same encoding as in the prover.
+    var vField fr.Element
+    vField.SetUint64(inp.value)
+
+    // Compute the commitment using native MiMC.
+    // Order must match Define: (Value, TokenType, Randomness).
+    cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
+    require.NoError(t, err, "mimc.Hash failed in buildSpendAssignment")
+
+    // Compute the value commitment using native Jubjub.
+    cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
+    require.NoError(t, err, "jubjub.ValueCommit failed in buildSpendAssignment")
+
+    return &circuit.SpendCircuit{
+        // Public inputs — computed from private inputs
+        CommitmentIn:   cm,
+        ValueCommitInX: cv.X,
+        ValueCommitInY: cv.Y,
+        TokenType:      inp.tokenType,
+        // Private inputs
+        Value:      vField,
+        Randomness: inp.randomness,
+        RCV:        inp.rcv,
+    }
+}
+
+func TestSpendCircuitValidWitness(t *testing.T) {
+	setupSpend(t)
+	
+	inp := newRandomSpendInputs()
+    assignment := buildSpendAssignment(t, inp)
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    proof, err := groth16.Prove(spendCS, spendPK, witness)
+    require.NoError(t, err, "groth16.Prove failed for a valid SpendCircuit witness")
+
+    publicWitness, err := witness.Public()
+    require.NoError(t, err)
+
+    err = groth16.Verify(proof, spendVK, publicWitness)
+    require.NoError(t, err, "groth16.Verify failed for a valid SpendCircuit proof")
+}
+
+func TestSpendCircuitInvalid_WrongValue(t *testing.T) {
+    setupSpend(t)
+
+    inp := newRandomSpendInputs()
+    assignment := buildSpendAssignment(t, inp)
+
+    var wrongValue fr.Element
+    wrongValue.SetUint64(inp.value - 1)
+    assignment.Value = wrongValue
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    err = spendCS.IsSolved(witness)
+    require.Error(t, err,
+        "CRITICAL: SpendCircuit accepted a witness with wrong Value — "+
+            "commitment constraint is not working")
+}
+
+func TestSpendCircuitInvalid_WrongRandomness(t *testing.T) {
+	setupSpend(t)
+
+	inp := newRandomSpendInputs()
+	assignment := buildSpendAssignment(t, inp)
+
+	var wrongRandomness fr.Element
+	wrongRandomness.SetRandom()
+	assignment.Randomness = wrongRandomness
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"SpendCircuit must reject a witness with wrong Randomness")
+}
+
+func TestSpendCircuitInvalid_WrongTokenType(t *testing.T) {
+	setupSpend(t)
+
+	inp := newRandomSpendInputs()
+	assignment := buildSpendAssignment(t, inp)
+
+	var wrongTokenType fr.Element
+	wrongTokenType.SetBytes([]byte("EUR"))
+	assignment.TokenType = wrongTokenType
+
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
+
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"SpendCircuit must reject a witness where TokenType mismatches CommitmentIn")
+}
+
+func TestSpendCircuitInvalid_WrongValueCommit(t *testing.T) {
+    setupSpend(t)
+
+    inp := newRandomSpendInputs()
+	assignment := buildSpendAssignment(t, inp)
+
+    var fakeRcv fr.Element
+    fakeRcv.SetRandom()
+
+    fakeCv, err := jubjub.ValueCommit(inp.value + 1, fakeRcv)
+    require.NoError(t, err)
+    assignment.ValueCommitInX = fakeCv.X
+    assignment.ValueCommitInY = fakeCv.Y
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    err = spendCS.IsSolved(witness)
+    require.Error(t, err,
+        "SpendCircuit must reject a witness where ValueCommit doesn't match Value/RCV")
+}
+
+func TestSpendCircuitInvalid_WrongRCV(t *testing.T) {
+    setupSpend(t)
+
+    inp := newRandomSpendInputs()
+    assignment := buildSpendAssignment(t, inp)
+
+    // Keep public ValueCommitInX/Y but change private RCV.
+    var wrongRCV fr.Element
+    wrongRCV.SetRandom()
+    assignment.RCV = wrongRCV
+
+    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+    require.NoError(t, err)
+
+    err = spendCS.IsSolved(witness)
+    require.Error(t, err,
+        "SpendCircuit must reject a witness where RCV doesn't produce the public value commitment")
+}

--- a/x/token/core/zkatsnark/circuit/spend_test.go
+++ b/x/token/core/zkatsnark/circuit/spend_test.go
@@ -6,150 +6,154 @@ SPDX-License-Identifier: Apache-2.0
 package circuit_test
 
 import (
-    "fmt"
-    "sync"
-    "testing"
+	"fmt"
+	"sync"
+	"testing"
 
-    "github.com/consensys/gnark-crypto/ecc"
-    "github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-    "github.com/consensys/gnark/backend/groth16"
-    "github.com/consensys/gnark/constraint"
-    "github.com/consensys/gnark/frontend"
-    "github.com/consensys/gnark/frontend/cs/r1cs"
-    "github.com/stretchr/testify/require"
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/constraint"
+	"github.com/consensys/gnark/frontend"
+	"github.com/consensys/gnark/frontend/cs/r1cs"
+	"github.com/stretchr/testify/require"
 
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
-    "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc"
 )
 
 // ── Package-level setup — compiled once for all spend tests ──────────────────
 
 var (
-    spendCS   constraint.ConstraintSystem
-    spendPK   groth16.ProvingKey
-    spendVK   groth16.VerifyingKey
-    spendOnce sync.Once
+	spendCS   constraint.ConstraintSystem
+	spendPK   groth16.ProvingKey
+	spendVK   groth16.VerifyingKey
+	spendOnce sync.Once
 )
 
 func setupSpend(t *testing.T) {
-    t.Helper()
-    spendOnce.Do(func() {
-        var err error
-        spendCS, err = frontend.Compile(
-            ecc.BLS12_381.ScalarField(),
-            r1cs.NewBuilder,
-            &circuit.SpendCircuit{},
-        )
-        if err != nil {
-            panic(fmt.Sprintf("SpendCircuit compilation failed: %v", err))
-        }
-        
-        fmt.Printf("SpendCircuit: %d constraints\n", spendCS.GetNbConstraints())
+	t.Helper()
+	spendOnce.Do(func() {
+		var err error
+		spendCS, err = frontend.Compile(
+			ecc.BLS12_381.ScalarField(),
+			r1cs.NewBuilder,
+			&circuit.SpendCircuit{},
+		)
+		if err != nil {
+			panic(fmt.Sprintf("SpendCircuit compilation failed: %v", err))
+		}
 
-        spendPK, spendVK, err = groth16.Setup(spendCS)
-        if err != nil {
-            panic(fmt.Sprintf("SpendCircuit groth16.Setup failed: %v", err))
-        }
-    })
+		fmt.Printf("SpendCircuit: %d constraints\n", spendCS.GetNbConstraints())
+
+		spendPK, spendVK, err = groth16.Setup(spendCS)
+		if err != nil {
+			panic(fmt.Sprintf("SpendCircuit groth16.Setup failed: %v", err))
+		}
+	})
 }
 
 type spendInputs struct {
-	value uint64
-	tokenType fr.Element
+	value      uint64
+	tokenType  fr.Element
 	randomness fr.Element
-	rcv fr.Element
+	rcv        fr.Element
 }
 
-func newRandomSpendInputs() spendInputs {
+func newRandomSpendInputs(t *testing.T) spendInputs {
+	t.Helper()
 	var tokenType, randomness, rcv fr.Element
 	tokenType.SetBytes([]byte("USD"))
-	randomness.SetRandom()
-	rcv.SetRandom()
+	_, err := randomness.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv.SetRandom()
+	require.NoError(t, err)
 
 	return spendInputs{
-        value:      100,
-        tokenType:  tokenType,
-        randomness: randomness,
-        rcv:        rcv,
-    }
+		value:      100,
+		tokenType:  tokenType,
+		randomness: randomness,
+		rcv:        rcv,
+	}
 }
 
 func buildSpendAssignment(t *testing.T, inp spendInputs) *circuit.SpendCircuit {
 	t.Helper()
 
-    // Encode value as a field element — same encoding as in the prover.
-    var vField fr.Element
-    vField.SetUint64(inp.value)
+	// Encode value as a field element — same encoding as in the prover.
+	var vField fr.Element
+	vField.SetUint64(inp.value)
 
-    // Compute the commitment using native MiMC.
-    // Order must match Define: (Value, TokenType, Randomness).
-    cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
-    require.NoError(t, err, "mimc.Hash failed in buildSpendAssignment")
+	// Compute the commitment using native MiMC.
+	// Order must match Define: (Value, TokenType, Randomness).
+	cm, err := mimc.Hash(vField, inp.tokenType, inp.randomness)
+	require.NoError(t, err, "mimc.Hash failed in buildSpendAssignment")
 
-    // Compute the value commitment using native Jubjub.
-    cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
-    require.NoError(t, err, "jubjub.ValueCommit failed in buildSpendAssignment")
+	// Compute the value commitment using native Jubjub.
+	cv, err := jubjub.ValueCommit(inp.value, inp.rcv)
+	require.NoError(t, err, "jubjub.ValueCommit failed in buildSpendAssignment")
 
-    return &circuit.SpendCircuit{
-        // Public inputs — computed from private inputs
-        CommitmentIn:   cm,
-        ValueCommitInX: cv.X,
-        ValueCommitInY: cv.Y,
-        TokenType:      inp.tokenType,
-        // Private inputs
-        Value:      vField,
-        Randomness: inp.randomness,
-        RCV:        inp.rcv,
-    }
+	return &circuit.SpendCircuit{
+		// Public inputs — computed from private inputs
+		CommitmentIn:   cm,
+		ValueCommitInX: cv.X,
+		ValueCommitInY: cv.Y,
+		TokenType:      inp.tokenType,
+		// Private inputs
+		Value:      vField,
+		Randomness: inp.randomness,
+		RCV:        inp.rcv,
+	}
 }
 
 func TestSpendCircuitValidWitness(t *testing.T) {
 	setupSpend(t)
-	
-	inp := newRandomSpendInputs()
-    assignment := buildSpendAssignment(t, inp)
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	inp := newRandomSpendInputs(t)
+	assignment := buildSpendAssignment(t, inp)
 
-    proof, err := groth16.Prove(spendCS, spendPK, witness)
-    require.NoError(t, err, "groth16.Prove failed for a valid SpendCircuit witness")
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    publicWitness, err := witness.Public()
-    require.NoError(t, err)
+	proof, err := groth16.Prove(spendCS, spendPK, witness)
+	require.NoError(t, err, "groth16.Prove failed for a valid SpendCircuit witness")
 
-    err = groth16.Verify(proof, spendVK, publicWitness)
-    require.NoError(t, err, "groth16.Verify failed for a valid SpendCircuit proof")
+	publicWitness, err := witness.Public()
+	require.NoError(t, err)
+
+	err = groth16.Verify(proof, spendVK, publicWitness)
+	require.NoError(t, err, "groth16.Verify failed for a valid SpendCircuit proof")
 }
 
 func TestSpendCircuitInvalid_WrongValue(t *testing.T) {
-    setupSpend(t)
+	setupSpend(t)
 
-    inp := newRandomSpendInputs()
-    assignment := buildSpendAssignment(t, inp)
+	inp := newRandomSpendInputs(t)
+	assignment := buildSpendAssignment(t, inp)
 
-    var wrongValue fr.Element
-    wrongValue.SetUint64(inp.value - 1)
-    assignment.Value = wrongValue
+	var wrongValue fr.Element
+	wrongValue.SetUint64(inp.value - 1)
+	assignment.Value = wrongValue
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    err = spendCS.IsSolved(witness)
-    require.Error(t, err,
-        "CRITICAL: SpendCircuit accepted a witness with wrong Value — "+
-            "commitment constraint is not working")
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"CRITICAL: SpendCircuit accepted a witness with wrong Value — "+
+			"commitment constraint is not working")
 }
 
 func TestSpendCircuitInvalid_WrongRandomness(t *testing.T) {
 	setupSpend(t)
 
-	inp := newRandomSpendInputs()
+	inp := newRandomSpendInputs(t)
 	assignment := buildSpendAssignment(t, inp)
 
 	var wrongRandomness fr.Element
-	wrongRandomness.SetRandom()
+	_, err := wrongRandomness.SetRandom()
+	require.NoError(t, err)
 	assignment.Randomness = wrongRandomness
 
 	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
@@ -163,7 +167,7 @@ func TestSpendCircuitInvalid_WrongRandomness(t *testing.T) {
 func TestSpendCircuitInvalid_WrongTokenType(t *testing.T) {
 	setupSpend(t)
 
-	inp := newRandomSpendInputs()
+	inp := newRandomSpendInputs(t)
 	assignment := buildSpendAssignment(t, inp)
 
 	var wrongTokenType fr.Element
@@ -179,42 +183,44 @@ func TestSpendCircuitInvalid_WrongTokenType(t *testing.T) {
 }
 
 func TestSpendCircuitInvalid_WrongValueCommit(t *testing.T) {
-    setupSpend(t)
+	setupSpend(t)
 
-    inp := newRandomSpendInputs()
+	inp := newRandomSpendInputs(t)
 	assignment := buildSpendAssignment(t, inp)
 
-    var fakeRcv fr.Element
-    fakeRcv.SetRandom()
+	var fakeRcv fr.Element
+	_, err := fakeRcv.SetRandom()
+	require.NoError(t, err)
 
-    fakeCv, err := jubjub.ValueCommit(inp.value + 1, fakeRcv)
-    require.NoError(t, err)
-    assignment.ValueCommitInX = fakeCv.X
-    assignment.ValueCommitInY = fakeCv.Y
+	fakeCv, err := jubjub.ValueCommit(inp.value+1, fakeRcv)
+	require.NoError(t, err)
+	assignment.ValueCommitInX = fakeCv.X
+	assignment.ValueCommitInY = fakeCv.Y
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    err = spendCS.IsSolved(witness)
-    require.Error(t, err,
-        "SpendCircuit must reject a witness where ValueCommit doesn't match Value/RCV")
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"SpendCircuit must reject a witness where ValueCommit doesn't match Value/RCV")
 }
 
 func TestSpendCircuitInvalid_WrongRCV(t *testing.T) {
-    setupSpend(t)
+	setupSpend(t)
 
-    inp := newRandomSpendInputs()
-    assignment := buildSpendAssignment(t, inp)
+	inp := newRandomSpendInputs(t)
+	assignment := buildSpendAssignment(t, inp)
 
-    // Keep public ValueCommitInX/Y but change private RCV.
-    var wrongRCV fr.Element
-    wrongRCV.SetRandom()
-    assignment.RCV = wrongRCV
+	// Keep public ValueCommitInX/Y but change private RCV.
+	var wrongRCV fr.Element
+	_, err := wrongRCV.SetRandom()
+	require.NoError(t, err)
+	assignment.RCV = wrongRCV
 
-    witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
-    require.NoError(t, err)
+	witness, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField())
+	require.NoError(t, err)
 
-    err = spendCS.IsSolved(witness)
-    require.Error(t, err,
-        "SpendCircuit must reject a witness where RCV doesn't produce the public value commitment")
+	err = spendCS.IsSolved(witness)
+	require.Error(t, err,
+		"SpendCircuit must reject a witness where RCV doesn't produce the public value commitment")
 }

--- a/x/token/core/zkatsnark/crypto/jubjub/commitment.go
+++ b/x/token/core/zkatsnark/crypto/jubjub/commitment.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package jubjub
 
 import (
-	"fmt"
+	"errors"
 	"math/big"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"

--- a/x/token/core/zkatsnark/crypto/jubjub/commitment_test.go
+++ b/x/token/core/zkatsnark/crypto/jubjub/commitment_test.go
@@ -23,7 +23,8 @@ import (
 
 func TestValueCommitDeterminism(t *testing.T) {
 	var rcv fr.Element
-	rcv.SetRandom()
+	_, err := rcv.SetRandom()
+	require.NoError(t, err)
 
 	cv1, _ := jubjub.ValueCommit(100, rcv)
 	cv2, _ := jubjub.ValueCommit(100, rcv)
@@ -37,9 +38,13 @@ func TestValueCommitDeterminism(t *testing.T) {
 // If this test fails, the conservation proof is unsound.
 func TestValueCommitHomomorphism(t *testing.T) {
 	var rcv1 fr.Element
-	rcv1.SetRandom()
+	_, err := rcv1.SetRandom()
+	require.NoError(t, err)
+
 	var rcv2 fr.Element
-	rcv2.SetRandom()
+	_, err = rcv2.SetRandom()
+	require.NoError(t, err)
+
 	var rcvSum fr.Element
 	rcvSum.Add(&rcv1, &rcv2)
 
@@ -56,8 +61,10 @@ func TestValueCommitHomomorphism(t *testing.T) {
 
 func TestValueCommitDistinct(t *testing.T) {
 	var rcv1, rcv2 fr.Element
-	rcv1.SetRandom()
-	rcv2.SetRandom()
+	_, err := rcv1.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv2.SetRandom()
+	require.NoError(t, err)
 
 	cv1, _ := jubjub.ValueCommit(100, rcv1)
 	cv2, _ := jubjub.ValueCommit(100, rcv2)
@@ -70,7 +77,8 @@ func TestValueCommitDistinct(t *testing.T) {
 func TestValueCommitOnCurve(t *testing.T) {
 	for i := range 20 {
 		var rcv fr.Element
-		rcv.SetRandom()
+		_, err := rcv.SetRandom()
+		require.NoError(t, err)
 		cv, _ := jubjub.ValueCommit(uint64(i+1), rcv)
 		require.True(t, cv.IsOnCurve())
 	}
@@ -84,7 +92,8 @@ func TestValueCommitSumEmpty(t *testing.T) {
 
 func TestNegatePoint(t *testing.T) {
 	var rcv fr.Element
-	rcv.SetRandom()
+	_, err := rcv.SetRandom()
+	require.NoError(t, err)
 	cv, _ := jubjub.ValueCommit(42, rcv)
 	neg := jubjub.NegatePoint(cv)
 	require.True(t, neg.IsOnCurve())
@@ -129,7 +138,8 @@ func TestValueCommitCrossConsistency(t *testing.T) {
 
 	for trial := range 20 {
 		var rcv fr.Element
-		rcv.SetRandom()
+		_, err = rcv.SetRandom()
+		require.NoError(t, err)
 		v := uint64(trial*137 + 1)
 
 		cvNative, err := jubjub.ValueCommit(v, rcv)

--- a/x/token/core/zkatsnark/crypto/jubjub/generators.go
+++ b/x/token/core/zkatsnark/crypto/jubjub/generators.go
@@ -8,6 +8,7 @@ package jubjub
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards"
@@ -46,9 +47,7 @@ func mustHashToCurve(seed string) twistededwards.PointAffine {
 		h := sha256.New()
 		h.Write([]byte(seed))
 		var cb [8]byte
-		for i := range 8 {
-			cb[7-i] = byte(counter >> (i * 8))
-		}
+		binary.BigEndian.PutUint64(cb[:], counter)
 		h.Write(cb[:])
 		digest := h.Sum(nil)
 

--- a/x/token/core/zkatsnark/crypto/jubjub/schnorr.go
+++ b/x/token/core/zkatsnark/crypto/jubjub/schnorr.go
@@ -9,6 +9,7 @@ package jubjub
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"math/big"
 

--- a/x/token/core/zkatsnark/crypto/jubjub/schnorr_test.go
+++ b/x/token/core/zkatsnark/crypto/jubjub/schnorr_test.go
@@ -19,7 +19,8 @@ import (
 
 func TestSchnorrSignVerify(t *testing.T) {
 	var sk fr.Element
-	sk.SetRandom()
+	_, err := sk.SetRandom()
+	require.NoError(t, err)
 	pk := jubjub.DerivePublicKey(sk, jubjub.G)
 	msg := []byte("test message")
 
@@ -32,28 +33,32 @@ func TestSchnorrSignVerify(t *testing.T) {
 
 func TestSchnorrWrongMessage(t *testing.T) {
 	var sk fr.Element
-	sk.SetRandom()
+	_, err := sk.SetRandom()
+	require.NoError(t, err)
 	pk := jubjub.DerivePublicKey(sk, jubjub.G)
 
 	sig, _ := jubjub.Sign(sk, []byte("original"), jubjub.G)
-	err := jubjub.Verify(pk, []byte("tampered"), sig, jubjub.G)
+	err = jubjub.Verify(pk, []byte("tampered"), sig, jubjub.G)
 	require.ErrorIs(t, err, jubjub.ErrInvalidSignature)
 }
 
 func TestSchnorrWrongPublicKey(t *testing.T) {
 	var sk1, sk2 fr.Element
-	sk1.SetRandom()
-	sk2.SetRandom()
+	_, err := sk1.SetRandom()
+	require.NoError(t, err)
+	_, err = sk2.SetRandom()
+	require.NoError(t, err)
 	pk2 := jubjub.DerivePublicKey(sk2, jubjub.G)
 
 	sig, _ := jubjub.Sign(sk1, []byte("msg"), jubjub.G)
-	err := jubjub.Verify(pk2, []byte("msg"), sig, jubjub.G)
+	err = jubjub.Verify(pk2, []byte("msg"), sig, jubjub.G)
 	require.ErrorIs(t, err, jubjub.ErrInvalidSignature)
 }
 
 func TestSchnorrNonceUniqueness(t *testing.T) {
 	var sk fr.Element
-	sk.SetRandom()
+	_, err := sk.SetRandom()
+	require.NoError(t, err)
 
 	sig1, _ := jubjub.Sign(sk, []byte("same message"), jubjub.G)
 	sig2, _ := jubjub.Sign(sk, []byte("same message"), jubjub.G)
@@ -67,10 +72,14 @@ func TestSchnorrNonceUniqueness(t *testing.T) {
 // This is exactly the sequence the TransferAction prover and validator follow.
 func TestSchnorrBindingSig(t *testing.T) {
 	var rcv1, rcv2, rcv3, rcv4 fr.Element
-	rcv1.SetRandom()
-	rcv2.SetRandom()
-	rcv3.SetRandom()
-	rcv4.SetRandom()
+	_, err := rcv1.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv2.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv3.SetRandom()
+	require.NoError(t, err)
+	_, err = rcv4.SetRandom()
+	require.NoError(t, err)
 
 	// bsk = rcv1 + rcv2 - rcv3 - rcv4
 	// Replace the fr.Element Add/Sub block with this:

--- a/x/token/core/zkatsnark/go.sum
+++ b/x/token/core/zkatsnark/go.sum
@@ -56,5 +56,7 @@ golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Description

This pr introduces the following circuits:

- ### SpendCircuit

Is used when a user wants to spend or transfer their existing tokens
Proves knowledge of a valid opening of a recorded commitment and ensures the published value commitment is formed correctly.
  * **Constraint Group 1:** Commitment Integrity (`CommitmentIn == MiMC(Value, TokenType, Randomness)`)
  * **Constraint Group 2:** Value Commitment Integrity (`(ValueCommitInX, ValueCommitInY) == Value·V + RCV·R`)

- ### OutputCircuit

Is used when new tokens are output or issued to a user
 Proves that a newly created output token is well-formed and its value is strictly within a permissible range, avoiding out-of-thin-air token creation. 
  * **Constraint Group 1:** Commitment Integrity 
  * **Constraint Group 2:** Value Commitment Integrity
  * **Constraint Group 3:** Range Check (`1 <= Value < 2^MaxBits`) enforcing the value is non-zero and avoids field-overflow.

## Testing & Validation
Comprehensive constraint system tests have been added (`spend_test.go`, `output_test.go`), verifying both valid proofs and rejecting invalid constraints:
- Verified valid witnesses via Groth16 Setup, Prove, and Verify.
- Tested invalid inputs: Wrong Value, Wrong Randomness, Wrong Token Type, Wrong Value Commitment, and Wrong RCV.
- **Critical Security Tests for Output:** 
  - `TestOutputCircuitInvalid_ZeroValue`: Ensured zero-value token generation fails.
  - `TestOutputCircuitInvalid_OverflowValue`: Validated that values `>= 2^MaxBits` correctly fail the range constraints (preventing overflow wrap-around attacks).

```
go test ./circuit/... -v     -run "TestSpendCircuit"     -timeout 120s
=== RUN   TestSpendCircuitValidWitness
SpendCircuit: 5816 constraints
--- PASS: TestSpendCircuitValidWitness (0.32s)
=== RUN   TestSpendCircuitInvalid_WrongValue
--- PASS: TestSpendCircuitInvalid_WrongValue (0.00s)
=== RUN   TestSpendCircuitInvalid_WrongRandomness
--- PASS: TestSpendCircuitInvalid_WrongRandomness (0.00s)
=== RUN   TestSpendCircuitInvalid_WrongTokenType
--- PASS: TestSpendCircuitInvalid_WrongTokenType (0.00s)
=== RUN   TestSpendCircuitInvalid_WrongValueCommit
--- PASS: TestSpendCircuitInvalid_WrongValueCommit (0.00s)
=== RUN   TestSpendCircuitInvalid_WrongRCV
--- PASS: TestSpendCircuitInvalid_WrongRCV (0.00s)
PASS
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit  0.331s
```

```
go test ./circuit/... -v     -run "TestOutputCircuit"     -timeout 120s
=== RUN   TestOutputCircuitValidWitness
OutputCircuit: 5882 constraints
--- PASS: TestOutputCircuitValidWitness (0.31s)
=== RUN   TestOutputCircuitInvalid_WrongValue
--- PASS: TestOutputCircuitInvalid_WrongValue (0.00s)
=== RUN   TestOutputCircuitInvalid_WrongRandomness
--- PASS: TestOutputCircuitInvalid_WrongRandomness (0.00s)
=== RUN   TestOutputCircuitInvalid_WrongValueCommit
--- PASS: TestOutputCircuitInvalid_WrongValueCommit (0.00s)
=== RUN   TestOutputCircuitInvalid_ZeroValue
--- PASS: TestOutputCircuitInvalid_ZeroValue (0.00s)
=== RUN   TestOutputCircuitInvalid_OverflowValue
--- PASS: TestOutputCircuitInvalid_OverflowValue (0.00s)
PASS
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit  0.323s
```

```
go test ./...
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark  [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit  0.661s
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets  [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub    (cached)
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc      (cached)
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params    [no test files]
```

## Next steps for this week

- Implement the proving and witness building layer
- Implement the migration(token upgrade) circuit and integrate it with prover layer