### PR TITLE
fix(ttx): enforce recipient data registration on external withdrawal path

### DIFF
--- a/docs/services/ttx.md
+++ b/docs/services/ttx.md
@@ -323,7 +323,8 @@ sequenceDiagram
 
     rect rgba(230, 230, 250, 0.35)
         Note over I,Iss: Phase 1 - Request
-        I->>I: Resolve recipient identity (caller-supplied or wallet-generated)
+        I->>I: Resolve local wallet (r.Wallet)
+        I->>I: If caller-supplied RecipientData: w.RegisterRecipient(RecipientData) else w.GetRecipientData()
         I->>Iss: Envelope{t:"withdrawal_req", b:WithdrawalRequest{TMSID, RecipientData, TokenType, Amount, NotAnonymous}}
     end
 
@@ -351,6 +352,19 @@ sequenceDiagram
 ```
 
 The attestation message is the same DER-encoded (`encoding/asn1`) structure used by the recipient-identity protocols, with `walletID` fixed to `nil` — the issuer does not need to know the requester's wallet identifier.
+
+### Caller-supplied recipient data (external wallet)
+
+A caller can drive the withdrawal for a recipient identity it generated outside the local
+wallet (an "external wallet") by passing `RecipientData` directly to
+`RequestWithdrawalForRecipient`. Before this data is sent to the issuer,
+`RequestWithdrawalView.getRecipientIdentity` resolves the caller's local `r.Wallet` and calls
+`OwnerWallet.RegisterRecipient(ctx, RecipientData)` on it. For an `AnonymousOwnerWallet` this
+runs `Deserializer.MatchIdentity(Identity, AuditInfo)` before registering and binding the
+identity, so a caller-supplied `Identity`/`AuditInfo` pair that doesn't match is rejected with
+an error and the withdrawal request is never sent. For a `LongTermOwnerWallet`,
+`RegisterRecipient` is currently a no-op, so this check does not add protection when the
+caller's local wallet is long-term-identity-backed rather than anonymous.
 
 ## Token Upgrade Flow
 

--- a/integration/token/fungible/views/withdraw.go
+++ b/integration/token/fungible/views/withdraw.go
@@ -47,16 +47,8 @@ func (i *WithdrawalInitiatorView) Call(context view.Context) (any, error) {
 	var session view.Session
 	var err error
 	if i.RecipientData != nil {
-		// Use the passed RecipientData.
-		// First register it locally
-		var tms *token.ManagementService
-		tms, err = token.GetManagementService(context, token.WithTMSID(i.TMSID))
-		assert.NoError(err, "failed getting management service")
-		var w *token.OwnerWallet
-		w, err = tms.WalletManager().OwnerWallet(context.Context(), i.Wallet)
-		assert.NoError(err, "cannot find wallet [%s:%s]", i.TMSID, i.Wallet)
-		assert.NoError(w.RegisterRecipient(context.Context(), i.RecipientData), "failed to register remote recipient")
-
+		// Use the passed RecipientData. RequestWithdrawalForRecipient validates and
+		// registers it locally against the wallet before using it.
 		// We have an external wallet here.
 		// We need to provide access to it to RequestWithdrawalForRecipientView.
 		// Indeed, a signature is needed to prove to the issuer that the caller owns the recipient data

--- a/token/services/ttx/withdrawal.go
+++ b/token/services/ttx/withdrawal.go
@@ -195,19 +195,6 @@ func (r *RequestWithdrawalView) Call(context view.Context) (any, error) {
 }
 
 func (r *RequestWithdrawalView) getRecipientIdentity(context view.Context) (*token.TMSID, *RecipientData, *token.OwnerWallet, error) {
-	if r.RecipientData != nil {
-		tms, err := token.GetManagementService(context, token.WithTMSID(r.TMSID))
-		if err != nil {
-			return nil, nil, nil, errors.Wrapf(err, "tms not found for [%s]", r.TMSID)
-		}
-
-		// TODO: check that RecipientData is registered
-
-		r.ExternalWallet = true
-
-		return new(tms.ID()), r.RecipientData, nil, nil
-	}
-
 	w := GetWallet(
 		context,
 		r.Wallet,
@@ -220,7 +207,17 @@ func (r *RequestWithdrawalView) getRecipientIdentity(context view.Context) (*tok
 	}
 
 	if r.RecipientData != nil {
-		return new(w.TMS().ID()), r.RecipientData, w, nil
+		// Register the caller-supplied recipient data with the local wallet
+		// before using it to drive the withdrawal handshake, so it is validated
+		// against the identity this wallet is bound to (and, for anonymous
+		// wallets, bound/recorded) rather than trusted as-is.
+		if err := w.RegisterRecipient(context.Context(), r.RecipientData); err != nil {
+			return nil, nil, nil, errors.Wrapf(err, "failed to register recipient data")
+		}
+
+		r.ExternalWallet = true
+
+		return new(w.TMS().ID()), r.RecipientData, nil, nil
 	}
 
 	recipientData, err := w.GetRecipientData(context.Context())

--- a/token/services/ttx/withdrawal_call_test.go
+++ b/token/services/ttx/withdrawal_call_test.go
@@ -1,0 +1,695 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ttx_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	driver_mock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	token_mock "github.com/LFDT-Panurus/panurus/token/mock"
+	"github.com/LFDT-Panurus/panurus/token/services/ttx"
+	mock2 "github.com/LFDT-Panurus/panurus/token/services/ttx/dep/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint"
+	endpointmock "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/endpoint/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWithdrawalTMSProvider is a minimal driver.TokenManagerServiceProvider that
+// returns the wrapped, pre-stubbed driver.TokenManagerService, unless err is
+// set, in which case it always fails (simulating an unresolvable TMS).
+type fakeWithdrawalTMSProvider struct {
+	tms driver.TokenManagerService
+	err error
+}
+
+func (f *fakeWithdrawalTMSProvider) ConfigurationFor(network, channel, namespace string) (driver.Configuration, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakeWithdrawalTMSProvider) GetTokenManagerService(_ driver.ServiceOptions) (driver.TokenManagerService, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.tms, nil
+}
+
+func (f *fakeWithdrawalTMSProvider) Update(_ driver.ServiceOptions) error { return nil }
+
+// passthroughWithdrawalNormalizer is a minimal token.Normalizer that returns
+// the options unchanged.
+type passthroughWithdrawalNormalizer struct{}
+
+func (passthroughWithdrawalNormalizer) Normalize(opt *token.ServiceOptions) (*token.ServiceOptions, error) {
+	return opt, nil
+}
+
+// newStubbedWithdrawalTMS returns a driver.TokenManagerService with all the
+// stubs required for ManagementService.init() to succeed, with the given
+// wallet service and deserializer (the deserializer drives the
+// *token.SignatureService that ManagementService builds internally).
+func newStubbedWithdrawalTMS(walletService driver.WalletService, deserializer driver.Deserializer) *driver_mock.TokenManagerService {
+	if deserializer == nil {
+		deserializer = &driver_mock.Deserializer{}
+	}
+
+	mockTMS := &driver_mock.TokenManagerService{}
+	mockTMS.WalletServiceReturns(walletService)
+	mockTMS.ValidatorReturns(&driver_mock.Validator{}, nil)
+	mockTMS.AuthorizationReturns(&driver_mock.Authorization{})
+	mockTMS.ConfigurationReturns(&driver_mock.Configuration{})
+	mockTMS.TokensServiceReturns(&driver_mock.TokensService{})
+	mockTMS.TokensUpgradeServiceReturns(&driver_mock.TokensUpgradeService{})
+	mockPPM := &driver_mock.PublicParamsManager{}
+	mockPPM.PublicParametersReturns(&driver_mock.PublicParameters{})
+	mockTMS.PublicParamsManagerReturns(mockPPM)
+	mockTMS.DeserializerReturns(deserializer)
+	mockTMS.IdentityProviderReturns(&driver_mock.IdentityProvider{})
+	mockTMS.CertificationServiceReturns(nil)
+
+	return mockTMS
+}
+
+// withdrawalCallTestInput configures newWithdrawalCallTestContext.
+type withdrawalCallTestInput struct {
+	WalletService    driver.WalletService
+	Deserializer     driver.Deserializer
+	BindingStore     *endpointmock.BindingStore
+	CancelledContext bool
+	TMSProviderErr   error
+}
+
+// newWithdrawalCallTestContext wires a *mock2.Context/*mock2.Session pair so
+// that RequestWithdrawalView.Call / ReceiveWithdrawalRequestView.Call can be
+// driven end-to-end: it resolves a real *token.ManagementServiceProvider
+// (needed because withdrawal.go calls token.GetManagementService/GetWallet
+// directly, not through the dep package abstraction), a real *endpoint.Service
+// backed by a mock BindingStore, and reports envelope metrics as unavailable
+// (which callers treat as "metrics disabled").
+func newWithdrawalCallTestContext(t *testing.T, input withdrawalCallTestInput) (*mock2.Context, *mock2.Session) {
+	t.Helper()
+
+	if input.BindingStore == nil {
+		input.BindingStore = &endpointmock.BindingStore{}
+	}
+	endpointSvc, err := endpoint.NewService(input.BindingStore)
+	require.NoError(t, err)
+
+	mockVaultProvider := &token_mock.VaultProvider{}
+	mockVaultProvider.VaultReturns(&driver_mock.Vault{}, nil)
+
+	mockTMS := newStubbedWithdrawalTMS(input.WalletService, input.Deserializer)
+	provider := token.NewManagementServiceProvider(
+		&fakeWithdrawalTMSProvider{tms: mockTMS, err: input.TMSProviderErr},
+		passthroughWithdrawalNormalizer{},
+		mockVaultProvider,
+		nil,
+		nil,
+	)
+
+	getService := func(v any) (any, error) {
+		switch v := v.(type) {
+		case *token.ManagementServiceProvider:
+			return provider, nil
+		case reflect.Type:
+			switch v.String() {
+			case "*endpoint.Service":
+				return endpointSvc, nil
+			case "*session.EnvelopeMetrics":
+				return nil, errors.New("envelope metrics not registered in test")
+			default:
+				return nil, errors.Errorf("unexpected service request [%s]", v.String())
+			}
+		default:
+			return nil, errors.Errorf("unexpected service request [%T]", v)
+		}
+	}
+
+	session := &mock2.Session{}
+	ch := make(chan *view.Message, 4)
+	session.ReceiveReturns(ch)
+	session.InfoReturns(view.SessionInfo{ID: "a_session", Caller: view.Identity("a_caller")})
+
+	baseCtx := t.Context()
+	if input.CancelledContext {
+		var cancel context.CancelFunc
+		baseCtx, cancel = context.WithCancel(baseCtx)
+		cancel()
+	}
+
+	ctx := &mock2.Context{}
+	ctx.ContextReturns(baseCtx)
+	ctx.GetServiceStub = getService
+	ctx.SessionReturns(session)
+	ctx.GetSessionReturns(session, nil)
+	ctx.RunViewStub = func(v view.View, _ ...view.RunViewOption) (any, error) {
+		return v.Call(ctx)
+	}
+
+	return ctx, session
+}
+
+func withdrawalEnvelope(t *testing.T, msgType string, body any) *view.Message {
+	t.Helper()
+
+	return &view.Message{Payload: mustEnvelopeBytes(t, msgType, body)}
+}
+
+func TestRequestWithdrawalView_Call(t *testing.T) {
+	recipientIdentity := driver.Identity("recipient-identity")
+
+	newLocalWalletService := func(t *testing.T, signErr, remote bool) *driver_mock.WalletService {
+		t.Helper()
+
+		mockOwnerWallet := &driver_mock.OwnerWallet{}
+		mockOwnerWallet.GetRecipientDataReturns(&driver.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")}, nil)
+		mockOwnerWallet.RemoteReturns(remote)
+		if signErr {
+			mockOwnerWallet.GetSignerReturns(nil, errors.New("no signer available"))
+		} else {
+			mockSigner := &driver_mock.Signer{}
+			mockSigner.SignReturns([]byte("a-signature"), nil)
+			mockOwnerWallet.GetSignerReturns(mockSigner, nil)
+		}
+
+		mockWalletService := &driver_mock.WalletService{}
+		mockWalletService.OwnerWalletReturns(mockOwnerWallet, nil)
+
+		return mockWalletService
+	}
+
+	t.Run("success local wallet", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		result, err := r.Call(ctx)
+
+		require.NoError(t, err)
+		out := result.([]any)
+		wr := out[0].(*ttx.WithdrawalRequest)
+		assert.Equal(t, uint64(10), wr.Amount)
+		assert.Same(t, session, out[1])
+		require.Equal(t, 2, session.SendWithContextCallCount())
+	})
+
+	t.Run("success external wallet", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		mockOwnerWallet := &driver_mock.OwnerWallet{}
+		mockOwnerWallet.RegisterRecipientReturns(nil)
+		ws.OwnerWalletReturns(mockOwnerWallet, nil)
+
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+		session.ReceiveReturns(ch)
+
+		externalSigner := &mock2.ExternalWalletSigner{}
+		externalSigner.SignReturns([]byte("an-external-signature"), nil)
+
+		recipientData := &ttx.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")}
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "external-wallet", token.TMSID{}, recipientData, map[string]ttx.ExternalWalletSigner{"external-wallet": externalSigner})
+
+		result, err := r.Call(ctx)
+
+		require.NoError(t, err)
+		out := result.([]any)
+		assert.Equal(t, *recipientData, out[0].(*ttx.WithdrawalRequest).RecipientData)
+		require.Equal(t, 1, externalSigner.SignCallCount())
+	})
+
+	t.Run("wallet not found", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ws.OwnerWalletReturns(nil, errors.New("no such wallet"))
+		ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "missing-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get recipient data")
+	})
+
+	t.Run("session open fails", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ctx.GetSessionReturns(nil, errors.New("no route to issuer"))
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get session")
+	})
+
+	t.Run("send request fails", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		session.SendWithContextReturns(errors.New("network down"))
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to send withdrawal request")
+	})
+
+	t.Run("receive challenge times out", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws, CancelledContext: true})
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to receive withdrawal challenge")
+	})
+
+	t.Run("empty challenge nonce", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: nil})
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing nonce")
+	})
+
+	t.Run("no signer for external wallet", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		mockOwnerWallet := &driver_mock.OwnerWallet{}
+		mockOwnerWallet.RegisterRecipientReturns(nil)
+		ws.OwnerWalletReturns(mockOwnerWallet, nil)
+
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+		session.ReceiveReturns(ch)
+
+		recipientData := &ttx.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")}
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "external-wallet", token.TMSID{}, recipientData, map[string]ttx.ExternalWalletSigner{})
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no signer for wallet")
+	})
+
+	t.Run("send response fails", func(t *testing.T) {
+		ws := newLocalWalletService(t, false, false)
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+		session.ReceiveReturns(ch)
+		session.SendWithContextReturnsOnCall(1, errors.New("network down"))
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to send withdrawal response")
+		require.Equal(t, 2, session.SendWithContextCallCount())
+	})
+
+	t.Run("local signer fails", func(t *testing.T) {
+		ws := newLocalWalletService(t, true, false)
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+		ch := make(chan *view.Message, 1)
+		ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewRequestWithdrawalView(view.Identity("an-issuer"), "TOK", 10, false, "local-wallet", token.TMSID{}, nil, nil)
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get signer")
+	})
+}
+
+func TestReceiveWithdrawalRequestView_Call(t *testing.T) {
+	recipientIdentity := driver.Identity("recipient-identity")
+	tmsID := token.TMSID{Network: "a-network", Channel: "a-channel", Namespace: "a-namespace"}
+
+	newTestDeserializer := func(verifyErr error) *driver_mock.Deserializer {
+		des := &driver_mock.Deserializer{}
+		verifier := &driver_mock.Verifier{}
+		verifier.VerifyReturns(verifyErr)
+		des.GetOwnerVerifierReturns(verifier, nil)
+
+		return des
+	}
+
+	newRequestMsg := func() *view.Message {
+		return withdrawalEnvelope(t, ttx.TypeWithdrawalRequest, &ttx.WithdrawalRequest{
+			TMSID:         tmsID,
+			RecipientData: ttx.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")},
+			TokenType:     "TOK",
+			Amount:        10,
+		})
+	}
+
+	newResponseMsg := func(sig []byte) *view.Message {
+		return withdrawalEnvelope(t, ttx.TypeWithdrawalResponse, &ttx.WithdrawalResponse{Signature: sig})
+	}
+
+	t.Run("success", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ws.RegisterRecipientIdentityReturns(nil)
+		bindingStore := &endpointmock.BindingStore{}
+		bindingStore.PutBindingsReturns(nil)
+
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+			BindingStore:  bindingStore,
+		})
+		ch := make(chan *view.Message, 2)
+		ch <- newRequestMsg()
+		ch <- newResponseMsg([]byte("a-signature"))
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		result, err := r.Call(ctx)
+
+		require.NoError(t, err)
+		wr := result.(*ttx.WithdrawalRequest)
+		assert.Equal(t, uint64(10), wr.Amount)
+		require.Equal(t, 1, ws.RegisterRecipientIdentityCallCount())
+		require.Equal(t, 1, bindingStore.PutBindingsCallCount())
+
+		require.Equal(t, 1, session.SendWithContextCallCount())
+		_, sentChallenge := session.SendWithContextArgsForCall(0)
+		nonceBody := mustUnwrapBody(t, sentChallenge, ttx.TypeWithdrawalChallenge)
+		var challenge ttx.WithdrawalChallenge
+		require.NoError(t, json.Unmarshal(nonceBody, &challenge))
+		assert.NotEmpty(t, challenge.Nonce)
+	})
+
+	t.Run("tms not found", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService:  ws,
+			Deserializer:   newTestDeserializer(nil),
+			TMSProviderErr: errors.New("tms provider unavailable"),
+		})
+		ch := make(chan *view.Message, 1)
+		ch <- newRequestMsg()
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tms not found")
+	})
+
+	t.Run("receive request times out", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService:    ws,
+			Deserializer:     newTestDeserializer(nil),
+			CancelledContext: true,
+		})
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to receive withdrawal request")
+	})
+
+	t.Run("send challenge fails", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+		})
+		ch := make(chan *view.Message, 1)
+		ch <- newRequestMsg()
+		session.ReceiveReturns(ch)
+		session.SendWithContextReturns(errors.New("network down"))
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to send withdrawal challenge")
+	})
+
+	t.Run("receive response fails", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+		})
+		// The channel is closed after the request is buffered, so the
+		// second receive (the response) sees a closed channel and gets a
+		// nil message immediately instead of blocking on the 1-minute
+		// per-phase timeout.
+		ch := make(chan *view.Message, 1)
+		ch <- newRequestMsg()
+		close(ch)
+		session.ReceiveReturns(ch)
+		session.SendWithContextReturns(nil)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to receive withdrawal response")
+	})
+
+	t.Run("verify fails", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(errors.New("bad signature")),
+		})
+		ch := make(chan *view.Message, 2)
+		ch <- newRequestMsg()
+		ch <- newResponseMsg([]byte("a-signature"))
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "attestation failed")
+	})
+
+	t.Run("empty signature on fresh path", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+		})
+		ch := make(chan *view.Message, 2)
+		ch <- newRequestMsg()
+		ch <- newResponseMsg(nil)
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty signature")
+	})
+
+	t.Run("register recipient identity fails", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ws.RegisterRecipientIdentityReturns(errors.New("storage down"))
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+		})
+		ch := make(chan *view.Message, 2)
+		ch <- newRequestMsg()
+		ch <- newResponseMsg([]byte("a-signature"))
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to register recipient identity")
+	})
+
+	t.Run("bind fails", func(t *testing.T) {
+		ws := &driver_mock.WalletService{}
+		ws.RegisterRecipientIdentityReturns(nil)
+		bindingStore := &endpointmock.BindingStore{}
+		bindingStore.PutBindingsReturns(errors.New("kvs down"))
+
+		ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+			WalletService: ws,
+			Deserializer:  newTestDeserializer(nil),
+			BindingStore:  bindingStore,
+		})
+		ch := make(chan *view.Message, 2)
+		ch <- newRequestMsg()
+		ch <- newResponseMsg([]byte("a-signature"))
+		session.ReceiveReturns(ch)
+
+		r := ttx.NewReceiveIssuanceRequestView()
+
+		_, err := r.Call(ctx)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed binding")
+	})
+}
+
+func TestRequestWithdrawal_And_ForRecipient(t *testing.T) {
+	recipientIdentity := driver.Identity("recipient-identity")
+
+	mockOwnerWallet := &driver_mock.OwnerWallet{}
+	mockOwnerWallet.GetRecipientDataReturns(&driver.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")}, nil)
+	mockSigner := &driver_mock.Signer{}
+	mockSigner.SignReturns([]byte("a-signature"), nil)
+	mockOwnerWallet.GetSignerReturns(mockSigner, nil)
+
+	ws := &driver_mock.WalletService{}
+	ws.OwnerWalletReturns(mockOwnerWallet, nil)
+
+	ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+	ch := make(chan *view.Message, 1)
+	ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalChallenge, &ttx.WithdrawalChallenge{Nonce: []byte("a-fresh-nonce")})
+	session.ReceiveReturns(ch)
+
+	identity, s, err := ttx.RequestWithdrawal(ctx, view.Identity("an-issuer"), "local-wallet", "TOK", 10, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, recipientIdentity, identity)
+	assert.Same(t, session, s)
+}
+
+func TestRequestWithdrawalForRecipient_CompileServiceOptionsFails(t *testing.T) {
+	ws := &driver_mock.WalletService{}
+	ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+
+	failingOpt := token.ServiceOption(func(*token.ServiceOptions) error {
+		return errors.New("bad option")
+	})
+
+	_, _, err := ttx.RequestWithdrawalForRecipient(ctx, view.Identity("an-issuer"), "local-wallet", "TOK", 10, false, nil, failingOpt)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compile options")
+}
+
+func TestRequestWithdrawalForRecipient_RunViewFails(t *testing.T) {
+	ws := &driver_mock.WalletService{}
+	ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+	ctx.RunViewReturns(nil, errors.New("view execution failed"))
+
+	_, _, err := ttx.RequestWithdrawalForRecipient(ctx, view.Identity("an-issuer"), "local-wallet", "TOK", 10, false, nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "view execution failed")
+}
+
+func TestRequestWithdrawalForRecipient_CompileCollectEndorsementsOptsFails(t *testing.T) {
+	ws := &driver_mock.WalletService{}
+	ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+
+	// CompileServiceOptions and CompileCollectEndorsementsOpts both apply the
+	// same opts list in sequence (the former directly, the latter via
+	// token.CompileServiceOptions). A stateful option that only fails on its
+	// second invocation lets the first call succeed, isolating the failure to
+	// the second call.
+	callCount := 0
+	statefulOpt := token.ServiceOption(func(*token.ServiceOptions) error {
+		callCount++
+		if callCount > 1 {
+			return errors.New("second compile fails")
+		}
+
+		return nil
+	})
+
+	_, _, err := ttx.RequestWithdrawalForRecipient(ctx, view.Identity("an-issuer"), "local-wallet", "TOK", 10, false, nil, statefulOpt)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compile collect endorsement options")
+}
+
+func TestReceiveWithdrawalRequest_RunViewFails(t *testing.T) {
+	ws := &driver_mock.WalletService{}
+	ctx, _ := newWithdrawalCallTestContext(t, withdrawalCallTestInput{WalletService: ws})
+	ctx.RunViewReturns(nil, errors.New("view execution failed"))
+
+	_, err := ttx.ReceiveWithdrawalRequest(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "view execution failed")
+}
+
+func TestReceiveWithdrawalRequest(t *testing.T) {
+	recipientIdentity := driver.Identity("recipient-identity")
+	tmsID := token.TMSID{Network: "a-network", Channel: "a-channel", Namespace: "a-namespace"}
+
+	des := &driver_mock.Deserializer{}
+	verifier := &driver_mock.Verifier{}
+	verifier.VerifyReturns(nil)
+	des.GetOwnerVerifierReturns(verifier, nil)
+
+	ws := &driver_mock.WalletService{}
+	ws.RegisterRecipientIdentityReturns(nil)
+	bindingStore := &endpointmock.BindingStore{}
+	bindingStore.PutBindingsReturns(nil)
+
+	ctx, session := newWithdrawalCallTestContext(t, withdrawalCallTestInput{
+		WalletService: ws,
+		Deserializer:  des,
+		BindingStore:  bindingStore,
+	})
+	ch := make(chan *view.Message, 2)
+	ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalRequest, &ttx.WithdrawalRequest{
+		TMSID:         tmsID,
+		RecipientData: ttx.RecipientData{Identity: recipientIdentity, AuditInfo: []byte("audit-info")},
+		TokenType:     "TOK",
+		Amount:        10,
+	})
+	ch <- withdrawalEnvelope(t, ttx.TypeWithdrawalResponse, &ttx.WithdrawalResponse{Signature: []byte("a-signature")})
+	session.ReceiveReturns(ch)
+
+	wr, err := ttx.ReceiveWithdrawalRequest(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10), wr.Amount)
+}

--- a/token/services/ttx/withdrawal_test.go
+++ b/token/services/ttx/withdrawal_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// This white-box (package ttx) file covers getRecipientIdentity, which is
+// unexported. It is kept separate from black-box tests so it can avoid
+// importing dep/mock, which cannot be imported from package ttx without
+// creating an import cycle (see cleanupsessions_test.go).
+package ttx
+
+import (
+	"context"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	driver_mock "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	token_mock "github.com/LFDT-Panurus/panurus/token/mock"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// fakeTMSProvider is a minimal driver.TokenManagerServiceProvider that always
+// returns the wrapped, pre-stubbed driver.TokenManagerService.
+type fakeTMSProvider struct {
+	tms driver.TokenManagerService
+}
+
+func (f *fakeTMSProvider) GetTokenManagerService(_ driver.ServiceOptions) (driver.TokenManagerService, error) {
+	return f.tms, nil
+}
+
+func (f *fakeTMSProvider) Update(_ driver.ServiceOptions) error { return nil }
+
+// passthroughNormalizer is a minimal token.Normalizer that returns the
+// options unchanged.
+type passthroughNormalizer struct{}
+
+func (passthroughNormalizer) Normalize(opt *token.ServiceOptions) (*token.ServiceOptions, error) {
+	return opt, nil
+}
+
+// minimalViewContext is a hand-rolled minimal view.Context fake (mirroring
+// the countingSession pattern in cleanupsessions_test.go) used because
+// dep/mock.Context cannot be imported from this white-box package.
+type minimalViewContext struct {
+	svc any
+	ctx context.Context
+}
+
+func (c *minimalViewContext) StartSpanFrom(ctx context.Context, _ string, _ ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return ctx, nil
+}
+func (c *minimalViewContext) GetService(_ any) (any, error) { return c.svc, nil }
+func (c *minimalViewContext) ID() string                    { return "test-context" }
+func (c *minimalViewContext) RunView(_ view.View, _ ...view.RunViewOption) (any, error) {
+	return nil, nil
+}
+func (c *minimalViewContext) Me() view.Identity         { return nil }
+func (c *minimalViewContext) IsMe(_ view.Identity) bool { return false }
+func (c *minimalViewContext) Initiator() view.View      { return nil }
+func (c *minimalViewContext) GetSession(_ view.View, _ view.Identity, _ ...view.View) (view.Session, error) {
+	return nil, nil
+}
+func (c *minimalViewContext) GetSessionByID(_ string, _ view.Identity) (view.Session, error) {
+	return nil, nil
+}
+func (c *minimalViewContext) Session() view.Session { return nil }
+func (c *minimalViewContext) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+
+	return context.Background()
+}
+func (c *minimalViewContext) OnError(_ func()) {}
+
+// newWithdrawalTestContext builds a minimalViewContext whose GetService call
+// resolves a real *token.ManagementServiceProvider backed by mockTMS, so that
+// token.GetManagementService (used by GetWallet) succeeds.
+func newWithdrawalTestContext(t *testing.T, mockTMS *driver_mock.TokenManagerService) *minimalViewContext {
+	t.Helper()
+
+	mockVaultProvider := &token_mock.VaultProvider{}
+	mockVaultProvider.VaultReturns(&driver_mock.Vault{}, nil)
+
+	provider := token.NewManagementServiceProvider(
+		&fakeTMSProvider{tms: mockTMS},
+		passthroughNormalizer{},
+		mockVaultProvider,
+		nil,
+		nil,
+	)
+
+	return &minimalViewContext{svc: provider}
+}
+
+// newStubbedTokenManagerService returns a driver.TokenManagerService with all
+// the stubs required for ManagementService.init() to succeed, with the given
+// wallet service.
+func newStubbedTokenManagerService(walletService driver.WalletService) *driver_mock.TokenManagerService {
+	mockTMS := &driver_mock.TokenManagerService{}
+	mockTMS.WalletServiceReturns(walletService)
+	mockTMS.ValidatorReturns(&driver_mock.Validator{}, nil)
+	mockTMS.AuthorizationReturns(&driver_mock.Authorization{})
+	mockTMS.ConfigurationReturns(&driver_mock.Configuration{})
+	mockTMS.TokensServiceReturns(&driver_mock.TokensService{})
+	mockTMS.TokensUpgradeServiceReturns(&driver_mock.TokensUpgradeService{})
+	mockPPM := &driver_mock.PublicParamsManager{}
+	mockPPM.PublicParametersReturns(&driver_mock.PublicParameters{})
+	mockTMS.PublicParamsManagerReturns(mockPPM)
+	mockTMS.DeserializerReturns(&driver_mock.Deserializer{})
+	mockTMS.IdentityProviderReturns(&driver_mock.IdentityProvider{})
+	mockTMS.CertificationServiceReturns(nil)
+
+	return mockTMS
+}
+
+// TestGetRecipientIdentity_ExternalRecipientData_RegistersAndReturnsData verifies that when
+// r.RecipientData is caller-supplied, getRecipientIdentity registers it against the local
+// wallet before using it, marks the wallet as external, and returns a nil *token.OwnerWallet
+// (so Call signs via the external signer, not the local wallet).
+func TestGetRecipientIdentity_ExternalRecipientData_RegistersAndReturnsData(t *testing.T) {
+	mockOwnerWallet := &driver_mock.OwnerWallet{}
+	mockOwnerWallet.RegisterRecipientReturns(nil)
+
+	mockWalletService := &driver_mock.WalletService{}
+	mockWalletService.OwnerWalletReturns(mockOwnerWallet, nil)
+
+	mockTMS := newStubbedTokenManagerService(mockWalletService)
+	ctx := newWithdrawalTestContext(t, mockTMS)
+
+	data := &RecipientData{
+		Identity:  driver.Identity("recipient-identity"),
+		AuditInfo: []byte("audit-info"),
+	}
+	r := &RequestWithdrawalView{
+		Wallet:        "external-wallet",
+		RecipientData: data,
+	}
+
+	tmsID, recipientData, w, err := r.getRecipientIdentity(ctx)
+
+	require.NoError(t, err)
+	assert.NotNil(t, tmsID)
+	assert.Same(t, data, recipientData)
+	assert.Nil(t, w)
+	assert.True(t, r.ExternalWallet, "external wallet flag must be set once RecipientData is used")
+
+	require.Equal(t, 1, mockOwnerWallet.RegisterRecipientCallCount())
+	_, registered := mockOwnerWallet.RegisterRecipientArgsForCall(0)
+	assert.Same(t, data, registered)
+}
+
+// TestGetRecipientIdentity_ExternalRecipientData_RegisterFails verifies that when the local
+// wallet rejects the caller-supplied RecipientData (e.g. identity/audit-info mismatch),
+// getRecipientIdentity returns an error and never proceeds with the withdrawal.
+func TestGetRecipientIdentity_ExternalRecipientData_RegisterFails(t *testing.T) {
+	mockOwnerWallet := &driver_mock.OwnerWallet{}
+	mockOwnerWallet.RegisterRecipientReturns(errors.New("failed to match identity"))
+
+	mockWalletService := &driver_mock.WalletService{}
+	mockWalletService.OwnerWalletReturns(mockOwnerWallet, nil)
+
+	mockTMS := newStubbedTokenManagerService(mockWalletService)
+	ctx := newWithdrawalTestContext(t, mockTMS)
+
+	r := &RequestWithdrawalView{
+		Wallet: "external-wallet",
+		RecipientData: &RecipientData{
+			Identity:  driver.Identity("recipient-identity"),
+			AuditInfo: []byte("mismatched-audit-info"),
+		},
+	}
+
+	tmsID, recipientData, w, err := r.getRecipientIdentity(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to register recipient data")
+	assert.Nil(t, tmsID)
+	assert.Nil(t, recipientData)
+	assert.Nil(t, w)
+	assert.False(t, r.ExternalWallet, "external wallet flag must not be set on failure")
+}
+
+// TestGetRecipientIdentity_NoRecipientData_UsesLocalWallet verifies that when no
+// RecipientData is supplied, getRecipientIdentity falls back to the local wallet's own
+// GetRecipientData and returns the wallet itself, unchanged from prior behavior.
+func TestGetRecipientIdentity_NoRecipientData_UsesLocalWallet(t *testing.T) {
+	localRecipientData := &driver.RecipientData{
+		Identity:  driver.Identity("local-identity"),
+		AuditInfo: []byte("local-audit-info"),
+	}
+
+	mockOwnerWallet := &driver_mock.OwnerWallet{}
+	mockOwnerWallet.GetRecipientDataReturns(localRecipientData, nil)
+
+	mockWalletService := &driver_mock.WalletService{}
+	mockWalletService.OwnerWalletReturns(mockOwnerWallet, nil)
+
+	mockTMS := newStubbedTokenManagerService(mockWalletService)
+	ctx := newWithdrawalTestContext(t, mockTMS)
+
+	r := &RequestWithdrawalView{Wallet: "local-wallet"}
+
+	tmsID, recipientData, w, err := r.getRecipientIdentity(ctx)
+
+	require.NoError(t, err)
+	assert.NotNil(t, tmsID)
+	assert.Same(t, localRecipientData, recipientData)
+	assert.NotNil(t, w)
+	assert.False(t, r.ExternalWallet)
+	assert.Equal(t, 0, mockOwnerWallet.RegisterRecipientCallCount())
+}

--- a/token/services/ttx/withdrawal_test.go
+++ b/token/services/ttx/withdrawal_test.go
@@ -31,6 +31,10 @@ type fakeTMSProvider struct {
 	tms driver.TokenManagerService
 }
 
+func (f *fakeTMSProvider) ConfigurationFor(network, channel, namespace string) (driver.Configuration, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (f *fakeTMSProvider) GetTokenManagerService(_ driver.ServiceOptions) (driver.TokenManagerService, error) {
 	return f.tms, nil
 }
@@ -216,4 +220,50 @@ func TestGetRecipientIdentity_NoRecipientData_UsesLocalWallet(t *testing.T) {
 	assert.NotNil(t, w)
 	assert.False(t, r.ExternalWallet)
 	assert.Equal(t, 0, mockOwnerWallet.RegisterRecipientCallCount())
+}
+
+// TestGetRecipientIdentity_GetRecipientDataFails verifies that when no
+// RecipientData is supplied and the local wallet's own GetRecipientData call
+// fails, getRecipientIdentity surfaces the error instead of proceeding.
+func TestGetRecipientIdentity_GetRecipientDataFails(t *testing.T) {
+	mockOwnerWallet := &driver_mock.OwnerWallet{}
+	mockOwnerWallet.GetRecipientDataReturns(nil, errors.New("keystore unavailable"))
+
+	mockWalletService := &driver_mock.WalletService{}
+	mockWalletService.OwnerWalletReturns(mockOwnerWallet, nil)
+
+	mockTMS := newStubbedTokenManagerService(mockWalletService)
+	ctx := newWithdrawalTestContext(t, mockTMS)
+
+	r := &RequestWithdrawalView{Wallet: "local-wallet"}
+
+	tmsID, recipientData, w, err := r.getRecipientIdentity(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get recipient data")
+	assert.Nil(t, tmsID)
+	assert.Nil(t, recipientData)
+	assert.Nil(t, w)
+}
+
+// TestGetRecipientIdentity_WalletNotFound verifies that when the requested wallet
+// cannot be resolved (e.g. the wallet service fails to return an owner wallet),
+// getRecipientIdentity surfaces a "wallet not found" error instead of panicking
+// on a nil wallet.
+func TestGetRecipientIdentity_WalletNotFound(t *testing.T) {
+	mockWalletService := &driver_mock.WalletService{}
+	mockWalletService.OwnerWalletReturns(nil, errors.New("no such wallet"))
+
+	mockTMS := newStubbedTokenManagerService(mockWalletService)
+	ctx := newWithdrawalTestContext(t, mockTMS)
+
+	r := &RequestWithdrawalView{Wallet: "missing-wallet"}
+
+	tmsID, recipientData, w, err := r.getRecipientIdentity(ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Nil(t, tmsID)
+	assert.Nil(t, recipientData)
+	assert.Nil(t, w)
 }


### PR DESCRIPTION
## Summary
- `RequestWithdrawalView.getRecipientIdentity` accepted caller-supplied `RecipientData` for the external-wallet withdrawal path as-is, with no check that the identity/audit-info pair was ever registered against the local wallet.
- Resolve the caller's local wallet and call `w.RegisterRecipient(ctx, r.RecipientData)` before using the data to drive the withdrawal handshake, so a mismatched identity/audit-info pair is rejected instead of silently accepted (`AnonymousOwnerWallet.RegisterRecipient` runs `Deserializer.MatchIdentity` before registering/binding).
- Removed the now-redundant manual `RegisterRecipient` call in `integration/token/fungible/views/withdraw.go`, since the library now enforces it.
- Updated `docs/services/ttx.md` to document the new enforcement point and its scope (full protection requires an `AnonymousOwnerWallet`-backed local wallet; `LongTermOwnerWallet` validation was addressed separately in #1917).

Fixes #1922

## Test plan
- [x] `go build ./...` and `(cd integration && go build ./...)` succeed
- [x] New unit tests in `token/services/ttx/withdrawal_test.go` cover: registration succeeds (external flag set, nil wallet returned), registration fails (error bubbles up, external flag not set), and the unchanged local-wallet fallback path (no `RecipientData` supplied)
- [x] `go test ./token/services/ttx/...` passes
- [x] `make checks` passes