### PR TITLE
ttx recipient callback to choose the wallet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,3 +317,14 @@ list-dep-modules:
 			fi; \
 		); \
 	done
+
+#########################
+# Release
+#########################
+
+.PHONY: tag-release
+tag-release: ## Create git tags for all modules at HEAD. Usage: make tag-release VERSION=v0.13.0 [DRY=1]
+ifndef VERSION
+	$(error VERSION is required. Usage: make tag-release VERSION=v0.13.0)
+endif
+	./ci/scripts/tag-release.sh $(if $(DRY),--dry) $(VERSION)

--- a/ci/scripts/tag-release.sh
+++ b/ci/scripts/tag-release.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [--dry] <version>"
+    echo "  --dry    Print tags that would be created without creating them"
+    echo "  version  Git tag version, e.g. v0.13.0"
+    exit 1
+}
+
+DRY=false
+VERSION=""
+for arg in "$@"; do
+    case "$arg" in
+        --dry) DRY=true ;;
+        -*) echo "Error: unknown flag $arg" >&2; usage ;;
+        *) [[ -n "$VERSION" ]] && usage; VERSION="$arg" ;;
+    esac
+done
+[[ -z "$VERSION" ]] && usage
+
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: version must match vMAJOR.MINOR.PATCH (got: $VERSION)" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+
+# Collect all module paths: root first, then submodules excluding tools
+MODULES=(".")
+while IFS= read -r gomod; do
+    dir="${gomod%/go.mod}"
+    dir="${dir#./}"
+    [[ "$dir" == "tools" ]] && continue
+    MODULES+=("$dir")
+done < <(find "$REPO_ROOT" -name go.mod -not -path '*/vendor/*' -not -path "$REPO_ROOT/go.mod" | sed "s|$REPO_ROOT/||" | sort)
+
+# Build the list of tags to create
+declare -a TAGS
+for module in "${MODULES[@]}"; do
+    if [[ "$module" == "." ]]; then
+        TAGS+=("$VERSION")
+    else
+        TAGS+=("${module}/${VERSION}")
+    fi
+done
+
+# Check for conflicts before creating anything
+CONFLICTS=()
+for tag in "${TAGS[@]}"; do
+    if git -C "$REPO_ROOT" tag --list "$tag" | grep -q .; then
+        CONFLICTS+=("$tag")
+    fi
+done
+
+if [[ ${#CONFLICTS[@]} -gt 0 ]]; then
+    echo "Warning: the following tags already exist — aborting without creating any tags:" >&2
+    for tag in "${CONFLICTS[@]}"; do
+        echo "  $tag" >&2
+    done
+    exit 1
+fi
+
+# Create all tags at HEAD
+HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+if $DRY; then
+    echo "Dry run — would create ${#TAGS[@]} tag(s) at $HEAD:"
+    for tag in "${TAGS[@]}"; do
+        echo "  $tag"
+    done
+    exit 0
+fi
+
+echo "Tagging ${#TAGS[@]} module(s) at $HEAD"
+for tag in "${TAGS[@]}"; do
+    git -C "$REPO_ROOT" tag "$tag"
+    echo "  created $tag"
+done
+
+echo "Done. Run 'git push origin --tags' to publish."

--- a/token/services/ttx/opts.go
+++ b/token/services/ttx/opts.go
@@ -243,3 +243,65 @@ func getRecipientWalletID(opts *token.ServiceOptions) string {
 
 	return wBoxed.(string)
 }
+
+// WalletSelector lets the responder to a RecipientRequest choose which wallet to use
+// to answer the request. defaultWallet is the wallet that would be used absent a
+// selector (the responder's configured wallet, or the request's WalletID as fallback).
+// Returning defaultWallet unchanged preserves the default behavior.
+type WalletSelector func(request *RecipientRequest, defaultWallet string) (string, error)
+
+// ExchangeWalletSelector is the WalletSelector equivalent for ExchangeRecipientRequest.
+type ExchangeWalletSelector func(request *ExchangeRecipientRequest, defaultWallet string) (string, error)
+
+// WithWalletSelector sets a callback used by the responder to a RecipientRequest to
+// choose which wallet to use, overriding the default wallet resolution.
+func WithWalletSelector(selector WalletSelector) token.ServiceOption {
+	return func(options *token.ServiceOptions) error {
+		if selector == nil {
+			return nil
+		}
+		if options.Params == nil {
+			options.Params = map[string]any{}
+		}
+		options.Params["WalletSelector"] = selector
+
+		return nil
+	}
+}
+
+// getWalletSelector extracts the WalletSelector from service options, if set.
+func getWalletSelector(opts *token.ServiceOptions) WalletSelector {
+	sBoxed, ok := opts.Params["WalletSelector"]
+	if !ok {
+		return nil
+	}
+
+	return sBoxed.(WalletSelector)
+}
+
+// WithExchangeWalletSelector sets a callback used by the responder to an
+// ExchangeRecipientRequest to choose which wallet to use, overriding the default wallet
+// resolution.
+func WithExchangeWalletSelector(selector ExchangeWalletSelector) token.ServiceOption {
+	return func(options *token.ServiceOptions) error {
+		if selector == nil {
+			return nil
+		}
+		if options.Params == nil {
+			options.Params = map[string]any{}
+		}
+		options.Params["ExchangeWalletSelector"] = selector
+
+		return nil
+	}
+}
+
+// getExchangeWalletSelector extracts the ExchangeWalletSelector from service options, if set.
+func getExchangeWalletSelector(opts *token.ServiceOptions) ExchangeWalletSelector {
+	sBoxed, ok := opts.Params["ExchangeWalletSelector"]
+	if !ok {
+		return nil
+	}
+
+	return sBoxed.(ExchangeWalletSelector)
+}

--- a/token/services/ttx/opts.go
+++ b/token/services/ttx/opts.go
@@ -206,13 +206,21 @@ func CompileServiceOptions(opts ...token.ServiceOption) (*token.ServiceOptions, 
 	return txOptions, nil
 }
 
+// Keys used to store application-specific parameters in token.ServiceOptions.Params.
+const (
+	paramsKeyRecipientData          = "RecipientData"
+	paramsKeyRecipientWalletID      = "RecipientWalletID"
+	paramsKeyWalletSelector         = "WalletSelector"
+	paramsKeyExchangeWalletSelector = "ExchangeWalletSelector"
+)
+
 // WithRecipientData is used to add a RecipientData to the service options
 func WithRecipientData(recipientData *RecipientData) token.ServiceOption {
 	return func(options *token.ServiceOptions) error {
 		if options.Params == nil {
 			options.Params = map[string]any{}
 		}
-		options.Params["RecipientData"] = recipientData
+		options.Params[paramsKeyRecipientData] = recipientData
 
 		return nil
 	}
@@ -227,7 +235,7 @@ func WithRecipientWalletID(walletID string) token.ServiceOption {
 		if options.Params == nil {
 			options.Params = map[string]any{}
 		}
-		options.Params["RecipientWalletID"] = walletID
+		options.Params[paramsKeyRecipientWalletID] = walletID
 
 		return nil
 	}
@@ -236,7 +244,7 @@ func WithRecipientWalletID(walletID string) token.ServiceOption {
 // getRecipientWalletID extracts the recipient wallet ID from service options.
 // Returns an empty string if the wallet ID is not set.
 func getRecipientWalletID(opts *token.ServiceOptions) string {
-	wBoxed, ok := opts.Params["RecipientWalletID"]
+	wBoxed, ok := opts.Params[paramsKeyRecipientWalletID]
 	if !ok {
 		return ""
 	}
@@ -255,6 +263,8 @@ type ExchangeWalletSelector func(request *ExchangeRecipientRequest, defaultWalle
 
 // WithWalletSelector sets a callback used by the responder to a RecipientRequest to
 // choose which wallet to use, overriding the default wallet resolution.
+// The returned token.ServiceOption never fails to apply; it always returns a nil error,
+// consistent with the other option setters in this file (e.g. WithRecipientData).
 func WithWalletSelector(selector WalletSelector) token.ServiceOption {
 	return func(options *token.ServiceOptions) error {
 		if selector == nil {
@@ -263,25 +273,32 @@ func WithWalletSelector(selector WalletSelector) token.ServiceOption {
 		if options.Params == nil {
 			options.Params = map[string]any{}
 		}
-		options.Params["WalletSelector"] = selector
+		options.Params[paramsKeyWalletSelector] = selector
 
 		return nil
 	}
 }
 
 // getWalletSelector extracts the WalletSelector from service options, if set.
+// Returns nil if the selector is not set or is not a WalletSelector.
 func getWalletSelector(opts *token.ServiceOptions) WalletSelector {
-	sBoxed, ok := opts.Params["WalletSelector"]
+	sBoxed, ok := opts.Params[paramsKeyWalletSelector]
+	if !ok {
+		return nil
+	}
+	selector, ok := sBoxed.(WalletSelector)
 	if !ok {
 		return nil
 	}
 
-	return sBoxed.(WalletSelector)
+	return selector
 }
 
 // WithExchangeWalletSelector sets a callback used by the responder to an
 // ExchangeRecipientRequest to choose which wallet to use, overriding the default wallet
 // resolution.
+// The returned token.ServiceOption never fails to apply; it always returns a nil error,
+// consistent with the other option setters in this file (e.g. WithRecipientData).
 func WithExchangeWalletSelector(selector ExchangeWalletSelector) token.ServiceOption {
 	return func(options *token.ServiceOptions) error {
 		if selector == nil {
@@ -290,18 +307,23 @@ func WithExchangeWalletSelector(selector ExchangeWalletSelector) token.ServiceOp
 		if options.Params == nil {
 			options.Params = map[string]any{}
 		}
-		options.Params["ExchangeWalletSelector"] = selector
+		options.Params[paramsKeyExchangeWalletSelector] = selector
 
 		return nil
 	}
 }
 
 // getExchangeWalletSelector extracts the ExchangeWalletSelector from service options, if set.
+// Returns nil if the selector is not set or is not an ExchangeWalletSelector.
 func getExchangeWalletSelector(opts *token.ServiceOptions) ExchangeWalletSelector {
-	sBoxed, ok := opts.Params["ExchangeWalletSelector"]
+	sBoxed, ok := opts.Params[paramsKeyExchangeWalletSelector]
+	if !ok {
+		return nil
+	}
+	selector, ok := sBoxed.(ExchangeWalletSelector)
 	if !ok {
 		return nil
 	}
 
-	return sBoxed.(ExchangeWalletSelector)
+	return selector
 }

--- a/token/services/ttx/recipients.go
+++ b/token/services/ttx/recipients.go
@@ -443,24 +443,34 @@ func (f *RequestRecipientIdentityView) aggregateAndDistributePolicy(context view
 }
 
 type RespondRequestRecipientIdentityView struct {
-	Wallet string
+	Wallet         string
+	WalletSelector WalletSelector
 }
 
 // RespondRequestRecipientIdentity executes the RespondRequestRecipientIdentityView.
 // The recipient sends back the identity to receive ownership of tokens.
-// The identity is taken from the default wallet.
+// The identity is taken from the default wallet, unless a WalletSelector option
+// (see WithWalletSelector) overrides the choice.
 // If the wallet is not found, an error is returned.
-func RespondRequestRecipientIdentity(context view.Context) (view.Identity, error) {
-	return RespondRequestRecipientIdentityUsingWallet(context, "")
+func RespondRequestRecipientIdentity(context view.Context, opts ...token.ServiceOption) (view.Identity, error) {
+	return RespondRequestRecipientIdentityUsingWallet(context, "", opts...)
 }
 
 // RespondRequestRecipientIdentityUsingWallet executes the RespondRequestRecipientIdentityView.
 // The recipient sends back the identity to receive ownership of tokens.
-// The identity is taken from the passed wallet.
+// The identity is taken from the passed wallet, unless a WalletSelector option
+// (see WithWalletSelector) overrides the choice.
 // If the wallet is not found, an error is returned.
 // If the wallet is the empty string, the identity is taken from the default wallet.
-func RespondRequestRecipientIdentityUsingWallet(context view.Context, wallet string) (view.Identity, error) {
-	id, err := context.RunView(&RespondRequestRecipientIdentityView{Wallet: wallet})
+func RespondRequestRecipientIdentityUsingWallet(context view.Context, wallet string, opts ...token.ServiceOption) (view.Identity, error) {
+	options, err := CompileServiceOptions(opts...)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed compiling service options")
+	}
+	id, err := context.RunView(&RespondRequestRecipientIdentityView{
+		Wallet:         wallet,
+		WalletSelector: getWalletSelector(options),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -481,6 +491,13 @@ func (s *RespondRequestRecipientIdentityView) Call(context view.Context) (any, e
 	wallet := s.Wallet
 	if len(wallet) == 0 && len(recipientRequest.WalletID) != 0 {
 		wallet = string(recipientRequest.WalletID)
+	}
+	if s.WalletSelector != nil {
+		selected, err := s.WalletSelector(recipientRequest, wallet)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed selecting wallet")
+		}
+		wallet = selected
 	}
 	logger.DebugfContext(context.Context(), "Respond request recipient identity using wallet [%s]", wallet)
 	tms, err := token.GetManagementService(context, token.WithTMSID(recipientRequest.TMSID))
@@ -837,14 +854,22 @@ func (f *ExchangeRecipientIdentitiesView) Call(context view.Context) (any, error
 }
 
 type RespondExchangeRecipientIdentitiesView struct {
-	Wallet string
+	Wallet         string
+	WalletSelector ExchangeWalletSelector
 }
 
 // RespondExchangeRecipientIdentities executes the RespondExchangeRecipientIdentitiesView.
 // The recipient sends back the identity to receive ownership of tokens.
-// The identity is taken from the default wallet
-func RespondExchangeRecipientIdentities(context view.Context) (view.Identity, view.Identity, error) {
-	ids, err := context.RunView(&RespondExchangeRecipientIdentitiesView{})
+// The identity is taken from the default wallet, unless an ExchangeWalletSelector option
+// (see WithExchangeWalletSelector) overrides the choice.
+func RespondExchangeRecipientIdentities(context view.Context, opts ...token.ServiceOption) (view.Identity, view.Identity, error) {
+	options, err := CompileServiceOptions(opts...)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed compiling service options")
+	}
+	ids, err := context.RunView(&RespondExchangeRecipientIdentitiesView{
+		WalletSelector: getExchangeWalletSelector(options),
+	})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -880,6 +905,13 @@ func (s *RespondExchangeRecipientIdentitiesView) Call(context view.Context) (any
 	wallet := s.Wallet
 	if len(wallet) == 0 && len(request.WalletID) != 0 {
 		wallet = string(request.WalletID)
+	}
+	if s.WalletSelector != nil {
+		selected, err := s.WalletSelector(request, wallet)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed selecting wallet")
+		}
+		wallet = selected
 	}
 	w, err := ts.WalletManager().OwnerWallet(context.Context(), wallet)
 	if err != nil {

--- a/token/services/ttx/recipients_test.go
+++ b/token/services/ttx/recipients_test.go
@@ -180,6 +180,92 @@ func TestGetRecipientWalletID(t *testing.T) {
 	})
 }
 
+func TestWithWalletSelector(t *testing.T) {
+	t.Run("nil selector leaves params untouched", func(t *testing.T) {
+		options, err := CompileServiceOptions(WithWalletSelector(nil))
+		require.NoError(t, err)
+		assert.Nil(t, getWalletSelector(options))
+	})
+
+	t.Run("no selector set returns nil", func(t *testing.T) {
+		options, err := CompileServiceOptions()
+		require.NoError(t, err)
+		assert.Nil(t, getWalletSelector(options))
+	})
+
+	t.Run("selector is stored and retrieved", func(t *testing.T) {
+		called := false
+		selector := func(request *RecipientRequest, defaultWallet string) (string, error) {
+			called = true
+
+			return "selected-wallet", nil
+		}
+		options, err := CompileServiceOptions(WithWalletSelector(selector))
+		require.NoError(t, err)
+		got := getWalletSelector(options)
+		require.NotNil(t, got)
+		wallet, err := got(&RecipientRequest{}, "default-wallet")
+		require.NoError(t, err)
+		assert.True(t, called)
+		assert.Equal(t, "selected-wallet", wallet)
+	})
+}
+
+func TestWithExchangeWalletSelector(t *testing.T) {
+	t.Run("nil selector leaves params untouched", func(t *testing.T) {
+		options, err := CompileServiceOptions(WithExchangeWalletSelector(nil))
+		require.NoError(t, err)
+		assert.Nil(t, getExchangeWalletSelector(options))
+	})
+
+	t.Run("no selector set returns nil", func(t *testing.T) {
+		options, err := CompileServiceOptions()
+		require.NoError(t, err)
+		assert.Nil(t, getExchangeWalletSelector(options))
+	})
+
+	t.Run("selector is stored and retrieved", func(t *testing.T) {
+		selector := func(request *ExchangeRecipientRequest, defaultWallet string) (string, error) {
+			return defaultWallet + "-exchange", nil
+		}
+		options, err := CompileServiceOptions(WithExchangeWalletSelector(selector))
+		require.NoError(t, err)
+		got := getExchangeWalletSelector(options)
+		require.NotNil(t, got)
+		wallet, err := got(&ExchangeRecipientRequest{}, "default-wallet")
+		require.NoError(t, err)
+		assert.Equal(t, "default-wallet-exchange", wallet)
+	})
+}
+
+func TestRespondRequestRecipientIdentityView_WalletSelector(t *testing.T) {
+	t.Run("selector overrides the default wallet", func(t *testing.T) {
+		v := &RespondRequestRecipientIdentityView{
+			Wallet: "configured-wallet",
+			WalletSelector: func(request *RecipientRequest, defaultWallet string) (string, error) {
+				assert.Equal(t, "configured-wallet", defaultWallet)
+
+				return "overridden-wallet", nil
+			},
+		}
+		wallet := v.Wallet
+		require.NotNil(t, v.WalletSelector)
+		selected, err := v.WalletSelector(&RecipientRequest{}, wallet)
+		require.NoError(t, err)
+		assert.Equal(t, "overridden-wallet", selected)
+	})
+
+	t.Run("selector error is surfaced by the caller", func(t *testing.T) {
+		v := &RespondRequestRecipientIdentityView{
+			WalletSelector: func(request *RecipientRequest, defaultWallet string) (string, error) {
+				return "", assert.AnError
+			},
+		}
+		_, err := v.WalletSelector(&RecipientRequest{}, "")
+		require.ErrorIs(t, err, assert.AnError)
+	})
+}
+
 func TestVerifyRecipientAttestation_EmptySignature(t *testing.T) {
 	rd := &RecipientData{Identity: view.Identity("alice")}
 


### PR DESCRIPTION
This PR adds the possibility to specify a callback to select the wallet during the recipient-related flows.