### PR TITLE
docs(token): document RestRecipientIdentity and TransferActionMetadataKeyPrefix

### DIFF
--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -234,6 +234,8 @@ The setup listener watches for changes to a specific ledger key that stores publ
 3. **Validation**: Parameters are validated before being applied
 4. **Persistence**: New parameters are stored in the local database
 
+The same delivery-based mechanism is reused by the [lookup service](../../token/services/network/fabric/lookup/deliveryllm.go) to detect transfer action metadata writes: it derives the transfer action metadata key prefix from [`KeyTranslator.TransferActionMetadataKeyPrefix`](../../token/services/network/common/rws/translator/rwset.go) and prefix-matches rwset writes against it, without needing to know each write's specific subkey ahead of time.
+
 ## State Queries
 
 The Fabric implementation provides efficient state querying through the chaincode:

--- a/docs/tokenapi.md
+++ b/docs/tokenapi.md
@@ -61,6 +61,8 @@ A [Request](../token/request.go) is a ledger-agnostic blueprint for a token tran
 *   **Issue**: Minting new tokens into the system.
 *   **Transfer**: Reassigning ownership of existing tokens (includes **Redeem** by transferring to a null owner; enhanced redeem flows can additionally require issuer authorization/signature).
 
+When a transfer selects inputs whose sum exceeds the requested output amount, the leftover ("rest" or change) is automatically assigned to a recipient: by default the sender wallet's own recipient identity, or, if the caller supplies `WithRestRecipientIdentity(...)` on the `Transfer` call, the explicitly provided recipient (which is registered with the wallet before use).
+
 ### The Request Lifecycle
 1.  **Assemble**: Add actions to the `Request` using a TMS.
 2.  **Sign**: Generate witnesses (signatures or ZK proofs) using the appropriate Wallets.

--- a/token/request.go
+++ b/token/request.go
@@ -101,7 +101,9 @@ type TransferOptions struct {
 	Selector Selector
 	// TokenIDs to transfer. If empty, the tokens will be selected.
 	TokenIDs []*token.ID
-	// RestRecipientIdentity TODO:
+	// RestRecipientIdentity is the recipient to which the transfer's leftover (change) amount is
+	// assigned when the selected inputs exceed the requested output sum. If nil, the change is
+	// assigned to the sender wallet's default recipient identity. Set via WithRestRecipientIdentity.
 	RestRecipientIdentity *RecipientData
 }
 

--- a/token/services/network/common/rws/translator/rwset.go
+++ b/token/services/network/common/rws/translator/rwset.go
@@ -42,7 +42,9 @@ type KeyTranslator interface {
 	CreateTransferActionMetadataKey(subkey string) (Key, error)
 	// GetTransferMetadataSubKey returns the subkey in the given transfer action metadata key
 	GetTransferMetadataSubKey(k string) (Key, error)
-	// TransferActionMetadataKeyPrefix TODO
+	// TransferActionMetadataKeyPrefix returns the key prefix shared by all transfer action metadata
+	// keys, i.e., the same prefix produced by CreateTransferActionMetadataKey with no subkey. It is
+	// used to prefix-match transfer action metadata writes without knowing a specific subkey.
 	TransferActionMetadataKeyPrefix() (Key, error)
 }
 


### PR DESCRIPTION
## Summary
- Fill in the placeholder "TODO" Godoc comments on `TransferOptions.RestRecipientIdentity` (`token/request.go`) and `KeyTranslator.TransferActionMetadataKeyPrefix` (`token/services/network/common/rws/translator/rwset.go`) with descriptions derived from their actual usage.
- Add corresponding notes to `docs/tokenapi.md` (transfer rest/change recipient handling) and `docs/services/network-fabric.md` (delivery-based lookup listener prefix matching).

Fixes #1924

## Test plan
- [x] `go build ./token/...`
- [x] `make checks`
- [x] `gofmt -l` on changed Go files (clean)
- [x] Confirmed the two doc-TODOs are gone via `grep -n "TODO"` on the changed files (the unrelated `HashedKeyTranslator` implementation stub TODO remains, intentionally out of scope)