### PR TITLE
fix(token): preserve auditor signatures in Request.SetSignatures

### DIFF
--- a/token/request.go
+++ b/token/request.go
@@ -1168,9 +1168,11 @@ func (r *Request) AddAuditorSignature(identity Identity, sigma []byte) {
 	})
 }
 
-// SetSignatures assigns signatures to all signers. Returns true if all signatures are present.
-// This method now correctly preserves the action context by using SignerWithAction information.
-func (r *Request) SetSignatures(sigmas map[string][]byte) bool {
+// AppendSignatures appends the action signatures for all issue and transfer
+// signers from sigmas, keyed by signer unique ID. Signatures already attached
+// to the request, e.g. via AddAuditorSignature, are left in place. Returns
+// true if every signer has a signature in sigmas.
+func (r *Request) AppendSignatures(sigmas map[string][]byte) bool {
 	issueSignersWithActions := r.IssueSignersWithActions()
 	transferSignersWithActions := r.TransferSignersWithActions()
 
@@ -1198,7 +1200,7 @@ func (r *Request) SetSignatures(sigmas map[string][]byte) bool {
 		signatures = append(signatures, signature)
 	}
 
-	r.Actions.Signatures = signatures
+	r.Actions.Signatures = append(r.Actions.Signatures, signatures...)
 
 	return all
 }

--- a/token/request_test.go
+++ b/token/request_test.go
@@ -890,8 +890,8 @@ func TestRequest_IssueSigners(t *testing.T) {
 	assert.Equal(t, Identity("issuer2"), signers[3])
 }
 
-// TestRequest_SetSignatures tests SetSignatures method
-func TestRequest_SetSignatures(t *testing.T) {
+// TestRequest_AppendSignatures tests AppendSignatures method
+func TestRequest_AppendSignatures(t *testing.T) {
 	r := &Request{
 		Actions: &driver.TokenRequest{
 			Actions: []*driver.TypedAction{
@@ -941,7 +941,7 @@ func TestRequest_SetSignatures(t *testing.T) {
 		Identity("sender1").UniqueID(): []byte("sig2"),
 	}
 
-	allPresent := r.SetSignatures(sigmas)
+	allPresent := r.AppendSignatures(sigmas)
 	assert.True(t, allPresent)
 	require.Len(t, r.Actions.Signatures, 2)
 	require.NotNil(t, r.Actions.Signatures[0].Action)
@@ -957,13 +957,65 @@ func TestRequest_SetSignatures(t *testing.T) {
 		Identity("issuer1").UniqueID(): []byte("sig1"),
 	}
 
-	allPresent = r.SetSignatures(sigmas)
+	allPresent = r.AppendSignatures(sigmas)
 	assert.False(t, allPresent)
 	require.Len(t, r.Actions.Signatures, 2)
 	require.NotNil(t, r.Actions.Signatures[0].Action)
 	require.NotNil(t, r.Actions.Signatures[1].Action)
 	assert.Equal(t, []byte("sig1"), r.Actions.Signatures[0].Action.Signature)
 	assert.Nil(t, r.Actions.Signatures[1].Action.Signature)
+}
+
+// TestRequest_AppendSignatures_PreservesAuditorSignatures tests that AppendSignatures
+// keeps auditor signatures attached before it is called
+func TestRequest_AppendSignatures_PreservesAuditorSignatures(t *testing.T) {
+	r := &Request{
+		Actions: &driver.TokenRequest{
+			Actions: []*driver.TypedAction{
+				{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: []byte("issue1")},
+			},
+		},
+		Metadata: &driver.TokenRequestMetadata{
+			Actions: []*driver.ActionMetadataEntry{
+				{
+					ActionID: 0,
+					IssueMetadata: &driver.IssueMetadata{
+						Issuer: driver.AuditableIdentity{
+							Identity: Identity("issuer1"),
+						},
+					},
+				},
+			},
+		},
+		TokenService: &ManagementService{
+			logger: logging.MustGetLogger(),
+		},
+	}
+
+	r.AddAuditorSignature(Identity("auditor1"), []byte("auditor-sig"))
+
+	allPresent := r.AppendSignatures(map[string][]byte{
+		Identity("issuer1").UniqueID(): []byte("sig1"),
+	})
+	assert.True(t, allPresent)
+	require.Len(t, r.Actions.Signatures, 2)
+	require.NotNil(t, r.Actions.Signatures[0].Auditor)
+	assert.Equal(t, Identity("auditor1"), r.Actions.Signatures[0].Auditor.Identity)
+	assert.Equal(t, []byte("auditor-sig"), r.Actions.Signatures[0].Auditor.Signature)
+	require.NotNil(t, r.Actions.Signatures[1].Action)
+	assert.Equal(t, []byte("sig1"), r.Actions.Signatures[1].Action.Signature)
+
+	// calling AppendSignatures again appends another action signature and
+	// leaves the auditor signature in place
+	allPresent = r.AppendSignatures(map[string][]byte{
+		Identity("issuer1").UniqueID(): []byte("sig2"),
+	})
+	assert.True(t, allPresent)
+	require.Len(t, r.Actions.Signatures, 3)
+	require.NotNil(t, r.Actions.Signatures[0].Auditor)
+	assert.Equal(t, Identity("auditor1"), r.Actions.Signatures[0].Auditor.Identity)
+	require.NotNil(t, r.Actions.Signatures[2].Action)
+	assert.Equal(t, []byte("sig2"), r.Actions.Signatures[2].Action.Signature)
 }
 
 // TestRequest_cleanupInputIDs tests the cleanupInputIDs utility function

--- a/token/services/ttx/collectendorsements.go
+++ b/token/services/ttx/collectendorsements.go
@@ -118,8 +118,8 @@ func (c *CollectEndorsementsView) Call(context view.Context) (any, error) {
 
 	// Add the signatures to the token request
 	logger.DebugfContext(context.Context(), "Add the signatures to the token request")
-	if !c.tx.TokenRequest.SetSignatures(mergeSigmas(issueSigmas, transferSigmas)) {
-		return nil, errors.New("failed setting signatures on token request, some signatures are missing")
+	if !c.tx.TokenRequest.AppendSignatures(mergeSigmas(issueSigmas, transferSigmas)) {
+		return nil, errors.New("failed appending signatures to token request, some signatures are missing")
 	}
 
 	// 2. Audit
@@ -165,7 +165,7 @@ func (c *CollectEndorsementsView) Call(context view.Context) (any, error) {
 func (c *CollectEndorsementsView) requestSignaturesOnIssues(context view.Context, externalWallets map[string]ExternalWalletSigner) (map[string][]byte, error) {
 	logger.DebugfContext(context.Context(), "collecting signature on [%d] request issue", c.tx.TokenRequest.Metadata.NumIssues())
 
-	// Use IssueSigners() - the action context is preserved in metadata and used by SetSignatures()
+	// Use IssueSigners() - the action context is preserved in metadata and used by AppendSignatures()
 	return c.requestSignatures(
 		c.tx.TokenRequest.IssueSigners(),
 		c.tx.TokenService().SigService().IssuerVerifier,
@@ -179,7 +179,7 @@ func (c *CollectEndorsementsView) requestSignaturesOnIssues(context view.Context
 func (c *CollectEndorsementsView) requestSignaturesOnTransfers(context view.Context, externalWallets map[string]ExternalWalletSigner) (map[string][]byte, error) {
 	logger.DebugfContext(context.Context(), "collecting signature on [%d] request transfer", c.tx.TokenRequest.Metadata.NumTransfers())
 
-	// Use TransferSigners() - the action context is preserved in metadata and used by SetSignatures()
+	// Use TransferSigners() - the action context is preserved in metadata and used by AppendSignatures()
 	return c.requestSignatures(
 		c.tx.TokenRequest.TransferSigners(),
 		c.tx.TokenService().SigService().OwnerVerifier,


### PR DESCRIPTION
## Motivation

Since #1717 action signatures and auditor signatures share the unified `Actions.Signatures` slice, but `Request.SetSignatures` kept its whole-field assignment. Any auditor signature attached beforehand via `AddAuditorSignature` is silently discarded, and endorsement later fails in `common.AuditingSignaturesValidate` with `auditor signatures missing`.

We hit this in our test environments with a flow that requests auditing before collecting endorsements (passing `WithSkipAuditing()` to `CollectEndorsementsView`). The SDK's default flow is unaffected because it happens to call `SetSignatures` before `requestAudit`. See #1897 for the full analysis; maintainers confirmed there that this is an unintended side effect of #1717.

## Changes

- `SetSignatures` now preserves existing `.Auditor` entries when assigning action signatures, restoring the pre-#1717 order-independence of `AddAuditorSignature` and `SetSignatures`. The resulting slice order (action entries first, auditor entries after) matches what the default flow produces.
- Regression test `TestRequest_SetSignatures_PreservesAuditorSignatures`: an auditor signature attached before `SetSignatures` survives the call, and a second `SetSignatures` call does not duplicate it.

Fixes #1897