### PR TITLE
Remove redundant indexes that duplicate primary keys

### DIFF
--- a/token/services/storage/db/sql/common/identity.go
+++ b/token/services/storage/db/sql/common/identity.go
@@ -535,7 +535,6 @@ func (db *IdentityStore) GetSchema() string {
 			PRIMARY KEY(id, type, url)
 		);
 		CREATE INDEX IF NOT EXISTS idx_ic_type_%s ON %s ( type );
-		CREATE INDEX IF NOT EXISTS idx_ic_id_type_%s ON %s ( id, type, url );
 
 		-- IdentityInfo
 		CREATE TABLE IF NOT EXISTS %s (
@@ -545,7 +544,6 @@ func (db *IdentityStore) GetSchema() string {
 			token_metadata BYTEA,
 			token_metadata_audit_info BYTEA
 		);
-		CREATE INDEX IF NOT EXISTS idx_audits_%s ON %s ( identity_hash );
 
 		-- Signers
 		CREATE TABLE IF NOT EXISTS %s (
@@ -553,15 +551,11 @@ func (db *IdentityStore) GetSchema() string {
 			identity BYTEA NOT NULL,
 			info BYTEA
 		);
-		CREATE INDEX IF NOT EXISTS idx_signers_%s ON %s ( identity_hash );
 		`,
 		db.table.IdentityConfigurations,
 		db.table.IdentityConfigurations, db.table.IdentityConfigurations,
-		db.table.IdentityConfigurations, db.table.IdentityConfigurations,
 		db.table.IdentityInfo,
-		db.table.IdentityInfo, db.table.IdentityInfo,
 		db.table.Signers,
-		db.table.Signers, db.table.Signers,
 	)
 }
 

--- a/token/services/storage/db/sql/common/tokens.go
+++ b/token/services/storage/db/sql/common/tokens.go
@@ -1334,7 +1334,6 @@ func (db *TokenStore) GetSchema() string {
 			PRIMARY KEY (tx_id, idx)
 		);
 		CREATE INDEX IF NOT EXISTS idx_spent_%s ON %s ( is_deleted, owner );
-		CREATE INDEX IF NOT EXISTS idx_tx_id_%s ON %s ( tx_id );
 		CREATE INDEX IF NOT EXISTS idx_owner_wallet_id_%s ON %s ( owner_wallet_id );
 		CREATE INDEX IF NOT EXISTS idx_owner_wallet_part_%s ON %s ( owner_wallet_id, token_type ) WHERE is_deleted = false AND owner = true;
 
@@ -1378,7 +1377,6 @@ func (db *TokenStore) GetSchema() string {
 		`,
 		db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests, db.table.Requests,
 		db.table.Tokens,
-		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,
 		db.table.Tokens, db.table.Tokens,

--- a/token/services/storage/db/sql/common/wallet.go
+++ b/token/services/storage/db/sql/common/wallet.go
@@ -147,14 +147,10 @@ func (db *WalletStore) GetSchema() string {
 			created_at TIMESTAMP,
 			PRIMARY KEY(identity_hash, wallet_id, role_id)
 		);
-		CREATE INDEX IF NOT EXISTS idx_identity_hash_%s ON %s ( identity_hash );
-		CREATE INDEX IF NOT EXISTS idx_identity_hash_and_wallet_and_role%s ON %s ( identity_hash, wallet_id, role_id );
 		CREATE INDEX IF NOT EXISTS idx_identity_hash_and_role%s ON %s ( identity_hash, role_id );
 		CREATE INDEX IF NOT EXISTS idx_role_id_%s ON %s ( role_id )
 		`,
 		db.table.Wallets,
-		db.table.Wallets, db.table.Wallets,
-		db.table.Wallets, db.table.Wallets,
 		db.table.Wallets, db.table.Wallets,
 		db.table.Wallets, db.table.Wallets,
 	)


### PR DESCRIPTION
Follow-up to #1891 (indexing work for #1873).

Removes six indexes that duplicated — or were a leading prefix of — their table's `PRIMARY KEY`. A non-unique index that is an exact prefix of the PK's btree provides no read benefit (the PK index already serves those prefix lookups on both PostgreSQL and SQLite), but every one of them is maintained on each `INSERT`/`UPDATE`. Dropping them is a pure write-path win.

| File | Index removed | Duplicates |
|------|---------------|-----------|
| `identity.go` | `idx_ic_id_type` | `PRIMARY KEY(id, type, url)` (exact) |
| `identity.go` | `idx_audits` | `PRIMARY KEY(identity_hash)` (exact) |
| `identity.go` | `idx_signers` | `PRIMARY KEY(identity_hash)` (exact) |
| `wallet.go` | `idx_identity_hash_and_wallet_and_role` | `PRIMARY KEY(identity_hash, wallet_id, role_id)` (exact) |
| `wallet.go` | `idx_identity_hash` | leading prefix of the same PK |
| `tokens.go` | `idx_tx_id` | leading prefix of `PRIMARY KEY(tx_id, idx)` |
