### PR TITLE
LongTermOwnerWallet.RegisterRecipient was an unconditional no-op, bypassing recipient validation  #1917

### DIFF
--- a/token/services/identity/role/wallets.go
+++ b/token/services/identity/role/wallets.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package role
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 
@@ -466,11 +467,23 @@ func (w *LongTermOwnerWallet) EnrollmentID() string {
 	return w.OwnerIdentityInfo.EnrollmentID()
 }
 
-// RegisterRecipient registers recipient data (identity + audit info).
-// The long-term owner wallet currently has a no-op implementation here
-// and returns nil. The TODO indicates where custom logic would be added.
+// RegisterRecipient validates that the passed recipient data (identity +
+// audit info) matches the long-term identity this wallet is bound to.
+// Unlike AnonymousOwnerWallet, no registration/binding is performed here
+// because the wallet's identity is already resolved and bound at
+// construction time (see NewLongTermOwnerWallet); this is purely a guard
+// against mismatched recipient data.
 func (w *LongTermOwnerWallet) RegisterRecipient(ctx context.Context, data *driver.RecipientData) error {
-	// TODO: if identity is equal to the one this wallet is bound to, then we are good. Otherwise return an error
+	if data == nil {
+		return errors.Wrapf(wallet.ErrNilRecipientData, "invalid recipient data")
+	}
+	if !w.Contains(ctx, data.Identity) {
+		return errors.Errorf("identity [%s] does not belong to this wallet [%s]", data.Identity, w.ID())
+	}
+	if !bytes.Equal(data.AuditInfo, w.OwnerAuditInfo) {
+		return errors.Errorf("audit info does not match the one this wallet [%s] is bound to", w.ID())
+	}
+
 	return nil
 }
 

--- a/token/services/identity/role/wallets_test.go
+++ b/token/services/identity/role/wallets_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role"
 	"github.com/LFDT-Panurus/panurus/token/services/identity/role/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/identity/wallet"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/metrics/disabled"
@@ -279,6 +280,37 @@ func TestLongTermOwnerWallet(t *testing.T) {
 
 		_, err = w.GetSigner(t.Context(), driver.Identity("other"))
 		require.Error(t, err)
+	})
+
+	t.Run("RegisterRecipient", func(t *testing.T) {
+		w, _, _ := setup(t)
+
+		// Case 1: nil data
+		err := w.RegisterRecipient(t.Context(), nil)
+		require.ErrorIs(t, err, wallet.ErrNilRecipientData)
+
+		// Case 2: matching identity and audit info
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  driver.Identity("ownerIdentity"),
+			AuditInfo: []byte("audit-info"),
+		})
+		require.NoError(t, err)
+
+		// Case 3: mismatched identity
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  driver.Identity("other"),
+			AuditInfo: []byte("audit-info"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not belong to this wallet")
+
+		// Case 4: matching identity, mismatched audit info
+		err = w.RegisterRecipient(t.Context(), &driver.RecipientData{
+			Identity:  driver.Identity("ownerIdentity"),
+			AuditInfo: []byte("other-audit-info"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "audit info does not match")
 	})
 }
 


### PR DESCRIPTION
Fix #1917

## Description

 - Rejects nil data (wallet.ErrNilRecipientData).
  - Rejects data whose Identity doesn't match w.OwnerIdentity (reuses the existing w.Contains check).
  - Rejects data whose AuditInfo doesn't match w.OwnerAuditInfo.
  - Otherwise returns nil.

No registration/binding side effects are added (unlike AnonymousOwnerWallet.RegisterRecipient), since the wallet's identity is already resolved and bound at construction time in NewLongTermOwnerWallet — this method is purely a guard.
