### PR TITLE
Protect AllTestTypes from silently dropping required infrastructure types  #1915

### DIFF
--- a/.github/workflows/protect-integration-test-types.yml
+++ b/.github/workflows/protect-integration-test-types.yml
@@ -1,0 +1,30 @@
+name: Protect Integration Test Types
+
+on:
+  pull_request:
+    branches: [ main, feature/evm-network-driver, feature/zkat-snark-driver ]
+    paths:
+      - 'integration/ports.go'
+      - 'integration/ports_test.go'
+      - '.github/workflows/protect-integration-test-types.yml'
+
+env:
+  GOFLAGS: -mod=mod
+
+jobs:
+  guard-all-test-types:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "integration/go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Verify AllTestTypes retains required infrastructure types
+        working-directory: integration
+        run: go test . -run TestAllTestTypesIncludesRequiredInfrastructureTypes -v

--- a/integration/ports_test.go
+++ b/integration/ports_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAllTestTypesIncludesRequiredInfrastructureTypes guards against
+// accidentally dropping one of the required infrastructure types from
+// AllTestTypes, which would silently narrow integration test coverage.
+func TestAllTestTypesIncludesRequiredInfrastructureTypes(t *testing.T) {
+	required := []*InfrastructureType{
+		WebSocketNoReplication,
+		LibP2PNoReplication,
+		WebSocketWithReplication,
+	}
+
+	for _, r := range required {
+		assert.Contains(t, AllTestTypes, r, "AllTestTypes must always include %v", r.Label)
+	}
+}


### PR DESCRIPTION
fix #1915