### PR TITLE
perf(auditor): reuse the audit record computed by Audit in Append

### DIFF
--- a/token/services/auditor/auditor.go
+++ b/token/services/auditor/auditor.go
@@ -8,6 +8,8 @@ package auditor
 
 import (
 	"context"
+	"slices"
+	"sync"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -83,6 +85,18 @@ type Service struct {
 	metrics         *Metrics
 	checkService    CheckService
 	lockConfig      *LockConfig
+
+	// auditRecords caches, per request anchor, a snapshot of the audit record
+	// computed by Audit for reuse by Append; entries are dropped by Release.
+	recordsMu    sync.Mutex
+	auditRecords map[token.RequestAnchor]auditRecordEntry
+}
+
+// auditRecordEntry pairs a cached audit record with the request it was
+// computed from.
+type auditRecordEntry struct {
+	request *token.Request
+	record  *token.AuditRecord
 }
 
 // NewService creates a new auditor Service with the provided dependencies.
@@ -124,6 +138,8 @@ func (a *Service) Validate(ctx context.Context, request *token.Request) error {
 // Audit extracts the list of inputs and outputs from the passed transaction.
 // In addition, the Audit locks the enrollment named ids with retry logic and exponential backoff
 // to prevent livelock conditions.
+// A snapshot of the computed audit record is cached so that Append can reuse
+// it; the returned streams stay independent of the cached snapshot.
 // The caller MUST call Release() to unlock these enrollment IDs after processing.
 //
 // IMPORTANT: The defer Release() statement MUST be placed immediately after checking
@@ -161,6 +177,7 @@ func (a *Service) Audit(ctx context.Context, tx Transaction) (*token.InputStream
 	}
 
 	logger.DebugfContext(ctx, "audit transaction [%s], acquire locks done", tx.ID())
+	a.stashAuditRecord(request, snapshotAuditRecord(request, record))
 	a.metrics.AuditDuration.Observe(time.Since(start).Seconds())
 
 	return record.Inputs, record.Outputs, nil
@@ -192,7 +209,8 @@ func (a *Service) acquireLocksWithRetry(ctx context.Context, anchor string, eids
 	return nil
 }
 
-// Append adds the passed transaction to the auditor database.
+// Append adds the passed transaction to the auditor database, reusing the
+// audit record computed by Audit, when available.
 // It also releases the locks acquired by Audit.
 func (a *Service) Append(ctx context.Context, tx Transaction) error {
 	start := time.Now()
@@ -204,7 +222,9 @@ func (a *Service) Append(ctx context.Context, tx Transaction) error {
 		return err
 	}
 	// append request to audit db
-	if err := a.auditDB.Append(ctx, newRequestWrapper(tx.Request(), tms)); err != nil {
+	wrapper := newRequestWrapper(tx.Request(), tms)
+	wrapper.cached = a.cachedAuditRecord(tx.Request())
+	if err := a.auditDB.Append(ctx, wrapper); err != nil {
 		a.metrics.AppendErrors.Add(1)
 
 		return errors.WithMessagef(err, "failed appending request %s", tx.ID())
@@ -234,10 +254,92 @@ func (a *Service) Append(ctx context.Context, tx Transaction) error {
 	return nil
 }
 
-// Release releases the lock acquired of the passed transaction.
+// Release releases the lock acquired of the passed transaction and drops the
+// audit record cached for it.
 func (a *Service) Release(ctx context.Context, tx Transaction) {
 	a.metrics.ReleasesTotal.Add(1)
-	a.auditDB.ReleaseLocks(ctx, string(tx.Request().Anchor))
+	anchor := tx.Request().Anchor
+	a.dropAuditRecord(anchor)
+	a.auditDB.ReleaseLocks(ctx, string(anchor))
+}
+
+// snapshotAuditRecord deep-copies record so that the cached copy and the
+// streams returned by Audit share no mutable memory.
+func snapshotAuditRecord(request *token.Request, record *token.AuditRecord) *token.AuditRecord {
+	inputs := record.Inputs.Inputs()
+	inputsCopy := make([]*token.Input, len(inputs))
+	for i, in := range inputs {
+		cp := *in
+		if in.Id != nil {
+			id := *in.Id
+			cp.Id = &id
+		}
+		cp.Owner = slices.Clone(in.Owner)
+		cp.OwnerAuditInfo = slices.Clone(in.OwnerAuditInfo)
+		if in.Quantity != nil {
+			cp.Quantity = in.Quantity.Clone()
+		}
+		inputsCopy[i] = &cp
+	}
+	outputs := record.Outputs.Outputs()
+	outputsCopy := make([]*token.Output, len(outputs))
+	for i, out := range outputs {
+		cp := *out
+		cp.Token.Owner = slices.Clone(out.Token.Owner)
+		cp.Owner = slices.Clone(out.Owner)
+		cp.OwnerAuditInfo = slices.Clone(out.OwnerAuditInfo)
+		if out.Quantity != nil {
+			cp.Quantity = out.Quantity.Clone()
+		}
+		cp.LedgerOutput = slices.Clone(out.LedgerOutput)
+		cp.LedgerOutputMetadata = slices.Clone(out.LedgerOutputMetadata)
+		cp.Issuer = slices.Clone(out.Issuer)
+		outputsCopy[i] = &cp
+	}
+	var attributes map[string][]byte
+	if record.Attributes != nil {
+		attributes = make(map[string][]byte, len(record.Attributes))
+		for k, v := range record.Attributes {
+			attributes[k] = slices.Clone(v)
+		}
+	}
+	precision := record.Outputs.Precision
+
+	return &token.AuditRecord{
+		Anchor:     record.Anchor,
+		Inputs:     token.NewInputStream(request.TokenService.Vault().NewQueryEngine(), inputsCopy, precision),
+		Outputs:    token.NewOutputStream(outputsCopy, precision),
+		Attributes: attributes,
+	}
+}
+
+func (a *Service) stashAuditRecord(request *token.Request, record *token.AuditRecord) {
+	a.recordsMu.Lock()
+	defer a.recordsMu.Unlock()
+	if a.auditRecords == nil {
+		a.auditRecords = map[token.RequestAnchor]auditRecordEntry{}
+	}
+	a.auditRecords[request.Anchor] = auditRecordEntry{request: request, record: record}
+}
+
+// cachedAuditRecord returns the audit record cached for the passed request,
+// or nil if none is cached or the cached one was computed from a different
+// request with the same anchor.
+func (a *Service) cachedAuditRecord(request *token.Request) *token.AuditRecord {
+	a.recordsMu.Lock()
+	defer a.recordsMu.Unlock()
+	entry, ok := a.auditRecords[request.Anchor]
+	if !ok || entry.request != request {
+		return nil
+	}
+
+	return entry.record
+}
+
+func (a *Service) dropAuditRecord(anchor token.RequestAnchor) {
+	a.recordsMu.Lock()
+	defer a.recordsMu.Unlock()
+	delete(a.auditRecords, anchor)
 }
 
 // SetStatus sets the status of the audit records with the passed transaction id to the passed status
@@ -264,6 +366,9 @@ func (a *Service) Check(ctx context.Context) ([]string, error) {
 type requestWrapper struct {
 	r   *token.Request
 	tms dep.TokenManagementService
+	// cached, when set, is a snapshot of the audit record computed by Audit
+	// for this request; AuditRecord reuses it instead of recomputing it.
+	cached *token.AuditRecord
 }
 
 // newRequestWrapper creates a new requestWrapper that wraps a token request with its associated
@@ -290,10 +395,16 @@ func (r *requestWrapper) PublicParamsHash() token.PPHash { return r.r.PublicPara
 
 // AuditRecord retrieves the audit record for the wrapped token request and completes any
 // inputs with missing enrollment IDs by querying the token vault.
+// The gap filling always runs, also on a cached record, because it depends on
+// the current vault state.
 func (r *requestWrapper) AuditRecord(ctx context.Context) (*token.AuditRecord, error) {
-	record, err := r.r.AuditRecord(ctx)
-	if err != nil {
-		return nil, err
+	record := r.cached
+	if record == nil {
+		var err error
+		record, err = r.r.AuditRecord(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := r.completeInputsWithEmptyEID(ctx, record); err != nil {
 		return nil, errors.WithMessagef(err, "failed filling gaps for request [%s]", r.r.Anchor)

--- a/token/services/auditor/auditor_internal_test.go
+++ b/token/services/auditor/auditor_internal_test.go
@@ -20,6 +20,11 @@ import (
 	drivermock "github.com/LFDT-Panurus/panurus/token/driver/mock"
 	tokenmock "github.com/LFDT-Panurus/panurus/token/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/network"
+	networkdriver "github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb"
+	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx/dep"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -208,45 +213,10 @@ func TestMetricsProviderCall(t *testing.T) {
 // requestWrapper tests — access unexported types directly within package auditor
 // ---------------------------------------------------------------------------
 
-func newInternalTestManagementService(t *testing.T) *token.ManagementService {
-	t.Helper()
-	mockTMS := &drivermock.TokenManagerService{}
-	mockVP := &tokenmock.VaultProvider{}
-
-	mockTMS.ValidatorReturns(&drivermock.Validator{}, nil)
-
-	mockPPM := &drivermock.PublicParamsManager{}
-	mockPP := &drivermock.PublicParameters{}
-	mockPP.PrecisionReturns(64)
-	mockPPM.PublicParametersReturns(mockPP)
-
-	mockTMS.PublicParamsManagerReturns(mockPPM)
-	mockTMS.TokensServiceReturns(&drivermock.TokensService{})
-	mockTMS.WalletServiceReturns(&drivermock.WalletService{})
-	mockTMS.IssueServiceReturns(&drivermock.IssueService{})
-	mockTMS.TransferServiceReturns(&drivermock.TransferService{})
-
-	mockQE := &drivermock.QueryEngine{}
-	mockQE.ListAuditTokensReturns([]*token2.Token{}, nil)
-	mockV := &drivermock.Vault{}
-	mockV.QueryEngineReturns(mockQE)
-	mockVP.VaultReturns(mockV, nil)
-
-	tms, err := token.NewManagementService(
-		token.TMSID{},
-		mockTMS,
-		logging.MustGetLogger("test"),
-		mockVP,
-		nil,
-		nil,
-	)
-	require.NoError(t, err)
-	require.NotNil(t, tms)
-
-	return tms
-}
-
-func newInternalTestManagementServiceWithTokens(t *testing.T, toks []*token2.Token) *token.ManagementService {
+// newInternalTestTMS builds a ManagementService backed by driver mocks whose
+// query engine returns toks; the query engine is also returned so tests can
+// count vault accesses.
+func newInternalTestTMS(t *testing.T, toks []*token2.Token) (*token.ManagementService, *drivermock.QueryEngine) {
 	t.Helper()
 	mockTMS := &drivermock.TokenManagerService{}
 	mockVP := &tokenmock.VaultProvider{}
@@ -280,6 +250,20 @@ func newInternalTestManagementServiceWithTokens(t *testing.T, toks []*token2.Tok
 	)
 	require.NoError(t, err)
 	require.NotNil(t, tms)
+
+	return tms, mockQE
+}
+
+func newInternalTestManagementService(t *testing.T) *token.ManagementService {
+	t.Helper()
+	tms, _ := newInternalTestTMS(t, []*token2.Token{})
+
+	return tms
+}
+
+func newInternalTestManagementServiceWithTokens(t *testing.T, toks []*token2.Token) *token.ManagementService {
+	t.Helper()
+	tms, _ := newInternalTestTMS(t, toks)
 
 	return tms
 }
@@ -422,4 +406,240 @@ func TestCompleteInputsWithEmptyEID_ToQuantityError(t *testing.T) {
 	err = rw.completeInputsWithEmptyEID(context.Background(), record)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed converting token quantity")
+}
+
+// ---------------------------------------------------------------------------
+// Audit-record cache tests (Audit → Append reuse)
+// ---------------------------------------------------------------------------
+
+func TestRequestWrapper_AuditRecord_ReusesCached(t *testing.T) {
+	tms := newInternalTestManagementService(t)
+	rw := newRequestWrapper(token.NewRequest(tms, token.RequestAnchor("tx-cache-hit")), tms)
+	cached := &token.AuditRecord{
+		Inputs: token.NewInputStream(nil, []*token.Input{{EnrollmentID: "alice"}}, 0),
+	}
+	rw.cached = cached
+
+	record, err := rw.AuditRecord(context.Background())
+	require.NoError(t, err)
+	assert.Same(t, cached, record)
+}
+
+func TestRequestWrapper_AuditRecord_CachedStillFillsGaps(t *testing.T) {
+	tms := newInternalTestManagementServiceWithTokens(t, []*token2.Token{
+		{Type: "USD", Quantity: "100", Owner: []byte("owner1")},
+	})
+	rw := newRequestWrapper(token.NewRequest(tms, token.RequestAnchor("tx-cache-gaps")), tms)
+	rw.cached = &token.AuditRecord{
+		Inputs:  token.NewInputStream(nil, []*token.Input{{Id: &token2.ID{TxId: "123"}}}, 0),
+		Outputs: token.NewOutputStream([]*token.Output{{EnrollmentID: "target"}}, 0),
+	}
+
+	record, err := rw.AuditRecord(context.Background())
+	require.NoError(t, err)
+	in := record.Inputs.At(0)
+	assert.Equal(t, "target", in.EnrollmentID)
+	assert.Equal(t, token2.Type("USD"), in.Type)
+}
+
+func TestService_AuditRecordCache(t *testing.T) {
+	// The zero value mirrors the ServiceManager composite-literal
+	// construction: the cache map must be lazily initialized.
+	svc := &Service{}
+	req := minimalRequest("anchor1")
+	record := &token.AuditRecord{Anchor: "anchor1"}
+
+	assert.Nil(t, svc.cachedAuditRecord(req))
+	assert.NotPanics(t, func() { svc.stashAuditRecord(req, record) })
+	assert.Same(t, record, svc.cachedAuditRecord(req))
+
+	// a different request reusing the same anchor must not see the record
+	assert.Nil(t, svc.cachedAuditRecord(minimalRequest("anchor1")))
+	assert.Nil(t, svc.cachedAuditRecord(minimalRequest("anchor2")))
+
+	svc.dropAuditRecord("anchor1")
+	assert.Nil(t, svc.cachedAuditRecord(req))
+}
+
+// ---------------------------------------------------------------------------
+// Service-level Audit → Append chain tests
+// ---------------------------------------------------------------------------
+
+type stubTransaction struct{ req *token.Request }
+
+func (s *stubTransaction) ID() string              { return string(s.req.Anchor) }
+func (s *stubTransaction) Network() string         { return "" }
+func (s *stubTransaction) Channel() string         { return "" }
+func (s *stubTransaction) Namespace() string       { return "" }
+func (s *stubTransaction) Request() *token.Request { return s.req }
+
+type stubNetworkProvider struct{ net *network.Network }
+
+func (s *stubNetworkProvider) GetNetwork(string, string) (*network.Network, error) {
+	return s.net, nil
+}
+
+// stubStoreTx and stubAuditStore implement just the store methods hit by
+// StoreService.Append; the embedded interfaces cover the rest. Counterfeiter
+// mocks cannot be used here: the mock package imports package auditor, which
+// would be an import cycle in this internal test.
+type stubStoreTx struct {
+	dbdriver.TransactionStoreTransaction
+}
+
+func (s *stubStoreTx) AddTokenRequest(context.Context, string, []byte, map[string][]byte, map[string][]byte, driver.PPHash) error {
+	return nil
+}
+func (s *stubStoreTx) AddMovement(context.Context, ...dbdriver.MovementRecord) error { return nil }
+func (s *stubStoreTx) AddTransaction(context.Context, ...dbdriver.TransactionRecord) error {
+	return nil
+}
+func (s *stubStoreTx) Commit() error { return nil }
+
+type stubAuditStore struct{ dbdriver.AuditTransactionStore }
+
+func (s *stubAuditStore) NewTransactionStoreTransaction() (dbdriver.TransactionStoreTransaction, error) {
+	return &stubStoreTx{}, nil
+}
+
+type stubNetworkDriver struct{ networkdriver.Network }
+
+func (s *stubNetworkDriver) AddFinalityListener(string, string, networkdriver.FinalityListener) error {
+	return nil
+}
+
+// stubTMSWithExtensions is never invoked in these tests: the wrapped TMS is
+// only consulted for gap filling, which short-circuits on records without
+// empty enrollment IDs.
+type stubTMSWithExtensions struct {
+	dep.TokenManagementServiceWithExtensions
+}
+
+type stubTMSProvider struct{}
+
+func (s *stubTMSProvider) TokenManagementService(...token.ServiceOption) (dep.TokenManagementServiceWithExtensions, error) {
+	return &stubTMSWithExtensions{}, nil
+}
+
+// newAuditTestService builds a Service the same way ServiceManager does
+// (composite literal, no auditRecords initialization) over mock storage,
+// network, and TMS provider. The returned query engine counts the vault
+// accesses performed to compute an audit record.
+func newAuditTestService(t *testing.T) (*Service, *drivermock.QueryEngine, *token.ManagementService) {
+	t.Helper()
+	tms, qe := newInternalTestTMS(t, []*token2.Token{})
+
+	auditDB, err := auditdb.NewStoreService(&stubAuditStore{})
+	require.NoError(t, err)
+
+	svc := &Service{
+		networkProvider: &stubNetworkProvider{net: network.NewNetwork(&stubNetworkDriver{}, nil)},
+		auditDB:         auditDB,
+		tmsProvider:     &stubTMSProvider{},
+		metrics:         newMetrics(nil),
+		lockConfig:      DefaultLockConfig(),
+	}
+
+	return svc, qe, tms
+}
+
+func TestSnapshotAuditRecord_IsolatedFromOriginal(t *testing.T) {
+	tms, _ := newInternalTestTMS(t, []*token2.Token{})
+	req := token.NewRequest(tms, "tx-snapshot")
+	quantity, err := token2.ToQuantity("100", 64)
+	require.NoError(t, err)
+	original := &token.AuditRecord{
+		Anchor: "tx-snapshot",
+		Inputs: token.NewInputStream(nil, []*token.Input{{
+			Id:             &token2.ID{TxId: "tx1", Index: 0},
+			EnrollmentID:   "alice",
+			Type:           "USD",
+			Owner:          []byte("owner-in"),
+			OwnerAuditInfo: []byte("audit-in"),
+			Quantity:       quantity,
+		}}, 64),
+		Outputs: token.NewOutputStream([]*token.Output{{
+			EnrollmentID: "bob",
+			Type:         "USD",
+			Owner:        []byte("owner-out"),
+			LedgerOutput: []byte("ledger"),
+		}}, 64),
+		Attributes: map[string][]byte{"k": []byte("v")},
+	}
+
+	snapshot := snapshotAuditRecord(req, original)
+	require.Equal(t, 1, snapshot.Inputs.Count())
+	require.Equal(t, 1, snapshot.Outputs.Count())
+	in, out := original.Inputs.At(0), original.Outputs.At(0)
+	snapIn, snapOut := snapshot.Inputs.At(0), snapshot.Outputs.At(0)
+	assert.NotSame(t, in, snapIn)
+	assert.NotSame(t, in.Id, snapIn.Id)
+	assert.Equal(t, "alice", snapIn.EnrollmentID)
+	assert.Equal(t, "bob", snapOut.EnrollmentID)
+
+	// caller-side mutations, including through inner pointers, do not reach
+	// the snapshot
+	in.EnrollmentID = "mallory"
+	in.Id.TxId = "tx-forged"
+	copy(in.Owner, "MALICE-XX")
+	copy(in.OwnerAuditInfo, "FORGED-XX")
+	out.EnrollmentID = "mallory"
+	copy(out.LedgerOutput, "FORGED")
+	original.Attributes["k"][0] = 'X'
+	assert.Equal(t, "alice", snapIn.EnrollmentID)
+	assert.Equal(t, "tx1", snapIn.Id.TxId)
+	assert.Equal(t, []byte("owner-in"), []byte(snapIn.Owner))
+	assert.Equal(t, []byte("audit-in"), snapIn.OwnerAuditInfo)
+	assert.Equal(t, "100", snapIn.Quantity.Decimal())
+	assert.Equal(t, "bob", snapOut.EnrollmentID)
+	assert.Equal(t, []byte("ledger"), snapOut.LedgerOutput)
+	assert.Equal(t, []byte("v"), snapshot.Attributes["k"])
+
+	// snapshot-side mutations (gap filling) do not reach the original
+	snapIn.EnrollmentID = "filled"
+	assert.Equal(t, "mallory", in.EnrollmentID)
+}
+
+func TestService_AuditThenAppend_ReusesAuditRecord(t *testing.T) {
+	svc, qe, tms := newAuditTestService(t)
+	tx := &stubTransaction{req: token.NewRequest(tms, "tx-audit-append")}
+
+	inputs, outputs, err := svc.Audit(context.Background(), tx)
+	require.NoError(t, err)
+	require.NotNil(t, inputs)
+	require.NotNil(t, outputs)
+	computations := qe.ListAuditTokensCallCount()
+	require.Positive(t, computations)
+	cached := svc.cachedAuditRecord(tx.req)
+	require.NotNil(t, cached)
+	// the cache holds a snapshot, not the streams handed to the caller
+	assert.NotSame(t, inputs, cached.Inputs)
+	assert.Equal(t, inputs.Count(), cached.Inputs.Count())
+	assert.Equal(t, outputs.Count(), cached.Outputs.Count())
+
+	require.NoError(t, svc.Append(context.Background(), tx))
+	// the audit record was reused, not recomputed
+	assert.Equal(t, computations, qe.ListAuditTokensCallCount())
+	// Append released the transaction and dropped the cached record
+	assert.Nil(t, svc.cachedAuditRecord(tx.req))
+}
+
+func TestService_Append_WithoutAudit_RecomputesAuditRecord(t *testing.T) {
+	svc, qe, tms := newAuditTestService(t)
+	tx := &stubTransaction{req: token.NewRequest(tms, "tx-append-only")}
+
+	require.NoError(t, svc.Append(context.Background(), tx))
+	assert.Equal(t, 1, qe.ListAuditTokensCallCount())
+}
+
+func TestService_AuditThenRelease_DropsCachedRecord(t *testing.T) {
+	svc, _, tms := newAuditTestService(t)
+	tx := &stubTransaction{req: token.NewRequest(tms, "tx-audit-release")}
+
+	_, _, err := svc.Audit(context.Background(), tx)
+	require.NoError(t, err)
+	require.NotNil(t, svc.cachedAuditRecord(tx.req))
+
+	svc.Release(context.Background(), tx)
+	assert.Nil(t, svc.cachedAuditRecord(tx.req))
 }


### PR DESCRIPTION
## Description

`Audit()` already computes the transaction's `token.AuditRecord` to extract the inputs/outputs and acquire the enrollment-ID locks, but `Append()` recomputed the same record — request deserialization plus a `ListAuditTokens` vault query — when persisting the request to the audit DB. In our test environments under sustained load this doubles the per-transaction audit-record cost and the vault read traffic on the auditor hot path.

This PR caches, per request anchor, a snapshot of the record computed by `Audit()` and lets `Append()` reuse it:

- The cached snapshot is a deep copy: the streams `Audit()` returns to business code stay independent of what `Append()` persists, and gap filling cannot mutate them.
- Each cache entry is bound to the `*token.Request` it was computed from; a lookup from a different request reusing the same anchor misses and safely falls back to recomputation. Duplicate anchors are outside the platform's operating assumptions (the audit DB locker keys locks by anchor as well), so on collision the cache only degrades to the previous behavior.
- Entries are dropped by `Release()`, which `Append()` already defers, so the cache stays bounded by in-flight audits. The map is lazily initialized, keeping the `Service` zero value safe.
- Gap filling (`completeInputsWithEmptyEID`) still runs on cache hits, since it depends on current vault state.

New unit tests cover the cache lifecycle (stash/lookup/drop, same-anchor isolation), snapshot isolation in both directions (caller-side mutations, including through inner pointers, never reach the cached record; gap filling never reaches the caller's streams), and a service-level Audit → Append chain verifying the record is computed exactly once on the cached path and recomputed on a cache miss.

Fixes #1881
