### PR TITLE
perf(postgres): install notification triggers lazily on first Subscribe

### DIFF
--- a/token/services/storage/db/sql/postgres/driver.go
+++ b/token/services/storage/db/sql/postgres/driver.go
@@ -106,6 +106,9 @@ func newTokenStoreProvider(dbProvider fscPostgres.DbProvider, tableNamesConfig c
 		if err != nil {
 			return nil, err
 		}
+		if o.SkipCreateTable {
+			notifier.skipSchemaManagement()
+		}
 
 		// db
 		p, err := NewTokenStoreWithNotifier(dbs, tableNames, notifier)
@@ -114,9 +117,6 @@ func newTokenStoreProvider(dbProvider fscPostgres.DbProvider, tableNamesConfig c
 		}
 		if !o.SkipCreateTable {
 			if err := p.CreateSchema(); err != nil {
-				return nil, err
-			}
-			if err := notifier.CreateSchema(); err != nil {
 				return nil, err
 			}
 		}
@@ -151,18 +151,12 @@ func newIdentityStoreProvider(dbProvider fscPostgres.DbProvider, tableNamesConfi
 		if err != nil {
 			return nil, err
 		}
-
-		// Get notifier for schema creation
-		notifier, err := NewIdentityNotifier(dbs, tableNames, o.DataSource)
-		if err != nil {
-			return nil, err
+		if o.SkipCreateTable {
+			p.notifier.skipSchemaManagement()
 		}
 
 		if !o.SkipCreateTable {
 			if err := p.CreateSchema(); err != nil {
-				return nil, err
-			}
-			if err := notifier.CreateSchema(); err != nil {
 				return nil, err
 			}
 		}
@@ -197,6 +191,9 @@ func newTransactionStoreProvider(dbProvider fscPostgres.DbProvider, tableNamesCo
 		if err != nil {
 			return nil, err
 		}
+		if o.SkipCreateTable {
+			notifier.skipSchemaManagement()
+		}
 
 		// db
 		p, err := NewTransactionStoreWithNotifier(dbs, tableNames, notifier)
@@ -205,9 +202,6 @@ func newTransactionStoreProvider(dbProvider fscPostgres.DbProvider, tableNamesCo
 		}
 		if !o.SkipCreateTable {
 			if err := p.CreateSchema(); err != nil {
-				return nil, err
-			}
-			if err := notifier.CreateSchema(); err != nil {
 				return nil, err
 			}
 		}

--- a/token/services/storage/db/sql/postgres/identity.go
+++ b/token/services/storage/db/sql/postgres/identity.go
@@ -21,8 +21,9 @@ import (
 // IdentityStore wraps common.IdentityStore to add advisory lock to schema creation
 type IdentityStore struct {
 	*sqlcommon.IdentityStore
-	writeDB *sql.DB
-	lockID  int64
+	writeDB  *sql.DB
+	lockID   int64
+	notifier *IdentityNotifier
 }
 
 // GetSchema overrides the base GetSchema to prefix with advisory lock
@@ -62,6 +63,7 @@ func NewIdentityStore(dbs *scommon.RWDB, tableNames sqlcommon.TableNames, dataSo
 		IdentityStore: baseStore,
 		writeDB:       dbs.WriteDB,
 		lockID:        createTableLockID("identity"),
+		notifier:      notifier,
 	}, nil
 }
 

--- a/token/services/storage/db/sql/postgres/notifier.go
+++ b/token/services/storage/db/sql/postgres/notifier.go
@@ -73,6 +73,14 @@ type Notifier struct {
 	// channelName is the name of the channel on which to receive notifications.
 	// It must be smaller than 63 characters per Postgres limit
 	channelName string
+	// ensureSchema installs the notification trigger on first subscription.
+	// Set by NewNotifier to CreateSchema; nil skips all runtime DDL and the
+	// deployment must pre-create the trigger (SkipCreateTable).
+	ensureSchema func() error
+	// startupErr records a lazy-startup failure: the trigger installation
+	// failed or the notifier was closed mid-install. Written once inside
+	// startOnce; the failure is final and every Subscribe returns it.
+	startupErr error
 }
 
 var logger = logging.MustGetLogger()
@@ -139,6 +147,7 @@ func NewNotifier(
 		closed:           false,
 		channelName:      channelName,
 	}
+	n.ensureSchema = n.CreateSchema
 
 	// attach handler that calls the subscribers
 	n.listener.Handle(channelName, &notificationHandler{
@@ -191,6 +200,23 @@ func (db *Notifier) Subscribe(callback driver.TriggerCallback) error {
 	db.startOnce.Do(func() {
 		justStarted = true
 		logger.Debugf("First subscription for notifier of [%s]. Notifier starts listening...", db.table)
+		// The notification trigger is installed on first subscription rather
+		// than at store creation: tables nobody subscribes to must not pay
+		// the per-row pg_notify cost (NOTIFY serializes transaction commits
+		// on a global queue lock).
+		if db.ensureSchema != nil {
+			if err := db.ensureSchema(); err != nil {
+				db.startupErr = errors.Wrapf(err, "failed creating notification schema for [%s]", db.table)
+
+				return
+			}
+		}
+		// the notifier may have been closed while the schema was installing
+		if err := db.ctx.Err(); err != nil {
+			db.startupErr = err
+
+			return
+		}
 		db.listenerWg.Go(func() {
 			if err := db.listener.Listen(db.ctx); err != nil {
 				// Send error to both the error channel and log it
@@ -203,6 +229,12 @@ func (db *Notifier) Subscribe(callback driver.TriggerCallback) error {
 			}
 		})
 	})
+
+	// startOnce.Do guarantees the write inside the closure is visible here.
+	// A startup failure is final: every subscription returns the same error.
+	if db.startupErr != nil {
+		return db.startupErr
+	}
 
 	if justStarted {
 		// Wait a bit to see if it fails immediately
@@ -326,6 +358,12 @@ func (db *Notifier) GetSchema() string {
 		convertOperations(db.notifyOperations), db.table,
 		funcName,
 	)
+}
+
+// skipSchemaManagement disables the lazy trigger installation; the deployment
+// is expected to pre-create the notification schema.
+func (db *Notifier) skipSchemaManagement() {
+	db.ensureSchema = nil
 }
 
 // CreateSchema creates the notification objects in the database.

--- a/token/services/storage/db/sql/postgres/notifier_test.go
+++ b/token/services/storage/db/sql/postgres/notifier_test.go
@@ -9,12 +9,14 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	herrors "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver"
+	fscPostgres "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
 	"github.com/jackc/pgxlisten"
 	"github.com/stretchr/testify/require"
 )
@@ -66,6 +68,257 @@ func TestNotifierSubscribeError(t *testing.T) {
 	err := db.Subscribe(func(operation driver.Operation, m map[driver.ColumnKey]string) {})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "listener failed to start")
+}
+
+// TestNotifierSubscribeInstallsSchemaOnce tests that the notification schema
+// (trigger) is installed lazily on the first subscription only.
+func TestNotifierSubscribeInstallsSchemaOnce(t *testing.T) {
+	var schemaCalls int
+	listenStarted := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table: "test_table",
+		listener: &mockListener{
+			ListenFN: func(ctx context.Context) error {
+				listenStarted <- struct{}{}
+				<-ctx.Done()
+
+				return ctx.Err()
+			},
+		},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error {
+		require.Empty(t, listenStarted, "schema must be installed before the listener starts")
+		schemaCalls++
+
+		return nil
+	}
+
+	for range 3 {
+		require.NoError(t, db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {}))
+	}
+	require.Equal(t, 1, schemaCalls, "schema must be installed exactly once, on first subscription")
+}
+
+// TestNotifierSubscribeSchemaError tests that Subscribe surfaces a schema
+// installation failure and does not start the listener.
+func TestNotifierSubscribeSchemaError(t *testing.T) {
+	var listenCalled bool
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table: "test_table",
+		listener: &mockListener{
+			ListenFN: func(ctx context.Context) error {
+				listenCalled = true
+
+				return nil
+			},
+		},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error { return errors.New("no DDL permissions") }
+
+	err := db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no DDL permissions")
+	require.False(t, listenCalled, "listener must not start when schema installation fails")
+}
+
+// TestNotifierSubscribeSchemaFailureIsFinal tests that a schema installation
+// failure is final: it is not retried and every Subscribe returns it.
+func TestNotifierSubscribeSchemaFailureIsFinal(t *testing.T) {
+	var schemaCalls int
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table:       "test_table",
+		listener:    &mockListener{},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error {
+		schemaCalls++
+
+		return errors.New("no DDL permissions")
+	}
+
+	for range 3 {
+		err := db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {})
+		require.ErrorContains(t, err, "no DDL permissions")
+	}
+	require.Equal(t, 1, schemaCalls, "a failed installation must not be retried")
+}
+
+// TestNotifierSubscribeSchemaErrorAllSubscribers tests that concurrent
+// subscribers all observe a schema installation failure.
+func TestNotifierSubscribeSchemaErrorAllSubscribers(t *testing.T) {
+	release := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table:       "test_table",
+		listener:    &mockListener{},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error {
+		<-release
+
+		return errors.New("no DDL permissions")
+	}
+
+	errs := make([]error, 8)
+	var wg sync.WaitGroup
+	for i := range errs {
+		wg.Go(func() {
+			errs[i] = db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {})
+		})
+	}
+	close(release)
+	wg.Wait()
+	for _, err := range errs {
+		require.ErrorContains(t, err, "no DDL permissions")
+	}
+}
+
+// TestNotifierCloseDuringSchemaInstall tests that closing the notifier while
+// the schema is being installed neither panics nor starts the listener.
+func TestNotifierCloseDuringSchemaInstall(t *testing.T) {
+	installing := make(chan struct{})
+	release := make(chan struct{})
+	var listenCalled bool
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table: "test_table",
+		listener: &mockListener{
+			ListenFN: func(ctx context.Context) error {
+				listenCalled = true
+
+				return nil
+			},
+		},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error {
+		close(installing)
+		<-release
+
+		return nil
+	}
+
+	subscribed := make(chan error, 1)
+	go func() {
+		subscribed <- db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {})
+	}()
+	<-installing
+	require.NoError(t, db.Close())
+	close(release)
+
+	err := <-subscribed
+	require.Error(t, err, "subscribing to a notifier closed mid-install must fail")
+	require.False(t, listenCalled, "listener must not start after Close")
+}
+
+// TestNotifierSkipSchemaManagement tests that a notifier with schema
+// management disabled runs no DDL and still starts the listener.
+func TestNotifierSkipSchemaManagement(t *testing.T) {
+	listenStarted := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	db := &Notifier{
+		table: "test_table",
+		listener: &mockListener{
+			ListenFN: func(ctx context.Context) error {
+				listenStarted <- struct{}{}
+				<-ctx.Done()
+
+				return ctx.Err()
+			},
+		},
+		listenerErr: make(chan error, 1),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+	db.ensureSchema = func() error {
+		t.Error("no DDL must run when schema management is disabled")
+
+		return nil
+	}
+	db.skipSchemaManagement()
+
+	require.NoError(t, db.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {}))
+	select {
+	case <-listenStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener did not start")
+	}
+}
+
+// TestNotifierLazyTriggerInstall verifies against a real Postgres that no
+// trigger exists before the first subscription, that subscribing installs it,
+// and that notifications are delivered afterwards.
+func TestNotifierLazyTriggerInstall(t *testing.T) {
+	terminate, pgConnStr := startContainer(t)
+	defer terminate()
+
+	dbs, err := fscPostgres.NewDbProvider().Get(fscPostgres.Opts{
+		DataSource:   pgConnStr,
+		MaxOpenConns: 5,
+		MaxIdleConns: 2,
+		MaxIdleTime:  time.Minute,
+	})
+	require.NoError(t, err)
+
+	const table = "lazy_trigger_test"
+	_, err = dbs.WriteDB.Exec("CREATE TABLE " + table + " (id TEXT PRIMARY KEY)")
+	require.NoError(t, err)
+
+	n := NewNotifier(dbs.WriteDB, table, pgConnStr, AllOperations, *NewSimplePrimaryKey("id"))
+	defer func() { require.NoError(t, n.Close()) }()
+
+	triggerCount := func() int {
+		var count int
+		require.NoError(t, dbs.WriteDB.QueryRow(
+			`SELECT count(*) FROM pg_trigger WHERE tgname = $1`, "trigger_"+table).Scan(&count))
+
+		return count
+	}
+	require.Zero(t, triggerCount(), "no trigger must exist before the first subscription")
+
+	notified := make(chan struct{}, 1)
+	require.NoError(t, n.Subscribe(func(driver.Operation, map[driver.ColumnKey]string) {
+		select {
+		case notified <- struct{}{}:
+		default:
+		}
+	}))
+	require.Equal(t, 1, triggerCount(), "the first subscription must install the trigger")
+
+	// LISTEN starts asynchronously: keep inserting until a notification lands
+	i := 0
+	require.Eventually(t, func() bool {
+		i++
+		_, err := dbs.WriteDB.Exec("INSERT INTO "+table+" (id) VALUES ($1)", fmt.Sprintf("id%d", i))
+		require.NoError(t, err)
+		select {
+		case <-notified:
+			return true
+		default:
+			return false
+		}
+	}, 15*time.Second, 200*time.Millisecond, "no notification received after installing the trigger")
 }
 
 // TestNotifierSubscribeClosed tests that Subscribe returns an error when notifier is closed


### PR DESCRIPTION
## Motivation

The postgres stores install their notification triggers (per-row `pg_notify`) at store creation. PostgreSQL serializes the commit of every notifying transaction on a global notification-queue lock, so once the triggers exist, every write to those tables pays that lock — whether or not anything ever subscribes. The token and transaction notifiers currently have no subscriber in the code base (the only production subscriber is the identity-configuration sync in `token/services/identity/membership/lm.go`), so on write-heavy tables the triggers broadcast to nobody while serializing all commits.

In our test environments under sustained load, the database showed hundreds of connections blocked on `COMMIT` waiting for the notification-queue lock (`wait_event_type=Lock, wait_event=object`); dropping the triggers took the lock-wait peaks from ~800 to zero.

## Changes

- `Notifier` installs the notification schema on the first `Subscribe` (inside the existing `startOnce`) instead of at store creation. A failed installation is final: it is recorded and returned by every subsequent `Subscribe`; closing the notifier while the schema is installing does not start the listener.
- The token/transaction/identity store providers no longer create the notification schema at startup. With `SkipCreateTable` the notifier runs no DDL at all (`skipSchemaManagement`) and the deployment pre-creates the notification schema like the rest of the schema.
- The identity store provider no longer builds a second, throwaway `IdentityNotifier` just for schema creation; the store keeps a reference to the one it already has.

Existing subscribers are unaffected: their first `Subscribe` installs the same schema that store creation used to.

## Tests

- Unit: the schema is installed exactly once across concurrent subscribers; an installation failure surfaces to every subscriber and is not retried; close-during-install starts no listener; skip mode runs no DDL and still listens.
- Against a real postgres: no trigger exists before the first subscription; subscribing installs it and notifications are delivered.
- Full `go test -race ./token/...` passes.

Fixes #1934