### PR TITLE
feat(auditdb): add HoldingsFilter.SumByEnrollmentID

### DIFF
--- a/token/services/storage/auditdb/filter.go
+++ b/token/services/storage/auditdb/filter.go
@@ -104,3 +104,19 @@ func (f *HoldingsFilter) Sum() *big.Int {
 
 	return sum
 }
+
+// SumByEnrollmentID returns the sum of the loaded records grouped by enrollment id.
+// Enrollment ids with no records are absent from the returned map.
+func (f *HoldingsFilter) SumByEnrollmentID() map[string]*big.Int {
+	sums := make(map[string]*big.Int)
+	for _, record := range f.records {
+		sum, ok := sums[record.EnrollmentID]
+		if !ok {
+			sum = big.NewInt(0)
+			sums[record.EnrollmentID] = sum
+		}
+		sum.Add(sum, record.Amount)
+	}
+
+	return sums
+}

--- a/token/services/storage/auditdb/filter_test.go
+++ b/token/services/storage/auditdb/filter_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package auditdb
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHoldingsFilterSumByEnrollmentID(t *testing.T) {
+	f := &HoldingsFilter{records: []*driver.MovementRecord{
+		{EnrollmentID: "alice", Amount: big.NewInt(100)},
+		{EnrollmentID: "bob", Amount: big.NewInt(70)},
+		{EnrollmentID: "alice", Amount: big.NewInt(-30)},
+		{EnrollmentID: "charlie", Amount: big.NewInt(0)},
+	}}
+
+	sums := f.SumByEnrollmentID()
+
+	assert.Len(t, sums, 3)
+	assert.Equal(t, big.NewInt(70), sums["alice"])
+	assert.Equal(t, big.NewInt(70), sums["bob"])
+	assert.Equal(t, big.NewInt(0), sums["charlie"])
+
+	total := big.NewInt(0)
+	for _, sum := range sums {
+		total.Add(total, sum)
+	}
+	assert.Equal(t, f.Sum(), total)
+}
+
+func TestHoldingsFilterSumByEnrollmentIDNoRecords(t *testing.T) {
+	f := &HoldingsFilter{}
+
+	assert.Empty(t, f.SumByEnrollmentID())
+}


### PR DESCRIPTION
Fixes #1877

`ByEnrollmentId` already accepts multiple enrollment ids in one filter (single `WHERE enrollment_id IN (...)` query), but the executed filter only exposes the grand total via `Sum()`. This adds `SumByEnrollmentID()`, a pure accessor over the records loaded by `Execute` that partitions them by enrollment id.

In our deployment the auditor checks per-party balance limits for every transaction (sender + each recipient); this collapses one filter execution per enrollment id into a single query for all parties, which removed N-1 database round trips per audited transaction in our test environments under sustained load.
