### PR TITLE
[BUG]: RequestSpendView in multisig blocks forever — WithTimeout() exists but is never applied to the channel wait  #1671

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ All PRs and pushes to `main` trigger these workflows:
 
 ### Coding Standards
 - **Error Handling**: Handle errors explicitly; avoid blank identifier for errors
+- **Error Construction**: Never use `fmt.Errorf` (or `fmt` at all) to build or wrap errors. Always use `github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors` instead (`errors.New`, `errors.Errorf`, `errors.Wrap`, `errors.Wrapf`, `errors.WithMessage`, `errors.WithMessagef`, `errors.Join`, etc.). This applies to source code, tests, and code samples in `docs/`.
 - **Interfaces**: Define small, focused interfaces on consumer side; favor composition
 - **Concurrency**: Use goroutines and channels; avoid shared state; validate with race detector
 - **Globals**: Avoid global variables for testability
@@ -178,7 +179,7 @@ Before implementing any task:
 3. Log blockers/decisions under `## Notes & Decisions`
 4. Mark plan as `✅ COMPLETE` when finished
 
-### Documentation Rule
+### Documentation Updates (Workflow Rule)
 Before marking a task complete, update or create the relevant documentation under `docs/`:
 - If the task changes a public API, protocol, or user-facing behaviour, update the corresponding `docs/` page (or create one if it does not exist).
 - Keep docs consistent with code: function names, message fields, flow diagrams, and examples must match the implementation.

--- a/docs/upgradability.md
+++ b/docs/upgradability.md
@@ -172,7 +172,7 @@ ppm := tms.PublicParametersManager()
 // Retrieve the current public parameters
 currentPP := ppm.PublicParameters()
 if currentPP == nil {
-    return fmt.Errorf("public parameters not available")
+    return errors.New("public parameters not available")
 }
 
 // Verify the parameters match the expected values

--- a/token/services/ttx/boolpolicy/spend.go
+++ b/token/services/ttx/boolpolicy/spend.go
@@ -18,11 +18,16 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/json/session"
 	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+// defaultSpendRequestTimeout is applied by NewRequestSpendView so callers that never
+// call WithTimeout are still protected against an unresponsive co-owner.
+const defaultSpendRequestTimeout = 30 * time.Second
 
 // SpendRequest carries a policy token selected for spending to co-owners.
 type SpendRequest struct {
@@ -84,12 +89,6 @@ type SpendResponse struct {
 	Err error
 }
 
-type answer struct {
-	response *SpendResponse
-	err      error
-	party    view.Identity
-}
-
 // RequestSpendView sends a SpendRequest to all co-owners of a policy token and
 // collects their acknowledgements.  This is needed for AND policies; OR-policy
 // spends can skip this step.
@@ -98,7 +97,8 @@ type RequestSpendView struct {
 	parties      []view.Identity
 	options      *token2.ServiceOptions
 
-	err error
+	err     error
+	timeout time.Duration
 }
 
 // NewRequestSpendView creates a RequestSpendView for the given policy token.
@@ -126,7 +126,15 @@ func NewRequestSpendView(unspentToken *token.UnspentToken, opts ...token2.Servic
 		unspentToken: unspentToken,
 		parties:      parties,
 		options:      serviceOptions,
+		timeout:      defaultSpendRequestTimeout,
 	}
+}
+
+// WithTimeout sets the maximum time to wait for all co-owners to respond.
+func (c *RequestSpendView) WithTimeout(timeout time.Duration) *RequestSpendView {
+	c.timeout = timeout
+
+	return c
 }
 
 // Call implements view.View.
@@ -140,56 +148,53 @@ func (c *RequestSpendView) Call(context view.Context) (any, error) {
 		return nil, errors.Wrapf(err, "failed getting TMS for [%s]", c.options.TMSID())
 	}
 	areMe := tms.SigService().AreMe(context.Context(), c.parties...)
-	answerChannel := make(chan *answer, len(c.parties))
+	collector := utils.NewAnswersCollector[string, *SpendResponse](len(c.parties), c.timeout)
 	counter := 0
 	for _, party := range c.parties {
 		if slices.Contains(areMe, party.UniqueID()) {
 			continue
 		}
-		go c.collectAnswers(context, party, request, answerChannel)
+		go c.collectAnswers(context, party, request, collector)
 		counter++
 	}
-	for range counter {
-		var a *answer
-		select {
-		case a = <-answerChannel:
-			// Received answer from party
-		case <-context.Context().Done():
-			return nil, errors.Wrapf(context.Context().Err(), "context cancelled while waiting for answer from party")
+	answers, err := collector.Collect(context.Context(), counter)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed waiting for policy answers")
+	}
+	for _, a := range answers {
+		if a.Err != nil {
+			return nil, errors.Wrapf(a.Err, "failure from [%s]", a.Key)
 		}
-		if a.err != nil {
-			return nil, errors.Wrapf(a.err, "failure from [%s]", a.party)
-		}
-		if a.response.Err != nil {
-			return nil, errors.Wrapf(a.response.Err, "failure from [%s]", a.party)
+		if a.Value.Err != nil {
+			return nil, errors.Wrapf(a.Value.Err, "failure from [%s]", a.Key)
 		}
 	}
 
 	return nil, nil
 }
 
-func (c *RequestSpendView) collectAnswers(context view.Context, party view.Identity, request *SpendRequest, ch chan *answer) {
+func (c *RequestSpendView) collectAnswers(context view.Context, party view.Identity, request *SpendRequest, collector *utils.AnswersCollector[string, *SpendResponse]) {
 	defer logger.DebugfContext(context.Context(), "received response from [%v]", party)
 
 	backendSession, err := context.GetSession(c, party, context.Initiator())
 	if err != nil {
-		ch <- &answer{err: errors.Wrapf(err, "failed to create session with [%s]", party), party: party}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to create session with [%s]", party))
 
 		return
 	}
 	s := session.NewTypedSession(context, backendSession)
 	if err = s.SendTyped(context.Context(), request, ttx.TypeSpendRequest); err != nil {
-		ch <- &answer{err: errors.Wrapf(err, "failed to send request to [%s]", party), party: party}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to send request to [%s]", party))
 
 		return
 	}
 	response := &SpendResponse{}
 	if err := s.ReceiveTyped(ttx.TypeSpendResponse, response); err != nil {
-		ch <- &answer{err: errors.Wrapf(err, "failed to receive response from [%s]", party), party: party}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to receive response from [%s]", party))
 
 		return
 	}
-	ch <- &answer{response: response, party: party}
+	collector.Send(party.UniqueID(), response, nil)
 }
 
 // ReceiveSpendTxView is the co-owner's view for AND-policy spends: it ACKs

--- a/token/services/ttx/boolpolicy/spend_test.go
+++ b/token/services/ttx/boolpolicy/spend_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package boolpolicy
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	driver_mock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	token_mock "github.com/LFDT-Panurus/panurus/token/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/boolpolicy"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	dep_mock "github.com/LFDT-Panurus/panurus/token/services/ttx/dep/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
+	jsession "github.com/LFDT-Panurus/panurus/token/services/utils/json/session"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyNormalizer is a no-op token.Normalizer used to drive a real
+// token.ManagementServiceProvider without depending on any specific driver.
+type dummyNormalizer struct{}
+
+func (d *dummyNormalizer) Normalize(opt *token.ServiceOptions) (*token.ServiceOptions, error) {
+	return opt, nil
+}
+
+// dummyTMSProvider hands back a single, pre-built driver.TokenManagerService
+// regardless of the requested options, so the test can control AreMe via the
+// underlying mock.IdentityProvider.
+type dummyTMSProvider struct {
+	tms driver.TokenManagerService
+}
+
+func (d *dummyTMSProvider) GetTokenManagerService(driver.ServiceOptions) (driver.TokenManagerService, error) {
+	return d.tms, nil
+}
+
+func (d *dummyTMSProvider) Update(driver.ServiceOptions) error {
+	return nil
+}
+
+// newSpendTestContext builds a mock.Context that resolves a real
+// token.ManagementServiceProvider (backed entirely by driver-level mocks), so
+// RequestSpendView.Call can run end-to-end without a live FSC network.
+func newSpendTestContext(t *testing.T, areMe []string, sessions map[string]view.Session) *dep_mock.Context {
+	t.Helper()
+
+	tms := &driver_mock.TokenManagerService{}
+	tms.ValidatorReturns(&driver_mock.Validator{}, nil)
+	tms.WalletServiceReturns(&driver_mock.WalletService{})
+	tms.AuthorizationReturns(&driver_mock.Authorization{})
+	tms.ConfigurationReturns(&driver_mock.Configuration{})
+
+	ppm := &driver_mock.PublicParamsManager{}
+	pp := &driver_mock.PublicParameters{}
+	ppm.PublicParametersReturns(pp)
+	tms.PublicParamsManagerReturns(ppm)
+
+	ip := &driver_mock.IdentityProvider{}
+	ip.AreMeReturns(areMe)
+	tms.IdentityProviderReturns(ip)
+	tms.DeserializerReturns(&driver_mock.Deserializer{})
+
+	vp := &token_mock.VaultProvider{}
+	vault := &driver_mock.Vault{}
+	vault.QueryEngineReturns(&driver_mock.QueryEngine{})
+	vp.VaultReturns(vault, nil)
+
+	provider := token.NewManagementServiceProvider(&dummyTMSProvider{tms: tms}, &dummyNormalizer{}, vp, nil, nil)
+
+	ctx := &dep_mock.Context{}
+	ctx.ContextReturns(t.Context())
+	ctx.InitiatorReturns(nil)
+	ctx.GetServiceCalls(func(v any) (any, error) {
+		if _, ok := v.(*token.ManagementServiceProvider); ok {
+			return provider, nil
+		}
+
+		return nil, errors.New("service not registered in test")
+	})
+	ctx.GetSessionStub = func(_ view.View, party view.Identity, _ ...view.View) (view.Session, error) {
+		return sessions[party.UniqueID()], nil
+	}
+
+	return ctx
+}
+
+// newSilentSession returns a mock.Session whose Send succeeds but whose
+// Receive channel never yields a message, simulating an unresponsive co-owner.
+func newSilentSession(t *testing.T) *dep_mock.Session {
+	t.Helper()
+	s := &dep_mock.Session{}
+	s.SendWithContextReturns(nil)
+	s.ReceiveReturns(make(chan *view.Message))
+
+	return s
+}
+
+func TestRequestSpendView_Call_TimesOutOnUnresponsiveParty(t *testing.T) {
+	partyA := view.Identity("party-a")
+	partyB := view.Identity("party-b")
+
+	owner, err := boolpolicy.WrapPolicyIdentity("$0 AND $1", partyA, partyB)
+	require.NoError(t, err)
+
+	unspentToken := &token2.UnspentToken{Owner: owner}
+
+	sessionB := newSilentSession(t)
+	ctx := newSpendTestContext(t, []string{partyA.UniqueID()}, map[string]view.Session{
+		partyB.UniqueID(): sessionB,
+	})
+
+	spendView := NewRequestSpendView(unspentToken).WithTimeout(50 * time.Millisecond)
+
+	start := time.Now()
+	_, err = spendView.Call(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, utils.ErrAnswersCollectorTimeout)
+	require.Less(t, elapsed, 5*time.Second, "Call should return promptly once the configured timeout elapses, not hang indefinitely")
+}
+
+func TestRequestSpendView_Call_AllPartiesRespond(t *testing.T) {
+	partyA := view.Identity("party-a")
+	partyB := view.Identity("party-b")
+
+	owner, err := boolpolicy.WrapPolicyIdentity("$0 AND $1", partyA, partyB)
+	require.NoError(t, err)
+
+	unspentToken := &token2.UnspentToken{Owner: owner}
+
+	// party A is "me" and is skipped; party B answers promptly.
+	sessionB := &dep_mock.Session{}
+	sessionB.SendWithContextReturns(nil)
+	ch := make(chan *view.Message, 1)
+	env, err := jsession.WrapEnvelope(&SpendResponse{}, ttx.TypeSpendResponse)
+	require.NoError(t, err)
+	raw, err := json.Marshal(env)
+	require.NoError(t, err)
+	ch <- &view.Message{Payload: raw, Status: int32(view.OK)}
+	sessionB.ReceiveReturns(ch)
+
+	ctx := newSpendTestContext(t, []string{partyA.UniqueID()}, map[string]view.Session{
+		partyB.UniqueID(): sessionB,
+	})
+
+	spendView := NewRequestSpendView(unspentToken).WithTimeout(2 * time.Second)
+	_, err = spendView.Call(ctx)
+	require.NoError(t, err)
+}

--- a/token/services/ttx/multisig/spend.go
+++ b/token/services/ttx/multisig/spend.go
@@ -14,11 +14,16 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
 	"github.com/LFDT-Panurus/panurus/token/services/utils/json/session"
 	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
+
+// defaultSpendRequestTimeout is applied by NewRequestSpendView so callers that never
+// call WithTimeout are still protected against an unresponsive co-signer.
+const defaultSpendRequestTimeout = 30 * time.Second
 
 // SpendRequest is the request to spend a token
 type SpendRequest struct {
@@ -75,12 +80,6 @@ type SpendResponse struct {
 	Err error
 }
 
-type answer struct {
-	response *SpendResponse
-	err      error
-	party    view.Identity
-}
-
 // RequestSpendView sends a SpendRequest to all parties and waits for their responses
 type RequestSpendView struct {
 	unspentToken *token.UnspentToken
@@ -113,6 +112,7 @@ func NewRequestSpendView(unspentToken *token.UnspentToken, opts ...token2.Servic
 		unspentToken: unspentToken,
 		parties:      identities,
 		options:      serviceOptions,
+		timeout:      defaultSpendRequestTimeout,
 	}
 }
 
@@ -124,7 +124,7 @@ func (c *RequestSpendView) Call(context view.Context) (any, error) {
 	// send Transaction to each party and wait for their responses
 	request := &SpendRequest{Token: c.unspentToken}
 
-	answerChannel := make(chan *answer, len(c.parties))
+	collector := utils.NewAnswersCollector[string, *SpendResponse](len(c.parties), c.timeout)
 	logger.DebugfContext(context.Context(), "Notify %d parties about request", len(c.parties))
 	logger.DebugfContext(context.Context(), "Request [%v]", len(c.parties), request)
 	counter := 0
@@ -141,24 +141,21 @@ func (c *RequestSpendView) Call(context view.Context) (any, error) {
 
 			continue
 		}
-		go c.collectSpendRequestAnswers(context, party, request, answerChannel)
+		go c.collectSpendRequestAnswers(context, party, request, collector)
 		counter++
 	}
 
-	for range counter {
-		logger.DebugfContext(context.Context(), "Wait for answer")
-		var a *answer
-		select {
-		case a = <-answerChannel:
-			logger.DebugfContext(context.Context(), "Received answer")
-		case <-context.Context().Done():
-			return nil, errors.Wrapf(context.Context().Err(), "context cancelled while waiting for multisig answer")
+	logger.DebugfContext(context.Context(), "Wait for %d answers", counter)
+	answers, err := collector.Collect(context.Context(), counter)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed waiting for multisig answers")
+	}
+	for _, a := range answers {
+		if a.Err != nil {
+			return nil, errors.Wrapf(a.Err, "got failure [%s] from [%s]", a.Key, a.Err)
 		}
-		if a.err != nil {
-			return nil, errors.Wrapf(a.err, "got failure [%s] from [%s]", a.party.String(), a.err)
-		}
-		if a.response.Err != nil {
-			return nil, errors.Wrapf(a.response.Err, "got failure [%s] from [%s]", a.party.String(), a.response.Err)
+		if a.Value.Err != nil {
+			return nil, errors.Wrapf(a.Value.Err, "got failure [%s] from [%s]", a.Key, a.Value.Err)
 		}
 	}
 
@@ -175,15 +172,12 @@ func (c *RequestSpendView) collectSpendRequestAnswers(
 	context view.Context,
 	party view.Identity,
 	request *SpendRequest,
-	answerChan chan *answer) {
+	collector *utils.AnswersCollector[string, *SpendResponse]) {
 	defer logger.DebugfContext(context.Context(), "received response for from [%v]", party)
 
 	backendSession, err := context.GetSession(c, party, context.Initiator())
 	if err != nil {
-		answerChan <- &answer{
-			err:   errors.Wrapf(err, "failed to create session with [%s]", party),
-			party: party,
-		}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to create session with [%s]", party))
 
 		return
 	}
@@ -192,25 +186,19 @@ func (c *RequestSpendView) collectSpendRequestAnswers(
 	logger.DebugfContext(context.Context(), "send request to [%v]", party)
 	err = s.SendTyped(context.Context(), request, ttx.TypeSpendRequest)
 	if err != nil {
-		answerChan <- &answer{
-			err:   errors.Wrapf(err, "failed to send request to [%s]", party),
-			party: party,
-		}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to send request to [%s]", party))
 
 		return
 	}
 	response := &SpendResponse{}
 	if err := s.ReceiveTyped(ttx.TypeSpendResponse, response); err != nil {
-		answerChan <- &answer{
-			err:   errors.Wrapf(err, "failed to receive response from [%s]", party),
-			party: party,
-		}
+		collector.Send(party.UniqueID(), nil, errors.Wrapf(err, "failed to receive response from [%s]", party))
 
 		return
 	}
 	logger.DebugfContext(context.Context(), "received response from [%v]: [%v]", party, response.Err)
 
-	answerChan <- &answer{response: response, party: party}
+	collector.Send(party.UniqueID(), response, nil)
 }
 
 // ReceiveSpendTxView is the co-owner's view: it ACKs the SpendRequest and

--- a/token/services/ttx/multisig/spend_test.go
+++ b/token/services/ttx/multisig/spend_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package multisig
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	driver_mock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	token_mock "github.com/LFDT-Panurus/panurus/token/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/multisig"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	dep_mock "github.com/LFDT-Panurus/panurus/token/services/ttx/dep/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/utils"
+	jsession "github.com/LFDT-Panurus/panurus/token/services/utils/json/session"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/require"
+)
+
+// dummyNormalizer is a no-op token.Normalizer used to drive a real
+// token.ManagementServiceProvider without depending on any specific driver.
+type dummyNormalizer struct{}
+
+func (d *dummyNormalizer) Normalize(opt *token.ServiceOptions) (*token.ServiceOptions, error) {
+	return opt, nil
+}
+
+// dummyTMSProvider hands back a single, pre-built driver.TokenManagerService
+// regardless of the requested options, so the test can control AreMe via the
+// underlying mock.IdentityProvider.
+type dummyTMSProvider struct {
+	tms driver.TokenManagerService
+}
+
+func (d *dummyTMSProvider) GetTokenManagerService(driver.ServiceOptions) (driver.TokenManagerService, error) {
+	return d.tms, nil
+}
+
+func (d *dummyTMSProvider) Update(driver.ServiceOptions) error {
+	return nil
+}
+
+// newSpendTestContext builds a mock.Context that resolves a real
+// token.ManagementServiceProvider (backed entirely by driver-level mocks), so
+// RequestSpendView.Call can run end-to-end without a live FSC network.
+func newSpendTestContext(t *testing.T, areMe []string, sessions map[string]view.Session) *dep_mock.Context {
+	t.Helper()
+
+	tms := &driver_mock.TokenManagerService{}
+	tms.ValidatorReturns(&driver_mock.Validator{}, nil)
+	tms.WalletServiceReturns(&driver_mock.WalletService{})
+	tms.AuthorizationReturns(&driver_mock.Authorization{})
+	tms.ConfigurationReturns(&driver_mock.Configuration{})
+
+	ppm := &driver_mock.PublicParamsManager{}
+	pp := &driver_mock.PublicParameters{}
+	ppm.PublicParametersReturns(pp)
+	tms.PublicParamsManagerReturns(ppm)
+
+	ip := &driver_mock.IdentityProvider{}
+	ip.AreMeReturns(areMe)
+	tms.IdentityProviderReturns(ip)
+	tms.DeserializerReturns(&driver_mock.Deserializer{})
+
+	vp := &token_mock.VaultProvider{}
+	vault := &driver_mock.Vault{}
+	vault.QueryEngineReturns(&driver_mock.QueryEngine{})
+	vp.VaultReturns(vault, nil)
+
+	provider := token.NewManagementServiceProvider(&dummyTMSProvider{tms: tms}, &dummyNormalizer{}, vp, nil, nil)
+
+	ctx := &dep_mock.Context{}
+	ctx.ContextReturns(t.Context())
+	ctx.InitiatorReturns(nil)
+	ctx.GetServiceCalls(func(v any) (any, error) {
+		if _, ok := v.(*token.ManagementServiceProvider); ok {
+			return provider, nil
+		}
+
+		return nil, errors.New("service not registered in test")
+	})
+	ctx.GetSessionStub = func(_ view.View, party view.Identity, _ ...view.View) (view.Session, error) {
+		return sessions[party.UniqueID()], nil
+	}
+
+	return ctx
+}
+
+// newSilentSession returns a mock.Session whose Send succeeds but whose
+// Receive channel never yields a message, simulating an unresponsive co-signer.
+func newSilentSession(t *testing.T) *dep_mock.Session {
+	t.Helper()
+	s := &dep_mock.Session{}
+	s.SendWithContextReturns(nil)
+	s.ReceiveReturns(make(chan *view.Message))
+
+	return s
+}
+
+func TestRequestSpendView_Call_TimesOutOnUnresponsiveParty(t *testing.T) {
+	partyA := view.Identity("party-a")
+	partyB := view.Identity("party-b")
+
+	owner, err := multisig.WrapIdentities(partyA, partyB)
+	require.NoError(t, err)
+
+	unspentToken := &token2.UnspentToken{Owner: owner}
+
+	sessionB := newSilentSession(t)
+	ctx := newSpendTestContext(t, []string{partyA.UniqueID()}, map[string]view.Session{
+		partyB.UniqueID(): sessionB,
+	})
+
+	spendView := NewRequestSpendView(unspentToken).WithTimeout(50 * time.Millisecond)
+
+	start := time.Now()
+	_, err = spendView.Call(ctx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, utils.ErrAnswersCollectorTimeout)
+	require.Less(t, elapsed, 5*time.Second, "Call should return promptly once the configured timeout elapses, not hang indefinitely")
+}
+
+func TestRequestSpendView_Call_AllPartiesRespond(t *testing.T) {
+	partyA := view.Identity("party-a")
+	partyB := view.Identity("party-b")
+
+	owner, err := multisig.WrapIdentities(partyA, partyB)
+	require.NoError(t, err)
+
+	unspentToken := &token2.UnspentToken{Owner: owner}
+
+	// party A is "me" and is skipped; party B answers promptly.
+	sessionB := &dep_mock.Session{}
+	sessionB.SendWithContextReturns(nil)
+	ch := make(chan *view.Message, 1)
+	env, err := jsession.WrapEnvelope(&SpendResponse{}, ttx.TypeSpendResponse)
+	require.NoError(t, err)
+	raw, err := json.Marshal(env)
+	require.NoError(t, err)
+	ch <- &view.Message{Payload: raw, Status: int32(view.OK)}
+	sessionB.ReceiveReturns(ch)
+
+	ctx := newSpendTestContext(t, []string{partyA.UniqueID()}, map[string]view.Session{
+		partyB.UniqueID(): sessionB,
+	})
+
+	spendView := NewRequestSpendView(unspentToken).WithTimeout(2 * time.Second)
+	_, err = spendView.Call(ctx)
+	require.NoError(t, err)
+}

--- a/token/services/utils/collector.go
+++ b/token/services/utils/collector.go
@@ -1,0 +1,91 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This file provides a generic fan-in helper for collecting answers from a fixed
+// number of concurrent workers, bounded by a timeout and a caller-supplied context.
+package utils
+
+import (
+	"context"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// DefaultAnswersCollectorTimeout is applied by NewAnswersCollector when the caller
+// passes a non-positive timeout, so a collector is never accidentally unbounded.
+const DefaultAnswersCollectorTimeout = 30 * time.Second
+
+// ErrAnswersCollectorTimeout is returned (wrapped) by Collect when the timeout
+// elapses before all expected answers arrive.
+var ErrAnswersCollectorTimeout = errors.New("timed out waiting for answers")
+
+// ErrAnswersCollectorCanceled is returned (wrapped) by Collect when the supplied
+// context is done before all expected answers arrive.
+var ErrAnswersCollectorCanceled = errors.New("canceled while waiting for answers")
+
+// Answer is a single worker's outcome, keyed by K (e.g. a party identifier).
+type Answer[K comparable, T any] struct {
+	Key   K
+	Value T
+	Err   error
+}
+
+// AnswersCollector collects a fixed number of Answer values sent concurrently by
+// worker goroutines, enforcing a timeout and honoring context cancellation. It
+// replaces the pattern of a bare `<-channel` receive (which can block forever) or a
+// receive `select`-ed only against ctx.Done() (which never returns if the caller's
+// context has no deadline and a worker goes silent).
+//
+// The underlying channel is buffered to the collector's capacity, so workers that
+// are still in flight when Collect returns (on timeout or cancellation) can always
+// complete their Send and exit without leaking a goroutine.
+type AnswersCollector[K comparable, T any] struct {
+	answers chan Answer[K, T]
+	timeout time.Duration
+}
+
+// NewAnswersCollector returns a collector sized for up to `capacity` concurrent
+// senders. If timeout is <= 0, DefaultAnswersCollectorTimeout is used instead.
+func NewAnswersCollector[K comparable, T any](capacity int, timeout time.Duration) *AnswersCollector[K, T] {
+	if timeout <= 0 {
+		timeout = DefaultAnswersCollectorTimeout
+	}
+
+	return &AnswersCollector[K, T]{
+		answers: make(chan Answer[K, T], capacity),
+		timeout: timeout,
+	}
+}
+
+// Send records a worker's outcome. It never blocks as long as the number of Send
+// calls does not exceed the capacity passed to NewAnswersCollector.
+func (c *AnswersCollector[K, T]) Send(key K, value T, err error) {
+	c.answers <- Answer[K, T]{Key: key, Value: value, Err: err}
+}
+
+// Collect waits for exactly `count` answers, returning them in arrival order. It
+// returns early with a wrapped ErrAnswersCollectorTimeout or ErrAnswersCollectorCanceled
+// if the timeout elapses or ctx is done first.
+func (c *AnswersCollector[K, T]) Collect(ctx context.Context, count int) ([]Answer[K, T], error) {
+	answers := make([]Answer[K, T], 0, count)
+
+	timer := time.NewTimer(c.timeout)
+	defer timer.Stop()
+
+	for range count {
+		select {
+		case a := <-c.answers:
+			answers = append(answers, a)
+		case <-ctx.Done():
+			return answers, errors.Join(ErrAnswersCollectorCanceled, errors.WithMessagef(ctx.Err(), "%d of %d answers received", len(answers), count))
+		case <-timer.C:
+			return answers, errors.Wrapf(ErrAnswersCollectorTimeout, "after %s: %d of %d answers received", c.timeout, len(answers), count)
+		}
+	}
+
+	return answers, nil
+}

--- a/token/services/utils/collector_test.go
+++ b/token/services/utils/collector_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This file tests collector.go, the generic fan-in AnswersCollector helper.
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnswersCollector_AllAnswersArrive(t *testing.T) {
+	c := NewAnswersCollector[string, int](3, time.Second)
+
+	go c.Send("a", 1, nil)
+	go c.Send("b", 2, nil)
+	go c.Send("c", 3, nil)
+
+	answers, err := c.Collect(context.Background(), 3)
+	require.NoError(t, err)
+	assert.Len(t, answers, 3)
+
+	got := map[string]int{}
+	for _, a := range answers {
+		require.NoError(t, a.Err)
+		got[a.Key] = a.Value
+	}
+	assert.Equal(t, map[string]int{"a": 1, "b": 2, "c": 3}, got)
+}
+
+func TestAnswersCollector_WorkerError(t *testing.T) {
+	c := NewAnswersCollector[string, int](2, time.Second)
+
+	boom := errors.New("boom")
+	go c.Send("a", 0, boom)
+	go c.Send("b", 2, nil)
+
+	answers, err := c.Collect(context.Background(), 2)
+	require.NoError(t, err)
+	assert.Len(t, answers, 2)
+
+	var sawErr bool
+	for _, a := range answers {
+		if a.Key == "a" {
+			require.ErrorIs(t, a.Err, boom)
+			sawErr = true
+		}
+	}
+	assert.True(t, sawErr, "expected to observe the error answer from party \"a\"")
+}
+
+func TestAnswersCollector_Timeout(t *testing.T) {
+	c := NewAnswersCollector[string, int](2, 20*time.Millisecond)
+
+	go c.Send("a", 1, nil)
+	// "b" never answers.
+
+	answers, err := c.Collect(context.Background(), 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAnswersCollectorTimeout)
+	assert.Len(t, answers, 1)
+}
+
+func TestAnswersCollector_ContextCanceled(t *testing.T) {
+	c := NewAnswersCollector[string, int](2, time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Send("a", 1, nil)
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	answers, err := c.Collect(ctx, 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAnswersCollectorCanceled)
+	assert.LessOrEqual(t, len(answers), 1)
+}
+
+func TestAnswersCollector_LateSendAfterTimeoutDoesNotBlock(t *testing.T) {
+	c := NewAnswersCollector[string, int](2, 10*time.Millisecond)
+
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		<-release
+		c.Send("late", 1, nil)
+		close(done)
+	}()
+
+	_, err := c.Collect(context.Background(), 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAnswersCollectorTimeout)
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("late Send blocked after Collect returned; buffered channel should have absorbed it")
+	}
+}
+
+func TestAnswersCollector_DefaultTimeoutApplied(t *testing.T) {
+	c := NewAnswersCollector[string, int](1, 0)
+	assert.Equal(t, DefaultAnswersCollectorTimeout, c.timeout)
+
+	c = NewAnswersCollector[string, int](1, -5*time.Second)
+	assert.Equal(t, DefaultAnswersCollectorTimeout, c.timeout)
+}


### PR DESCRIPTION
Fixes #1671: RequestSpendView.Call() in the multisig and boolpolicy identity services could block forever waiting for a co-signer's answer, since the timeout field/WithTimeout() setter
  on multisig.RequestSpendView were dead code (never applied to the wait loop), and boolpolicy.RequestSpendView had no timeout knob at all.

  - Extracted the duplicated fan-out/collect pattern into a new generic utils.AnswersCollector[K, T] (token/services/utils/collector.go), which bounds the wait with a per-call timeout
  (defaulting to 30s if unset) and honors context cancellation, returning a descriptive wrapped error either way.
  - Rewired multisig/spend.go to actually apply its timeout/WithTimeout() via the new collector, and added the same timeout field + WithTimeout() setter to boolpolicy/spend.go, which
  previously had none.
  - Added regression tests for both packages proving Call now returns promptly (instead of hanging) when a co-signer/co-owner never responds, plus a happy-path test, and unit tests for
  the collector itself (all-answers, worker error, timeout, context cancellation, late-send-after-return).

  Additional changes

  - Enforced a new coding rule: never use fmt.Errorf/fmt to construct or wrap errors — always use github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors (New, Errorf, Wrap,
  Wrapf, WithMessage, WithMessagef, Join, etc.). Documented this in AGENTS.md and fixed the one violation found in docs/upgradability.md, plus rewrote collector.go's two error sites to
  use errors.Join/errors.Wrapf instead of fmt.Errorf.
  - Added a "Documentation Updates" workflow rule to AGENTS.md requiring docs/ to be updated (when affected) before any task is reported as complete.