### PR TITLE
cleanup(fabricx): remove stale TODO and dead code in StateMustExist

### DIFF
--- a/token/services/network/fabricx/endorsement/rwset.go
+++ b/token/services/network/fabricx/endorsement/rwset.go
@@ -67,18 +67,7 @@ func (w *RWSetWrapper) StateMustExist(key translator.Key, version translator.Key
 	case translator.VersionZero:
 		return w.RWSet.AddReadAt(w.Namespace, key, vault.MarshalVersion(0))
 	case translator.Latest:
-		// TODO: AF
 		return w.RWSet.AddReadAt(w.Namespace, key, vault.MarshalVersion(w.ppVersion))
-		// // When StateMustExist is called on VersionZero, Latest behaviour is used instead.
-		// // This works under the assumption that keys are used only once.
-		// h, err := w.RWSet.GetState(w.Namespace, key)
-		// if err != nil {
-		//	return errors.Wrapf(err, "failed to read state [%s:%s] for [%s]", w.Namespace, key, w.TxID)
-		// }
-		// if len(h) == 0 {
-		//	return errors.Errorf("state [%s:%s] does not exist for [%s]", w.Namespace, key, w.TxID)
-		// }
-		// return nil
 	default:
 		return errors.Errorf("invalid version [%d]", version)
 	}


### PR DESCRIPTION
## Summary
- `RWSetWrapper.StateMustExist`'s `Latest` branch (`token/services/network/fabricx/endorsement/rwset.go`) carried a `TODO: AF` marker and ~12 lines of dead commented-out code from the original read-then-check implementation it replaced.
- Confirmed with the author that the current pp-version-based `AddReadAt` check is the intended, final design (not provisional) — no behavioral change, just removal of stale TODO/dead code.

Fixes #1920

## Test plan
- [x] `go build ./token/services/network/fabricx/...`
- [x] `gofmt -l` clean on the changed file