### PR TITLE
Add indexes to tables improve performance

### DIFF
--- a/token/services/storage/db/sql/common/endorser.go
+++ b/token/services/storage/db/sql/common/endorser.go
@@ -69,7 +69,8 @@ func (db *EndorserStore) GetSchema() string {
 			status_message TEXT NOT NULL,
 			stored_at TIMESTAMP NOT NULL
 		);
-	`, db.table)
+		CREATE INDEX IF NOT EXISTS idx_status_storedat_%s ON %s ( status, stored_at );
+	`, db.table, db.table, db.table)
 }
 
 // CreateSchema creates the database schema for the endorser store

--- a/token/services/storage/db/sql/common/tokenlock.go
+++ b/token/services/storage/db/sql/common/tokenlock.go
@@ -95,9 +95,12 @@ func (db *TokenLockStore) GetSchema() string {
 			created_at TIMESTAMP NOT NULL,
 			PRIMARY KEY(tx_id, idx),
 			FOREIGN KEY (tx_id, idx) REFERENCES %s
-		);`,
+		);
+		CREATE INDEX IF NOT EXISTS idx_consumer_tx_id_%s ON %s ( consumer_tx_id );`,
 		db.Table.TokenLocks,
 		db.Table.Tokens,
+		db.Table.TokenLocks,
+		db.Table.TokenLocks,
 	)
 }
 

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -1339,6 +1339,7 @@ func (db *TokenStore) GetSchema() string {
 		);
 		CREATE INDEX IF NOT EXISTS idx_status_%s ON %s ( status );
 		CREATE INDEX IF NOT EXISTS idx_recovery_claim_%s ON %s ( status, recovery_claim_expires_at, stored_at ) WHERE status = 1;
+		CREATE INDEX IF NOT EXISTS idx_recovery_expiry_%s ON %s ( recovery_claim_expires_at ) WHERE recovery_claim_expires_at IS NOT NULL;
 
 		-- Tokens
 		CREATE TABLE IF NOT EXISTS %s (
@@ -1367,8 +1368,10 @@ func (db *TokenStore) GetSchema() string {
 			PRIMARY KEY (tx_id, idx)
 		);
 		CREATE INDEX IF NOT EXISTS idx_spent_%s ON %s ( is_deleted, owner );
+		CREATE INDEX IF NOT EXISTS idx_ski_cleanup_%s ON %s ( is_deleted, spent_at );
 		CREATE INDEX IF NOT EXISTS idx_owner_wallet_id_%s ON %s ( owner_wallet_id );
 		CREATE INDEX IF NOT EXISTS idx_owner_wallet_part_%s ON %s ( owner_wallet_id, token_type ) WHERE is_deleted = false AND owner = true;
+		CREATE INDEX IF NOT EXISTS idx_issued_%s ON %s ( redeemed, token_type ) WHERE issuer = true;
 
 		-- Ownership
 		CREATE TABLE IF NOT EXISTS %s (
@@ -1408,8 +1411,10 @@ func (db *TokenStore) GetSchema() string {
 		);
 		CREATE INDEX IF NOT EXISTS idx_cleaned_at_%s ON %s ( cleaned_at );
 		`,
-		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
+		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
 		db.table.Tokens,
+		db.table.Tokens, db.table.Tokens,
+		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -448,6 +448,7 @@ func (db *TransactionStore) GetSchema() string {
 		);
 		CREATE INDEX IF NOT EXISTS idx_status_%s ON %s ( status );
 		CREATE INDEX IF NOT EXISTS idx_recovery_claim_%s ON %s ( status, recovery_claim_expires_at, stored_at ) WHERE status = 1;
+		CREATE INDEX IF NOT EXISTS idx_recovery_expiry_%s ON %s ( recovery_claim_expires_at ) WHERE recovery_claim_expires_at IS NOT NULL;
 
 		-- transactions
 		CREATE TABLE IF NOT EXISTS %s (
@@ -487,7 +488,7 @@ func (db *TransactionStore) GetSchema() string {
 		);
 		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
 		`,
-		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
+		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
 		db.table.Transactions, db.table.Requests, db.table.Transactions, db.table.Transactions, db.table.Transactions, db.table.Transactions, db.table.Transactions, db.table.Transactions, db.table.Transactions, db.table.Transactions,
 		db.table.Movements, db.table.Requests, db.table.Movements, db.table.Movements, db.table.Movements, db.table.Movements,
 		db.table.TransactionEndorseAck, db.table.TransactionEndorseAck, db.table.TransactionEndorseAck,


### PR DESCRIPTION
Fixes: 1873

Add the indexes, to improve query performance to the following tables:

1. token_locks: index on consumer_tx_id.
2. validations: index on status/stored_at (matching what transactions/requests already have).
3. tokens: extend or add an index covering (is_deleted, spent_at) for the SKI cleanup query).