### PR TITLE
perf(identity): point-query the identity store on LocalMembership cache miss

### DIFF
--- a/token/services/identity/driver/mock/iss.go
+++ b/token/services/identity/driver/mock/iss.go
@@ -48,6 +48,21 @@ type IdentityStoreService struct {
 		result1 bool
 		result2 error
 	}
+	ConfigurationsByIDStub        func(context.Context, string, string) ([]driver.IdentityConfiguration, error)
+	configurationsByIDMutex       sync.RWMutex
+	configurationsByIDArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}
+	configurationsByIDReturns struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}
+	configurationsByIDReturnsOnCall map[int]struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}
 	GetAuditInfoStub        func(context.Context, []byte) ([]byte, error)
 	getAuditInfoMutex       sync.RWMutex
 	getAuditInfoArgsForCall []struct {
@@ -121,6 +136,21 @@ type IdentityStoreService struct {
 		result1 []byte
 		result2 []byte
 		result3 error
+	}
+	IterateSignersStub        func(context.Context, int, int) ([]driver.SignerEntry, error)
+	iterateSignersMutex       sync.RWMutex
+	iterateSignersArgsForCall []struct {
+		arg1 context.Context
+		arg2 int
+		arg3 int
+	}
+	iterateSignersReturns struct {
+		result1 []driver.SignerEntry
+		result2 error
+	}
+	iterateSignersReturnsOnCall map[int]struct {
+		result1 []driver.SignerEntry
+		result2 error
 	}
 	IteratorConfigurationsStub        func(context.Context, string) (driver.IdentityConfigurationIterator, error)
 	iteratorConfigurationsMutex       sync.RWMutex
@@ -202,21 +232,6 @@ type IdentityStoreService struct {
 	}
 	storeSignerInfoReturnsOnCall map[int]struct {
 		result1 error
-	}
-	IterateSignersStub        func(context.Context, int, int) ([]driver.SignerEntry, error)
-	iterateSignersMutex       sync.RWMutex
-	iterateSignersArgsForCall []struct {
-		arg1 context.Context
-		arg2 int
-		arg3 int
-	}
-	iterateSignersReturns struct {
-		result1 []driver.SignerEntry
-		result2 error
-	}
-	iterateSignersReturnsOnCall map[int]struct {
-		result1 []driver.SignerEntry
-		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -400,6 +415,72 @@ func (fake *IdentityStoreService) ConfigurationExistsReturnsOnCall(i int, result
 	}
 	fake.configurationExistsReturnsOnCall[i] = struct {
 		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IdentityStoreService) ConfigurationsByID(arg1 context.Context, arg2 string, arg3 string) ([]driver.IdentityConfiguration, error) {
+	fake.configurationsByIDMutex.Lock()
+	ret, specificReturn := fake.configurationsByIDReturnsOnCall[len(fake.configurationsByIDArgsForCall)]
+	fake.configurationsByIDArgsForCall = append(fake.configurationsByIDArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ConfigurationsByIDStub
+	fakeReturns := fake.configurationsByIDReturns
+	fake.recordInvocation("ConfigurationsByID", []interface{}{arg1, arg2, arg3})
+	fake.configurationsByIDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDCallCount() int {
+	fake.configurationsByIDMutex.RLock()
+	defer fake.configurationsByIDMutex.RUnlock()
+	return len(fake.configurationsByIDArgsForCall)
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDCalls(stub func(context.Context, string, string) ([]driver.IdentityConfiguration, error)) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = stub
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDArgsForCall(i int) (context.Context, string, string) {
+	fake.configurationsByIDMutex.RLock()
+	defer fake.configurationsByIDMutex.RUnlock()
+	argsForCall := fake.configurationsByIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDReturns(result1 []driver.IdentityConfiguration, result2 error) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = nil
+	fake.configurationsByIDReturns = struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDReturnsOnCall(i int, result1 []driver.IdentityConfiguration, result2 error) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = nil
+	if fake.configurationsByIDReturnsOnCall == nil {
+		fake.configurationsByIDReturnsOnCall = make(map[int]struct {
+			result1 []driver.IdentityConfiguration
+			result2 error
+		})
+	}
+	fake.configurationsByIDReturnsOnCall[i] = struct {
+		result1 []driver.IdentityConfiguration
 		result2 error
 	}{result1, result2}
 }
@@ -747,6 +828,72 @@ func (fake *IdentityStoreService) GetTokenInfoReturnsOnCall(i int, result1 []byt
 		result2 []byte
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *IdentityStoreService) IterateSigners(arg1 context.Context, arg2 int, arg3 int) ([]driver.SignerEntry, error) {
+	fake.iterateSignersMutex.Lock()
+	ret, specificReturn := fake.iterateSignersReturnsOnCall[len(fake.iterateSignersArgsForCall)]
+	fake.iterateSignersArgsForCall = append(fake.iterateSignersArgsForCall, struct {
+		arg1 context.Context
+		arg2 int
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.IterateSignersStub
+	fakeReturns := fake.iterateSignersReturns
+	fake.recordInvocation("IterateSigners", []interface{}{arg1, arg2, arg3})
+	fake.iterateSignersMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *IdentityStoreService) IterateSignersCallCount() int {
+	fake.iterateSignersMutex.RLock()
+	defer fake.iterateSignersMutex.RUnlock()
+	return len(fake.iterateSignersArgsForCall)
+}
+
+func (fake *IdentityStoreService) IterateSignersCalls(stub func(context.Context, int, int) ([]driver.SignerEntry, error)) {
+	fake.iterateSignersMutex.Lock()
+	defer fake.iterateSignersMutex.Unlock()
+	fake.IterateSignersStub = stub
+}
+
+func (fake *IdentityStoreService) IterateSignersArgsForCall(i int) (context.Context, int, int) {
+	fake.iterateSignersMutex.RLock()
+	defer fake.iterateSignersMutex.RUnlock()
+	argsForCall := fake.iterateSignersArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IdentityStoreService) IterateSignersReturns(result1 []driver.SignerEntry, result2 error) {
+	fake.iterateSignersMutex.Lock()
+	defer fake.iterateSignersMutex.Unlock()
+	fake.IterateSignersStub = nil
+	fake.iterateSignersReturns = struct {
+		result1 []driver.SignerEntry
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IdentityStoreService) IterateSignersReturnsOnCall(i int, result1 []driver.SignerEntry, result2 error) {
+	fake.iterateSignersMutex.Lock()
+	defer fake.iterateSignersMutex.Unlock()
+	fake.IterateSignersStub = nil
+	if fake.iterateSignersReturnsOnCall == nil {
+		fake.iterateSignersReturnsOnCall = make(map[int]struct {
+			result1 []driver.SignerEntry
+			result2 error
+		})
+	}
+	fake.iterateSignersReturnsOnCall[i] = struct {
+		result1 []driver.SignerEntry
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *IdentityStoreService) IteratorConfigurations(arg1 context.Context, arg2 string) (driver.IdentityConfigurationIterator, error) {
@@ -1154,72 +1301,6 @@ func (fake *IdentityStoreService) StoreSignerInfoReturnsOnCall(i int, result1 er
 	fake.storeSignerInfoReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
-}
-
-func (fake *IdentityStoreService) IterateSigners(arg1 context.Context, arg2 int, arg3 int) ([]driver.SignerEntry, error) {
-	fake.iterateSignersMutex.Lock()
-	ret, specificReturn := fake.iterateSignersReturnsOnCall[len(fake.iterateSignersArgsForCall)]
-	fake.iterateSignersArgsForCall = append(fake.iterateSignersArgsForCall, struct {
-		arg1 context.Context
-		arg2 int
-		arg3 int
-	}{arg1, arg2, arg3})
-	stub := fake.IterateSignersStub
-	fakeReturns := fake.iterateSignersReturns
-	fake.recordInvocation("IterateSigners", []interface{}{arg1, arg2, arg3})
-	fake.iterateSignersMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *IdentityStoreService) IterateSignersCallCount() int {
-	fake.iterateSignersMutex.RLock()
-	defer fake.iterateSignersMutex.RUnlock()
-	return len(fake.iterateSignersArgsForCall)
-}
-
-func (fake *IdentityStoreService) IterateSignersCalls(stub func(context.Context, int, int) ([]driver.SignerEntry, error)) {
-	fake.iterateSignersMutex.Lock()
-	defer fake.iterateSignersMutex.Unlock()
-	fake.IterateSignersStub = stub
-}
-
-func (fake *IdentityStoreService) IterateSignersArgsForCall(i int) (context.Context, int, int) {
-	fake.iterateSignersMutex.RLock()
-	defer fake.iterateSignersMutex.RUnlock()
-	argsForCall := fake.iterateSignersArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *IdentityStoreService) IterateSignersReturns(result1 []driver.SignerEntry, result2 error) {
-	fake.iterateSignersMutex.Lock()
-	defer fake.iterateSignersMutex.Unlock()
-	fake.IterateSignersStub = nil
-	fake.iterateSignersReturns = struct {
-		result1 []driver.SignerEntry
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *IdentityStoreService) IterateSignersReturnsOnCall(i int, result1 []driver.SignerEntry, result2 error) {
-	fake.iterateSignersMutex.Lock()
-	defer fake.iterateSignersMutex.Unlock()
-	fake.IterateSignersStub = nil
-	if fake.iterateSignersReturnsOnCall == nil {
-		fake.iterateSignersReturnsOnCall = make(map[int]struct {
-			result1 []driver.SignerEntry
-			result2 error
-		})
-	}
-	fake.iterateSignersReturnsOnCall[i] = struct {
-		result1 []driver.SignerEntry
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *IdentityStoreService) Invocations() map[string][][]interface{} {

--- a/token/services/identity/driver/storage.go
+++ b/token/services/identity/driver/storage.go
@@ -155,6 +155,8 @@ type IdentityStoreService interface {
 	// GetConfiguration returns the configuration with the given id, type, and url.
 	// It returns nil if the configuration does not exist.
 	GetConfiguration(ctx context.Context, id, typ, url string) (*IdentityConfiguration, error)
+	// ConfigurationsByID returns all configurations with the given id and type, regardless of their url.
+	ConfigurationsByID(ctx context.Context, id, configurationType string) ([]IdentityConfiguration, error)
 	// ConfigurationExists returns true if a configuration with the given id and type exists.
 	ConfigurationExists(ctx context.Context, id, typ, url string) (bool, error)
 	// IteratorConfigurations returns an iterator to all configurations stored

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/LFDT-Panurus/panurus/token"
 	tdriver "github.com/LFDT-Panurus/panurus/token/driver"
@@ -76,6 +77,8 @@ type IdentityStoreService interface {
 	AddConfiguration(ctx context.Context, wp idriver.IdentityConfiguration) error
 	// GetConfiguration returns the configuration with the given id and type.
 	GetConfiguration(ctx context.Context, id, typ, url string) (*idriver.IdentityConfiguration, error)
+	// ConfigurationsByID returns all configurations with the given id and type, regardless of their url.
+	ConfigurationsByID(ctx context.Context, id, configurationType string) ([]idriver.IdentityConfiguration, error)
 	// ConfigurationExists returns true if a configuration with the given id,
 	// type and URL already exists in the store.
 	ConfigurationExists(ctx context.Context, id, typ, url string) (bool, error)
@@ -735,31 +738,49 @@ func (l *LocalMembership) addLocalIdentity(ctx context.Context, config *Identity
 	return nil
 }
 
+// refreshAndGet resolves a label that missed the in-memory maps against the
+// identity store. The store is point-queried for that label only: a hit means
+// the configuration was registered by another node sharing the store (load
+// just that one), a miss means the label is genuinely unknown and returns
+// without ever taking the write lock.
 func (l *LocalMembership) refreshAndGet(ctx context.Context, label string) *LocalIdentity {
-	l.localIdentitiesMutex.Lock()
-	defer l.localIdentitiesMutex.Unlock()
-
-	// Double check
-	identities, ok := l.localIdentitiesByName[label]
-	if ok {
-		return identities[0].Identity
-	}
-	mapped, ok := l.localIdentitiesByIdentity[label]
-	if ok {
-		return mapped
+	// Double check: the identity may have been registered while the caller
+	// released the read lock.
+	l.localIdentitiesMutex.RLock()
+	res := l.lookup(label)
+	l.localIdentitiesMutex.RUnlock()
+	if res != nil {
+		return res
 	}
 
-	l.logger.DebugfContext(ctx, "refresh and get local identity for label [%s]", utils.Hashable(label))
-	storedIdentityConfigurations, err := l.storedIdentityConfigurations(ctx)
-	if err != nil {
-		l.logger.ErrorfContext(ctx, "failed to load stored identity configurations: %s", err)
-
+	// Configuration ids are stored in text columns, a label that is not valid
+	// UTF-8 cannot match any stored configuration.
+	if !utf8.ValidString(label) {
 		return nil
 	}
 
-	for _, identityConfiguration := range storedIdentityConfigurations {
-		key := l.configKey(&identityConfiguration)
-		if _, ok := l.localIdentitiesByConfig[key]; ok {
+	l.logger.DebugfContext(ctx, "refresh and get local identity for label [%s]", utils.Hashable(label))
+	configurations, err := l.identityDB.ConfigurationsByID(ctx, label, l.IdentityType)
+	if err != nil {
+		l.logger.ErrorfContext(ctx, "failed to load stored identity configurations for [%s]: %s", utils.Hashable(label), err)
+
+		return nil
+	}
+	if len(configurations) == 0 {
+		return nil
+	}
+
+	l.localIdentitiesMutex.Lock()
+	defer l.localIdentitiesMutex.Unlock()
+
+	// double check under the write lock: another goroutine may have registered
+	// the same configuration meanwhile
+	if res := l.lookup(label); res != nil {
+		return res
+	}
+
+	for _, identityConfiguration := range configurations {
+		if _, ok := l.localIdentitiesByConfig[l.configKey(&identityConfiguration)]; ok {
 			continue
 		}
 
@@ -769,13 +790,16 @@ func (l *LocalMembership) refreshAndGet(ctx context.Context, label string) *Loca
 		}
 	}
 
-	// check again
-	identities, ok = l.localIdentitiesByName[label]
-	if ok {
+	return l.lookup(label)
+}
+
+// lookup returns the local identity bound to label, or nil. The caller must
+// hold localIdentitiesMutex.
+func (l *LocalMembership) lookup(label string) *LocalIdentity {
+	if identities, ok := l.localIdentitiesByName[label]; ok {
 		return identities[0].Identity
 	}
-	mapped, ok = l.localIdentitiesByIdentity[label]
-	if ok {
+	if mapped, ok := l.localIdentitiesByIdentity[label]; ok {
 		return mapped
 	}
 

--- a/token/services/identity/membership/lm.go
+++ b/token/services/identity/membership/lm.go
@@ -452,10 +452,9 @@ func (l *LocalMembership) subscribeNotifier() error {
 	return nil
 }
 
+// handleConfig registers the store configuration a change notification points
+// at. The store read runs outside the write lock.
 func (l *LocalMembership) handleConfig(id, typ, url string) {
-	l.localIdentitiesMutex.Lock()
-	defer l.localIdentitiesMutex.Unlock()
-
 	l.logger.Debugf("handle config for [%s:%s:%s]", id, typ, url)
 	config, err := l.identityDB.GetConfiguration(context.Background(), id, typ, url)
 	if err != nil {
@@ -468,6 +467,9 @@ func (l *LocalMembership) handleConfig(id, typ, url string) {
 
 		return
 	}
+
+	l.localIdentitiesMutex.Lock()
+	defer l.localIdentitiesMutex.Unlock()
 
 	key := l.configKey(config)
 	if _, ok := l.localIdentitiesByConfig[key]; ok {

--- a/token/services/identity/membership/lm_discovery_test.go
+++ b/token/services/identity/membership/lm_discovery_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package membership_test
 
 import (
+	"context"
 	"slices"
 	"sync"
 	"testing"
@@ -271,6 +272,84 @@ func TestLocalMembership_Notifier(t *testing.T) {
 	// Wait for background processing (though handleConfig is called synchronously in the callback in my implementation,
 	// but the callback itself is called from the notifier which might be background).
 	// In my lm.go, the callback is executed by the notifier loop.
+
+	assert.Eventually(t, func() bool {
+		ids, _ := lm.IDs()
+
+		return slices.Contains(ids, "new")
+	}, 2*time.Second, 100*time.Millisecond)
+}
+
+func TestLocalMembership_NotificationReadsStoreOutsideLock(t *testing.T) {
+	ctx := t.Context()
+
+	ip := &mock.IdentityProvider{}
+	des := &mock.SignerDeserializerManager{}
+	iss := &mock.IdentityStoreService{}
+	iss.ConfigurationExistsReturns(false, nil)
+	iss.AddConfigurationReturns(nil)
+
+	notifier := &mock.IdentityConfigurationNotifier{}
+	iss.NotifierReturns(notifier, nil)
+
+	km := &mock.KeyManager{}
+	km.EnrollmentIDReturns("e1")
+	km.IdentityReturns(&idriver.IdentityDescriptor{Identity: []byte("id1")}, nil)
+	km.IdentityTypeReturns(identity.Type(99))
+
+	kmp := &mock.KeyManagerProvider{}
+	kmp.GetReturns(km, nil)
+
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		des,
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+
+	iss.IteratorConfigurationsReturns(&mock.IdentityConfigurationIterator{}, nil)
+
+	var mu sync.Mutex
+	var subCallback func(idriver.Operation, idriver.IdentityConfigurationRecord)
+	notifier.SubscribeStub = func(callback func(idriver.Operation, idriver.IdentityConfigurationRecord)) error {
+		mu.Lock()
+		defer mu.Unlock()
+		subCallback = callback
+
+		return nil
+	}
+
+	require.NoError(t, lm.Load(ctx, nil, nil))
+
+	assert.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return subCallback != nil
+	}, 2*time.Second, 100*time.Millisecond)
+
+	newConfig := idriver.IdentityConfiguration{ID: "new", URL: "/tmp/new", Type: "testType"}
+	iss.GetConfigurationStub = func(context.Context, string, string, string) (*idriver.IdentityConfiguration, error) {
+		// re-enter a read path: this deadlocks if the notification handler
+		// held the write lock across the store read
+		_, _ = lm.IDs()
+
+		return &newConfig, nil
+	}
+
+	mu.Lock()
+	callback := subCallback
+	mu.Unlock()
+	callback(idriver.Insert, idriver.IdentityConfigurationRecord{
+		ID:   "new",
+		Type: "testType",
+		URL:  "/tmp/new",
+	})
 
 	assert.Eventually(t, func() bool {
 		ids, _ := lm.IDs()

--- a/token/services/identity/membership/lm_discovery_test.go
+++ b/token/services/identity/membership/lm_discovery_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package membership_test
 
 import (
-	"context"
 	"slices"
 	"sync"
 	"testing"
@@ -79,10 +78,7 @@ func TestLocalMembership_Discovery(t *testing.T) {
 
 	// Mock DB update
 	newConfig := idriver.IdentityConfiguration{ID: "new", URL: "/tmp/new", Type: "testType"}
-	iter := &mock.IdentityConfigurationIterator{}
-	iter.NextReturnsOnCall(0, &newConfig, nil)
-	iter.NextReturnsOnCall(1, nil, nil)
-	iss.IteratorConfigurationsReturns(iter, nil)
+	iss.ConfigurationsByIDReturns([]idriver.IdentityConfiguration{newConfig}, nil)
 
 	// Discovery via GetIdentityInfo
 	info, err := lm.GetIdentityInfo(ctx, "new", nil)
@@ -91,6 +87,10 @@ func TestLocalMembership_Discovery(t *testing.T) {
 
 	ids, _ = lm.IDs()
 	assert.Contains(t, ids, "new")
+
+	// discovered through a point query, without a second full scan
+	assert.Equal(t, 1, iss.ConfigurationsByIDCallCount())
+	assert.Equal(t, 1, iss.IteratorConfigurationsCallCount())
 }
 
 func TestLocalMembership_DefaultOverride(t *testing.T) {
@@ -141,10 +141,7 @@ func TestLocalMembership_DefaultOverride(t *testing.T) {
 
 	// Discovery of a new identity (it was previously default: true, but now we don't support it)
 	newConfig := idriver.IdentityConfiguration{ID: "id2", URL: "/tmp/id2", Type: "testType"}
-	iter := &mock.IdentityConfigurationIterator{}
-	iter.NextReturnsOnCall(0, &newConfig, nil)
-	iter.NextReturnsOnCall(1, nil, nil)
-	iss.IteratorConfigurationsReturns(iter, nil)
+	iss.ConfigurationsByIDReturns([]idriver.IdentityConfiguration{newConfig}, nil)
 
 	_, err = lm.GetIdentityInfo(ctx, "id2", nil)
 	require.NoError(t, err)
@@ -187,16 +184,9 @@ func TestLocalMembership_DoubleCheckedLocking(t *testing.T) {
 
 	newConfig := idriver.IdentityConfiguration{ID: "new", URL: "/tmp/new", Type: "testType"}
 
-	// We want to ensure that refresh happens only once even if multiple goroutines call it
-	var refreshCount int
-	iss.IteratorConfigurationsStub = func(ctx context.Context, typ string) (membership.IdentityConfigurationIterator, error) {
-		refreshCount++
-		iter := &mock.IdentityConfigurationIterator{}
-		iter.NextReturnsOnCall(0, &newConfig, nil)
-		iter.NextReturnsOnCall(1, nil, nil)
-
-		return iter, nil
-	}
+	// We want to ensure that the configuration is registered only once even if
+	// multiple goroutines discover it concurrently
+	iss.ConfigurationsByIDReturns([]idriver.IdentityConfiguration{newConfig}, nil)
 
 	var wg sync.WaitGroup
 	for range 10 {
@@ -206,7 +196,9 @@ func TestLocalMembership_DoubleCheckedLocking(t *testing.T) {
 	}
 	wg.Wait()
 
-	assert.Equal(t, 1, refreshCount)
+	assert.Equal(t, 1, kmp.GetCallCount())
+	// no full rescan beyond the initial Load
+	assert.Equal(t, 1, iss.IteratorConfigurationsCallCount())
 }
 
 func TestLocalMembership_Notifier(t *testing.T) {

--- a/token/services/identity/membership/lm_test.go
+++ b/token/services/identity/membership/lm_test.go
@@ -835,3 +835,100 @@ func TestPriorityComparison(t *testing.T) {
 	assert.Equal(t, 5, list[1].Priority)
 	assert.Equal(t, 10, list[2].Priority)
 }
+
+func TestRefreshAndGet_PointQueryLoadsReplicaConfiguration(t *testing.T) {
+	ctx := t.Context()
+
+	ip := &mock.IdentityProvider{}
+	ip.BindReturns(nil)
+
+	iss := &mock.IdentityStoreService{}
+	iss.NotifierReturns(nil, storage.ErrNotSupported)
+	iss.IteratorConfigurationsReturns(&mock.IdentityConfigurationIterator{}, nil)
+	// the shared store holds a configuration registered by another replica
+	iss.ConfigurationsByIDReturns([]idriver.IdentityConfiguration{
+		{ID: "replica-wallet", URL: "/tmp/replica", Type: "testType"},
+	}, nil)
+
+	km := &mock.KeyManager{}
+	km.EnrollmentIDReturns("e1")
+	km.AnonymousReturns(false)
+	km.IsRemoteReturns(false)
+	km.IdentityReturns(&idriver.IdentityDescriptor{Identity: []byte("id1"), AuditInfo: []byte("ai")}, nil)
+	km.IdentityTypeReturns(identity.Type(99))
+
+	kmp := &mock.KeyManagerProvider{}
+	kmp.GetReturns(km, nil)
+
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		&mock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+	require.NoError(t, lm.Load(ctx, nil, nil))
+
+	info, err := lm.GetIdentityInfo(ctx, "replica-wallet", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "replica-wallet", info.ID())
+
+	// resolved through the point query, without a second full scan
+	require.Equal(t, 1, iss.ConfigurationsByIDCallCount())
+	_, id, typ := iss.ConfigurationsByIDArgsForCall(0)
+	assert.Equal(t, "replica-wallet", id)
+	assert.Equal(t, "testType", typ)
+	assert.Equal(t, 1, iss.IteratorConfigurationsCallCount())
+}
+
+func TestRefreshAndGet_UnknownLabelDoesNotFullScan(t *testing.T) {
+	ctx := t.Context()
+
+	iss := &mock.IdentityStoreService{}
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		&mock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		&mock.IdentityProvider{},
+	)
+
+	_, err := lm.GetIdentityInfo(ctx, "unknown", nil)
+	require.Error(t, err)
+
+	require.Equal(t, 1, iss.ConfigurationsByIDCallCount())
+	_, id, typ := iss.ConfigurationsByIDArgsForCall(0)
+	assert.Equal(t, "unknown", id)
+	assert.Equal(t, "testType", typ)
+	assert.Equal(t, 0, iss.IteratorConfigurationsCallCount())
+}
+
+func TestRefreshAndGet_NonUTF8LabelSkipsStore(t *testing.T) {
+	ctx := t.Context()
+
+	iss := &mock.IdentityStoreService{}
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("test"),
+		&mock.Config{},
+		[]byte("netid"),
+		&mock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		&mock.IdentityProvider{},
+	)
+
+	// raw identity bytes are not valid UTF-8 and cannot be a configuration id
+	_, err := lm.GetIdentityInfo(ctx, string([]byte{0xff, 0xfe, 0xfd}), nil)
+	require.Error(t, err)
+
+	assert.Equal(t, 0, iss.ConfigurationsByIDCallCount())
+	assert.Equal(t, 0, iss.IteratorConfigurationsCallCount())
+}

--- a/token/services/identity/membership/mock/iss.go
+++ b/token/services/identity/membership/mock/iss.go
@@ -38,6 +38,21 @@ type IdentityStoreService struct {
 		result1 bool
 		result2 error
 	}
+	ConfigurationsByIDStub        func(context.Context, string, string) ([]driver.IdentityConfiguration, error)
+	configurationsByIDMutex       sync.RWMutex
+	configurationsByIDArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}
+	configurationsByIDReturns struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}
+	configurationsByIDReturnsOnCall map[int]struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}
 	GetConfigurationStub        func(context.Context, string, string, string) (*driver.IdentityConfiguration, error)
 	getConfigurationMutex       sync.RWMutex
 	getConfigurationArgsForCall []struct {
@@ -209,6 +224,72 @@ func (fake *IdentityStoreService) ConfigurationExistsReturnsOnCall(i int, result
 	}
 	fake.configurationExistsReturnsOnCall[i] = struct {
 		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IdentityStoreService) ConfigurationsByID(arg1 context.Context, arg2 string, arg3 string) ([]driver.IdentityConfiguration, error) {
+	fake.configurationsByIDMutex.Lock()
+	ret, specificReturn := fake.configurationsByIDReturnsOnCall[len(fake.configurationsByIDArgsForCall)]
+	fake.configurationsByIDArgsForCall = append(fake.configurationsByIDArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ConfigurationsByIDStub
+	fakeReturns := fake.configurationsByIDReturns
+	fake.recordInvocation("ConfigurationsByID", []interface{}{arg1, arg2, arg3})
+	fake.configurationsByIDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDCallCount() int {
+	fake.configurationsByIDMutex.RLock()
+	defer fake.configurationsByIDMutex.RUnlock()
+	return len(fake.configurationsByIDArgsForCall)
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDCalls(stub func(context.Context, string, string) ([]driver.IdentityConfiguration, error)) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = stub
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDArgsForCall(i int) (context.Context, string, string) {
+	fake.configurationsByIDMutex.RLock()
+	defer fake.configurationsByIDMutex.RUnlock()
+	argsForCall := fake.configurationsByIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDReturns(result1 []driver.IdentityConfiguration, result2 error) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = nil
+	fake.configurationsByIDReturns = struct {
+		result1 []driver.IdentityConfiguration
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *IdentityStoreService) ConfigurationsByIDReturnsOnCall(i int, result1 []driver.IdentityConfiguration, result2 error) {
+	fake.configurationsByIDMutex.Lock()
+	defer fake.configurationsByIDMutex.Unlock()
+	fake.ConfigurationsByIDStub = nil
+	if fake.configurationsByIDReturnsOnCall == nil {
+		fake.configurationsByIDReturnsOnCall = make(map[int]struct {
+			result1 []driver.IdentityConfiguration
+			result2 error
+		})
+	}
+	fake.configurationsByIDReturnsOnCall[i] = struct {
+		result1 []driver.IdentityConfiguration
 		result2 error
 	}{result1, result2}
 }

--- a/token/services/identity/role/registry_test.go
+++ b/token/services/identity/role/registry_test.go
@@ -16,11 +16,15 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	mock2 "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity"
 	idriver "github.com/LFDT-Panurus/panurus/token/services/identity/driver"
 	imock "github.com/LFDT-Panurus/panurus/token/services/identity/driver/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/membership"
+	mmock "github.com/LFDT-Panurus/panurus/token/services/identity/membership/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -262,4 +266,76 @@ func TestLookup_WithUnknownType_Error(t *testing.T) {
 	r.MapToIdentityReturns(nil, "", errors.New("fail"))
 	_, _, _, err := reg.Lookup(t.Context(), struct{ X int }{1})
 	require.Error(t, err)
+}
+
+// TestLookup_ByIdentityBytesResolvesViaSharedStores pins the cross-replica
+// resolution chain for a lookup by raw identity bytes: the wallet store maps
+// the identity to its wallet id, and the identity store point query loads that
+// configuration by name — no full store scan and no reliance on notifications.
+func TestLookup_ByIdentityBytesResolvesViaSharedStores(t *testing.T) {
+	ctx := t.Context()
+
+	// identity store: empty at Load, later holds "alice" registered by another
+	// replica; the point query answers by exact id+type only
+	iss := &mmock.IdentityStoreService{}
+	iss.NotifierReturns(nil, storage.ErrNotSupported)
+	iss.IteratorConfigurationsReturns(&mmock.IdentityConfigurationIterator{}, nil)
+	aliceConfig := idriver.IdentityConfiguration{ID: "alice", URL: "/tmp/alice", Type: "testType"}
+	iss.ConfigurationsByIDStub = func(_ context.Context, id, typ string) ([]idriver.IdentityConfiguration, error) {
+		if id == "alice" && typ == "testType" {
+			return []idriver.IdentityConfiguration{aliceConfig}, nil
+		}
+
+		return nil, nil
+	}
+
+	km := &mmock.KeyManager{}
+	km.EnrollmentIDReturns("e1")
+	km.AnonymousReturns(false)
+	km.IdentityReturns(&idriver.IdentityDescriptor{Identity: []byte("alice-long-term-id"), AuditInfo: []byte("ai")}, nil)
+	km.IdentityTypeReturns(identity.Type(99))
+	kmp := &mmock.KeyManagerProvider{}
+	kmp.GetReturns(km, nil)
+
+	ip := &mmock.IdentityProvider{}
+	ip.BindReturns(nil)
+
+	lm := membership.NewLocalMembership(
+		logging.MustGetLogger("role_test"),
+		&mmock.Config{},
+		[]byte("netid"),
+		&mmock.SignerDeserializerManager{},
+		iss,
+		"testType",
+		false,
+		ip,
+		kmp,
+	)
+	require.NoError(t, lm.Load(ctx, nil, nil))
+
+	r := role.NewRole(logging.MustGetLogger("role_test"), idriver.OwnerRole, "network", []byte("node-id"), lm)
+
+	// wallet store: holds the identity->wallet binding written by the replica
+	// that created the wallet
+	walletStore := &imock.WalletStoreService{}
+	walletStore.GetWalletIDReturns("alice", nil)
+
+	reg := role.NewRegistry(logging.MustGetLogger("role_test"), r, walletStore, &mock.WalletFactory{})
+
+	// raw identity bytes, unknown to this process and not valid UTF-8
+	rawIdentity := []byte{0xff, 0xfe, 0x01, 0x02}
+	wallet, idInfo, wID, err := reg.Lookup(ctx, rawIdentity)
+	require.NoError(t, err)
+	require.Nil(t, wallet)
+	require.NotNil(t, idInfo)
+	require.Equal(t, "alice", wID)
+	require.Equal(t, "alice", idInfo.ID())
+
+	// the configuration is now loaded locally
+	ids, err := lm.IDs()
+	require.NoError(t, err)
+	require.Contains(t, ids, "alice")
+
+	// resolved through the point query, without a second full scan
+	require.Equal(t, 1, iss.IteratorConfigurationsCallCount())
 }

--- a/token/services/storage/db/kvs/identitydb.go
+++ b/token/services/storage/db/kvs/identitydb.go
@@ -105,6 +105,32 @@ func (s *IdentityStore) IteratorConfigurations(ctx context.Context, configuratio
 	return &IdentityConfigurationsIterator{Iterator: it}, nil
 }
 
+// ConfigurationsByID returns all configurations with the given id and type, regardless of their url.
+// The composite key encodes id and url together, so this implementation scans the type and filters by id.
+func (s *IdentityStore) ConfigurationsByID(ctx context.Context, id, configurationType string) ([]storage.IdentityConfiguration, error) {
+	it, err := s.IteratorConfigurations(ctx, configurationType)
+	if err != nil {
+		return nil, err
+	}
+	defer it.Close()
+
+	var res []storage.IdentityConfiguration
+	for {
+		c, err := it.Next()
+		if err != nil {
+			return nil, err
+		}
+		if c == nil {
+			break
+		}
+		if c.ID == id {
+			res = append(res, *c)
+		}
+	}
+
+	return res, nil
+}
+
 func (s *IdentityStore) ConfigurationExists(ctx context.Context, id, configurationType, url string) (bool, error) {
 	k, err := kvs.CreateCompositeKey(
 		IdentityDBPrefix,

--- a/token/services/storage/db/sql/common/identity.go
+++ b/token/services/storage/db/sql/common/identity.go
@@ -209,6 +209,32 @@ func (db *IdentityStore) GetConfiguration(ctx context.Context, id, typ, url stri
 	return c, nil
 }
 
+// ConfigurationsByID returns all configurations with the given id and type, regardless of their url.
+func (db *IdentityStore) ConfigurationsByID(ctx context.Context, id, configurationType string) ([]driver.IdentityConfiguration, error) {
+	query, args := q.Select().
+		FieldsByName("id", "type", "url", "conf", "raw").
+		From(q.Table(db.table.IdentityConfigurations)).
+		Where(cond.And(cond.Eq("id", id), cond.Eq("type", configurationType))).
+		Format(db.ci)
+	logging.Debug(logger, query, args)
+	rows, err := db.readDB.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var res []driver.IdentityConfiguration
+	for rows.Next() {
+		var c driver.IdentityConfiguration
+		if err := rows.Scan(&c.ID, &c.Type, &c.URL, &c.Config, &c.Raw); err != nil {
+			return nil, err
+		}
+		res = append(res, c)
+	}
+
+	return res, rows.Err()
+}
+
 // IteratorConfigurations returns an iterator to all configurations of the given type.
 func (db *IdentityStore) IteratorConfigurations(ctx context.Context, configurationType string) (idriver.IdentityConfigurationIterator, error) {
 	query, args := q.Select().


### PR DESCRIPTION
Refs #1619. Follow-up to the discussion in #1827 (closed in favor of this approach, see https://github.com/LFDT-Panurus/panurus/pull/1827#issuecomment-4921186034).

## Problem

`LocalMembership.refreshAndGet` reloads **every** stored identity configuration under the global write lock whenever a label misses the in-memory maps. On nodes that resolve many foreign identities — an auditor checking `IsMine` for every transaction is the worst case (#1619) — every lookup pays a full store scan serialized on one mutex, and a pending writer also blocks all readers. In our test environments under sustained load, this lock dominates mutex contention on auditor nodes.

#1827 skipped the lookup for pure auditors behind a cached flag; as the discussion there concluded, any "cached answer + event-driven invalidation" design is fragile under replication — the flag is only as correct as the delivery of the event that invalidates it.

## Change

Keep the miss, make it cheap:

- **`refreshAndGet` point-queries the store for the missed label only**, via a new `IdentityStoreService.ConfigurationsByID(id, type)`. A hit loads just that configuration (the write lock is held only for the in-memory registration); a miss returns without taking the write lock at all. The SQL implementation is answered by the existing `PRIMARY KEY(id, type, url)` prefix; the kvs implementation scans the type and filters, since its composite key encodes id and url together.
- Labels that are not valid UTF-8 (raw identity bytes) cannot match a stored configuration id (a TEXT column) and skip the store entirely.
- **`handleConfig` reads the store outside the write lock.** Notifications fire for every stored configuration write, including the node's own, so each one used to stall all lookups for the duration of a store round trip.

Correctness under replication is structural rather than event-driven: the shared store is consulted on every miss — the same semantics as today's full reload — so replicas need no flags and no notifications to answer correctly. Notifications remain a warm-cache optimization; a failed notification is repaired by the next miss for that label.

Lookups **by raw identity bytes** for wallets created on another replica also resolve through shared state: the wallet store binding maps the identity to its wallet id (`Registry.Lookup`'s existing fallback), and the by-name point query then loads the configuration. This chain is pinned by a test.

## Tests

- Point query loads a configuration registered by another replica; unknown labels do not trigger a full scan; non-UTF-8 labels do not touch the store (`lm_test.go`).
- Discovery tests moved to the point-query channel; the concurrent-discovery test asserts a single registration under concurrency (`lm_discovery_test.go`).
- Lock discipline: the notification handler re-enters a read path from within the store read — this deadlocks if the handler held the lock across the read (verified red-green) (`lm_discovery_test.go`).
- Cross-replica lookup by raw identity bytes resolves via the wallet-store binding plus the point query, with no full scan and no notification (`registry_test.go`).

`go build ./token/...`, `go vet`, `go test -race` on the identity and storage trees, and golangci-lint v2.12.2 with the repo config are green.

## Notes for reviewers

- Both `IdentityStoreService` interfaces (driver-level and the membership-local one) gain `ConfigurationsByID`; both counterfeiter fakes regenerated.
- While reworking `refreshAndGet` I hit a latent quirk worth knowing about: `registerIdentityConfiguration` rewrites `config.URL` via `TranslatePath` before `addLocalIdentity` keys `localIdentitiesByConfig`, so a `configKey` computed before registration never matches the stored one. Duplicate registration is actually prevented by the label double-check under the write lock (as in the current code), which the new code keeps.
