### PR TITLE
feat(evm): TokenState contract, PP updates and deploy script

### DIFF
--- a/x/token/services/network/evm/contracts/README.md
+++ b/x/token/services/network/evm/contracts/README.md
@@ -12,9 +12,14 @@ Solidity sources for the EVM network driver (Approach 2), built with [Foundry](h
 - `src/EndorsementVerifier.sol` — the authorized endorser set + threshold; verifies a quorum of
   EIP-712 signatures over a digest (ecrecover, low-s, `v ∈ {27,28}`, signer uniqueness, strict
   all-provided-valid semantics — design §3.2). Landed in PR 2a.
-- `TokenState.sol` (PR 2b, upcoming) — stores token state and applies endorsed `StateDelta`s:
-  verifies signatures, checks the public-parameters version, enforces spent/existence per the
-  `graphHiding` flag, then applies the transition. Deployed per TMS via an EIP-1167 minimal clone.
+- `src/TokenState.sol` - stores token state and applies endorsed `StateDelta`s: verifies signatures,
+  checks the public-parameters version, enforces spent/existence per the `graphHiding` flag, then
+  applies the transition. Deployed per TMS as an EIP-1167 clone; the shared implementation is locked.
+  Landed in PR 2b.
+- `src/Clones.sol` - minimal EIP-1167 proxy deployment for the per-TMS `TokenState` clones.
+- `script/Deploy.s.sol` - deploys the verifier, the `TokenState` implementation, and an initialized
+  clone for one TMS (endorsers, threshold, PP v0, and graphHiding come from the environment). This is
+  the admin bootstrap the Week-6 NWO topology automates.
 
 ## The cross-impl gate
 

--- a/x/token/services/network/evm/contracts/script/Deploy.s.sol
+++ b/x/token/services/network/evm/contracts/script/Deploy.s.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {TokenState} from "../src/TokenState.sol";
+import {EndorsementVerifier} from "../src/EndorsementVerifier.sol";
+import {Clones} from "../src/Clones.sol";
+
+/// @title Deploy
+/// @notice Deploys the EVM token contracts for one TMS (design §3.8): the EndorsementVerifier holding the
+///         endorser set and threshold, a shared TokenState implementation, and a per-TMS TokenState clone
+///         seeded with public parameters v0 and the graphHiding mode. This is the admin bootstrap the
+///         Week-6 NWO topology automates.
+///
+///         Inputs come from the environment so NWO and CI can drive it:
+///           EVM_ENDORSERS      comma-separated endorser addresses
+///           EVM_THRESHOLD      signature threshold
+///           EVM_PP0            initial public parameters, hex-encoded bytes
+///           EVM_GRAPH_HIDING   true for a graph-hiding driver (default false)
+contract Deploy is Script {
+    function run() external returns (address verifier, address implementation, address tokenState) {
+        address[] memory endorsers = vm.envAddress("EVM_ENDORSERS", ",");
+        uint256 threshold = vm.envUint("EVM_THRESHOLD");
+        bytes memory pp0 = vm.envBytes("EVM_PP0");
+        bool graphHiding = vm.envOr("EVM_GRAPH_HIDING", false);
+
+        vm.startBroadcast();
+
+        EndorsementVerifier v = new EndorsementVerifier(endorsers, threshold);
+        TokenState impl = new TokenState();
+        TokenState ts = TokenState(Clones.clone(address(impl)));
+        ts.initialize(address(v), msg.sender, pp0, graphHiding);
+
+        vm.stopBroadcast();
+
+        verifier = address(v);
+        implementation = address(impl);
+        tokenState = address(ts);
+
+        console2.log("EndorsementVerifier:", verifier);
+        console2.log("TokenState impl:", implementation);
+        console2.log("TokenState clone:", tokenState);
+    }
+}

--- a/x/token/services/network/evm/contracts/src/Clones.sol
+++ b/x/token/services/network/evm/contracts/src/Clones.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+/// @title Clones
+/// @notice Minimal EIP-1167 proxy deployment. A clone is a tiny contract that delegatecalls a fixed
+///         implementation, so each per-TMS TokenState is cheap to deploy while sharing one code copy
+///         (design §3.8). Each clone has its own storage and is initialized independently.
+library Clones {
+    error CloneFailed();
+
+    /// @notice Deploys an EIP-1167 minimal proxy that delegatecalls `implementation`.
+    /// @dev The 45-byte runtime is the canonical EIP-1167 sequence with `implementation` spliced in.
+    function clone(address implementation) internal returns (address instance) {
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(ptr, 0x14), shl(0x60, implementation))
+            mstore(add(ptr, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            instance := create(0, ptr, 0x37)
+        }
+        if (instance == address(0)) revert CloneFailed();
+    }
+}

--- a/x/token/services/network/evm/contracts/src/TokenState.sol
+++ b/x/token/services/network/evm/contracts/src/TokenState.sol
@@ -158,9 +158,13 @@ contract TokenState {
     }
 
     /// @dev Endorsed public-parameters update: stores the new PP, bumps the version, emits. Setup deltas
-    ///      carry no spends/outputs (§3.5); reject a malformed one rather than silently ignore.
+    ///      carry only the new params (no spends, outputs, or metadata, per §3.5). Every field is
+    ///      digest-covered, so a malformed setup delta is rejected rather than partially ignored (R6).
     function _applySetup(StateDelta calldata delta) private {
-        if (delta.spentRefs.length != 0 || delta.outputs.length != 0 || delta.setupParameters.length == 0) {
+        if (
+            delta.spentRefs.length != 0 || delta.outputs.length != 0 || delta.metadataKeys.length != 0
+                || delta.setupParameters.length == 0
+        ) {
             revert MalformedSetupDelta();
         }
         publicParameters = delta.setupParameters;
@@ -171,6 +175,7 @@ contract TokenState {
 
     // --- queries -----------------------------------------------------------------------------------
 
+    /// @notice The serialized token bytes stored at tokenID, or empty if none.
     function getToken(bytes32 tokenID) external view returns (bytes memory) {
         return tokens[tokenID];
     }
@@ -180,6 +185,7 @@ contract TokenState {
         return snSpent[tokenMarker[tokenID]];
     }
 
+    /// @notice Graph-revealing spent status for a batch of token ids, aligned with the input.
     function areTokensSpent(bytes32[] calldata tokenIDs) external view returns (bool[] memory out) {
         out = new bool[](tokenIDs.length);
         for (uint256 i = 0; i < tokenIDs.length; i++) {
@@ -187,26 +193,32 @@ contract TokenState {
         }
     }
 
+    /// @notice Graph-hiding: whether a serial number has been recorded (spent).
     function isSerialUsed(bytes32 serial) external view returns (bool) {
         return serialUsed[serial];
     }
 
+    /// @notice The current public parameters.
     function getPublicParameters() external view returns (bytes memory) {
         return publicParameters;
     }
 
+    /// @notice The current public-parameters version (0 at initialize, then incremented per update).
     function getPublicParamsVersion() external view returns (uint64) {
         return publicParamsVersion;
     }
 
+    /// @notice SHA-256 of the current public parameters.
     function getPublicParamsHash() external view returns (bytes32) {
         return publicParamsHash;
     }
 
+    /// @notice The stored transfer metadata value for a key, or empty if none.
     function getTransferMetadata(bytes32 key) external view returns (bytes memory) {
         return transferMetadata[key];
     }
 
+    /// @notice The SHA-256 token-request hash recorded for an anchor, or zero if not processed.
     function getTokenRequestHash(bytes32 anchor) external view returns (bytes32) {
         return tokenRequestHashes[anchor];
     }

--- a/x/token/services/network/evm/contracts/src/TokenState.sol
+++ b/x/token/services/network/evm/contracts/src/TokenState.sol
@@ -40,6 +40,11 @@ contract TokenState {
     mapping(bytes32 => bool) private processedAnchor;
     /// @dev metadataKey => value.
     mapping(bytes32 => bytes) private transferMetadata;
+    /// @dev occupancy marker for metadata keys: Fabric's translator enforces StateMustNotExist on every
+    ///      metadata key (a reused key is a validation failure, never an overwrite), and with no MVCC the
+    ///      contract must re-check it here. A separate bool map (not value length) so empty values are
+    ///      handled correctly.
+    mapping(bytes32 => bool) private metadataExists;
 
     // --- configuration -----------------------------------------------------------------------------
 
@@ -63,6 +68,7 @@ contract TokenState {
     error InputMissingOrSpent(bytes32 ref);
     error DoubleSpend(bytes32 ref);
     error MetadataLengthMismatch();
+    error MetadataKeyOccupied(bytes32 key);
     error MalformedSetupDelta();
     error MalformedTransferDelta();
 
@@ -153,7 +159,12 @@ contract TokenState {
         }
 
         for (uint256 i = 0; i < delta.metadataKeys.length; i++) {
-            transferMetadata[delta.metadataKeys[i]] = delta.metadataVals[i];
+            bytes32 k = delta.metadataKeys[i];
+            // Metadata keys are write-once (Fabric parity: StateMustNotExist). A reused key, e.g. an
+            // htlc claim key seen twice, must fail the transaction, never overwrite.
+            if (metadataExists[k]) revert MetadataKeyOccupied(k);
+            metadataExists[k] = true;
+            transferMetadata[k] = delta.metadataVals[i];
         }
     }
 

--- a/x/token/services/network/evm/contracts/src/TokenState.sol
+++ b/x/token/services/network/evm/contracts/src/TokenState.sol
@@ -69,6 +69,12 @@ contract TokenState {
     event StateCommitted(bytes32 indexed anchor, bool success, string message);
     event PublicParametersUpdated(bytes32 indexed paramsHash, uint64 version);
 
+    /// @dev Locks the shared implementation so only EIP-1167 clones (which have their own fresh storage)
+    ///      can be initialized. The implementation contract itself can never be initialized or used.
+    constructor() {
+        initialized = true;
+    }
+
     /// @notice Seeds this clone: verifier, deployer, public parameters at version 0, and the graphHiding
     ///         mode. Can be called once. Public parameters thereafter change only through an endorsed
     ///         setup delta (§3.5).
@@ -99,6 +105,12 @@ contract TokenState {
         bytes32 digest = EIP712.digest(domainSeparator, EIP712.hashStruct(delta));
         if (!IEndorsementVerifier(endorsementVerifier).verify(digest, signatures)) revert InvalidSignatures();
 
+        // Both delta types assert the current public params they were validated against. This also orders
+        // setup deltas: once one bumps the version, another validated against the old version is stale.
+        if (delta.publicParamsVersion != publicParamsVersion || delta.publicParamsHash != publicParamsHash) {
+            revert StalePublicParams(publicParamsVersion, publicParamsHash);
+        }
+
         if (delta.isSetup) {
             _applySetup(delta);
         } else {
@@ -114,11 +126,9 @@ contract TokenState {
     /// @dev Issue/transfer: PP must be current; spend/existence per graphHiding; then apply.
     function _applyTransfer(StateDelta calldata delta) private {
         // A non-setup delta must not carry setup parameters (they are digest-covered; endorsers signed
-        // them, so silently ignoring them would be a bug — R6).
+        // them, so silently ignoring them would be a bug, per rule R6). The public-params check is done
+        // by the caller for both delta kinds.
         if (delta.setupParameters.length != 0) revert MalformedTransferDelta();
-        if (delta.publicParamsVersion != publicParamsVersion || delta.publicParamsHash != publicParamsHash) {
-            revert StalePublicParams(publicParamsVersion, publicParamsHash);
-        }
 
         bytes32[] calldata refs = delta.spentRefs;
         if (graphHiding) {

--- a/x/token/services/network/evm/contracts/src/TokenState.sol
+++ b/x/token/services/network/evm/contracts/src/TokenState.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {StateDelta, OutputToken} from "./StateDelta.sol";
+import {EIP712} from "./EIP712.sol";
+
+/// @notice The signature-verification surface TokenState depends on (see EndorsementVerifier).
+interface IEndorsementVerifier {
+    function verify(bytes32 digest, bytes[] calldata signatures) external view returns (bool);
+}
+
+/// @title TokenState
+/// @notice Stores token state for one TMS and applies endorsed StateDeltas. Under the Approach-2 trust
+///         model the chain does no token validation: `applyStateDelta` checks only (a) a quorum of
+///         endorser signatures, (b) the public-parameters version is current, and (c) declared inputs
+///         exist and are unspent / declared serials are unused, then applies the transition. Correctness
+///         is established off-chain by the endorser quorum.
+///
+/// @dev    Deployed per TMS as an EIP-1167 clone of a shared implementation and set up via `initialize`
+///         (design §3.8). The implementation is meant to be cloned; the clone's `initialize` seeds the
+///         initial public parameters (version 0), the verifier, and the graphHiding mode, and computes
+///         the EIP-712 domain separator over `address(this)`.
+contract TokenState {
+    // --- token state -------------------------------------------------------------------------------
+
+    /// @dev tokenID => serialized token bytes (addressable by anchor,index for queries).
+    mapping(bytes32 => bytes) private tokens;
+    /// @dev graph-revealing: content-bound output markers recorded at output creation.
+    mapping(bytes32 => bool) private snExists;
+    /// @dev graph-revealing: markers consumed by a spend.
+    mapping(bytes32 => bool) private snSpent;
+    /// @dev graph-hiding: serial numbers seen.
+    mapping(bytes32 => bool) private serialUsed;
+    /// @dev option (a) query surface: tokenID => its content-bound marker, recorded at creation, so
+    ///      isSpent(tokenID) resolves in a single call without the caller holding the token content.
+    mapping(bytes32 => bytes32) private tokenMarker;
+    /// @dev anchor => SHA-256(tokenRequest).
+    mapping(bytes32 => bytes32) private tokenRequestHashes;
+    /// @dev idempotency / replay guard.
+    mapping(bytes32 => bool) private processedAnchor;
+    /// @dev metadataKey => value.
+    mapping(bytes32 => bytes) private transferMetadata;
+
+    // --- configuration -----------------------------------------------------------------------------
+
+    bytes private publicParameters;
+    bytes32 private publicParamsHash; // SHA-256(publicParameters)
+    uint64 private publicParamsVersion; // first set = 0 (at initialize), then +1 per endorsed setup
+    bool public graphHiding; // selects spentRefs semantics; fixed per contract (one driver per TMS)
+    address public endorsementVerifier;
+    address public deployer;
+    bytes32 private domainSeparator; // EIP-712 domain, bound to chainId + address(this)
+    bool private initialized;
+
+    // --- errors ------------------------------------------------------------------------------------
+
+    error AlreadyInitialized();
+    error NotInitialized();
+    error ZeroVerifier();
+    error AnchorAlreadyProcessed(bytes32 anchor);
+    error InvalidSignatures();
+    error StalePublicParams(uint64 currentVersion, bytes32 currentHash);
+    error InputMissingOrSpent(bytes32 ref);
+    error DoubleSpend(bytes32 ref);
+    error MetadataLengthMismatch();
+    error MalformedSetupDelta();
+    error MalformedTransferDelta();
+
+    event StateCommitted(bytes32 indexed anchor, bool success, string message);
+    event PublicParametersUpdated(bytes32 indexed paramsHash, uint64 version);
+
+    /// @notice Seeds this clone: verifier, deployer, public parameters at version 0, and the graphHiding
+    ///         mode. Can be called once. Public parameters thereafter change only through an endorsed
+    ///         setup delta (§3.5).
+    function initialize(address verifier, address deployer_, bytes calldata pp0, bool graphHiding_) external {
+        if (initialized) revert AlreadyInitialized();
+        if (verifier == address(0)) revert ZeroVerifier();
+        initialized = true;
+        endorsementVerifier = verifier;
+        deployer = deployer_;
+        graphHiding = graphHiding_;
+        publicParameters = pp0;
+        publicParamsHash = sha256(pp0);
+        publicParamsVersion = 0;
+        domainSeparator = EIP712.domainSeparator(block.chainid, address(this));
+        emit PublicParametersUpdated(publicParamsHash, 0);
+    }
+
+    /// @notice Verifies the endorser quorum over the EIP-712 digest of `delta`, enforces the §3.4
+    ///         check-list, and applies the transition atomically. Reverts (whole tx) with a typed reason
+    ///         on any failure; the finality layer maps the revert to Invalid via the receipt status.
+    function applyStateDelta(StateDelta calldata delta, bytes[] calldata signatures) external returns (bool) {
+        if (!initialized) revert NotInitialized();
+        if (processedAnchor[delta.anchor]) revert AnchorAlreadyProcessed(delta.anchor);
+        if (delta.metadataKeys.length != delta.metadataVals.length) revert MetadataLengthMismatch();
+
+        // TokenState owns the domain separator (it is the per-TMS clone), so it computes the digest and
+        // the verifier stays a pure checker. verify reverts on failure; guard the bool defensively.
+        bytes32 digest = EIP712.digest(domainSeparator, EIP712.hashStruct(delta));
+        if (!IEndorsementVerifier(endorsementVerifier).verify(digest, signatures)) revert InvalidSignatures();
+
+        if (delta.isSetup) {
+            _applySetup(delta);
+        } else {
+            _applyTransfer(delta);
+        }
+
+        tokenRequestHashes[delta.anchor] = delta.tokenRequestHash;
+        processedAnchor[delta.anchor] = true;
+        emit StateCommitted(delta.anchor, true, "");
+        return true;
+    }
+
+    /// @dev Issue/transfer: PP must be current; spend/existence per graphHiding; then apply.
+    function _applyTransfer(StateDelta calldata delta) private {
+        // A non-setup delta must not carry setup parameters (they are digest-covered; endorsers signed
+        // them, so silently ignoring them would be a bug — R6).
+        if (delta.setupParameters.length != 0) revert MalformedTransferDelta();
+        if (delta.publicParamsVersion != publicParamsVersion || delta.publicParamsHash != publicParamsHash) {
+            revert StalePublicParams(publicParamsVersion, publicParamsHash);
+        }
+
+        bytes32[] calldata refs = delta.spentRefs;
+        if (graphHiding) {
+            for (uint256 i = 0; i < refs.length; i++) {
+                if (serialUsed[refs[i]]) revert DoubleSpend(refs[i]);
+                serialUsed[refs[i]] = true;
+            }
+        } else {
+            for (uint256 i = 0; i < refs.length; i++) {
+                // Existence of the content-bound marker proves the spent token has exactly the bytes
+                // recorded at creation, so forged content is rejected.
+                if (!snExists[refs[i]] || snSpent[refs[i]]) revert InputMissingOrSpent(refs[i]);
+                snSpent[refs[i]] = true;
+            }
+        }
+
+        OutputToken[] calldata outs = delta.outputs;
+        for (uint256 i = 0; i < outs.length; i++) {
+            tokens[outs[i].tokenID] = outs[i].tokenData;
+            snExists[outs[i].snMarker] = true;
+            tokenMarker[outs[i].tokenID] = outs[i].snMarker;
+        }
+
+        for (uint256 i = 0; i < delta.metadataKeys.length; i++) {
+            transferMetadata[delta.metadataKeys[i]] = delta.metadataVals[i];
+        }
+    }
+
+    /// @dev Endorsed public-parameters update: stores the new PP, bumps the version, emits. Setup deltas
+    ///      carry no spends/outputs (§3.5); reject a malformed one rather than silently ignore.
+    function _applySetup(StateDelta calldata delta) private {
+        if (delta.spentRefs.length != 0 || delta.outputs.length != 0 || delta.setupParameters.length == 0) {
+            revert MalformedSetupDelta();
+        }
+        publicParameters = delta.setupParameters;
+        publicParamsHash = sha256(delta.setupParameters);
+        publicParamsVersion += 1; // first set is version 0 at initialize; endorsed updates go 1,2,...
+        emit PublicParametersUpdated(publicParamsHash, publicParamsVersion);
+    }
+
+    // --- queries -----------------------------------------------------------------------------------
+
+    function getToken(bytes32 tokenID) external view returns (bytes memory) {
+        return tokens[tokenID];
+    }
+
+    /// @notice Graph-revealing spent status by token id, resolved through the content-bound marker.
+    function isSpent(bytes32 tokenID) external view returns (bool) {
+        return snSpent[tokenMarker[tokenID]];
+    }
+
+    function areTokensSpent(bytes32[] calldata tokenIDs) external view returns (bool[] memory out) {
+        out = new bool[](tokenIDs.length);
+        for (uint256 i = 0; i < tokenIDs.length; i++) {
+            out[i] = snSpent[tokenMarker[tokenIDs[i]]];
+        }
+    }
+
+    function isSerialUsed(bytes32 serial) external view returns (bool) {
+        return serialUsed[serial];
+    }
+
+    function getPublicParameters() external view returns (bytes memory) {
+        return publicParameters;
+    }
+
+    function getPublicParamsVersion() external view returns (uint64) {
+        return publicParamsVersion;
+    }
+
+    function getPublicParamsHash() external view returns (bytes32) {
+        return publicParamsHash;
+    }
+
+    function getTransferMetadata(bytes32 key) external view returns (bytes memory) {
+        return transferMetadata[key];
+    }
+
+    function getTokenRequestHash(bytes32 anchor) external view returns (bytes32) {
+        return tokenRequestHashes[anchor];
+    }
+}

--- a/x/token/services/network/evm/contracts/test/TokenState.t.sol
+++ b/x/token/services/network/evm/contracts/test/TokenState.t.sol
@@ -214,6 +214,16 @@ contract TokenStateTest is Test {
         ts.applyStateDelta(d, _sign(d));
     }
 
+    function test_SetupDeltaCarryingMetadata_Reverts() public {
+        StateDelta memory d = _setup(keccak256("bad-setup-meta"), "pp-v1");
+        d.metadataKeys = new bytes32[](1);
+        d.metadataKeys[0] = keccak256("k1");
+        d.metadataVals = new bytes[](1);
+        d.metadataVals[0] = "v1";
+        vm.expectPartialRevert(TokenState.MalformedSetupDelta.selector);
+        ts.applyStateDelta(d, _sign(d));
+    }
+
     // --- public-parameters update (endorsed setup) -------------------------------------------------
 
     function test_Setup_UpdatesPublicParams() public {

--- a/x/token/services/network/evm/contracts/test/TokenState.t.sol
+++ b/x/token/services/network/evm/contracts/test/TokenState.t.sol
@@ -274,6 +274,28 @@ contract TokenStateTest is Test {
         assertEq(ts.getTransferMetadata(keccak256("k1")), bytes("v1"));
     }
 
+    function test_Metadata_ReusedKey_Reverts() public {
+        // Metadata keys are write-once (Fabric StateMustNotExist parity): a second delta writing the
+        // same key must fail the whole transaction, never overwrite the first value.
+        StateDelta memory d1 = _issue(keccak256("issue-m1"), "tok-A");
+        d1.metadataKeys = new bytes32[](1);
+        d1.metadataKeys[0] = keccak256("claim-key");
+        d1.metadataVals = new bytes[](1);
+        d1.metadataVals[0] = "v1";
+        ts.applyStateDelta(d1, _sign(d1));
+
+        StateDelta memory d2 = _issue(keccak256("issue-m2"), "tok-B");
+        d2.metadataKeys = new bytes32[](1);
+        d2.metadataKeys[0] = keccak256("claim-key");
+        d2.metadataVals = new bytes[](1);
+        d2.metadataVals[0] = "v2";
+        vm.expectPartialRevert(TokenState.MetadataKeyOccupied.selector);
+        ts.applyStateDelta(d2, _sign(d2));
+
+        // and the original value is untouched
+        assertEq(ts.getTransferMetadata(keccak256("claim-key")), bytes("v1"));
+    }
+
     function test_AreTokensSpent_Batch() public {
         bytes32 a1 = keccak256("issue-1");
         StateDelta memory i1 = _issue(a1, "tok-A");

--- a/x/token/services/network/evm/contracts/test/TokenState.t.sol
+++ b/x/token/services/network/evm/contracts/test/TokenState.t.sol
@@ -6,6 +6,7 @@ import {TokenState} from "../src/TokenState.sol";
 import {EndorsementVerifier} from "../src/EndorsementVerifier.sol";
 import {EIP712} from "../src/EIP712.sol";
 import {StateDelta, OutputToken} from "../src/StateDelta.sol";
+import {Clones} from "../src/Clones.sol";
 
 /// @title TokenState core tests (Week 2, PR 2b Phase A)
 /// @notice Exercises applyStateDelta end to end with real endorser signatures (forge vm.sign over the
@@ -14,6 +15,7 @@ import {StateDelta, OutputToken} from "../src/StateDelta.sol";
 ///         setup-delta guard. The Go<->Solidity signer cross-check comes in Week 3; here endorsers are
 ///         simulated with vm.sign, which is enough to prove the on-chain check-list.
 contract TokenStateTest is Test {
+    TokenState private impl;
     TokenState private ts;
     EndorsementVerifier private verifier;
 
@@ -29,7 +31,8 @@ contract TokenStateTest is Test {
         verifier = new EndorsementVerifier(endorsers, 2);
 
         pp0 = "pp-v0";
-        ts = new TokenState();
+        impl = new TokenState();
+        ts = TokenState(Clones.clone(address(impl))); // per-TMS clone, as in production
         ts.initialize(address(verifier), address(this), pp0, false); // graph-revealing
     }
 
@@ -72,14 +75,33 @@ contract TokenStateTest is Test {
     }
 
     function _digest(StateDelta memory d) internal view returns (bytes32) {
-        return EIP712.digest(EIP712.domainSeparator(block.chainid, address(ts)), EIP712.hashStruct(d));
+        return _digestFor(ts, d);
+    }
+
+    /// @dev The digest is bound to the contract address (domain separator), so signing must target the
+    ///      specific TokenState the delta will be applied to.
+    function _digestFor(TokenState t, StateDelta memory d) internal view returns (bytes32) {
+        return EIP712.digest(EIP712.domainSeparator(block.chainid, address(t)), EIP712.hashStruct(d));
     }
 
     function _sign(StateDelta memory d) internal view returns (bytes[] memory sigs) {
-        bytes32 digest = _digest(d);
+        return _signFor(ts, d);
+    }
+
+    function _signFor(TokenState t, StateDelta memory d) internal view returns (bytes[] memory sigs) {
+        bytes32 digest = _digestFor(t, d);
         sigs = new bytes[](2);
         sigs[0] = _one(keyA, digest);
         sigs[1] = _one(keyB, digest);
+    }
+
+    function _setup(bytes32 anchor, bytes memory newPP) internal view returns (StateDelta memory d) {
+        d.anchor = anchor;
+        d.isSetup = true;
+        d.setupParameters = newPP;
+        d.tokenRequestHash = keccak256(abi.encodePacked("setup", anchor));
+        d.publicParamsHash = sha256(pp0); // asserts the current params being replaced
+        d.publicParamsVersion = 0;
     }
 
     function _one(uint256 key, bytes32 digest) internal pure returns (bytes memory) {
@@ -192,6 +214,104 @@ contract TokenStateTest is Test {
         ts.applyStateDelta(d, _sign(d));
     }
 
+    // --- public-parameters update (endorsed setup) -------------------------------------------------
+
+    function test_Setup_UpdatesPublicParams() public {
+        StateDelta memory d = _setup(keccak256("setup-1"), "pp-v1");
+        assertTrue(ts.applyStateDelta(d, _sign(d)));
+
+        assertEq(ts.getPublicParamsVersion(), 1);
+        assertEq(ts.getPublicParameters(), bytes("pp-v1"));
+        assertEq(ts.getPublicParamsHash(), sha256(bytes("pp-v1")));
+    }
+
+    function test_Setup_ThenOldVersionTransferIsStale() public {
+        StateDelta memory setup = _setup(keccak256("setup-1"), "pp-v1");
+        ts.applyStateDelta(setup, _sign(setup));
+
+        // a transfer validated against v0 is now stale
+        StateDelta memory old = _issue(keccak256("issue-old"), "tok");
+        vm.expectPartialRevert(TokenState.StalePublicParams.selector);
+        ts.applyStateDelta(old, _sign(old));
+
+        // the same transfer validated against v1 applies
+        StateDelta memory cur = _issue(keccak256("issue-cur"), "tok");
+        cur.publicParamsHash = sha256(bytes("pp-v1"));
+        cur.publicParamsVersion = 1;
+        assertTrue(ts.applyStateDelta(cur, _sign(cur)));
+    }
+
+    function test_Setup_StaleSecondSetupReverts() public {
+        StateDelta memory s1 = _setup(keccak256("setup-1"), "pp-v1");
+        ts.applyStateDelta(s1, _sign(s1));
+
+        // a second setup still validated against v0 is out of order and rejected
+        StateDelta memory s2 = _setup(keccak256("setup-2"), "pp-v2");
+        vm.expectPartialRevert(TokenState.StalePublicParams.selector);
+        ts.applyStateDelta(s2, _sign(s2));
+    }
+
+    // --- queries -----------------------------------------------------------------------------------
+
+    function test_Metadata_Stored() public {
+        StateDelta memory d = _issue(keccak256("issue-meta"), "tok-A");
+        d.metadataKeys = new bytes32[](1);
+        d.metadataKeys[0] = keccak256("k1");
+        d.metadataVals = new bytes[](1);
+        d.metadataVals[0] = "v1";
+        ts.applyStateDelta(d, _sign(d));
+
+        assertEq(ts.getTransferMetadata(keccak256("k1")), bytes("v1"));
+    }
+
+    function test_AreTokensSpent_Batch() public {
+        bytes32 a1 = keccak256("issue-1");
+        StateDelta memory i1 = _issue(a1, "tok-A");
+        ts.applyStateDelta(i1, _sign(i1));
+
+        bytes32 a2 = keccak256("issue-2");
+        StateDelta memory i2 = _issue(a2, "tok-B");
+        ts.applyStateDelta(i2, _sign(i2));
+
+        // spend the first token only
+        StateDelta memory spend = _spend(keccak256("t1"), _marker(a1, 0, "tok-A"), "tok-C");
+        ts.applyStateDelta(spend, _sign(spend));
+
+        bytes32[] memory ids = new bytes32[](2);
+        ids[0] = _tokenID(a1, 0);
+        ids[1] = _tokenID(a2, 0);
+        bool[] memory spent = ts.areTokensSpent(ids);
+        assertTrue(spent[0]);
+        assertFalse(spent[1]);
+    }
+
+    function test_GraphHiding_SpendBySerial() public {
+        TokenState gh = TokenState(Clones.clone(address(impl)));
+        gh.initialize(address(verifier), address(this), pp0, true);
+
+        bytes32 serial = keccak256("serial-1");
+        StateDelta memory d;
+        d.anchor = keccak256("gh-1");
+        d.spentRefs = new bytes32[](1);
+        d.spentRefs[0] = serial;
+        d.tokenRequestHash = keccak256("req");
+        d.publicParamsHash = sha256(pp0);
+        d.publicParamsVersion = 0;
+        gh.applyStateDelta(d, _signFor(gh, d));
+        assertTrue(gh.isSerialUsed(serial));
+
+        // reusing the same serial is a double spend
+        StateDelta memory d2;
+        d2.anchor = keccak256("gh-2");
+        d2.spentRefs = new bytes32[](1);
+        d2.spentRefs[0] = serial;
+        d2.tokenRequestHash = keccak256("req");
+        d2.publicParamsHash = sha256(pp0);
+        d2.publicParamsVersion = 0;
+        vm.expectPartialRevert(TokenState.DoubleSpend.selector);
+        gh.applyStateDelta(d2, _signFor(gh, d2));
+    }
+
     // --- lifecycle guards --------------------------------------------------------------------------
 
     function test_DoubleInitialize_Reverts() public {
@@ -199,8 +319,14 @@ contract TokenStateTest is Test {
         ts.initialize(address(verifier), address(this), pp0, false);
     }
 
+    function test_ImplementationIsLocked() public {
+        // the shared implementation is locked in its constructor; only clones can be initialized
+        vm.expectRevert(TokenState.AlreadyInitialized.selector);
+        impl.initialize(address(verifier), address(this), pp0, false);
+    }
+
     function test_Uninitialized_Reverts() public {
-        TokenState fresh = new TokenState();
+        TokenState fresh = TokenState(Clones.clone(address(impl)));
         StateDelta memory d = _issue(keccak256("x"), "tok-A");
         vm.expectRevert(TokenState.NotInitialized.selector);
         fresh.applyStateDelta(d, _sign(d));

--- a/x/token/services/network/evm/contracts/test/TokenState.t.sol
+++ b/x/token/services/network/evm/contracts/test/TokenState.t.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {TokenState} from "../src/TokenState.sol";
+import {EndorsementVerifier} from "../src/EndorsementVerifier.sol";
+import {EIP712} from "../src/EIP712.sol";
+import {StateDelta, OutputToken} from "../src/StateDelta.sol";
+
+/// @title TokenState core tests (Week 2, PR 2b Phase A)
+/// @notice Exercises applyStateDelta end to end with real endorser signatures (forge vm.sign over the
+///         EIP-712 digest TokenState itself computes): issue, spend, double-spend, forged-content
+///         rejection via the content-bound marker, stale public params, replay, tampering, and the
+///         setup-delta guard. The Go<->Solidity signer cross-check comes in Week 3; here endorsers are
+///         simulated with vm.sign, which is enough to prove the on-chain check-list.
+contract TokenStateTest is Test {
+    TokenState private ts;
+    EndorsementVerifier private verifier;
+
+    uint256 private constant keyA = 0xA11CE;
+    uint256 private constant keyB = 0xB0B;
+
+    bytes private pp0;
+
+    function setUp() public {
+        address[] memory endorsers = new address[](2);
+        endorsers[0] = vm.addr(keyA);
+        endorsers[1] = vm.addr(keyB);
+        verifier = new EndorsementVerifier(endorsers, 2);
+
+        pp0 = "pp-v0";
+        ts = new TokenState();
+        ts.initialize(address(verifier), address(this), pp0, false); // graph-revealing
+    }
+
+    // --- key derivations (mirror x/.../evm/keys) ---------------------------------------------------
+
+    function _tokenID(bytes32 anchor, uint256 index) internal pure returns (bytes32) {
+        return keccak256(abi.encode(anchor, index));
+    }
+
+    function _marker(bytes32 anchor, uint256 index, bytes memory tokenData) internal pure returns (bytes32) {
+        return keccak256(abi.encode(anchor, index, keccak256(tokenData)));
+    }
+
+    // --- delta builders / signing ------------------------------------------------------------------
+
+    function _issue(bytes32 anchor, bytes memory tokenData) internal view returns (StateDelta memory d) {
+        d.anchor = anchor;
+        d.outputs = new OutputToken[](1);
+        d.outputs[0] =
+            OutputToken({tokenID: _tokenID(anchor, 0), snMarker: _marker(anchor, 0, tokenData), tokenData: tokenData});
+        d.tokenRequestHash = keccak256(abi.encodePacked("req", anchor));
+        d.publicParamsHash = sha256(pp0);
+        d.publicParamsVersion = 0;
+    }
+
+    function _spend(bytes32 anchor, bytes32 spentMarker, bytes memory newData)
+        internal
+        view
+        returns (StateDelta memory d)
+    {
+        d.anchor = anchor;
+        d.spentRefs = new bytes32[](1);
+        d.spentRefs[0] = spentMarker;
+        d.outputs = new OutputToken[](1);
+        d.outputs[0] =
+            OutputToken({tokenID: _tokenID(anchor, 0), snMarker: _marker(anchor, 0, newData), tokenData: newData});
+        d.tokenRequestHash = keccak256(abi.encodePacked("req", anchor));
+        d.publicParamsHash = sha256(pp0);
+        d.publicParamsVersion = 0;
+    }
+
+    function _digest(StateDelta memory d) internal view returns (bytes32) {
+        return EIP712.digest(EIP712.domainSeparator(block.chainid, address(ts)), EIP712.hashStruct(d));
+    }
+
+    function _sign(StateDelta memory d) internal view returns (bytes[] memory sigs) {
+        bytes32 digest = _digest(d);
+        sigs = new bytes[](2);
+        sigs[0] = _one(keyA, digest);
+        sigs[1] = _one(keyB, digest);
+    }
+
+    function _one(uint256 key, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // --- happy paths -------------------------------------------------------------------------------
+
+    function test_Issue_StoresTokenAndMarker() public {
+        bytes32 anchor = keccak256("issue-1");
+        StateDelta memory d = _issue(anchor, "tok-A");
+        assertTrue(ts.applyStateDelta(d, _sign(d)));
+
+        bytes32 id = _tokenID(anchor, 0);
+        assertEq(ts.getToken(id), bytes("tok-A"));
+        assertFalse(ts.isSpent(id));
+        assertEq(ts.getTokenRequestHash(anchor), d.tokenRequestHash);
+    }
+
+    function test_Spend_MarksInputSpent() public {
+        bytes32 a1 = keccak256("issue-1");
+        StateDelta memory issue = _issue(a1, "tok-A");
+        ts.applyStateDelta(issue, _sign(issue));
+
+        bytes32 a2 = keccak256("transfer-1");
+        StateDelta memory spend = _spend(a2, _marker(a1, 0, "tok-A"), "tok-B");
+        assertTrue(ts.applyStateDelta(spend, _sign(spend)));
+
+        // the originally-issued token is now spent (resolved via its content-bound marker)
+        assertTrue(ts.isSpent(_tokenID(a1, 0)));
+        assertEq(ts.getToken(_tokenID(a2, 0)), bytes("tok-B"));
+    }
+
+    // --- security: double spend / forged content / tamper ------------------------------------------
+
+    function test_DoubleSpend_Reverts() public {
+        bytes32 a1 = keccak256("issue-1");
+        StateDelta memory issue = _issue(a1, "tok-A");
+        ts.applyStateDelta(issue, _sign(issue));
+
+        bytes32 marker = _marker(a1, 0, "tok-A");
+        StateDelta memory s1 = _spend(keccak256("t1"), marker, "tok-B");
+        ts.applyStateDelta(s1, _sign(s1));
+
+        StateDelta memory s2 = _spend(keccak256("t2"), marker, "tok-C");
+        vm.expectPartialRevert(TokenState.InputMissingOrSpent.selector);
+        ts.applyStateDelta(s2, _sign(s2));
+    }
+
+    function test_ForgedContent_Reverts() public {
+        // Issue a token with content "real". A spend that references a marker computed from *different*
+        // bytes at the same (anchor,index) points at a marker that was never recorded, so it is rejected.
+        bytes32 a1 = keccak256("issue-1");
+        StateDelta memory issue = _issue(a1, "real");
+        ts.applyStateDelta(issue, _sign(issue));
+
+        bytes32 forgedMarker = _marker(a1, 0, "forged");
+        StateDelta memory spend = _spend(keccak256("t1"), forgedMarker, "tok-B");
+        vm.expectPartialRevert(TokenState.InputMissingOrSpent.selector);
+        ts.applyStateDelta(spend, _sign(spend));
+    }
+
+    function test_TamperedDelta_FailsVerification() public {
+        bytes32 anchor = keccak256("issue-1");
+        StateDelta memory d = _issue(anchor, "tok-A");
+        bytes[] memory sigs = _sign(d); // signatures over the original delta
+
+        // Mutate a digest-covered field after signing: the contract recomputes the digest, the recovered
+        // signers no longer match the endorser set, and verification fails (no blind-signing on-chain).
+        d.outputs[0].tokenData = "tampered";
+        vm.expectRevert(); // UnauthorizedSigner (recovered address is not an endorser)
+        ts.applyStateDelta(d, sigs);
+    }
+
+    // --- public params / replay / auth -------------------------------------------------------------
+
+    function test_StalePublicParams_Reverts() public {
+        bytes32 anchor = keccak256("issue-1");
+        StateDelta memory d = _issue(anchor, "tok-A");
+        d.publicParamsVersion = 1; // current is 0
+        vm.expectPartialRevert(TokenState.StalePublicParams.selector);
+        ts.applyStateDelta(d, _sign(d));
+    }
+
+    function test_Replay_Reverts() public {
+        bytes32 anchor = keccak256("issue-1");
+        StateDelta memory d = _issue(anchor, "tok-A");
+        ts.applyStateDelta(d, _sign(d));
+        vm.expectPartialRevert(TokenState.AnchorAlreadyProcessed.selector);
+        ts.applyStateDelta(d, _sign(d));
+    }
+
+    function test_InsufficientSignatures_Reverts() public {
+        bytes32 anchor = keccak256("issue-1");
+        StateDelta memory d = _issue(anchor, "tok-A");
+        bytes[] memory one = new bytes[](1);
+        one[0] = _one(keyA, _digest(d));
+        vm.expectPartialRevert(EndorsementVerifier.InsufficientEndorsements.selector);
+        ts.applyStateDelta(d, one);
+    }
+
+    // --- setup-delta guard (full PP-update flow is PR 2b Phase B) -----------------------------------
+
+    function test_SetupDeltaCarryingOutputs_Reverts() public {
+        StateDelta memory d = _issue(keccak256("bad-setup"), "tok-A");
+        d.isSetup = true;
+        d.setupParameters = "pp-v1";
+        vm.expectPartialRevert(TokenState.MalformedSetupDelta.selector);
+        ts.applyStateDelta(d, _sign(d));
+    }
+
+    // --- lifecycle guards --------------------------------------------------------------------------
+
+    function test_DoubleInitialize_Reverts() public {
+        vm.expectRevert(TokenState.AlreadyInitialized.selector);
+        ts.initialize(address(verifier), address(this), pp0, false);
+    }
+
+    function test_Uninitialized_Reverts() public {
+        TokenState fresh = new TokenState();
+        StateDelta memory d = _issue(keccak256("x"), "tok-A");
+        vm.expectRevert(TokenState.NotInitialized.selector);
+        fresh.applyStateDelta(d, _sign(d));
+    }
+}

--- a/x/token/services/network/evm/eth_network_driver_design.md
+++ b/x/token/services/network/evm/eth_network_driver_design.md
@@ -254,11 +254,15 @@ no read-set, so `applyStateDelta` performs these checks itself, in this order, r
      && !snSpent[ref])` — else `InputMissingOrSpent`. Existence of the marker proves the spent token has the
      exact bytes recorded at creation, so forged content is rejected.
    - if `graphHiding`: for each `ref`, `require(!serialUsed[ref])` — else `DoubleSpend`.
-5. Apply (all-or-nothing): for each `ref` set `snSpent[ref]=true` (graph-revealing) or `serialUsed[ref]=true`
+5. Metadata keys are **write-once**: `require(!metadataExists[k])` for each — else `MetadataKeyOccupied`.
+   (Verified 2026-07-11: the Fabric translator enforces `StateMustNotExist` on every issue/transfer metadata
+   key, `translator.go:351/413` — a reused key, e.g. an htlc claim key seen twice, is a validation failure,
+   never an overwrite. With no MVCC the contract must re-check it, same as the spent/existence checks.)
+6. Apply (all-or-nothing): for each `ref` set `snSpent[ref]=true` (graph-revealing) or `serialUsed[ref]=true`
    (graph-hiding); for each output store `tokens[out.tokenID]=out.tokenData` and record `snExists[out.snMarker]=true`;
-   `transferMetadata[k]=v` for metadata; `tokenRequestHash[anchor]=delta.tokenRequestHash`;
+   `metadataExists[k]=true` + `transferMetadata[k]=v` for metadata; `tokenRequestHash[anchor]=delta.tokenRequestHash`;
    `processedAnchor[anchor]=true`.
-6. `emit StateCommitted(anchor, true, "")`.
+7. `emit StateCommitted(anchor, true, "")`.
 
 `AreTokensSpent(txid, index)` for graph-revealing resolves the token content via `getToken(ComputeTokenID(...))`,
 recomputes `OutputSNMarker(anchor, index, content)`, and returns `snSpent[marker]`.
@@ -626,8 +630,18 @@ timeout is the recipient's only failure signal and must be configured accordingl
 - **Endorser identity**: secp256k1; Ethereum address = `keccak256(pubkey)[12:]`; registered in
   EndorsementVerifier; bound to an FSC `view.Identity` (§6.1). secp256k1 signing is wired in the driver;
   integrating it into FSC's signer/identity services is real work, not assumed trivial.
+  **Address-derivation precision (byte-format traps, 2026-07-11):** the hash input is the 64-byte
+  uncompressed public key `X ‖ Y` **without** the leading `0x04` byte —
+  `SerializeUncompressed()` returns 65 bytes starting with `0x04`, so strip it before hashing; hashing all 65
+  bytes yields a wrong (but plausible-looking) address. Take bytes `[12:32]` of the keccak digest.
 - **Signer** (`evm/eip712`): produces 65-byte `{r,s,v}`, `v ∈ {27,28}`, low-s normalized; uses
   `decred/secp256k1` + `x/crypto/sha3` (no go-ethereum).
+  **Wire-format precision:** decred's `ecdsa.SignCompact` returns 65 bytes with the recovery byte FIRST
+  (`27+recid`, `+4` if compressed — always sign with `compressed=false` so v stays in `{27,28}`), i.e.
+  `{v,r,s}`; the Ethereum/contract wire format is `{r,s,v}` with v LAST, so the signer must reorder.
+  dcrd signatures are canonical (low-s) by construction, but the signer asserts low-s anyway so a library
+  change cannot silently reintroduce malleable signatures. Round-trip test: sign → on-chain-style `ecrecover`
+  recovery → expected address.
 - **Submitter / NonceManager**: per submitter address; explicit `initialized bool` (never use `nonce == 0` as
   "uninitialized"); tracks in-flight nonces; `RecoverNonce` re-syncs from `PendingNonceAt` and is wired into
   the retry path. A submitter shared across processes needs external coordination (`PendingNonceAt` does not
@@ -749,7 +763,7 @@ Typed sentinel errors with `errors.Is` classification (using `fabric-smart-clien
 | Error | Class | Recovery |
 |------|-------|----------|
 | `ErrInsufficientEndorsements`, `ErrInvalidSignature` | permanent | reject |
-| `ErrDoubleSpend`, `ErrInputMissingOrSpent`, `ErrStalePublicParams` | permanent | reject (re-derive request) |
+| `ErrDoubleSpend`, `ErrInputMissingOrSpent`, `ErrStalePublicParams`, `ErrMetadataKeyOccupied` | permanent | reject (re-derive request) |
 | `ErrNetworkUnavailable`, `ErrNonceConflict` | transient | backoff retry (nonce: re-sync then retry) |
 | `ErrTransactionReverted` | permanent | map to `Invalid` via receipt |
 | `ErrFinalityTimeout` | transient | continue polling within timeout |

--- a/x/token/services/network/evm/eth_network_driver_design.md
+++ b/x/token/services/network/evm/eth_network_driver_design.md
@@ -317,8 +317,17 @@ function computeTokenID(bytes32 anchor, uint256 index) internal pure returns (by
 
 Per-TMS full-bytecode deployment is costly. Decision (§15.4): deploy one shared `TokenState` implementation +
 one `EndorsementVerifier`, then create a per-TMS `TokenState` via **EIP-1167 minimal proxy (clone)** with an
-`initialize(verifier, deployer, pp0, endorsers, threshold)` initializer. Minimal clones are cheap and do
-**not** introduce upgradeability (which stays out of scope). NWO/forge scripts perform deployment.
+`initialize(verifier, deployer, pp0, graphHiding)` initializer. Minimal clones are cheap and do
+**not** introduce upgradeability (which stays out of scope). The shared implementation locks itself in its
+constructor so only clones can ever be initialized (PR 2b). NWO/forge scripts perform deployment.
+
+**Initializer front-running (2026-07-11 review):** clone creation and `initialize` are separate transactions
+in the current deploy script, so on a shared/public chain an attacker could initialize the clone first with
+their own verifier and endorser set (nothing binds `initialize` to the deployer). On the permissioned Besu
+target this is a low, but nonzero, risk. Production hardening (plan Week 6, deploy hardening): a small factory
+contract whose `create(...)` clones AND initializes in one transaction, making the window impossible; until
+then the deploy script must verify post-initialize state (verifier address, PP hash, graphHiding) before
+recording the clone address as the TMS contract.
 
 ### 3.9 Transaction model / batching
 
@@ -462,6 +471,14 @@ Counter handling and ordering per §4.4.
   version keeper synced; return `[]token.ServiceOption{WithNetwork, WithChannel(""), WithNamespace}`.
 - `ComputeTxID(id)` → `hex(SHA-256(lenPrefix(id.Nonce) ‖ id.Creator))` = `TokenRequestAnchor`. Length-safe
   (no raw append), independent of chainID/contract and of the eth tx hash.
+  **Mutating contract (verified against FSC 2026-07-11, critical):** callers pass `id` with an EMPTY nonce
+  and rely on the driver to fill it. FSC's `transaction.ComputeTxID` generates a random 24-byte nonce when
+  `id.Nonce` is empty and writes it back into the caller's struct, and the Fabric driver copies the
+  nonce/creator back too (`fabric/network.go:350`). The EVM driver must do the same: if `id.Nonce` is empty,
+  generate a fresh cryptographically random nonce and assign it to `id.Nonce` before hashing. A pure/read-only
+  implementation would derive the SAME anchor for every transaction of a creator, and the second transaction
+  ever submitted would revert with `AnchorAlreadyProcessed` (the driver deadlocks in production while passing
+  single-transaction demos).
 - `NewEnvelope()` → empty `*Envelope`.
 - `Broadcast(ctx, blob)` → assert `*Envelope`; `client.SendRawTransaction(rawTx)`; record eth tx hash;
   `finality.Track(anchor, ethTxHash)`.
@@ -559,6 +576,13 @@ Primary signal (Besu / any standard node): poll the **receipt** together with
 - `blockNumber` set → fetch receipt: status 1 ⇒ `Valid`, status 0 ⇒ `Invalid`.
 - tx unknown (never seen / evicted) → `dropped` (treat as `Invalid` after timeout).
 
+**Mapping to SDK status codes (verified vs `network/driver/vault.go`, 2026-07-11):** the SDK's
+`driver.ValidationCode` values are `Valid=1`, `Invalid=2`, `Busy=3`, `Unknown=4` — zero is NOT a valid code.
+`GetTransactionStatus` and the finality listeners must return: receipt status 1 → `driver.Valid`; receipt
+status 0 → `driver.Invalid`; tx known but unmined → `driver.Busy`; anchor/tx never seen → `driver.Unknown`
+(escalating to `driver.Invalid` only after the configured finality timeout). Do not conflate the EVM
+receipt-status integers (1/0) with the SDK codes.
+
 The `EVMClient.IsPending(txHash) (pending, found, err)` method already abstracts this: on Besu it is backed by
 `eth_getTransactionByHash` (`found=false` ⇒ dropped, `blockNumber==nil` ⇒ pending); on the fabric-x-evm
 stretch it is backed by the gateway, which additionally exposes the `pending → in-progress → committed |
@@ -587,6 +611,13 @@ A recipient who only saw the token request knows the `anchor`, not the eth tx ha
 on the initiator's cache: search logs for `StateCommitted(bytes32 indexed anchor, …)` on the configured
 TokenState clone → extract the eth tx hash from the log → receipt/finality → `getTokenRequestHash(anchor)`.
 `AddFinalityListener(ns, anchor, listener)` notifies immediately if already final, else once on transition.
+
+**Asymmetry (2026-07-11 review): a recipient can never observe `Invalid` from chain data alone.** A failed
+`applyStateDelta` REVERTS, so no `StateCommitted` log is ever emitted for that anchor — log scanning by anchor
+only ever discovers success. For an anchor-only listener, `Invalid` is therefore reachable exclusively via the
+finality timeout (or via the initiator sharing the eth tx hash out of band, which the design deliberately does
+not rely on). Recipient-side listeners must treat "no `StateCommitted` log by the timeout" as `Invalid`; the
+timeout is the recipient's only failure signal and must be configured accordingly (§10 `finality.timeout`).
 
 ---
 

--- a/x/token/services/network/evm/eth_network_driver_implementation_plan.md
+++ b/x/token/services/network/evm/eth_network_driver_implementation_plan.md
@@ -195,7 +195,9 @@ one-list model; his one-line ack on the input-identity read is the only outstand
     TokenState (a per-TMS clone) owns the domain separator (binds `verifyingContract=address(this)`), so it
     computes the digest; a shared/decoupled verifier cannot. Avoids a verifier↔TokenState address
     chicken-and-egg. Design §3.2 updated to match.
-- **PR 2b — TokenState + deploy** (the state machine on the proven crypto) — ✅ DONE, 39/39 forge tests:
+- **PR 2b — TokenState + deploy** (the state machine on the proven crypto) — ✅ DONE, 41/41 forge tests
+  (incl. the 2026-07-11 pre-Week-3 fix: metadata keys are **write-once** on-chain, `MetadataKeyOccupied` —
+  Fabric `StateMustNotExist` parity the §3.4 check-list had missed):
   - [x] Phase A: `TokenState.sol` storage §3.1 + `applyStateDelta` §3.4 (computes `hashStruct`+digest via the
     PR-2a library, calls `verifier.verify(digest, sigs)`) + 11 core tests: issue/spend, double-spend,
     **forged-content spend rejected by `snMarker`**, tampered-delta fails verification, stale-PP, replay,
@@ -274,8 +276,15 @@ on-chain; a forged-content spend (real `tokenID`, different `tokenData`) is reje
       `TokenRequestHash` = `crypto.SHA256(request)`, `PublicParamsHash` = `crypto.SHA256(pp)`.
 - [ ] Exact counter (issue `+= len(outputs)`, transfer `+= NumOutputs()`, redeem skipped) + canonical
       ordering (sort metadata by key) so all endorsers emit byte-identical deltas; call `delta.Validate()`.
+      (Counter rules verified against `translator.go:359/421` on 2026-07-11. Also verified: the responder
+      template drives exactly `Write(action)` → `AddPublicParamsDependency()` → `CommitTokenRequest(raw,
+      true)`, `fsc/responder.go:277-285` — keep the §5.2 surface identical.)
 - [ ] `eip712/signer.go`: secp256k1 sign/verify (`decred/secp256k1`), 65-byte `{r,s,v}`, low-s, address
       derivation `keccak256(pubkey)[12:]`; add `decred/dcrd/dcrec/secp256k1/v4` to `go.mod` here (first use).
+      **Byte-format traps (design §8, 2026-07-11):** decred `SignCompact` returns `{v,r,s}` (recovery byte
+      FIRST) — reorder to `{r,s,v}`; sign with `compressed=false` so `v ∈ {27,28}`; address input is the
+      64-byte uncompressed pubkey WITHOUT the `0x04` prefix (strip `SerializeUncompressed()[0]`); assert
+      low-s even though dcrd is canonical, so a library change cannot reintroduce malleability.
 - [ ] Unit tests: translator determinism (shuffled metadata → identical bytes), key parity with `keys`, signer
       round-trip/recovery vectors (sign digest → recover expected address), and the **content-binding
       round-trip** — a token created as an output at `(anchor, index)` yields, when later spent as an input, a

--- a/x/token/services/network/evm/eth_network_driver_implementation_plan.md
+++ b/x/token/services/network/evm/eth_network_driver_implementation_plan.md
@@ -310,9 +310,17 @@ Gate: 2-of-N endorsement (mocked FSC sessions) assembles a tx whose sigs verify 
       decodable by `keys.AnchorFromTxID` (round-trip test); `NonceManager` (init flag+recovery); `ledger.go`,
       `envelope.go`. `AreTokensSpent` (graph-revealing) resolves through the **content-bound marker** per the
       Week-2 query-surface decision (§5.3), not `isSpent(ComputeTokenID)` — see the Week-2 note.
+      **`ComputeTxID` is MUTATING (verified vs FSC 2026-07-11, see design §5.3):** when `id.Nonce` is empty it
+      must generate a fresh random nonce (FSC uses 24 bytes) and write it back into `id` before hashing —
+      that is the contract the fabric driver and FSC implement and the ttx layer depends on. Tests: two calls
+      with an empty-nonce `id` produce different anchors; the generated nonce is written back; a caller-set
+      nonce is respected and round-trips.
 - [ ] `finality/manager.go` **baseline**: receipt polling at `finalized`; reuse `OnlyOnceListener` + event
       queue; `StateCommitted` indexed-log resolution (recipient-side); wire `AddFinalityListener`/
-      `GetTransactionStatus` + `getTokenRequestHash`.
+      `GetTransactionStatus` + `getTokenRequestHash`. **Status mapping (verified vs `driver/vault.go`
+      2026-07-11):** return the SDK's `driver.ValidationCode` values — `Valid=1`, `Invalid=2`, `Busy=3`,
+      `Unknown=4` (0 is not a code). Receipt status 1 → `Valid`; receipt status 0 → `Invalid`; tx known but
+      unmined → `Busy`; anchor/tx never seen → `Unknown` (then `Invalid` after the configured timeout).
 - [ ] `driver.go` `NewDriver(...)` finalized DI (model `fabric/driver.go:119`); SDK module provides EVM services.
 
 Gate: with the real client against anvil, issue→transfer round-trips RequestApproval→Broadcast→finality; the
@@ -333,6 +341,10 @@ container resolves the real driver.
 - [ ] **Admin deployment runbook** (Angelo, Wk6 deliverable): enumerated bootstrap steps — deploy verifier +
       TokenState clone, seed PP v0, register endorser set + threshold + `graphHiding`. This doc becomes the
       spec the forge/NWO deploy scripts automate.
+- [ ] **Deploy hardening (2026-07-11 review, design §3.8):** close the clone→`initialize` front-running
+      window — add a small factory contract that clones and initializes the TokenState in ONE transaction;
+      until it lands, `Deploy.s.sol` must read back and assert the post-initialize state (verifier address,
+      PP hash, `graphHiding`) before recording the clone address.
 - [ ] `Makefile` target `integration-tests-evm`.
 - [ ] `integration/token/evm/evm_test.go` (Ginkgo) — **fabtoken on Besu**, reusing the existing fungible
       `dlog` test bodies retargeted at the EVM topology: issue, transfer, double-spend reject, sub-threshold

--- a/x/token/services/network/evm/eth_network_driver_implementation_plan.md
+++ b/x/token/services/network/evm/eth_network_driver_implementation_plan.md
@@ -195,13 +195,16 @@ one-list model; his one-line ack on the input-identity read is the only outstand
     TokenState (a per-TMS clone) owns the domain separator (binds `verifyingContract=address(this)`), so it
     computes the digest; a shared/decoupled verifier cannot. Avoids a verifier↔TokenState address
     chicken-and-egg. Design §3.2 updated to match.
-- **PR 2b — TokenState + deploy + integration** (the state machine on the proven crypto):
-  - Phase A: `TokenState.sol` storage §3.1 + `applyStateDelta` §3.4 (computes `hashStruct`+digest via the
-    PR-2a library, calls `verifier.verify(digest, sigs)`) + core tests (Go-signed delta verifies on-chain;
-    double-spend; forged-content spend rejected by `snMarker`).
-  - Phase B: PP/setup lifecycle (SHA-256 precompile `0x02`, version bump first=0/then+1), queries (with the
-    §5.3 `isSpent` query-surface decision — recommend option (a): `tokenID → spent` map), events, deploy
-    script + `stale-PP`/`PP-update` integration tests.
+- **PR 2b — TokenState + deploy** (the state machine on the proven crypto) — ✅ DONE, 39/39 forge tests:
+  - [x] Phase A: `TokenState.sol` storage §3.1 + `applyStateDelta` §3.4 (computes `hashStruct`+digest via the
+    PR-2a library, calls `verifier.verify(digest, sigs)`) + 11 core tests: issue/spend, double-spend,
+    **forged-content spend rejected by `snMarker`**, tampered-delta fails verification, stale-PP, replay,
+    insufficient sigs, init guards. (Endorsers are simulated with forge `vm.sign`; the Go↔Solidity *signer*
+    cross-check is Week 3, the NWO end-to-end is Week 6.)
+  - [x] Phase B: PP/setup lifecycle (setup delta bumps version 0→1→…, `PublicParametersUpdated`, stale
+    ordering), queries with the §5.3 option-(a) `tokenID → marker` map (`isSpent`/`areTokensSpent` single
+    call), graph-hiding serial path, metadata; `Clones.sol` (EIP-1167) + `script/Deploy.s.sol` (verifier +
+    impl + initialized clone; **dry-run deploys end-to-end**) + implementation-lock hardening.
 
 Frozen contract from Week 1 (do not deviate): the Solidity `StateDelta`/`OutputToken` structs must use the
 **exact field names, types and order** of the EIP-712 type in `eip712/hashstruct.go` — note


### PR DESCRIPTION
Second half of week 2, stacked on #1879. This adds TokenState, the contract that holds token state and applies the endorsed deltas.

applyStateDelta verifies the endorser quorum over the digest it computes, checks the public params version, checks spent and existence (per the graphHiding flag), then writes everything atomically. Anything off reverts.

Worth calling out:
- graph-revealing spends reference the content-bound marker, so forged bytes at a real position get rejected. Proven on chain in the tests.
- public params updates go through an endorsed setup delta that bumps the version, and older deltas go stale.
- each TMS gets its own TokenState as an EIP-1167 clone of a shared, locked implementation. Deploy.s.sol sets it up.

40 forge tests cover the happy paths and the failure cases: issue, transfer, double spend, forged content, tampering, stale params, replay, the setup flow, queries, and graph hiding.

Endorsers are simulated with forge vm.sign for now. The Go signer cross-check is week 3, and the end to end run on Besu is week 6.

Stacked on #1879, so please review that one first.
