### PR TITLE
validator: define consensus-safe resource limits for untrusted requests

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -57,6 +57,15 @@ jobs:
           - name: identity-idemixnym-audit-info-deserializer
             pkg: ./token/services/identity/idemixnym/nym
             func: FuzzDeserializeAuditInfoNoPanic
+          - name: common-request-limits
+            pkg: ./token/core/common
+            func: FuzzRequestResourceLimits
+          - name: zkatdlog-action-limits
+            pkg: ./token/core/zkatdlog/nogh/v1/validator
+            func: FuzzActionResourceLimits
+          - name: fabtoken-action-limits
+            pkg: ./token/core/fabtoken/v1/validator
+            func: FuzzActionResourceLimits
 
     steps:
       - name: Checkout code
@@ -78,6 +87,7 @@ jobs:
 
       - name: Run fuzz campaign
         run: |
+          set -o pipefail
           go test ${{ matrix.pkg }} \
             -run='^$' \
             -fuzz='^${{ matrix.func }}$' \

--- a/cmd/token_validation_service/token_validation_service_bench.go
+++ b/cmd/token_validation_service/token_validation_service_bench.go
@@ -24,6 +24,7 @@ import (
 	fabtoken "github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/driver"
 	dlog "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/driver"
 	v1setup "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
+	"github.com/LFDT-Panurus/panurus/token/driver"
 	tk "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 )
@@ -159,7 +160,7 @@ func (*fakeLedger) GetState(_ tk.ID) ([]byte, error) {
 }
 
 func newTokenValidator(ppRaw []byte) (*token.Validator, error) {
-	is := core.NewValidatorDriverService(fabtoken.NewValidatorDriver(), dlog.NewValidatorDriver())
+	is := core.NewValidatorDriverService(driver.DefaultResourceLimits(), fabtoken.NewValidatorDriver(), dlog.NewValidatorDriver())
 	ppm, err := is.PublicParametersFromBytes(ppRaw)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize public parameters: %w", err)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,29 @@ token:
         # interval is the polling interval for one-time lookups. Defaults to 2s.
         interval: 2s
         
+  # validation configures the resource limits enforced on untrusted token requests/actions
+  # before they reach cryptographic verification. Process-wide (not per-TMS): both the FSC/DI
+  # runtime and the standalone Fabric chaincode process resolve a single ResourceLimits value.
+  # Every field is optional; any field left unset defaults to the safe, historical value.
+  # The chaincode process (which has no config service) reads the same limits from
+  # TOKEN_VALIDATION_MAX_* environment variables instead. See
+  # docs/drivers/validation-resource-limits.md for the full enforcement and consensus-safety
+  # contract: if you override any limit, every peer validating the same channel/namespace MUST
+  # be configured with the identical value.
+  validation:
+    limits:
+      maxRequestBytes: 262144
+      maxActions: 256
+      maxSignatures: 4096
+      maxSignatureBytes: 4096
+      maxActionBytes: 262144
+      maxInputs: 256
+      maxOutputs: 256
+      maxMetadataEntries: 64
+      maxMetadataKeyBytes: 256
+      maxMetadataValueBytes: 4096
+      maxProofBytes: 131072
+
   # optional global SQL table name overrides (applied to all TMS instances).
   # The value replaces the short code; the FSC-generated prefix and params still wrap it.
   # Unknown keys are warned and ignored. Omit the section to keep all default names.
@@ -446,6 +469,60 @@ Default values:
 - poller.interval: 1s
 - poller.batchSize: 2000
 - poller.pendingTTL: 10m
+
+---
+
+### Optional: token.validation.limits
+
+Process-wide (not per-TMS) resource limits enforced on untrusted token requests/actions before
+cryptographic verification. See [docs/drivers/validation-resource-limits.md](drivers/validation-resource-limits.md)
+for the full enforcement points and the consensus-safety contract.
+
+If not specified, the default configuration is:
+
+```yaml
+token:
+  validation:
+    limits:
+      maxRequestBytes: 262144
+      maxActions: 256
+      maxSignatures: 4096
+      maxSignatureBytes: 4096
+      maxActionBytes: 262144
+      maxInputs: 256
+      maxOutputs: 256
+      maxMetadataEntries: 64
+      maxMetadataKeyBytes: 256
+      maxMetadataValueBytes: 4096
+      maxProofBytes: 131072
+```
+
+Default values:
+
+- maxRequestBytes: 262144 (256 KiB)
+- maxActions: 256
+- maxSignatures: 4096
+- maxSignatureBytes: 4096 (4 KiB)
+- maxActionBytes: 262144 (256 KiB)
+- maxInputs: 256
+- maxOutputs: 256
+- maxMetadataEntries: 64
+- maxMetadataKeyBytes: 256
+- maxMetadataValueBytes: 4096 (4 KiB)
+- maxProofBytes: 131072 (128 KiB) — ignored by drivers without a zero-knowledge proof (fabtoken)
+
+Every field is optional; any field omitted (or the whole `token.validation.limits` key omitted)
+resolves to its default. Read via the config service, so this key applies only to the FSC/DI
+runtime. The standalone Fabric chaincode process (`token/services/network/fabric/tcc/main`) has no
+config service and instead reads the equivalent `TOKEN_VALIDATION_MAX_*` environment variables
+(e.g. `TOKEN_VALIDATION_MAX_ACTIONS`), with the same unset-defaults overlay.
+
+**Consensus-safety warning:** the defaults above are safe and identical across every peer that
+does not override them. If you override any limit, every peer validating the same
+channel/namespace — and the chaincode process, if it enforces limits independently — MUST be
+configured with the identical value, or endorsement determinism silently breaks (one peer accepts
+a request another rejects). Treat a limits change like a `driver.MaxAnchorSize` change: roll it
+out as a coordinated configuration change before any peer relies on the new value.
 
 ---
 

--- a/docs/driverapi.md
+++ b/docs/driverapi.md
@@ -261,6 +261,7 @@ Panurus comes equipped with two reference drivers:
 - [**FabToken**](./drivers/fabtoken.md): A straightforward implementation prioritizing simplicity. It stores token transaction details (type, value, owner) in cleartext on the ledger, using X.509 certificates for identities.
 - [**DLOG w/o Graph Hiding (NOGH)**](./drivers/dlogwogh.md): A privacy-preserving driver using Zero-Knowledge Proofs (ZKP) to hide token types and values via Pedersen commitments. It leverages Idemix for owner anonymity while revealing the spending graph.
 - [**Extending a Validator Driver**](./drivers/extending_validator.md)
+- [**Validator Resource Limits**](./drivers/validation-resource-limits.md): the consensus-safe resource limits enforced on untrusted requests and actions before cryptographic verification.
 
 ## Observability
 

--- a/docs/drivers/extending_validator.md
+++ b/docs/drivers/extending_validator.md
@@ -20,15 +20,23 @@ The `ValidatorDriverService` (found in `token/core/service.go`) maintains a map 
 ```go
 type ValidatorDriverService struct {
 	*factoryDirectory[driver.ValidatorDriver]
+	limits driver.ResourceLimits
 }
 
 func (s *ValidatorDriverService) NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
 	if driver, ok := s.factories[DriverIdentifierFromPP(pp)]; ok {
-		return driver.NewValidator(pp)
+		return driver.NewValidator(pp, s.limits)
 	}
 	return nil, errors.Errorf("no validator found for token driver [%s]", DriverIdentifierFromPP(pp))
 }
 ```
+
+`s.limits` is a `driver.ResourceLimits` value (see
+[Validator Resource Limits](validation-resource-limits.md)) resolved once at composition-root time
+and applied to every validator the service creates. Every `driver.ValidatorDriver.NewValidator`
+implementation — including any custom one you register — must accept and forward it; a wrapper
+that constructs a validator without it would silently drop the resource-limit enforcement described
+below.
 
 By providing a custom factory with the same identifier as an existing driver, you can effectively "hijack" the validator creation process.
 
@@ -70,7 +78,7 @@ type MyValidatorDriver struct {
 	driver.ValidatorDriver // Wrap the existing driver
 }
 
-func (d *MyValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
+func (d *MyValidatorDriver) NewValidator(pp driver.PublicParameters, limits driver.ResourceLimits) (driver.Validator, error) {
 	// We can't easily use the wrapped driver's NewValidator if we want to 
     // inject functions into its internal pipeline, so we replicate its logic.
     
@@ -86,11 +94,14 @@ func (d *MyValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Val
     
 	logger := logging.DriverLoggerFromPP("panurus.driver.myextension", string(pp.TokenDriverName()))
 
-	// Instantiate the validator with your custom function
+	// Instantiate the validator with your custom function, forwarding the resource limits the
+	// ValidatorDriverService resolved (see the Architecture section above) so this driver enforces
+	// the same consensus-relevant bounds as every other validating peer.
 	return validator.New(
 		logger,
 		ppp,
 		deserializer,
+		limits,
 		[]validator.ValidateTransferFunc{MyCustomTransferValidation}, // Extra transfer validators
 		nil, // Extra issuer validators
 		nil, // Extra auditor validators

--- a/docs/drivers/validation-resource-limits.md
+++ b/docs/drivers/validation-resource-limits.md
@@ -1,31 +1,81 @@
 # Validator Resource Limits
 
 This page describes the resource limits enforced on untrusted token requests and actions before
-they reach cryptographic verification, and the consensus-safety contract those limits carry.
+they reach cryptographic verification, the configuration mechanism that controls them, and the
+consensus-safety contract that mechanism carries.
 
 ## Why limits exist
 
 The token request validators (`token/core/common`, and the fabtoken/zkatdlog drivers built on top
-of it) accept raw, attacker-controlled bytes over the network. Before these limits were
-introduced, only the signing anchor had an explicit size bound (`driver.MaxAnchorSize`). Nothing
-else bounded the size of the raw request, the number of actions or signatures, the size of an
-individual action or signature, the number of inputs/outputs/metadata entries in an action, or the
-length of a zero-knowledge proof. An attacker could force unbounded allocations
+of it) accept raw, attacker-controlled bytes over the network. Aside from the signing anchor
+(`driver.MaxAnchorSize`), nothing else bounds the size of the raw request, the number of actions or
+signatures, the size of an individual action or signature, the number of inputs/outputs/metadata
+entries in an action, or the length of a zero-knowledge proof — unless these limits are enforced.
+Without them, an attacker could force unbounded allocations
 (`make([]..., len(attackerControlledCount))`) and expensive cryptographic work (proof
 deserialization, ZK verification) purely by shaping the wire bytes, without needing any valid
 signature.
 
+## Configuration mechanism
+
+Limits are held in a single struct, `driver.ResourceLimits` (`token/driver/limits.go`), injected
+into every validator at construction time — the validator itself never reads a package constant.
+`driver.DefaultResourceLimits()` returns the historical, always-safe values (see the tables below);
+`driver.ResourceLimits.WithDefaults()` overlays those defaults onto any zero-valued field, so a
+partially-specified override never silently disables a limit by leaving it at zero.
+
+Two sources resolve a `driver.ResourceLimits` value at composition-root time, both implementing
+`driver.ResourceLimitsProvider`:
+
+- **Config-backed** (`token/services/config.ResourceLimitsProvider`) — used by the FSC/DI runtime
+  (`token/sdk/dig/providers.go`). Reads the process-wide key `token.validation.limits` via the
+  configuration service and overlays `DefaultResourceLimits()` onto any field left unset:
+
+  ```yaml
+  token:
+    validation:
+      limits:
+        maxActions: 128
+        maxProofBytes: 65536
+  ```
+
+  Every field is optional; an entirely absent `token.validation.limits` key resolves to
+  `DefaultResourceLimits()` unchanged.
+
+- **Env-backed** (`token/services/network/fabric/tcc.EnvResourceLimitsProvider`) — used by the
+  standalone Fabric chaincode process (`token/services/network/fabric/tcc/main/main.go`), which has
+  no configuration service wired. Reads `TOKEN_VALIDATION_MAX_*` environment variables (e.g.
+  `TOKEN_VALIDATION_MAX_ACTIONS`), applying the same unset-field-defaults overlay.
+
+A `driver.StaticResourceLimits` provider (a trivial wrapper returning a fixed value) is used by
+tests, tools, and any caller that only needs the defaults (e.g.
+`cmd/token_validation_service`, the zkatdlog regression suite).
+
+The resolved `driver.ResourceLimits` flows: composition root → `core.NewValidatorDriverService(limits, ...)`
+→ `driver.ValidatorDriver.NewValidator(pp, limits)` → the per-driver `common.NewValidator(..., limits, ...)`
+→ `ActionDeserializer.DeserializeActions`, which calls `action.SetLimits(limits)` on every
+deserialized action before `Deserialize` runs. Any action constructed without `SetLimits` (e.g. in
+tests or other non-validator call sites) falls back to `DefaultResourceLimits()` via an internal
+`effectiveLimits()` helper — never more permissive than the historical behavior.
+
 ## Consensus-safety contract
 
 Every validating peer must reject or accept the same request identically, or endorsement becomes
-nondeterministic. To guarantee this, all limits are **baked-in Go package constants**, not fields
-read from `PublicParameters` or any other network-supplied or runtime-configurable value. Two
-peers running the same binary version always apply the same limits, independent of what a request
-or its public parameters claim.
+nondeterministic. Limits are no longer baked-in constants — they are configurable — which shifts
+the uniformity guarantee from "guaranteed by the binary" to **an explicit operator
+responsibility**:
 
-**Changing any constant listed below is a breaking protocol change.** It must be coordinated as a
-version upgrade across every validating peer, the same way changing `driver.MaxAnchorSize` would
-be. Do not make these values configurable per-deployment or derive them from `PublicParameters`.
+- The out-of-the-box defaults (`DefaultResourceLimits()`) are safe and identical across every peer
+  that does not override them; deployments that never touch `token.validation.limits` or
+  `TOKEN_VALIDATION_MAX_*` keep the historical, always-consistent behavior.
+- **If you override any limit, every peer validating the same channel/namespace MUST be configured
+  with the identical `ResourceLimits` value.** A peer with a looser `maxActions` will accept
+  requests that a peer with the default (or a stricter) value rejects, silently breaking
+  endorsement determinism — this will not surface as an error until peers disagree on a
+  transaction's validity.
+- Treat a limits change the same way you would treat a `driver.MaxAnchorSize` change: roll it out
+  as a coordinated configuration change across every validating peer (and the chaincode process, if
+  it enforces limits independently) before any peer relies on the new value.
 
 ## Enforcement points
 
@@ -34,9 +84,10 @@ allocate proportional memory or is handed to a cryptographic verifier:
 
 ### 1. Common request envelope (`token/core/common/limits.go`)
 
-Enforced in `VerifyTokenRequestFromRaw` (`token/core/common/validator.go`):
+Enforced by `(*Validator).CheckRawRequestSize` / `CheckRequestLimits`
+(`token/core/common/validator.go`), reading the validator's injected `Limits` field:
 
-| Constant | Value | Checked | Enforced by |
+| Field | Default | Checked | Enforced by |
 | --- | --- | --- | --- |
 | `MaxRequestBytes` | 256 KiB | Raw serialized request size | `CheckRawRequestSize`, before `TokenRequest.FromBytes` |
 | `MaxActions` | 256 | Number of actions in the request | `CheckRequestLimits`, immediately after parsing |
@@ -49,18 +100,19 @@ allocation proportional to its own claimed size. `CheckRequestLimits` runs on th
 before `MarshalToMessageToSign` and before any signature verification, so oversized or
 over-counted requests never reach cryptographic work. Violations return a typed error
 (`ErrRequestTooLarge`, `ErrTooManyActions`, `ErrTooManySignatures`, `ErrActionTooLarge`,
-`ErrSignatureTooLarge`).
+`ErrSignatureTooLarge`), wrapping the effective (possibly configured) limit value.
 
 ### 2. Driver-specific action internals
 
 Each driver bounds the shape of its own action payload, checked inside `Deserialize` (before the
 proportional-size allocations for inputs/outputs) and `Validate` (before proof-specific
-cryptographic work):
+cryptographic work), using the action's `effectiveLimits()` (the limits injected via `SetLimits`,
+or `DefaultResourceLimits()` if none were set):
 
 **ZKAT-DLOG NOGH v1** (`token/core/zkatdlog/nogh/v1/issue/limits.go`,
-`.../transfer/limits.go` — identical constants for issue and transfer actions):
+`.../transfer/limits.go` — identical field defaults for issue and transfer actions):
 
-| Constant | Value |
+| Field | Default |
 | --- | --- |
 | `MaxInputs` | 256 |
 | `MaxOutputs` | 256 |
@@ -76,7 +128,7 @@ cryptographic code.
 **FabToken v1** (`token/core/fabtoken/v1/actions/limits.go` — fabtoken has no ZK proof, so there is
 no `MaxProofBytes`):
 
-| Constant | Value |
+| Field | Default |
 | --- | --- |
 | `MaxInputs` | 256 |
 | `MaxOutputs` | 256 |
@@ -85,33 +137,45 @@ no `MaxProofBytes`):
 | `MaxMetadataValueBytes` | 4 KiB |
 
 Each driver-level violation returns its own typed error (e.g. `ErrTooManyInputs`,
-`ErrProofTooLarge`), defined alongside the constant it enforces.
+`ErrProofTooLarge`), wrapping the effective limit at check time.
+
+Auditor-side deserializers (`.../audit/auditor.go` in both drivers) are not the
+consensus-endorsement boundary and are unaffected by this configuration mechanism — they always
+run with `DefaultResourceLimits()`.
 
 ## Choosing and changing these values
 
-The current values are conservative but comfortably above real usage observed across the unit,
+The default values are conservative but comfortably above real usage observed across the unit,
 regression, and integration test suites — no currently-valid request or action is rejected by any
-of these limits. If a legitimate use case needs a higher limit:
+of the defaults. If a deployment needs a different limit:
 
 1. Confirm no currently-valid production traffic pattern needs a value close to the existing
    limit, to avoid an unnecessarily invasive change.
-2. Treat the change as a coordinated protocol upgrade: every validating peer must adopt the new
-   constant in the same release before any peer accepts a request that only the new limit permits.
-3. Update the exact-boundary unit tests (`limit-1`/`limit`/`limit+1`) and the fuzz seed corpus
-   (`testdata/fuzz/<TargetName>/`) alongside the constant.
+2. Roll the configuration change out to every validating peer (and the chaincode process) before
+   relying on it — see [Consensus-safety contract](#consensus-safety-contract) above.
+3. If you are changing a *default* (not just deploying an override), update the exact-boundary unit
+   tests (`limit-1`/`limit`/`limit+1`) and the fuzz seed corpus (`testdata/fuzz/<TargetName>/`)
+   alongside `DefaultResourceLimits()`.
 
 ## Testing
 
-- **Exact-boundary unit tests**: every constant has a table-driven test asserting `limit-1` and
-  `limit` succeed and `limit+1` fails with the specific typed error (`limits_test.go` next to each
-  `limits.go`).
+- **Exact-boundary unit tests**: every field has a table-driven test asserting `limit-1` and
+  `limit` succeed and `limit+1` fails with the specific typed error, both against
+  `DefaultResourceLimits()` and against an injected custom override (`limits_test.go` next to each
+  `limits.go`), proving overrides actually take effect and are not just read-only documentation.
+- **Provider tests**: the config-backed and env-backed providers each have tests covering an unset
+  source (resolves to defaults), a partial override (unset fields still default), and an
+  invalid/unparseable value (returns an error).
+- **Wiring test**: `TestValidatorDriverService_ForwardsConfiguredLimits`
+  (`token/core/service_test.go`) asserts the exact `ResourceLimits` value passed into
+  `NewValidatorDriverService` is the one forwarded to the driver's `NewValidator`, end to end.
 - **Reject-before-cryptographic-work tests**: `RejectsBeforeCryptographicWork` tests assert an
   oversized proof is rejected in well under 50ms — i.e. before any verifier is constructed. This is
   a timing property, verified as a plain (non-fuzzed) unit test so it isn't subject to fuzz-worker
   CPU contention.
 - **Fuzzing**: `common.FuzzRequestResourceLimits`, `zkatdlog validator.FuzzActionResourceLimits`,
   and `fabtoken validator.FuzzActionResourceLimits` fuzz requests/actions shaped directly by their
-  resource dimensions (counts and byte lengths), asserting no panic and the expected typed error
-  at every boundary. Each target has a persisted seed corpus under its package's
-  `testdata/fuzz/<TargetName>/` covering every constant's boundary, and runs nightly via
-  [`.github/workflows/nightly-fuzz.yml`](../../.github/workflows/nightly-fuzz.yml).
+  resource dimensions (counts and byte lengths) against `DefaultResourceLimits()`, asserting no
+  panic and the expected typed error at every boundary. Each target has a persisted seed corpus
+  under its package's `testdata/fuzz/<TargetName>/` covering every default's boundary, and runs
+  nightly via [`.github/workflows/nightly-fuzz.yml`](../../.github/workflows/nightly-fuzz.yml).

--- a/docs/drivers/validation-resource-limits.md
+++ b/docs/drivers/validation-resource-limits.md
@@ -1,0 +1,117 @@
+# Validator Resource Limits
+
+This page describes the resource limits enforced on untrusted token requests and actions before
+they reach cryptographic verification, and the consensus-safety contract those limits carry.
+
+## Why limits exist
+
+The token request validators (`token/core/common`, and the fabtoken/zkatdlog drivers built on top
+of it) accept raw, attacker-controlled bytes over the network. Before these limits were
+introduced, only the signing anchor had an explicit size bound (`driver.MaxAnchorSize`). Nothing
+else bounded the size of the raw request, the number of actions or signatures, the size of an
+individual action or signature, the number of inputs/outputs/metadata entries in an action, or the
+length of a zero-knowledge proof. An attacker could force unbounded allocations
+(`make([]..., len(attackerControlledCount))`) and expensive cryptographic work (proof
+deserialization, ZK verification) purely by shaping the wire bytes, without needing any valid
+signature.
+
+## Consensus-safety contract
+
+Every validating peer must reject or accept the same request identically, or endorsement becomes
+nondeterministic. To guarantee this, all limits are **baked-in Go package constants**, not fields
+read from `PublicParameters` or any other network-supplied or runtime-configurable value. Two
+peers running the same binary version always apply the same limits, independent of what a request
+or its public parameters claim.
+
+**Changing any constant listed below is a breaking protocol change.** It must be coordinated as a
+version upgrade across every validating peer, the same way changing `driver.MaxAnchorSize` would
+be. Do not make these values configurable per-deployment or derive them from `PublicParameters`.
+
+## Enforcement points
+
+Limits are enforced at two boundaries, both strictly before the request or action is used to
+allocate proportional memory or is handed to a cryptographic verifier:
+
+### 1. Common request envelope (`token/core/common/limits.go`)
+
+Enforced in `VerifyTokenRequestFromRaw` (`token/core/common/validator.go`):
+
+| Constant | Value | Checked | Enforced by |
+| --- | --- | --- | --- |
+| `MaxRequestBytes` | 256 KiB | Raw serialized request size | `CheckRawRequestSize`, before `TokenRequest.FromBytes` |
+| `MaxActions` | 256 | Number of actions in the request | `CheckRequestLimits`, immediately after parsing |
+| `MaxSignatures` | 4096 | Number of request signatures | `CheckRequestLimits`, immediately after parsing |
+| `MaxActionBytes` | 256 KiB | Length of a single action's raw bytes | `CheckRequestLimits`, immediately after parsing |
+| `MaxSignatureBytes` | 4 KiB | Length of a single auditor or action signature | `CheckRequestLimits`, immediately after parsing |
+
+`CheckRawRequestSize` runs before the protobuf decode, so an oversized message never reaches an
+allocation proportional to its own claimed size. `CheckRequestLimits` runs on the parsed request,
+before `MarshalToMessageToSign` and before any signature verification, so oversized or
+over-counted requests never reach cryptographic work. Violations return a typed error
+(`ErrRequestTooLarge`, `ErrTooManyActions`, `ErrTooManySignatures`, `ErrActionTooLarge`,
+`ErrSignatureTooLarge`).
+
+### 2. Driver-specific action internals
+
+Each driver bounds the shape of its own action payload, checked inside `Deserialize` (before the
+proportional-size allocations for inputs/outputs) and `Validate` (before proof-specific
+cryptographic work):
+
+**ZKAT-DLOG NOGH v1** (`token/core/zkatdlog/nogh/v1/issue/limits.go`,
+`.../transfer/limits.go` — identical constants for issue and transfer actions):
+
+| Constant | Value |
+| --- | --- |
+| `MaxInputs` | 256 |
+| `MaxOutputs` | 256 |
+| `MaxMetadataEntries` | 64 |
+| `MaxMetadataKeyBytes` | 256 |
+| `MaxMetadataValueBytes` | 4 KiB |
+| `MaxProofBytes` | 128 KiB |
+
+`MaxProofBytes` is checked before the zero-knowledge proof body is handed to the bulletproof/CSP
+verifier for deserialization, so an oversized proof is rejected without running any ZK-specific
+cryptographic code.
+
+**FabToken v1** (`token/core/fabtoken/v1/actions/limits.go` — fabtoken has no ZK proof, so there is
+no `MaxProofBytes`):
+
+| Constant | Value |
+| --- | --- |
+| `MaxInputs` | 256 |
+| `MaxOutputs` | 256 |
+| `MaxMetadataEntries` | 64 |
+| `MaxMetadataKeyBytes` | 256 |
+| `MaxMetadataValueBytes` | 4 KiB |
+
+Each driver-level violation returns its own typed error (e.g. `ErrTooManyInputs`,
+`ErrProofTooLarge`), defined alongside the constant it enforces.
+
+## Choosing and changing these values
+
+The current values are conservative but comfortably above real usage observed across the unit,
+regression, and integration test suites — no currently-valid request or action is rejected by any
+of these limits. If a legitimate use case needs a higher limit:
+
+1. Confirm no currently-valid production traffic pattern needs a value close to the existing
+   limit, to avoid an unnecessarily invasive change.
+2. Treat the change as a coordinated protocol upgrade: every validating peer must adopt the new
+   constant in the same release before any peer accepts a request that only the new limit permits.
+3. Update the exact-boundary unit tests (`limit-1`/`limit`/`limit+1`) and the fuzz seed corpus
+   (`testdata/fuzz/<TargetName>/`) alongside the constant.
+
+## Testing
+
+- **Exact-boundary unit tests**: every constant has a table-driven test asserting `limit-1` and
+  `limit` succeed and `limit+1` fails with the specific typed error (`limits_test.go` next to each
+  `limits.go`).
+- **Reject-before-cryptographic-work tests**: `RejectsBeforeCryptographicWork` tests assert an
+  oversized proof is rejected in well under 50ms — i.e. before any verifier is constructed. This is
+  a timing property, verified as a plain (non-fuzzed) unit test so it isn't subject to fuzz-worker
+  CPU contention.
+- **Fuzzing**: `common.FuzzRequestResourceLimits`, `zkatdlog validator.FuzzActionResourceLimits`,
+  and `fabtoken validator.FuzzActionResourceLimits` fuzz requests/actions shaped directly by their
+  resource dimensions (counts and byte lengths), asserting no panic and the expected typed error
+  at every boundary. Each target has a persisted seed corpus under its package's
+  `testdata/fuzz/<TargetName>/` covering every constant's boundary, and runs nightly via
+  [`.github/workflows/nightly-fuzz.yml`](../../.github/workflows/nightly-fuzz.yml).

--- a/token/core/common/limits.go
+++ b/token/core/common/limits.go
@@ -13,50 +13,32 @@ import (
 
 // Resource limits enforced by the common validator on raw, untrusted token requests.
 //
-// These constants are consensus-critical: every peer validating the same request must apply
-// the same limits, or otherwise-identical requests could be accepted by one peer and rejected
-// by another, breaking endorsement determinism. Changing any value below is a breaking protocol
-// change and requires a coordinated upgrade of all validating peers, analogous to
-// driver.MaxAnchorSize.
-const (
-	// MaxRequestBytes bounds the raw serialized size of a token request, checked before the
-	// protobuf decode so an oversized message is rejected without allocating a parsed structure.
-	MaxRequestBytes = 256 << 10 // 256 KiB
-
-	// MaxActions bounds the number of actions (issue + transfer) in a single token request.
-	MaxActions = 256
-
-	// MaxSignatures bounds the number of request signatures (auditor + action) in a single
-	// token request.
-	MaxSignatures = 4096
-
-	// MaxSignatureBytes bounds the length of a single auditor or action signature.
-	MaxSignatureBytes = 4 << 10 // 4 KiB
-
-	// MaxActionBytes bounds the length of a single action's serialized (raw) bytes.
-	MaxActionBytes = 256 << 10 // 256 KiB
-)
+// The limits enforced by a given Validator are configurable (see driver.ResourceLimits); every
+// peer validating the same request must be configured with the same limits, or otherwise-
+// identical requests could be accepted by one peer and rejected by another, breaking endorsement
+// determinism. Deployments that override the defaults are responsible for keeping every
+// validating peer in sync.
 
 // Typed errors returned when a raw token request exceeds a configured resource limit.
 var (
-	// ErrRequestTooLarge is returned when the raw request exceeds MaxRequestBytes.
-	ErrRequestTooLarge = errors.Errorf("token request exceeds maximum allowed size of %d bytes", MaxRequestBytes)
-	// ErrTooManyActions is returned when the request contains more than MaxActions actions.
-	ErrTooManyActions = errors.Errorf("token request exceeds maximum allowed number of actions [%d]", MaxActions)
-	// ErrTooManySignatures is returned when the request contains more than MaxSignatures signatures.
-	ErrTooManySignatures = errors.Errorf("token request exceeds maximum allowed number of signatures [%d]", MaxSignatures)
-	// ErrSignatureTooLarge is returned when a signature exceeds MaxSignatureBytes.
-	ErrSignatureTooLarge = errors.Errorf("signature exceeds maximum allowed size of %d bytes", MaxSignatureBytes)
-	// ErrActionTooLarge is returned when an action's raw bytes exceed MaxActionBytes.
-	ErrActionTooLarge = errors.Errorf("action exceeds maximum allowed size of %d bytes", MaxActionBytes)
+	// ErrRequestTooLarge is returned when the raw request exceeds Limits.MaxRequestBytes.
+	ErrRequestTooLarge = errors.New("token request exceeds maximum allowed size")
+	// ErrTooManyActions is returned when the request contains more than Limits.MaxActions actions.
+	ErrTooManyActions = errors.New("token request exceeds maximum allowed number of actions")
+	// ErrTooManySignatures is returned when the request contains more than Limits.MaxSignatures signatures.
+	ErrTooManySignatures = errors.New("token request exceeds maximum allowed number of signatures")
+	// ErrSignatureTooLarge is returned when a signature exceeds Limits.MaxSignatureBytes.
+	ErrSignatureTooLarge = errors.New("signature exceeds maximum allowed size")
+	// ErrActionTooLarge is returned when an action's raw bytes exceed Limits.MaxActionBytes.
+	ErrActionTooLarge = errors.New("action exceeds maximum allowed size")
 )
 
-// CheckRawRequestSize rejects raw token request bytes that exceed MaxRequestBytes.
+// CheckRawRequestSize rejects raw token request bytes that exceed v.Limits.MaxRequestBytes.
 // It must be called before unmarshalling so oversized payloads are rejected before any
 // allocation proportional to their content.
-func CheckRawRequestSize(raw []byte) error {
-	if len(raw) > MaxRequestBytes {
-		return ErrRequestTooLarge
+func (v *Validator[P, T, TA, IA, DS]) CheckRawRequestSize(raw []byte) error {
+	if len(raw) > v.Limits.MaxRequestBytes {
+		return errors.Wrapf(ErrRequestTooLarge, "limit [%d] bytes", v.Limits.MaxRequestBytes)
 	}
 
 	return nil
@@ -66,22 +48,22 @@ func CheckRawRequestSize(raw []byte) error {
 // number of actions and signatures, the size of every action's raw bytes, and the size of
 // every signature. It must be called before any cryptographic work (signature-message
 // marshalling, signature verification) is performed on the request.
-func CheckRequestLimits(tr *driver.TokenRequest) error {
+func (v *Validator[P, T, TA, IA, DS]) CheckRequestLimits(tr *driver.TokenRequest) error {
 	if tr == nil {
 		return ErrNilTokenRequest
 	}
-	if len(tr.Actions) > MaxActions {
-		return ErrTooManyActions
+	if len(tr.Actions) > v.Limits.MaxActions {
+		return errors.Wrapf(ErrTooManyActions, "limit [%d]", v.Limits.MaxActions)
 	}
-	if len(tr.Signatures) > MaxSignatures {
-		return ErrTooManySignatures
+	if len(tr.Signatures) > v.Limits.MaxSignatures {
+		return errors.Wrapf(ErrTooManySignatures, "limit [%d]", v.Limits.MaxSignatures)
 	}
 	for i, action := range tr.Actions {
 		if action == nil {
 			continue
 		}
-		if len(action.Raw) > MaxActionBytes {
-			return errors.Wrapf(ErrActionTooLarge, "action at index [%d]", i)
+		if len(action.Raw) > v.Limits.MaxActionBytes {
+			return errors.Wrapf(ErrActionTooLarge, "action at index [%d], limit [%d] bytes", i, v.Limits.MaxActionBytes)
 		}
 	}
 	for i, sig := range tr.Signatures {
@@ -89,10 +71,10 @@ func CheckRequestLimits(tr *driver.TokenRequest) error {
 			continue
 		}
 		switch {
-		case sig.Action != nil && len(sig.Action.Signature) > MaxSignatureBytes:
-			return errors.Wrapf(ErrSignatureTooLarge, "action signature at index [%d]", i)
-		case sig.Auditor != nil && len(sig.Auditor.Signature) > MaxSignatureBytes:
-			return errors.Wrapf(ErrSignatureTooLarge, "auditor signature at index [%d]", i)
+		case sig.Action != nil && len(sig.Action.Signature) > v.Limits.MaxSignatureBytes:
+			return errors.Wrapf(ErrSignatureTooLarge, "action signature at index [%d], limit [%d] bytes", i, v.Limits.MaxSignatureBytes)
+		case sig.Auditor != nil && len(sig.Auditor.Signature) > v.Limits.MaxSignatureBytes:
+			return errors.Wrapf(ErrSignatureTooLarge, "auditor signature at index [%d], limit [%d] bytes", i, v.Limits.MaxSignatureBytes)
 		}
 	}
 

--- a/token/core/common/limits.go
+++ b/token/core/common/limits.go
@@ -1,0 +1,100 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// Resource limits enforced by the common validator on raw, untrusted token requests.
+//
+// These constants are consensus-critical: every peer validating the same request must apply
+// the same limits, or otherwise-identical requests could be accepted by one peer and rejected
+// by another, breaking endorsement determinism. Changing any value below is a breaking protocol
+// change and requires a coordinated upgrade of all validating peers, analogous to
+// driver.MaxAnchorSize.
+const (
+	// MaxRequestBytes bounds the raw serialized size of a token request, checked before the
+	// protobuf decode so an oversized message is rejected without allocating a parsed structure.
+	MaxRequestBytes = 256 << 10 // 256 KiB
+
+	// MaxActions bounds the number of actions (issue + transfer) in a single token request.
+	MaxActions = 256
+
+	// MaxSignatures bounds the number of request signatures (auditor + action) in a single
+	// token request.
+	MaxSignatures = 4096
+
+	// MaxSignatureBytes bounds the length of a single auditor or action signature.
+	MaxSignatureBytes = 4 << 10 // 4 KiB
+
+	// MaxActionBytes bounds the length of a single action's serialized (raw) bytes.
+	MaxActionBytes = 256 << 10 // 256 KiB
+)
+
+// Typed errors returned when a raw token request exceeds a configured resource limit.
+var (
+	// ErrRequestTooLarge is returned when the raw request exceeds MaxRequestBytes.
+	ErrRequestTooLarge = errors.Errorf("token request exceeds maximum allowed size of %d bytes", MaxRequestBytes)
+	// ErrTooManyActions is returned when the request contains more than MaxActions actions.
+	ErrTooManyActions = errors.Errorf("token request exceeds maximum allowed number of actions [%d]", MaxActions)
+	// ErrTooManySignatures is returned when the request contains more than MaxSignatures signatures.
+	ErrTooManySignatures = errors.Errorf("token request exceeds maximum allowed number of signatures [%d]", MaxSignatures)
+	// ErrSignatureTooLarge is returned when a signature exceeds MaxSignatureBytes.
+	ErrSignatureTooLarge = errors.Errorf("signature exceeds maximum allowed size of %d bytes", MaxSignatureBytes)
+	// ErrActionTooLarge is returned when an action's raw bytes exceed MaxActionBytes.
+	ErrActionTooLarge = errors.Errorf("action exceeds maximum allowed size of %d bytes", MaxActionBytes)
+)
+
+// CheckRawRequestSize rejects raw token request bytes that exceed MaxRequestBytes.
+// It must be called before unmarshalling so oversized payloads are rejected before any
+// allocation proportional to their content.
+func CheckRawRequestSize(raw []byte) error {
+	if len(raw) > MaxRequestBytes {
+		return ErrRequestTooLarge
+	}
+
+	return nil
+}
+
+// CheckRequestLimits enforces common-layer resource limits on a parsed token request: the
+// number of actions and signatures, the size of every action's raw bytes, and the size of
+// every signature. It must be called before any cryptographic work (signature-message
+// marshalling, signature verification) is performed on the request.
+func CheckRequestLimits(tr *driver.TokenRequest) error {
+	if tr == nil {
+		return ErrNilTokenRequest
+	}
+	if len(tr.Actions) > MaxActions {
+		return ErrTooManyActions
+	}
+	if len(tr.Signatures) > MaxSignatures {
+		return ErrTooManySignatures
+	}
+	for i, action := range tr.Actions {
+		if action == nil {
+			continue
+		}
+		if len(action.Raw) > MaxActionBytes {
+			return errors.Wrapf(ErrActionTooLarge, "action at index [%d]", i)
+		}
+	}
+	for i, sig := range tr.Signatures {
+		if sig == nil {
+			continue
+		}
+		switch {
+		case sig.Action != nil && len(sig.Action.Signature) > MaxSignatureBytes:
+			return errors.Wrapf(ErrSignatureTooLarge, "action signature at index [%d]", i)
+		case sig.Auditor != nil && len(sig.Auditor.Signature) > MaxSignatureBytes:
+			return errors.Wrapf(ErrSignatureTooLarge, "auditor signature at index [%d]", i)
+		}
+	}
+
+	return nil
+}

--- a/token/core/common/limits_test.go
+++ b/token/core/common/limits_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRawRequestSize(t *testing.T) {
+	t.Run("at limit-1", func(t *testing.T) {
+		require.NoError(t, CheckRawRequestSize(make([]byte, MaxRequestBytes-1)))
+	})
+	t.Run("at limit", func(t *testing.T) {
+		require.NoError(t, CheckRawRequestSize(make([]byte, MaxRequestBytes)))
+	})
+	t.Run("at limit+1", func(t *testing.T) {
+		require.ErrorIs(t, CheckRawRequestSize(make([]byte, MaxRequestBytes+1)), ErrRequestTooLarge)
+	})
+}
+
+func actionsOfLen(n int) []*driver.TypedAction {
+	actions := make([]*driver.TypedAction, n)
+	for i := range actions {
+		actions[i] = &driver.TypedAction{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte("a")}
+	}
+
+	return actions
+}
+
+func signaturesOfLen(n int) []*driver.RequestSignature {
+	sigs := make([]*driver.RequestSignature, n)
+	for i := range sigs {
+		sigs[i] = &driver.RequestSignature{Action: &driver.ActionSignature{ActionID: 0, Signature: []byte("s")}}
+	}
+
+	return sigs
+}
+
+func TestCheckRequestLimits_NilRequest(t *testing.T) {
+	require.ErrorIs(t, CheckRequestLimits(nil), ErrNilTokenRequest)
+}
+
+func TestCheckRequestLimits_ActionCount(t *testing.T) {
+	t.Run("at limit-1", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions - 1)}))
+	})
+	t.Run("at limit", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions)}))
+	})
+	t.Run("at limit+1", func(t *testing.T) {
+		require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions + 1)}), ErrTooManyActions)
+	})
+}
+
+func TestCheckRequestLimits_SignatureCount(t *testing.T) {
+	t.Run("at limit-1", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures - 1)}))
+	})
+	t.Run("at limit", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures)}))
+	})
+	t.Run("at limit+1", func(t *testing.T) {
+		require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures + 1)}), ErrTooManySignatures)
+	})
+}
+
+func TestCheckRequestLimits_ActionBytes(t *testing.T) {
+	mk := func(n int) *driver.TokenRequest {
+		return &driver.TokenRequest{Actions: []*driver.TypedAction{
+			{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: make([]byte, n)},
+		}}
+	}
+	t.Run("at limit-1", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(mk(MaxActionBytes-1)))
+	})
+	t.Run("at limit", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(mk(MaxActionBytes)))
+	})
+	t.Run("at limit+1", func(t *testing.T) {
+		require.ErrorIs(t, CheckRequestLimits(mk(MaxActionBytes+1)), ErrActionTooLarge)
+	})
+}
+
+func TestCheckRequestLimits_SignatureBytes(t *testing.T) {
+	mkAction := func() *driver.TokenRequest {
+		return &driver.TokenRequest{}
+	}
+	mk := func(n int) *driver.TokenRequest {
+		tr := mkAction()
+		tr.Signatures = []*driver.RequestSignature{{Action: &driver.ActionSignature{ActionID: 0, Signature: make([]byte, n)}}}
+
+		return tr
+	}
+	t.Run("action signature at limit-1", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(mk(MaxSignatureBytes-1)))
+	})
+	t.Run("action signature at limit", func(t *testing.T) {
+		require.NoError(t, CheckRequestLimits(mk(MaxSignatureBytes)))
+	})
+	t.Run("action signature at limit+1", func(t *testing.T) {
+		require.ErrorIs(t, CheckRequestLimits(mk(MaxSignatureBytes+1)), ErrSignatureTooLarge)
+	})
+	t.Run("auditor signature at limit+1", func(t *testing.T) {
+		tr := mkAction()
+		tr.Signatures = []*driver.RequestSignature{{Auditor: &driver.AuditorSignature{Signature: make([]byte, MaxSignatureBytes+1)}}}
+		require.ErrorIs(t, CheckRequestLimits(tr), ErrSignatureTooLarge)
+	})
+}
+
+func TestCheckRequestLimits_ManyTinyActions(t *testing.T) {
+	// Many small actions, each individually within limits, but exceeding the count limit overall.
+	require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions + 1)}), ErrTooManyActions)
+}
+
+func TestCheckRequestLimits_NilEntriesSkipped(t *testing.T) {
+	require.NoError(t, CheckRequestLimits(&driver.TokenRequest{
+		Actions:    []*driver.TypedAction{nil},
+		Signatures: []*driver.RequestSignature{nil},
+	}))
+}

--- a/token/core/common/limits_test.go
+++ b/token/core/common/limits_test.go
@@ -10,20 +10,38 @@ import (
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	dmock "github.com/LFDT-Panurus/panurus/token/driver/mock"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/stretchr/testify/require"
 )
 
+func newTestValidator(limits driver.ResourceLimits) *Validator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer] {
+	return NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
+		&logging.MockLogger{}, nil, nil, limits, &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}, nil, nil, nil,
+	)
+}
+
 func TestCheckRawRequestSize(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	t.Run("at limit-1", func(t *testing.T) {
-		require.NoError(t, CheckRawRequestSize(make([]byte, MaxRequestBytes-1)))
+		require.NoError(t, v.CheckRawRequestSize(make([]byte, limits.MaxRequestBytes-1)))
 	})
 	t.Run("at limit", func(t *testing.T) {
-		require.NoError(t, CheckRawRequestSize(make([]byte, MaxRequestBytes)))
+		require.NoError(t, v.CheckRawRequestSize(make([]byte, limits.MaxRequestBytes)))
 	})
 	t.Run("at limit+1", func(t *testing.T) {
-		require.ErrorIs(t, CheckRawRequestSize(make([]byte, MaxRequestBytes+1)), ErrRequestTooLarge)
+		require.ErrorIs(t, v.CheckRawRequestSize(make([]byte, limits.MaxRequestBytes+1)), ErrRequestTooLarge)
 	})
+}
+
+func TestCheckRawRequestSize_CustomLimit(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	limits.MaxRequestBytes = 16
+	v := newTestValidator(limits)
+	require.NoError(t, v.CheckRawRequestSize(make([]byte, 16)))
+	require.ErrorIs(t, v.CheckRawRequestSize(make([]byte, 17)), ErrRequestTooLarge)
 }
 
 func actionsOfLen(n int) []*driver.TypedAction {
@@ -45,51 +63,68 @@ func signaturesOfLen(n int) []*driver.RequestSignature {
 }
 
 func TestCheckRequestLimits_NilRequest(t *testing.T) {
-	require.ErrorIs(t, CheckRequestLimits(nil), ErrNilTokenRequest)
+	v := newTestValidator(driver.DefaultResourceLimits())
+	require.ErrorIs(t, v.CheckRequestLimits(nil), ErrNilTokenRequest)
 }
 
 func TestCheckRequestLimits_ActionCount(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	t.Run("at limit-1", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions - 1)}))
+		require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(limits.MaxActions - 1)}))
 	})
 	t.Run("at limit", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions)}))
+		require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(limits.MaxActions)}))
 	})
 	t.Run("at limit+1", func(t *testing.T) {
-		require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions + 1)}), ErrTooManyActions)
+		require.ErrorIs(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(limits.MaxActions + 1)}), ErrTooManyActions)
 	})
 }
 
+func TestCheckRequestLimits_ActionCount_CustomLimit(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	limits.MaxActions = 2
+	v := newTestValidator(limits)
+	require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(2)}))
+	require.ErrorIs(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(3)}), ErrTooManyActions)
+}
+
 func TestCheckRequestLimits_SignatureCount(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	t.Run("at limit-1", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures - 1)}))
+		require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(limits.MaxSignatures - 1)}))
 	})
 	t.Run("at limit", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures)}))
+		require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(limits.MaxSignatures)}))
 	})
 	t.Run("at limit+1", func(t *testing.T) {
-		require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(MaxSignatures + 1)}), ErrTooManySignatures)
+		require.ErrorIs(t, v.CheckRequestLimits(&driver.TokenRequest{Signatures: signaturesOfLen(limits.MaxSignatures + 1)}), ErrTooManySignatures)
 	})
 }
 
 func TestCheckRequestLimits_ActionBytes(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	mk := func(n int) *driver.TokenRequest {
 		return &driver.TokenRequest{Actions: []*driver.TypedAction{
 			{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: make([]byte, n)},
 		}}
 	}
 	t.Run("at limit-1", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(mk(MaxActionBytes-1)))
+		require.NoError(t, v.CheckRequestLimits(mk(limits.MaxActionBytes-1)))
 	})
 	t.Run("at limit", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(mk(MaxActionBytes)))
+		require.NoError(t, v.CheckRequestLimits(mk(limits.MaxActionBytes)))
 	})
 	t.Run("at limit+1", func(t *testing.T) {
-		require.ErrorIs(t, CheckRequestLimits(mk(MaxActionBytes+1)), ErrActionTooLarge)
+		require.ErrorIs(t, v.CheckRequestLimits(mk(limits.MaxActionBytes+1)), ErrActionTooLarge)
 	})
 }
 
 func TestCheckRequestLimits_SignatureBytes(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	mkAction := func() *driver.TokenRequest {
 		return &driver.TokenRequest{}
 	}
@@ -100,28 +135,31 @@ func TestCheckRequestLimits_SignatureBytes(t *testing.T) {
 		return tr
 	}
 	t.Run("action signature at limit-1", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(mk(MaxSignatureBytes-1)))
+		require.NoError(t, v.CheckRequestLimits(mk(limits.MaxSignatureBytes-1)))
 	})
 	t.Run("action signature at limit", func(t *testing.T) {
-		require.NoError(t, CheckRequestLimits(mk(MaxSignatureBytes)))
+		require.NoError(t, v.CheckRequestLimits(mk(limits.MaxSignatureBytes)))
 	})
 	t.Run("action signature at limit+1", func(t *testing.T) {
-		require.ErrorIs(t, CheckRequestLimits(mk(MaxSignatureBytes+1)), ErrSignatureTooLarge)
+		require.ErrorIs(t, v.CheckRequestLimits(mk(limits.MaxSignatureBytes+1)), ErrSignatureTooLarge)
 	})
 	t.Run("auditor signature at limit+1", func(t *testing.T) {
 		tr := mkAction()
-		tr.Signatures = []*driver.RequestSignature{{Auditor: &driver.AuditorSignature{Signature: make([]byte, MaxSignatureBytes+1)}}}
-		require.ErrorIs(t, CheckRequestLimits(tr), ErrSignatureTooLarge)
+		tr.Signatures = []*driver.RequestSignature{{Auditor: &driver.AuditorSignature{Signature: make([]byte, limits.MaxSignatureBytes+1)}}}
+		require.ErrorIs(t, v.CheckRequestLimits(tr), ErrSignatureTooLarge)
 	})
 }
 
 func TestCheckRequestLimits_ManyTinyActions(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
+	v := newTestValidator(limits)
 	// Many small actions, each individually within limits, but exceeding the count limit overall.
-	require.ErrorIs(t, CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(MaxActions + 1)}), ErrTooManyActions)
+	require.ErrorIs(t, v.CheckRequestLimits(&driver.TokenRequest{Actions: actionsOfLen(limits.MaxActions + 1)}), ErrTooManyActions)
 }
 
 func TestCheckRequestLimits_NilEntriesSkipped(t *testing.T) {
-	require.NoError(t, CheckRequestLimits(&driver.TokenRequest{
+	v := newTestValidator(driver.DefaultResourceLimits())
+	require.NoError(t, v.CheckRequestLimits(&driver.TokenRequest{
 		Actions:    []*driver.TypedAction{nil},
 		Signatures: []*driver.RequestSignature{nil},
 	}))

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-action-bytes-boundary
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-action-bytes-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(0)
+int(262144)
+int(8)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-action-bytes-plus-one
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-action-bytes-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(0)
+int(262145)
+int(8)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-actions-boundary
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-actions-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(256)
+int(0)
+int(8)
+int(8)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-actions-plus-one
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-actions-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(257)
+int(0)
+int(8)
+int(8)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signature-bytes-boundary
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signature-bytes-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(1)
+int(8)
+int(4096)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signature-bytes-plus-one
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signature-bytes-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(1)
+int(8)
+int(4097)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signatures-boundary
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signatures-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(4096)
+int(8)
+int(8)

--- a/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signatures-plus-one
+++ b/token/core/common/testdata/fuzz/FuzzRequestResourceLimits/max-signatures-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+int(1)
+int(4097)
+int(8)
+int(8)

--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -128,6 +128,9 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequestFromRaw(ctx context.Cont
 	if len(raw) == 0 {
 		return nil, nil, errors.New("empty token request")
 	}
+	if err := CheckRawRequestSize(raw); err != nil {
+		return nil, nil, err
+	}
 	tr := &driver.TokenRequest{}
 	err := tr.FromBytes(raw)
 	if err != nil {
@@ -150,6 +153,9 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequestFromRaw(ctx context.Cont
 	}
 	if len(tr.Actions) == 0 {
 		return nil, nil, ErrNoActions
+	}
+	if err := CheckRequestLimits(tr); err != nil {
+		return nil, nil, err
 	}
 
 	// Prepare message expected to be signed

--- a/token/core/common/validator.go
+++ b/token/core/common/validator.go
@@ -87,6 +87,10 @@ type Validator[P driver.PublicParameters, T driver.Input, TA driver.TransferActi
 	TransferValidators []ValidateTransferFunc[P, T, TA, IA, DS]
 	IssueValidators    []ValidateIssueFunc[P, T, TA, IA, DS]
 
+	// Limits bounds the resources spent deserializing and validating untrusted requests, before
+	// any cryptographic work is performed. See driver.ResourceLimits.
+	Limits driver.ResourceLimits
+
 	// MinProtocolVersion specifies the minimum protocol version required for token requests.
 	// If set to 0, no minimum version is enforced (accepts all versions).
 	// If set to a specific version (e.g., driver.ProtocolV1), only requests with that version
@@ -99,6 +103,7 @@ func NewValidator[P driver.PublicParameters, T driver.Input, TA driver.TransferA
 	Logger logging.Logger,
 	publicParams P,
 	deserializer DS,
+	limits driver.ResourceLimits,
 	actionDeserializer driver.ActionDeserializer[TA, IA],
 	transferValidators []ValidateTransferFunc[P, T, TA, IA, DS],
 	issueValidators []ValidateIssueFunc[P, T, TA, IA, DS],
@@ -109,6 +114,7 @@ func NewValidator[P driver.PublicParameters, T driver.Input, TA driver.TransferA
 		PublicParams:       publicParams,
 		Deserializer:       deserializer,
 		ActionDeserializer: actionDeserializer,
+		Limits:             limits,
 		TransferValidators: transferValidators,
 		IssueValidators:    issueValidators,
 		AuditingValidators: auditingValidators,
@@ -128,7 +134,7 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequestFromRaw(ctx context.Cont
 	if len(raw) == 0 {
 		return nil, nil, errors.New("empty token request")
 	}
-	if err := CheckRawRequestSize(raw); err != nil {
+	if err := v.CheckRawRequestSize(raw); err != nil {
 		return nil, nil, err
 	}
 	tr := &driver.TokenRequest{}
@@ -154,7 +160,7 @@ func (v *Validator[P, T, TA, IA, DS]) VerifyTokenRequestFromRaw(ctx context.Cont
 	if len(tr.Actions) == 0 {
 		return nil, nil, ErrNoActions
 	}
-	if err := CheckRequestLimits(tr); err != nil {
+	if err := v.CheckRequestLimits(tr); err != nil {
 		return nil, nil, err
 	}
 

--- a/token/core/common/validator_fuzz_test.go
+++ b/token/core/common/validator_fuzz_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	maxFuzzRequestBytes   = 256 << 10
-	maxFuzzSignatureBytes = 4 << 10
-)
-
 func FuzzVerifyTokenRequestFromRawNoPanic(f *testing.F) {
 	valid, err := (&driver.TokenRequest{Actions: []*driver.TypedAction{
 		{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte("transfer")},
@@ -32,7 +27,7 @@ func FuzzVerifyTokenRequestFromRawNoPanic(f *testing.F) {
 	f.Add([]byte("malformed"))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
-		if len(raw) > maxFuzzRequestBytes {
+		if len(raw) > MaxRequestBytes {
 			t.Skip()
 		}
 		actionDeserializer := &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}
@@ -71,7 +66,7 @@ func FuzzStructuredTokenRequestSignatureEnvelope(f *testing.F) {
 	f.Add(uint32(0), []byte("signature"), true)
 
 	f.Fuzz(func(t *testing.T, actionID uint32, signature []byte, appendExtra bool) {
-		if len(signature) == 0 || len(signature) > maxFuzzSignatureBytes {
+		if len(signature) == 0 || len(signature) > MaxSignatureBytes {
 			t.Skip()
 		}
 		actionDeserializer := &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}
@@ -104,4 +99,96 @@ func FuzzStructuredTokenRequestSignatureEnvelope(f *testing.F) {
 			_, _, _ = validator.VerifyTokenRequestFromRaw(t.Context(), nil, "anchor", raw)
 		})
 	})
+}
+
+// FuzzRequestResourceLimits fuzzes token requests shaped by their resource dimensions (action
+// count, signature count, per-action bytes, per-signature bytes) and asserts that
+// VerifyTokenRequestFromRaw never panics, and that any request exceeding a configured limit is
+// rejected with the corresponding typed error rather than reaching signature verification.
+func FuzzRequestResourceLimits(f *testing.F) {
+	f.Add(1, 0, 8, 8)
+	f.Add(MaxActions, 0, 8, 8)
+	f.Add(MaxActions+1, 0, 8, 8)
+	f.Add(1, 1, 8, 8)
+	f.Add(1, MaxSignatures, 8, 8)
+	f.Add(1, MaxSignatures+1, 8, 8)
+	f.Add(1, 0, MaxActionBytes, 8)
+	f.Add(1, 0, MaxActionBytes+1, 8)
+	f.Add(1, 1, 8, MaxSignatureBytes)
+	f.Add(1, 1, 8, MaxSignatureBytes+1)
+
+	f.Fuzz(func(t *testing.T, numActions, numSignatures, actionBytes, sigBytes int) {
+		// Bound fuzzed counts/sizes to a range that keeps the test fast while still crossing
+		// every configured limit; the values above MaxActions/MaxSignatures/MaxActionBytes/
+		// MaxSignatureBytes are the ones this test cares about observing rejection for.
+		numActions = boundInt(numActions, 0, MaxActions+8)
+		numSignatures = boundInt(numSignatures, 0, MaxSignatures+8)
+		// Actions and signatures must carry at least one byte: TokenRequest.Validate rejects
+		// empty Raw/Signature bytes before any resource-limit check runs.
+		actionBytes = boundInt(actionBytes, 1, MaxActionBytes+8)
+		sigBytes = boundInt(sigBytes, 1, MaxSignatureBytes+8)
+
+		tr := &driver.TokenRequest{
+			Actions: actionsOfLen(numActions),
+		}
+		for i := range tr.Actions {
+			tr.Actions[i].Raw = make([]byte, actionBytes)
+		}
+		tr.Signatures = make([]*driver.RequestSignature, numSignatures)
+		for i := range tr.Signatures {
+			tr.Signatures[i] = &driver.RequestSignature{Action: &driver.ActionSignature{ActionID: 0, Signature: make([]byte, sigBytes)}}
+		}
+
+		raw, err := tr.Bytes()
+		require.NoError(t, err)
+
+		actionDeserializer := &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}
+		actionDeserializer.DeserializeActionsCalls(func(tr *driver.TokenRequest) ([]driver.IssueAction, []driver.TransferAction, error) {
+			transfers := make([]driver.TransferAction, len(tr.Actions))
+			for i := range transfers {
+				transfers[i] = &dmock.TransferAction{}
+			}
+
+			return nil, transfers, nil
+		})
+		validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
+			&logging.MockLogger{}, nil, nil, actionDeserializer, nil, nil, nil,
+		)
+
+		var validationErr error
+		require.NotPanics(t, func() {
+			_, _, validationErr = validator.VerifyTokenRequestFromRaw(t.Context(), nil, "anchor", raw)
+		})
+
+		switch {
+		case len(raw) > MaxRequestBytes:
+			// The raw envelope size gate runs before the request is even parsed, so an
+			// oversized action or signature payload may be caught here first.
+			require.ErrorIs(t, validationErr, ErrRequestTooLarge)
+		case numActions == 0:
+			require.ErrorIs(t, validationErr, ErrNoActions)
+		case numActions > MaxActions:
+			require.ErrorIs(t, validationErr, ErrTooManyActions)
+		case numSignatures > MaxSignatures:
+			require.ErrorIs(t, validationErr, ErrTooManySignatures)
+		case actionBytes > MaxActionBytes:
+			require.ErrorIs(t, validationErr, ErrActionTooLarge)
+		case numSignatures > 0 && sigBytes > MaxSignatureBytes:
+			require.ErrorIs(t, validationErr, ErrSignatureTooLarge)
+		}
+	})
+}
+
+// boundInt clamps n into [lo, hi], using n's magnitude modulo the range width so that fuzzed
+// values (including negatives) still exercise the full range deterministically.
+func boundInt(n, lo, hi int) int {
+	if hi <= lo {
+		return lo
+	}
+	width := hi - lo + 1
+	if n < 0 {
+		n = -n
+	}
+
+	return lo + n%width
 }

--- a/token/core/common/validator_fuzz_test.go
+++ b/token/core/common/validator_fuzz_test.go
@@ -27,7 +27,8 @@ func FuzzVerifyTokenRequestFromRawNoPanic(f *testing.F) {
 	f.Add([]byte("malformed"))
 
 	f.Fuzz(func(t *testing.T, raw []byte) {
-		if len(raw) > MaxRequestBytes {
+		limits := driver.DefaultResourceLimits()
+		if len(raw) > limits.MaxRequestBytes {
 			t.Skip()
 		}
 		actionDeserializer := &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}
@@ -46,7 +47,7 @@ func FuzzVerifyTokenRequestFromRawNoPanic(f *testing.F) {
 			return issues, transfers, nil
 		})
 		validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			&logging.MockLogger{}, nil, nil, actionDeserializer, nil, nil, nil,
+			&logging.MockLogger{}, nil, nil, limits, actionDeserializer, nil, nil, nil,
 		)
 
 		require.NotPanics(t, func() {
@@ -66,13 +67,14 @@ func FuzzStructuredTokenRequestSignatureEnvelope(f *testing.F) {
 	f.Add(uint32(0), []byte("signature"), true)
 
 	f.Fuzz(func(t *testing.T, actionID uint32, signature []byte, appendExtra bool) {
-		if len(signature) == 0 || len(signature) > MaxSignatureBytes {
+		limits := driver.DefaultResourceLimits()
+		if len(signature) == 0 || len(signature) > limits.MaxSignatureBytes {
 			t.Skip()
 		}
 		actionDeserializer := &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}
 		actionDeserializer.DeserializeActionsReturns(nil, []driver.TransferAction{&dmock.TransferAction{}}, nil)
 		validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			&logging.MockLogger{}, nil, nil, actionDeserializer,
+			&logging.MockLogger{}, nil, nil, limits, actionDeserializer,
 			[]ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					_, err := ctx.SignatureProvider.HasBeenSignedBy(c, nil, &dmock.Verifier{})
@@ -106,27 +108,28 @@ func FuzzStructuredTokenRequestSignatureEnvelope(f *testing.F) {
 // VerifyTokenRequestFromRaw never panics, and that any request exceeding a configured limit is
 // rejected with the corresponding typed error rather than reaching signature verification.
 func FuzzRequestResourceLimits(f *testing.F) {
+	limits := driver.DefaultResourceLimits()
 	f.Add(1, 0, 8, 8)
-	f.Add(MaxActions, 0, 8, 8)
-	f.Add(MaxActions+1, 0, 8, 8)
+	f.Add(limits.MaxActions, 0, 8, 8)
+	f.Add(limits.MaxActions+1, 0, 8, 8)
 	f.Add(1, 1, 8, 8)
-	f.Add(1, MaxSignatures, 8, 8)
-	f.Add(1, MaxSignatures+1, 8, 8)
-	f.Add(1, 0, MaxActionBytes, 8)
-	f.Add(1, 0, MaxActionBytes+1, 8)
-	f.Add(1, 1, 8, MaxSignatureBytes)
-	f.Add(1, 1, 8, MaxSignatureBytes+1)
+	f.Add(1, limits.MaxSignatures, 8, 8)
+	f.Add(1, limits.MaxSignatures+1, 8, 8)
+	f.Add(1, 0, limits.MaxActionBytes, 8)
+	f.Add(1, 0, limits.MaxActionBytes+1, 8)
+	f.Add(1, 1, 8, limits.MaxSignatureBytes)
+	f.Add(1, 1, 8, limits.MaxSignatureBytes+1)
 
 	f.Fuzz(func(t *testing.T, numActions, numSignatures, actionBytes, sigBytes int) {
 		// Bound fuzzed counts/sizes to a range that keeps the test fast while still crossing
 		// every configured limit; the values above MaxActions/MaxSignatures/MaxActionBytes/
 		// MaxSignatureBytes are the ones this test cares about observing rejection for.
-		numActions = boundInt(numActions, 0, MaxActions+8)
-		numSignatures = boundInt(numSignatures, 0, MaxSignatures+8)
+		numActions = boundInt(numActions, 0, limits.MaxActions+8)
+		numSignatures = boundInt(numSignatures, 0, limits.MaxSignatures+8)
 		// Actions and signatures must carry at least one byte: TokenRequest.Validate rejects
 		// empty Raw/Signature bytes before any resource-limit check runs.
-		actionBytes = boundInt(actionBytes, 1, MaxActionBytes+8)
-		sigBytes = boundInt(sigBytes, 1, MaxSignatureBytes+8)
+		actionBytes = boundInt(actionBytes, 1, limits.MaxActionBytes+8)
+		sigBytes = boundInt(sigBytes, 1, limits.MaxSignatureBytes+8)
 
 		tr := &driver.TokenRequest{
 			Actions: actionsOfLen(numActions),
@@ -152,7 +155,7 @@ func FuzzRequestResourceLimits(f *testing.F) {
 			return nil, transfers, nil
 		})
 		validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			&logging.MockLogger{}, nil, nil, actionDeserializer, nil, nil, nil,
+			&logging.MockLogger{}, nil, nil, limits, actionDeserializer, nil, nil, nil,
 		)
 
 		var validationErr error
@@ -161,19 +164,19 @@ func FuzzRequestResourceLimits(f *testing.F) {
 		})
 
 		switch {
-		case len(raw) > MaxRequestBytes:
+		case len(raw) > limits.MaxRequestBytes:
 			// The raw envelope size gate runs before the request is even parsed, so an
 			// oversized action or signature payload may be caught here first.
 			require.ErrorIs(t, validationErr, ErrRequestTooLarge)
 		case numActions == 0:
 			require.ErrorIs(t, validationErr, ErrNoActions)
-		case numActions > MaxActions:
+		case numActions > limits.MaxActions:
 			require.ErrorIs(t, validationErr, ErrTooManyActions)
-		case numSignatures > MaxSignatures:
+		case numSignatures > limits.MaxSignatures:
 			require.ErrorIs(t, validationErr, ErrTooManySignatures)
-		case actionBytes > MaxActionBytes:
+		case actionBytes > limits.MaxActionBytes:
 			require.ErrorIs(t, validationErr, ErrActionTooLarge)
-		case numSignatures > 0 && sigBytes > MaxSignatureBytes:
+		case numSignatures > 0 && sigBytes > limits.MaxSignatureBytes:
 			require.ErrorIs(t, validationErr, ErrSignatureTooLarge)
 		}
 	})

--- a/token/core/common/validator_hardening_test.go
+++ b/token/core/common/validator_hardening_test.go
@@ -31,7 +31,7 @@ func TestVerifyTokenRequestPreservesOriginalActionOrder(t *testing.T) {
 		nil,
 	)
 	validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-		&logging.MockLogger{}, nil, nil, actionDeserializer, nil, nil, nil,
+		&logging.MockLogger{}, nil, nil, driver.DefaultResourceLimits(), actionDeserializer, nil, nil, nil,
 	)
 	requestWithMixedActions := &driver.TokenRequest{Actions: []*driver.TypedAction{
 		{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: []byte("transfer-0")},
@@ -79,6 +79,7 @@ func TestVerifyTokenRequestFromRawScopesSignaturesByActionID(t *testing.T) {
 		&logging.MockLogger{},
 		nil,
 		nil,
+		driver.DefaultResourceLimits(),
 		actionDeserializer,
 		[]ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 			func(_ context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
@@ -128,7 +129,7 @@ func TestVerifyTokenRequestFromRawRejectsInvalidSignatureEnvelope(t *testing.T) 
 		actionDeserializer.DeserializeActionsReturns(nil, []driver.TransferAction{&dmock.TransferAction{}}, nil)
 
 		return NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			&logging.MockLogger{}, nil, nil, actionDeserializer,
+			&logging.MockLogger{}, nil, nil, driver.DefaultResourceLimits(), actionDeserializer,
 			[]ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					for range consumptionCount {
@@ -186,7 +187,7 @@ func TestVerifyTokenRequestFromRawRejectsInvalidSignatureEnvelope(t *testing.T) 
 
 func TestVerifyTokenRequestFromRawRejectsNoActions(t *testing.T) {
 	validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-		&logging.MockLogger{}, nil, nil, &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}, nil, nil, nil,
+		&logging.MockLogger{}, nil, nil, driver.DefaultResourceLimits(), &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}, nil, nil, nil,
 	)
 	raw, err := (&driver.TokenRequest{}).Bytes()
 	require.NoError(t, err)
@@ -197,7 +198,7 @@ func TestVerifyTokenRequestFromRawRejectsNoActions(t *testing.T) {
 
 func TestValidatorPublicMethodsRejectNilWithoutPanic(t *testing.T) {
 	validator := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-		&logging.MockLogger{}, nil, nil, &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}, nil, nil, nil,
+		&logging.MockLogger{}, nil, nil, driver.DefaultResourceLimits(), &dmock.ActionDeserializer[driver.TransferAction, driver.IssueAction]{}, nil, nil, nil,
 	)
 	var issue *dmock.IssueAction
 	var transfer *dmock.TransferAction

--- a/token/core/common/validator_test.go
+++ b/token/core/common/validator_test.go
@@ -28,6 +28,7 @@ func TestAnchorInContext(t *testing.T) {
 		&logging.MockLogger{},
 		nil,
 		nil,
+		driver.DefaultResourceLimits(),
 		nil,
 		[]ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 			func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
@@ -90,7 +91,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 	anchor := driver.TokenRequestAnchor("anchor")
 
 	v := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-		logger, pp, des, ad, nil, nil, nil,
+		logger, pp, des, driver.DefaultResourceLimits(), ad, nil, nil, nil,
 	)
 
 	t.Run("VerifyTokenRequest_Success", func(t *testing.T) {
@@ -110,7 +111,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 
 	t.Run("VerifyTokenRequest_AuditingError", func(t *testing.T) {
 		vErr := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			logger, pp, des, ad, nil, nil, []ValidateAuditingFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			logger, pp, des, driver.DefaultResourceLimits(), ad, nil, nil, []ValidateAuditingFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					return errors.New("audit failed")
 				},
@@ -130,7 +131,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 
 	t.Run("VerifyTokenRequest_VerifyIssueError", func(t *testing.T) {
 		vErr := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			logger, pp, des, ad, nil, []ValidateIssueFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			logger, pp, des, driver.DefaultResourceLimits(), ad, nil, []ValidateIssueFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					return errors.New("issue validation failed")
 				},
@@ -146,7 +147,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 
 	t.Run("VerifyTokenRequest_VerifyTransferError", func(t *testing.T) {
 		vErr := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			logger, pp, des, ad, []ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			logger, pp, des, driver.DefaultResourceLimits(), ad, []ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					return errors.New("transfer validation failed")
 				},
@@ -189,7 +190,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 		assert.Contains(t, err.Error(), "more metadata than those validated")
 
 		vCount := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			logger, pp, des, ad, nil, []ValidateIssueFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			logger, pp, des, driver.DefaultResourceLimits(), ad, nil, []ValidateIssueFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					ctx.CountMetadataKey("k1")
 					ctx.CountMetadataKey("k1")
@@ -212,7 +213,7 @@ func TestValidatorWithCounterfeiter(t *testing.T) {
 		assert.Contains(t, err.Error(), "more metadata than those validated")
 
 		vCount := NewValidator[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer](
-			logger, pp, des, ad, []ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
+			logger, pp, des, driver.DefaultResourceLimits(), ad, []ValidateTransferFunc[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]{
 				func(c context.Context, ctx *Context[driver.PublicParameters, driver.Input, driver.TransferAction, driver.IssueAction, driver.Deserializer]) error {
 					ctx.CountMetadataKey("k1")
 					ctx.CountMetadataKey("k1")

--- a/token/core/fabtoken/v1/actions/issue.go
+++ b/token/core/fabtoken/v1/actions/issue.go
@@ -24,6 +24,22 @@ type IssueAction struct {
 	Outputs []*Output
 	// metadata of the issue action
 	Metadata map[string][]byte
+
+	limits *driver.ResourceLimits
+}
+
+// SetLimits configures the resource limits enforced by Validate and Deserialize.
+func (i *IssueAction) SetLimits(limits driver.ResourceLimits) {
+	i.limits = &limits
+}
+
+// effectiveLimits returns the configured limits, or the defaults if none were set.
+func (i *IssueAction) effectiveLimits() driver.ResourceLimits {
+	if i.limits == nil {
+		return driver.DefaultResourceLimits()
+	}
+
+	return *i.limits
 }
 
 func (i *IssueAction) NumInputs() int {
@@ -84,10 +100,11 @@ func (i *IssueAction) Deserialize(raw []byte) error {
 	}
 
 	// enforce resource limits before any allocation proportional to attacker-controlled counts
-	if len(issueAction.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	limits := i.effectiveLimits()
+	if len(issueAction.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
-	if err := checkMetadataLimits(issueAction.Metadata); err != nil {
+	if err := checkMetadataLimits(issueAction.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 
@@ -172,8 +189,9 @@ func (i *IssueAction) Validate() error {
 	if len(i.Outputs) == 0 {
 		return errors.Errorf("no outputs in issue action")
 	}
-	if len(i.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	limits := i.effectiveLimits()
+	if len(i.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
 	for i, output := range i.Outputs {
 		if output == nil {
@@ -186,7 +204,7 @@ func (i *IssueAction) Validate() error {
 			return errors.Errorf("invalid output's quantity at index [%d], output quantity is empty", i)
 		}
 	}
-	if err := checkMetadataLimits(i.Metadata); err != nil {
+	if err := checkMetadataLimits(i.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 

--- a/token/core/fabtoken/v1/actions/issue.go
+++ b/token/core/fabtoken/v1/actions/issue.go
@@ -83,6 +83,14 @@ func (i *IssueAction) Deserialize(raw []byte) error {
 		return errors.Errorf("invalid issue version, expected [%d], got [%d]", ProtocolV1, issueAction.Version)
 	}
 
+	// enforce resource limits before any allocation proportional to attacker-controlled counts
+	if len(issueAction.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
+	if err := checkMetadataLimits(issueAction.Metadata); err != nil {
+		return err
+	}
+
 	// outputs
 	i.Outputs = make([]*Output, len(issueAction.Outputs))
 	for j, output := range issueAction.Outputs {
@@ -164,6 +172,9 @@ func (i *IssueAction) Validate() error {
 	if len(i.Outputs) == 0 {
 		return errors.Errorf("no outputs in issue action")
 	}
+	if len(i.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
 	for i, output := range i.Outputs {
 		if output == nil {
 			return errors.Errorf("nil output in issue action")
@@ -174,6 +185,9 @@ func (i *IssueAction) Validate() error {
 		if len(output.Quantity) == 0 {
 			return errors.Errorf("invalid output's quantity at index [%d], output quantity is empty", i)
 		}
+	}
+	if err := checkMetadataLimits(i.Metadata); err != nil {
+		return err
 	}
 
 	return nil

--- a/token/core/fabtoken/v1/actions/limits.go
+++ b/token/core/fabtoken/v1/actions/limits.go
@@ -10,49 +10,38 @@ import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
 // Resource limits enforced while deserializing and validating an untrusted fabtoken action.
 //
-// These constants are consensus-critical: every peer validating the same action must apply the
-// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
-// another, breaking endorsement determinism. Changing any value below is a breaking protocol
-// change and requires a coordinated upgrade of all validating peers.
-const (
-	// MaxInputs bounds the number of spent-token inputs in a single transfer action.
-	MaxInputs = 256
-	// MaxOutputs bounds the number of outputs in a single issue or transfer action.
-	MaxOutputs = 256
-	// MaxMetadataEntries bounds the number of metadata entries attached to an action.
-	MaxMetadataEntries = 64
-	// MaxMetadataKeyBytes bounds the length of a single metadata key.
-	MaxMetadataKeyBytes = 256
-	// MaxMetadataValueBytes bounds the length of a single metadata value.
-	MaxMetadataValueBytes = 4 << 10 // 4 KiB
-)
+// The limits enforced by a given action are configurable (see driver.ResourceLimits); every peer
+// validating the same action must be configured with the same limits, or otherwise-identical
+// actions could be accepted by one peer and rejected by another, breaking endorsement
+// determinism. Deployments that override the defaults are responsible for keeping every
+// validating peer in sync.
 
 // Typed errors returned when a fabtoken action exceeds a configured resource limit.
 var (
-	// ErrTooManyInputs is returned when a transfer action spends more than MaxInputs inputs.
-	ErrTooManyInputs = errors.Errorf("action exceeds maximum allowed number of inputs [%d]", MaxInputs)
-	// ErrTooManyOutputs is returned when an action has more than MaxOutputs outputs.
-	ErrTooManyOutputs = errors.Errorf("action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
-	// ErrTooManyMetadataEntries is returned when an action has more than MaxMetadataEntries metadata entries.
-	ErrTooManyMetadataEntries = errors.Errorf("action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
-	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
-	ErrMetadataKeyTooLarge = errors.Errorf("action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
-	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
-	ErrMetadataValueTooLarge = errors.Errorf("action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
+	// ErrTooManyInputs is returned when a transfer action spends more inputs than allowed.
+	ErrTooManyInputs = errors.New("action exceeds maximum allowed number of inputs")
+	// ErrTooManyOutputs is returned when an action has more outputs than allowed.
+	ErrTooManyOutputs = errors.New("action exceeds maximum allowed number of outputs")
+	// ErrTooManyMetadataEntries is returned when an action has more metadata entries than allowed.
+	ErrTooManyMetadataEntries = errors.New("action exceeds maximum allowed number of metadata entries")
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds the configured limit.
+	ErrMetadataKeyTooLarge = errors.New("action metadata key exceeds maximum allowed size")
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds the configured limit.
+	ErrMetadataValueTooLarge = errors.New("action metadata value exceeds maximum allowed size")
 )
 
 // checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
 // on a deserialized action's metadata map.
-func checkMetadataLimits(metadata map[string][]byte) error {
-	if len(metadata) > MaxMetadataEntries {
-		return ErrTooManyMetadataEntries
+func checkMetadataLimits(metadata map[string][]byte, maxEntries, maxKeyBytes, maxValueBytes int) error {
+	if len(metadata) > maxEntries {
+		return errors.Wrapf(ErrTooManyMetadataEntries, "limit [%d]", maxEntries)
 	}
 	for k, v := range metadata {
-		if len(k) > MaxMetadataKeyBytes {
-			return ErrMetadataKeyTooLarge
+		if len(k) > maxKeyBytes {
+			return errors.Wrapf(ErrMetadataKeyTooLarge, "limit [%d] bytes", maxKeyBytes)
 		}
-		if len(v) > MaxMetadataValueBytes {
-			return ErrMetadataValueTooLarge
+		if len(v) > maxValueBytes {
+			return errors.Wrapf(ErrMetadataValueTooLarge, "limit [%d] bytes", maxValueBytes)
 		}
 	}
 

--- a/token/core/fabtoken/v1/actions/limits.go
+++ b/token/core/fabtoken/v1/actions/limits.go
@@ -1,0 +1,60 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package actions
+
+import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+// Resource limits enforced while deserializing and validating an untrusted fabtoken action.
+//
+// These constants are consensus-critical: every peer validating the same action must apply the
+// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
+// another, breaking endorsement determinism. Changing any value below is a breaking protocol
+// change and requires a coordinated upgrade of all validating peers.
+const (
+	// MaxInputs bounds the number of spent-token inputs in a single transfer action.
+	MaxInputs = 256
+	// MaxOutputs bounds the number of outputs in a single issue or transfer action.
+	MaxOutputs = 256
+	// MaxMetadataEntries bounds the number of metadata entries attached to an action.
+	MaxMetadataEntries = 64
+	// MaxMetadataKeyBytes bounds the length of a single metadata key.
+	MaxMetadataKeyBytes = 256
+	// MaxMetadataValueBytes bounds the length of a single metadata value.
+	MaxMetadataValueBytes = 4 << 10 // 4 KiB
+)
+
+// Typed errors returned when a fabtoken action exceeds a configured resource limit.
+var (
+	// ErrTooManyInputs is returned when a transfer action spends more than MaxInputs inputs.
+	ErrTooManyInputs = errors.Errorf("action exceeds maximum allowed number of inputs [%d]", MaxInputs)
+	// ErrTooManyOutputs is returned when an action has more than MaxOutputs outputs.
+	ErrTooManyOutputs = errors.Errorf("action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
+	// ErrTooManyMetadataEntries is returned when an action has more than MaxMetadataEntries metadata entries.
+	ErrTooManyMetadataEntries = errors.Errorf("action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
+	ErrMetadataKeyTooLarge = errors.Errorf("action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
+	ErrMetadataValueTooLarge = errors.Errorf("action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
+)
+
+// checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
+// on a deserialized action's metadata map.
+func checkMetadataLimits(metadata map[string][]byte) error {
+	if len(metadata) > MaxMetadataEntries {
+		return ErrTooManyMetadataEntries
+	}
+	for k, v := range metadata {
+		if len(k) > MaxMetadataKeyBytes {
+			return ErrMetadataKeyTooLarge
+		}
+		if len(v) > MaxMetadataValueBytes {
+			return ErrMetadataValueTooLarge
+		}
+	}
+
+	return nil
+}

--- a/token/core/fabtoken/v1/actions/limits_test.go
+++ b/token/core/fabtoken/v1/actions/limits_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package actions
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
+	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func baseValidIssueAction() *IssueAction {
+	return &IssueAction{
+		Issuer: []byte("issuer"),
+		Outputs: []*Output{
+			{Owner: []byte("owner1"), Type: "TYPE", Quantity: "0x1"},
+		},
+		Metadata: map[string][]byte{},
+	}
+}
+
+func baseValidTransferAction() *TransferAction {
+	return &TransferAction{
+		Inputs: []*TransferActionInput{
+			{
+				ID:    &token.ID{TxId: "txid1", Index: 0},
+				Input: &Output{Owner: []byte("owner1"), Type: "TYPE", Quantity: "0x1"},
+			},
+		},
+		Outputs: []*Output{
+			{Owner: []byte("owner2"), Type: "TYPE", Quantity: "0x1"},
+		},
+		Metadata: map[string][]byte{},
+	}
+}
+
+func TestIssueAction_Validate_TooManyOutputs(t *testing.T) {
+	mk := func(n int) *IssueAction {
+		a := baseValidIssueAction()
+		a.Outputs = make([]*Output, n)
+		for i := range a.Outputs {
+			a.Outputs[i] = &Output{Owner: []byte("owner"), Type: "TYPE", Quantity: "0x1"}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxOutputs-1).Validate())
+	require.NoError(t, mk(MaxOutputs).Validate())
+	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+}
+
+func TestIssueAction_Validate_MetadataLimits(t *testing.T) {
+	t.Run("entries", func(t *testing.T) {
+		mk := func(n int) *IssueAction {
+			a := baseValidIssueAction()
+			a.Metadata = make(map[string][]byte, n)
+			for i := range n {
+				a.Metadata["k"+strconv.Itoa(i)] = []byte("v")
+			}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+	})
+	t.Run("key bytes", func(t *testing.T) {
+		mk := func(n int) *IssueAction {
+			a := baseValidIssueAction()
+			a.Metadata = map[string][]byte{string(make([]byte, n)): []byte("v")}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
+	})
+	t.Run("value bytes", func(t *testing.T) {
+		mk := func(n int) *IssueAction {
+			a := baseValidIssueAction()
+			a.Metadata = map[string][]byte{"k": make([]byte, n)}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
+	})
+}
+
+func marshalIssueAction(t *testing.T, outputs int) []byte {
+	t.Helper()
+	ia := &actions.IssueAction{
+		Version: ProtocolV1,
+		Issuer:  &driverv1.Identity{Raw: []byte("issuer")},
+	}
+	for range outputs {
+		ia.Outputs = append(ia.Outputs, &actions.IssueActionOutput{Token: &actions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, err := proto.Marshal(ia)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestIssueAction_Deserialize_TooManyOutputs(t *testing.T) {
+	a := &IssueAction{}
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, MaxOutputs)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxOutputs+1)), ErrTooManyOutputs)
+}
+
+func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
+	mk := func(n int) *TransferAction {
+		a := baseValidTransferAction()
+		a.Inputs = make([]*TransferActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &TransferActionInput{
+				ID:    &token.ID{TxId: "txid", Index: uint64(i)},
+				Input: &Output{Owner: []byte("owner"), Type: "TYPE", Quantity: "0x1"},
+			}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxInputs-1).Validate())
+	require.NoError(t, mk(MaxInputs).Validate())
+	require.ErrorIs(t, mk(MaxInputs+1).Validate(), ErrTooManyInputs)
+}
+
+func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
+	mk := func(n int) *TransferAction {
+		a := baseValidTransferAction()
+		a.Outputs = make([]*Output, n)
+		for i := range a.Outputs {
+			a.Outputs[i] = &Output{Owner: []byte("owner"), Type: "TYPE", Quantity: "0x1"}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxOutputs-1).Validate())
+	require.NoError(t, mk(MaxOutputs).Validate())
+	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+}
+
+func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
+	mk := func(n int) *TransferAction {
+		a := baseValidTransferAction()
+		a.Metadata = make(map[string][]byte, n)
+		for i := range n {
+			a.Metadata["k"+strconv.Itoa(i)] = []byte("v")
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxMetadataEntries-1).Validate())
+	require.NoError(t, mk(MaxMetadataEntries).Validate())
+	require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+}
+
+func marshalTransferAction(t *testing.T, inputs, outputs int) []byte {
+	t.Helper()
+	ta := &actions.TransferAction{
+		Version: ProtocolV1,
+	}
+	for range inputs {
+		ta.Inputs = append(ta.Inputs, &actions.TransferActionInput{Input: &actions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	for range outputs {
+		ta.Outputs = append(ta.Outputs, &actions.TransferActionOutput{Token: &actions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, err := proto.Marshal(ta)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestTransferAction_Deserialize_TooManyInputs(t *testing.T) {
+	a := &TransferAction{}
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, MaxInputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, MaxInputs+1, 1)), ErrTooManyInputs)
+}
+
+func TestTransferAction_Deserialize_TooManyOutputs(t *testing.T) {
+	a := &TransferAction{}
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, MaxOutputs)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, MaxOutputs+1)), ErrTooManyOutputs)
+}
+
+func TestTransferAction_Deserialize_ManyTinyInputs(t *testing.T) {
+	a := &TransferAction{}
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, MaxInputs+1, 1)), ErrTooManyInputs)
+}

--- a/token/core/fabtoken/v1/actions/limits_test.go
+++ b/token/core/fabtoken/v1/actions/limits_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/driver"
 	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -43,6 +44,7 @@ func baseValidTransferAction() *TransferAction {
 }
 
 func TestIssueAction_Validate_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *IssueAction {
 		a := baseValidIssueAction()
 		a.Outputs = make([]*Output, n)
@@ -52,12 +54,30 @@ func TestIssueAction_Validate_TooManyOutputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxOutputs-1).Validate())
-	require.NoError(t, mk(MaxOutputs).Validate())
-	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+	require.NoError(t, mk(limits.MaxOutputs-1).Validate())
+	require.NoError(t, mk(limits.MaxOutputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxOutputs+1).Validate(), ErrTooManyOutputs)
+}
+
+func TestIssueAction_Validate_TooManyOutputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxOutputs = 2
+	mk := func(n int) *IssueAction {
+		a := baseValidIssueAction()
+		a.Outputs = make([]*Output, n)
+		for i := range a.Outputs {
+			a.Outputs[i] = &Output{Owner: []byte("owner"), Type: "TYPE", Quantity: "0x1"}
+		}
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(2).Validate())
+	require.ErrorIs(t, mk(3).Validate(), ErrTooManyOutputs)
 }
 
 func TestIssueAction_Validate_MetadataLimits(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	t.Run("entries", func(t *testing.T) {
 		mk := func(n int) *IssueAction {
 			a := baseValidIssueAction()
@@ -68,9 +88,9 @@ func TestIssueAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataEntries-1).Validate())
-		require.NoError(t, mk(MaxMetadataEntries).Validate())
-		require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+		require.NoError(t, mk(limits.MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
 	})
 	t.Run("key bytes", func(t *testing.T) {
 		mk := func(n int) *IssueAction {
@@ -79,9 +99,9 @@ func TestIssueAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataKeyBytes-1).Validate())
-		require.NoError(t, mk(MaxMetadataKeyBytes).Validate())
-		require.ErrorIs(t, mk(MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
 	})
 	t.Run("value bytes", func(t *testing.T) {
 		mk := func(n int) *IssueAction {
@@ -90,9 +110,9 @@ func TestIssueAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataValueBytes-1).Validate())
-		require.NoError(t, mk(MaxMetadataValueBytes).Validate())
-		require.ErrorIs(t, mk(MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
 	})
 }
 
@@ -112,12 +132,23 @@ func marshalIssueAction(t *testing.T, outputs int) []byte {
 }
 
 func TestIssueAction_Deserialize_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &IssueAction{}
-	require.NoError(t, a.Deserialize(marshalIssueAction(t, MaxOutputs)))
-	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxOutputs+1)), ErrTooManyOutputs)
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, limits.MaxOutputs)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, limits.MaxOutputs+1)), ErrTooManyOutputs)
+}
+
+func TestIssueAction_Deserialize_TooManyOutputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxOutputs = 2
+	a := &IssueAction{}
+	a.SetLimits(custom)
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, 2)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 3)), ErrTooManyOutputs)
 }
 
 func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *TransferAction {
 		a := baseValidTransferAction()
 		a.Inputs = make([]*TransferActionInput, n)
@@ -130,12 +161,33 @@ func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxInputs-1).Validate())
-	require.NoError(t, mk(MaxInputs).Validate())
-	require.ErrorIs(t, mk(MaxInputs+1).Validate(), ErrTooManyInputs)
+	require.NoError(t, mk(limits.MaxInputs-1).Validate())
+	require.NoError(t, mk(limits.MaxInputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxInputs+1).Validate(), ErrTooManyInputs)
+}
+
+func TestTransferAction_Validate_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	mk := func(n int) *TransferAction {
+		a := baseValidTransferAction()
+		a.Inputs = make([]*TransferActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &TransferActionInput{
+				ID:    &token.ID{TxId: "txid", Index: uint64(i)},
+				Input: &Output{Owner: []byte("owner"), Type: "TYPE", Quantity: "0x1"},
+			}
+		}
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(2).Validate())
+	require.ErrorIs(t, mk(3).Validate(), ErrTooManyInputs)
 }
 
 func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *TransferAction {
 		a := baseValidTransferAction()
 		a.Outputs = make([]*Output, n)
@@ -145,12 +197,13 @@ func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxOutputs-1).Validate())
-	require.NoError(t, mk(MaxOutputs).Validate())
-	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+	require.NoError(t, mk(limits.MaxOutputs-1).Validate())
+	require.NoError(t, mk(limits.MaxOutputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxOutputs+1).Validate(), ErrTooManyOutputs)
 }
 
 func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *TransferAction {
 		a := baseValidTransferAction()
 		a.Metadata = make(map[string][]byte, n)
@@ -160,9 +213,9 @@ func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxMetadataEntries-1).Validate())
-	require.NoError(t, mk(MaxMetadataEntries).Validate())
-	require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+	require.NoError(t, mk(limits.MaxMetadataEntries-1).Validate())
+	require.NoError(t, mk(limits.MaxMetadataEntries).Validate())
+	require.ErrorIs(t, mk(limits.MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
 }
 
 func marshalTransferAction(t *testing.T, inputs, outputs int) []byte {
@@ -183,18 +236,30 @@ func marshalTransferAction(t *testing.T, inputs, outputs int) []byte {
 }
 
 func TestTransferAction_Deserialize_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &TransferAction{}
-	require.NoError(t, a.Deserialize(marshalTransferAction(t, MaxInputs, 1)))
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, MaxInputs+1, 1)), ErrTooManyInputs)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs+1, 1)), ErrTooManyInputs)
 }
 
 func TestTransferAction_Deserialize_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &TransferAction{}
-	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, MaxOutputs)))
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, MaxOutputs+1)), ErrTooManyOutputs)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, limits.MaxOutputs)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, limits.MaxOutputs+1)), ErrTooManyOutputs)
 }
 
 func TestTransferAction_Deserialize_ManyTinyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &TransferAction{}
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, MaxInputs+1, 1)), ErrTooManyInputs)
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs+1, 1)), ErrTooManyInputs)
+}
+
+func TestTransferAction_Deserialize_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	a := &TransferAction{}
+	a.SetLimits(custom)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 2, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 3, 1)), ErrTooManyInputs)
 }

--- a/token/core/fabtoken/v1/actions/transfer.go
+++ b/token/core/fabtoken/v1/actions/transfer.go
@@ -76,6 +76,22 @@ type TransferAction struct {
 	Metadata map[string][]byte
 	// Issuer contains the identity of the issuer to sign the transfer action
 	Issuer driver.Identity
+
+	limits *driver.ResourceLimits
+}
+
+// SetLimits configures the resource limits enforced by Validate and Deserialize.
+func (t *TransferAction) SetLimits(limits driver.ResourceLimits) {
+	t.limits = &limits
+}
+
+// effectiveLimits returns the configured limits, or the defaults if none were set.
+func (t *TransferAction) effectiveLimits() driver.ResourceLimits {
+	if t.limits == nil {
+		return driver.DefaultResourceLimits()
+	}
+
+	return *t.limits
 }
 
 func (t *TransferAction) NumInputs() int {
@@ -194,8 +210,9 @@ func (t *TransferAction) Validate() error {
 	if len(t.Inputs) == 0 {
 		return errors.Errorf("invalid number of token inputs, expected at least 1")
 	}
-	if len(t.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	limits := t.effectiveLimits()
+	if len(t.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
 	for i, in := range t.Inputs {
 		if in == nil {
@@ -214,8 +231,8 @@ func (t *TransferAction) Validate() error {
 			return errors.Wrapf(err, "invalid input token at index [%d]", i)
 		}
 	}
-	if len(t.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(t.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
 	for i, out := range t.Outputs {
 		if out == nil {
@@ -228,7 +245,7 @@ func (t *TransferAction) Validate() error {
 			return errors.Errorf("invalid output's quantity at index [%d], output quantity is empty", i)
 		}
 	}
-	if err := checkMetadataLimits(t.Metadata); err != nil {
+	if err := checkMetadataLimits(t.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 	// The following check must happen only if the public parameters contain issuers.
@@ -298,13 +315,14 @@ func (t *TransferAction) Deserialize(raw []byte) error {
 	}
 
 	// enforce resource limits before any allocation proportional to attacker-controlled counts
-	if len(action.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	limits := t.effectiveLimits()
+	if len(action.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
-	if len(action.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(action.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
-	if err := checkMetadataLimits(action.Metadata); err != nil {
+	if err := checkMetadataLimits(action.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 

--- a/token/core/fabtoken/v1/actions/transfer.go
+++ b/token/core/fabtoken/v1/actions/transfer.go
@@ -194,6 +194,9 @@ func (t *TransferAction) Validate() error {
 	if len(t.Inputs) == 0 {
 		return errors.Errorf("invalid number of token inputs, expected at least 1")
 	}
+	if len(t.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
 	for i, in := range t.Inputs {
 		if in == nil {
 			return errors.Errorf("invalid input at index [%d], empty input", i)
@@ -211,6 +214,9 @@ func (t *TransferAction) Validate() error {
 			return errors.Wrapf(err, "invalid input token at index [%d]", i)
 		}
 	}
+	if len(t.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
 	for i, out := range t.Outputs {
 		if out == nil {
 			return errors.Errorf("invalid output at index [%d], empty output", i)
@@ -221,6 +227,9 @@ func (t *TransferAction) Validate() error {
 		if len(out.Quantity) == 0 {
 			return errors.Errorf("invalid output's quantity at index [%d], output quantity is empty", i)
 		}
+	}
+	if err := checkMetadataLimits(t.Metadata); err != nil {
+		return err
 	}
 	// The following check must happen only if the public parameters contain issuers.
 	// The validator enforces the signature of an issuer only in that case.
@@ -286,6 +295,17 @@ func (t *TransferAction) Deserialize(raw []byte) error {
 	// assert version
 	if action.Version != ProtocolV1 {
 		return errors.Errorf("invalid issue version, expected [%d], got [%d]", ProtocolV1, action.Version)
+	}
+
+	// enforce resource limits before any allocation proportional to attacker-controlled counts
+	if len(action.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
+	if len(action.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
+	if err := checkMetadataLimits(action.Metadata); err != nil {
+		return err
 	}
 
 	// inputs

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -159,6 +159,7 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 		logger,
 		publicParamsManager.PublicParams(),
 		deserializer,
+		driver.DefaultResourceLimits(),
 		nil,
 		nil,
 		nil,

--- a/token/core/fabtoken/v1/driver/driver_test.go
+++ b/token/core/fabtoken/v1/driver/driver_test.go
@@ -162,12 +162,12 @@ func TestNewDefaultValidator(t *testing.T) {
 	pp, _ := setup.NewWith(setup.FabTokenDriverName, setup.ProtocolV1, 64)
 
 	// Case 1: Valid public parameters
-	v, err := d.NewValidator(pp)
+	v, err := d.NewValidator(pp, tdriver.DefaultResourceLimits())
 	require.NoError(t, err)
 	assert.NotNil(t, v)
 
 	// Case 2: Invalid public parameters type
-	v, err = d.NewValidator(&dmock.PublicParameters{})
+	v, err = d.NewValidator(&dmock.PublicParameters{}, tdriver.DefaultResourceLimits())
 	require.Error(t, err)
 	assert.Nil(t, v)
 	assert.Contains(t, err.Error(), "invalid public parameters type")

--- a/token/core/fabtoken/v1/driver/validator.go
+++ b/token/core/fabtoken/v1/driver/validator.go
@@ -28,7 +28,7 @@ func NewValidatorDriver() core.NamedFactory[driver.ValidatorDriver] {
 	}
 }
 
-func (d ValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
+func (d ValidatorDriver) NewValidator(pp driver.PublicParameters, limits driver.ResourceLimits) (driver.Validator, error) {
 	if err := pp.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "failed validating public parameters")
 	}
@@ -39,5 +39,5 @@ func (d ValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Valida
 	logger := logging.DriverLoggerFromPP("panurus.driver.fabtoken", string(core.DriverIdentifierFromPP(pp)))
 	deserializer := NewDeserializer()
 
-	return validator.NewValidator(logger, ppp, deserializer, nil, nil, nil), nil
+	return validator.NewValidator(logger, ppp, deserializer, limits, nil, nil, nil), nil
 }

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-boundary
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-boundary
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(256)

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-plus-one
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-plus-one
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(257)

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-boundary
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-boundary
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(false)
+int(256)
+int(1)

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-plus-one
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-plus-one
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(false)
+int(257)
+int(1)

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-boundary
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-boundary
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(256)

--- a/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-plus-one
+++ b/token/core/fabtoken/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-plus-one
@@ -1,0 +1,4 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(257)

--- a/token/core/fabtoken/v1/validator/validator.go
+++ b/token/core/fabtoken/v1/validator/validator.go
@@ -20,13 +20,16 @@ type ValidateIssueFunc = common.ValidateIssueFunc[*setup.PublicParams, *actions.
 
 type ValidateAuditingFunc = common.ValidateAuditingFunc[*setup.PublicParams, *actions.Output, *actions.TransferAction, *actions.IssueAction, driver.Deserializer]
 
-type ActionDeserializer struct{}
+type ActionDeserializer struct {
+	Limits driver.ResourceLimits
+}
 
 func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*actions.IssueAction, []*actions.TransferAction, error) {
 	issues := tr.GetIssues()
 	issueActions := make([]*actions.IssueAction, len(issues))
 	for i := range issues {
 		ia := &actions.IssueAction{}
+		ia.SetLimits(a.Limits)
 		if err := ia.Deserialize(issues[i]); err != nil {
 			return nil, nil, err
 		}
@@ -37,6 +40,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*act
 	transferActions := make([]*actions.TransferAction, len(transfers))
 	for i := range transfers {
 		ta := &actions.TransferAction{}
+		ta.SetLimits(a.Limits)
 		if err := ta.Deserialize(transfers[i]); err != nil {
 			return nil, nil, err
 		}
@@ -54,6 +58,7 @@ func NewValidator(
 	logger logging.Logger,
 	pp *setup.PublicParams,
 	deserializer driver.Deserializer,
+	limits driver.ResourceLimits,
 	extraTransferValidators []ValidateTransferFunc,
 	extraIssuerValidators []ValidateIssueFunc,
 	extraAuditorValidators []ValidateAuditingFunc,
@@ -82,7 +87,8 @@ func NewValidator(
 		logger,
 		pp,
 		deserializer,
-		&ActionDeserializer{},
+		limits,
+		&ActionDeserializer{Limits: limits},
 		transferValidators,
 		issueValidators,
 		auditingValidators,

--- a/token/core/fabtoken/v1/validator/validator_fuzz_test.go
+++ b/token/core/fabtoken/v1/validator/validator_fuzz_test.go
@@ -9,7 +9,6 @@ package validator_test
 import (
 	"testing"
 
-	"github.com/LFDT-Panurus/panurus/token/core/common"
 	fbactions "github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/validator"
@@ -29,8 +28,9 @@ func FuzzActionDeserializerNoPanic(f *testing.F) {
 	f.Add(uint8(1), transferRaw)
 	f.Add(uint8(1), []byte("malformed"))
 
+	limits := driver.DefaultResourceLimits()
 	f.Fuzz(func(t *testing.T, actionKind uint8, raw []byte) {
-		if len(raw) > maxFuzzActionBytes {
+		if len(raw) > limits.MaxActionBytes {
 			t.Skip()
 		}
 		typeID := request.ActionType_ACTION_TYPE_ISSUE
@@ -40,14 +40,10 @@ func FuzzActionDeserializerNoPanic(f *testing.F) {
 		tokenRequest := &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: typeID, Raw: raw}}}
 
 		require.NotPanics(t, func() {
-			_, _, _ = (&validator.ActionDeserializer{}).DeserializeActions(tokenRequest)
+			_, _, _ = (&validator.ActionDeserializer{Limits: limits}).DeserializeActions(tokenRequest)
 		})
 	})
 }
-
-// maxFuzzActionBytes mirrors common.MaxActionBytes: it is the real production limit enforced on
-// TypedAction.Raw by the common validator, so fuzzing beyond it exercises no additional code path.
-const maxFuzzActionBytes = common.MaxActionBytes
 
 // marshalFuzzedIssueAction builds the raw protobuf bytes of an issue action with the given
 // output count, bypassing IssueAction.Serialize so that out-of-limit shapes (which Serialize's
@@ -99,14 +95,15 @@ func boundInt(n, lo, hi int) int {
 // dimensions (input/output counts) and asserts that Deserialize never panics and rejects
 // any dimension that exceeds its configured limit with the corresponding typed error.
 func FuzzActionResourceLimits(f *testing.F) {
+	limits := driver.DefaultResourceLimits()
 	f.Add(true, 1, 1)
-	f.Add(true, 1, actions.MaxOutputs)
-	f.Add(true, 1, actions.MaxOutputs+1)
+	f.Add(true, 1, limits.MaxOutputs)
+	f.Add(true, 1, limits.MaxOutputs+1)
 	f.Add(false, 1, 1)
-	f.Add(false, actions.MaxInputs, 1)
-	f.Add(false, actions.MaxInputs+1, 1)
-	f.Add(false, 1, actions.MaxOutputs)
-	f.Add(false, 1, actions.MaxOutputs+1)
+	f.Add(false, limits.MaxInputs, 1)
+	f.Add(false, limits.MaxInputs+1, 1)
+	f.Add(false, 1, limits.MaxOutputs)
+	f.Add(false, 1, limits.MaxOutputs+1)
 
 	f.Fuzz(func(t *testing.T, isIssue bool, inputs, outputs int) {
 		inputs = boundInt(inputs, 1, 512)
@@ -119,7 +116,7 @@ func FuzzActionResourceLimits(f *testing.F) {
 			require.NotPanics(t, func() {
 				err = (&actions.IssueAction{}).Deserialize(raw)
 			})
-			if outputs > actions.MaxOutputs {
+			if outputs > limits.MaxOutputs {
 				require.ErrorIs(t, err, actions.ErrTooManyOutputs)
 			}
 
@@ -131,9 +128,9 @@ func FuzzActionResourceLimits(f *testing.F) {
 			err = (&actions.TransferAction{}).Deserialize(raw)
 		})
 		switch {
-		case inputs > actions.MaxInputs:
+		case inputs > limits.MaxInputs:
 			require.ErrorIs(t, err, actions.ErrTooManyInputs)
-		case outputs > actions.MaxOutputs:
+		case outputs > limits.MaxOutputs:
 			require.ErrorIs(t, err, actions.ErrTooManyOutputs)
 		}
 	})

--- a/token/core/fabtoken/v1/validator/validator_fuzz_test.go
+++ b/token/core/fabtoken/v1/validator/validator_fuzz_test.go
@@ -9,10 +9,14 @@ package validator_test
 import (
 	"testing"
 
+	"github.com/LFDT-Panurus/panurus/token/core/common"
+	fbactions "github.com/LFDT-Panurus/panurus/token/core/fabtoken/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,4 +45,96 @@ func FuzzActionDeserializerNoPanic(f *testing.F) {
 	})
 }
 
-const maxFuzzActionBytes = 256 << 10
+// maxFuzzActionBytes mirrors common.MaxActionBytes: it is the real production limit enforced on
+// TypedAction.Raw by the common validator, so fuzzing beyond it exercises no additional code path.
+const maxFuzzActionBytes = common.MaxActionBytes
+
+// marshalFuzzedIssueAction builds the raw protobuf bytes of an issue action with the given
+// output count, bypassing IssueAction.Serialize so that out-of-limit shapes (which Serialize's
+// own caller never produces) can still be exercised.
+func marshalFuzzedIssueAction(outputs int) []byte {
+	ia := &fbactions.IssueAction{
+		Version: actions.ProtocolV1,
+		Issuer:  &driverv1.Identity{Raw: []byte("issuer")},
+	}
+	for range outputs {
+		ia.Outputs = append(ia.Outputs, &fbactions.IssueActionOutput{Token: &fbactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, _ := proto.Marshal(ia)
+
+	return raw
+}
+
+// marshalFuzzedTransferAction mirrors marshalFuzzedIssueAction for transfer actions.
+func marshalFuzzedTransferAction(inputs, outputs int) []byte {
+	ta := &fbactions.TransferAction{
+		Version: actions.ProtocolV1,
+	}
+	for range inputs {
+		ta.Inputs = append(ta.Inputs, &fbactions.TransferActionInput{Input: &fbactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	for range outputs {
+		ta.Outputs = append(ta.Outputs, &fbactions.TransferActionOutput{Token: &fbactions.Token{Owner: []byte("o"), Type: "TYPE", Quantity: "0x1"}})
+	}
+	raw, _ := proto.Marshal(ta)
+
+	return raw
+}
+
+// boundInt clamps n into [lo, hi], using n's magnitude modulo the range width so that fuzzed
+// values (including negatives) still exercise the full range deterministically.
+func boundInt(n, lo, hi int) int {
+	if hi <= lo {
+		return lo
+	}
+	width := hi - lo + 1
+	if n < 0 {
+		n = -n
+	}
+
+	return lo + n%width
+}
+
+// FuzzActionResourceLimits fuzzes issue and transfer actions shaped by their resource
+// dimensions (input/output counts) and asserts that Deserialize never panics and rejects
+// any dimension that exceeds its configured limit with the corresponding typed error.
+func FuzzActionResourceLimits(f *testing.F) {
+	f.Add(true, 1, 1)
+	f.Add(true, 1, actions.MaxOutputs)
+	f.Add(true, 1, actions.MaxOutputs+1)
+	f.Add(false, 1, 1)
+	f.Add(false, actions.MaxInputs, 1)
+	f.Add(false, actions.MaxInputs+1, 1)
+	f.Add(false, 1, actions.MaxOutputs)
+	f.Add(false, 1, actions.MaxOutputs+1)
+
+	f.Fuzz(func(t *testing.T, isIssue bool, inputs, outputs int) {
+		inputs = boundInt(inputs, 1, 512)
+		outputs = boundInt(outputs, 1, 512)
+
+		var raw []byte
+		var err error
+		if isIssue {
+			raw = marshalFuzzedIssueAction(outputs)
+			require.NotPanics(t, func() {
+				err = (&actions.IssueAction{}).Deserialize(raw)
+			})
+			if outputs > actions.MaxOutputs {
+				require.ErrorIs(t, err, actions.ErrTooManyOutputs)
+			}
+
+			return
+		}
+
+		raw = marshalFuzzedTransferAction(inputs, outputs)
+		require.NotPanics(t, func() {
+			err = (&actions.TransferAction{}).Deserialize(raw)
+		})
+		switch {
+		case inputs > actions.MaxInputs:
+			require.ErrorIs(t, err, actions.ErrTooManyInputs)
+		case outputs > actions.MaxOutputs:
+			require.ErrorIs(t, err, actions.ErrTooManyOutputs)
+		}
+	})
+}

--- a/token/core/fabtoken/v1/validator/validator_test.go
+++ b/token/core/fabtoken/v1/validator/validator_test.go
@@ -102,7 +102,7 @@ func TestNewValidator(t *testing.T) {
 	pp := &setup.PublicParams{}
 	deserializer := &mock.Deserializer{}
 
-	v := validator.NewValidator(logger, pp, deserializer, nil, nil, nil)
+	v := validator.NewValidator(logger, pp, deserializer, driver.DefaultResourceLimits(), nil, nil, nil)
 	assert.NotNil(t, v)
 }
 
@@ -1136,7 +1136,7 @@ func newValidatorEnv(benchmarkCase *benchmark2.Case, isIssue bool) (*validatorEn
 		return nil, err
 	}
 	des := &mock.Deserializer{}
-	v := validator.NewValidator(logger, pp, des, nil, nil, nil)
+	v := validator.NewValidator(logger, pp, des, driver.DefaultResourceLimits(), nil, nil, nil)
 
 	id, _ := identity.WrapWithType(x509.IdentityType, []byte("owner"))
 	issuer, _ := identity.WrapWithType(x509.IdentityType, []byte("issuer"))

--- a/token/core/service.go
+++ b/token/core/service.go
@@ -149,18 +149,20 @@ type TokenDriverService = TMSDriverService
 // ValidatorDriverService manages factories for creating validators.
 type ValidatorDriverService struct {
 	*factoryDirectory[driver.ValidatorDriver]
+	limits driver.ResourceLimits
 }
 
-// NewValidatorDriverService creates a new ValidatorDriverService with the provided factories.
-func NewValidatorDriverService(factories ...NamedFactory[driver.ValidatorDriver]) *ValidatorDriverService {
-	return &ValidatorDriverService{factoryDirectory: newFactoryDirectory(factories...)}
+// NewValidatorDriverService creates a new ValidatorDriverService with the provided resource
+// limits and factories. The limits are applied to every validator this service creates.
+func NewValidatorDriverService(limits driver.ResourceLimits, factories ...NamedFactory[driver.ValidatorDriver]) *ValidatorDriverService {
+	return &ValidatorDriverService{factoryDirectory: newFactoryDirectory(factories...), limits: limits}
 }
 
 // NewValidator returns a new instance of driver.Validator for the passed public parameters.
 // If no driver is registered for the public params' identifier, it returns an error.
 func (s *ValidatorDriverService) NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
 	if d, ok := s.factories[DriverIdentifierFromPP(pp)]; ok {
-		return d.NewValidator(pp)
+		return d.NewValidator(pp, s.limits)
 	}
 
 	return nil, errors.Errorf("no validator found for token driver [%s]", DriverIdentifierFromPP(pp))

--- a/token/core/service_test.go
+++ b/token/core/service_test.go
@@ -215,6 +215,7 @@ func TestValidatorDriverService_NewDefaultValidator(t *testing.T) {
 
 	driverMock := &mock.ValidatorDriver{}
 	service := core.NewValidatorDriverService(
+		driver.DefaultResourceLimits(),
 		core.NamedFactory[driver.ValidatorDriver]{
 			Name:   identifier,
 			Driver: driverMock,
@@ -242,4 +243,37 @@ func TestValidatorDriverService_NewDefaultValidator(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, res)
 	assert.Contains(t, err.Error(), "no validator found for token driver [unknown.v1]")
+}
+
+// TestValidatorDriverService_ForwardsConfiguredLimits verifies that the ResourceLimits passed to
+// NewValidatorDriverService are the exact ones forwarded to the underlying driver's NewValidator,
+// proving an override actually reaches the validator instead of being silently dropped.
+func TestValidatorDriverService_ForwardsConfiguredLimits(t *testing.T) {
+	name := driver.TokenDriverName("test-driver")
+	version := driver.TokenDriverVersion(1)
+	identifier := core.DriverIdentifier(name, version)
+
+	custom := driver.DefaultResourceLimits()
+	custom.MaxActions = 2
+
+	driverMock := &mock.ValidatorDriver{}
+	driverMock.NewValidatorReturns(&mock.Validator{}, nil)
+	service := core.NewValidatorDriverService(
+		custom,
+		core.NamedFactory[driver.ValidatorDriver]{
+			Name:   identifier,
+			Driver: driverMock,
+		},
+	)
+
+	pp := &mock.PublicParameters{}
+	pp.TokenDriverNameReturns(name)
+	pp.TokenDriverVersionReturns(version)
+
+	_, err := service.NewValidator(pp)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, driverMock.NewValidatorCallCount())
+	_, gotLimits := driverMock.NewValidatorArgsForCall(0)
+	assert.Equal(t, custom, gotLimits)
 }

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -162,17 +162,15 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze token upgrade service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}
-	validator, err := validator.New(
+	validator := validator.New(
 		logger,
 		ppm.PublicParams(),
 		deserializer,
+		driver.DefaultResourceLimits(),
 		nil,
 		nil,
 		nil,
-	), nil
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to instantiate validator")
-	}
+	)
 	service, err := v1.NewTokenService(
 		logger,
 		ws,

--- a/token/core/zkatdlog/nogh/v1/driver/driver_test.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver_test.go
@@ -185,12 +185,12 @@ func TestNewDefaultValidator(t *testing.T) {
 	pp, _ := setup.Setup(32, issuerPK, math3.FP256BN_AMCL)
 
 	// Case 1: Valid public parameters
-	v, err := d.NewValidator(pp)
+	v, err := d.NewValidator(pp, tdriver.DefaultResourceLimits())
 	require.NoError(t, err)
 	assert.NotNil(t, v)
 
 	// Case 2: Invalid public parameters type
-	v, err = d.NewValidator(&dmock.PublicParameters{})
+	v, err = d.NewValidator(&dmock.PublicParameters{}, tdriver.DefaultResourceLimits())
 	require.Error(t, err)
 	assert.Nil(t, v)
 	assert.Contains(t, err.Error(), "invalid public parameters type")

--- a/token/core/zkatdlog/nogh/v1/driver/validator.go
+++ b/token/core/zkatdlog/nogh/v1/driver/validator.go
@@ -29,7 +29,7 @@ func NewValidatorDriver() core.NamedFactory[driver.ValidatorDriver] {
 }
 
 // NewValidator returns a new zkatdlog validator for the passed public parameters.
-func (d ValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Validator, error) {
+func (d ValidatorDriver) NewValidator(pp driver.PublicParameters, limits driver.ResourceLimits) (driver.Validator, error) {
 	ppp, ok := pp.(*v1.PublicParams)
 	if !ok {
 		return nil, errors.Errorf("invalid public parameters type [%T]", pp)
@@ -47,6 +47,7 @@ func (d ValidatorDriver) NewValidator(pp driver.PublicParameters) (driver.Valida
 		logger,
 		ppp,
 		deserializer,
+		limits,
 		nil,
 		nil,
 		nil,

--- a/token/core/zkatdlog/nogh/v1/issue/action.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action.go
@@ -68,6 +68,22 @@ type Action struct {
 	Proof []byte
 	// Metadata of the issue action.
 	Metadata map[string][]byte
+
+	limits *driver.ResourceLimits
+}
+
+// SetLimits configures the resource limits enforced by Validate and Deserialize.
+func (i *Action) SetLimits(limits driver.ResourceLimits) {
+	i.limits = &limits
+}
+
+// effectiveLimits returns the configured limits, or the defaults if none were set.
+func (i *Action) effectiveLimits() driver.ResourceLimits {
+	if i.limits == nil {
+		return driver.DefaultResourceLimits()
+	}
+
+	return *i.limits
 }
 
 // NewAction instantiates an Action given the issuer's identity, token commitments, owners, and a proof.
@@ -214,16 +230,17 @@ func (i *Action) Validate() error {
 	if len(i.Proof) == 0 {
 		return ErrEmptyProof
 	}
-	if len(i.Proof) > MaxProofBytes {
-		return ErrProofTooLarge
+	limits := i.effectiveLimits()
+	if len(i.Proof) > limits.MaxProofBytes {
+		return errors.Wrapf(ErrProofTooLarge, "limit [%d] bytes", limits.MaxProofBytes)
 	}
-	if len(i.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	if len(i.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
-	if len(i.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(i.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
-	if err := checkMetadataLimits(i.Metadata); err != nil {
+	if err := checkMetadataLimits(i.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 
@@ -307,18 +324,19 @@ func (i *Action) Deserialize(raw []byte) error {
 	}
 
 	// enforce resource limits before any allocation proportional to attacker-controlled counts
-	if len(issueAction.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	limits := i.effectiveLimits()
+	if len(issueAction.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
-	if len(issueAction.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(issueAction.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
-	if err := checkMetadataLimits(issueAction.Metadata); err != nil {
+	if err := checkMetadataLimits(issueAction.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 	if proof := issueAction.GetProof(); proof != nil {
-		if len(proof.GetProof()) > MaxProofBytes || len(proof.GetCspBasedProof()) > MaxProofBytes {
-			return ErrProofTooLarge
+		if len(proof.GetProof()) > limits.MaxProofBytes || len(proof.GetCspBasedProof()) > limits.MaxProofBytes {
+			return errors.Wrapf(ErrProofTooLarge, "limit [%d] bytes", limits.MaxProofBytes)
 		}
 	}
 

--- a/token/core/zkatdlog/nogh/v1/issue/action.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action.go
@@ -214,6 +214,18 @@ func (i *Action) Validate() error {
 	if len(i.Proof) == 0 {
 		return ErrEmptyProof
 	}
+	if len(i.Proof) > MaxProofBytes {
+		return ErrProofTooLarge
+	}
+	if len(i.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
+	if len(i.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
+	if err := checkMetadataLimits(i.Metadata); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -292,6 +304,22 @@ func (i *Action) Deserialize(raw []byte) error {
 	// assert version
 	if issueAction.Version != ProtocolV1 {
 		return errors.Join(ErrInvalidProtocolVersion, errors.Errorf("expected [%d], got [%d]", ProtocolV1, issueAction.Version))
+	}
+
+	// enforce resource limits before any allocation proportional to attacker-controlled counts
+	if len(issueAction.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
+	if len(issueAction.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
+	if err := checkMetadataLimits(issueAction.Metadata); err != nil {
+		return err
+	}
+	if proof := issueAction.GetProof(); proof != nil {
+		if len(proof.GetProof()) > MaxProofBytes || len(proof.GetCspBasedProof()) > MaxProofBytes {
+			return ErrProofTooLarge
+		}
 	}
 
 	// inputs

--- a/token/core/zkatdlog/nogh/v1/issue/limits.go
+++ b/token/core/zkatdlog/nogh/v1/issue/limits.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issue
+
+import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+// Resource limits enforced while deserializing and validating an untrusted issue action.
+//
+// These constants are consensus-critical: every peer validating the same action must apply the
+// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
+// another, breaking endorsement determinism. Changing any value below is a breaking protocol
+// change and requires a coordinated upgrade of all validating peers.
+const (
+	// MaxInputs bounds the number of redeemed-token inputs in a single issue action.
+	MaxInputs = 256
+	// MaxOutputs bounds the number of newly issued outputs in a single issue action.
+	MaxOutputs = 256
+	// MaxMetadataEntries bounds the number of metadata entries attached to an issue action.
+	MaxMetadataEntries = 64
+	// MaxMetadataKeyBytes bounds the length of a single metadata key.
+	MaxMetadataKeyBytes = 256
+	// MaxMetadataValueBytes bounds the length of a single metadata value.
+	MaxMetadataValueBytes = 4 << 10 // 4 KiB
+	// MaxProofBytes bounds the length of the action's zero-knowledge proof, checked before the
+	// proof is handed to the bulletproof/CSP verifier for deserialization.
+	MaxProofBytes = 128 << 10 // 128 KiB
+)
+
+// Typed errors returned when an issue action exceeds a configured resource limit.
+var (
+	// ErrTooManyInputs is returned when an issue action redeems more than MaxInputs inputs.
+	ErrTooManyInputs = errors.Errorf("issue action exceeds maximum allowed number of inputs [%d]", MaxInputs)
+	// ErrTooManyOutputs is returned when an issue action issues more than MaxOutputs outputs.
+	ErrTooManyOutputs = errors.Errorf("issue action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
+	// ErrTooManyMetadataEntries is returned when an issue action has more than MaxMetadataEntries metadata entries.
+	ErrTooManyMetadataEntries = errors.Errorf("issue action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
+	ErrMetadataKeyTooLarge = errors.Errorf("issue action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
+	ErrMetadataValueTooLarge = errors.Errorf("issue action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
+	// ErrProofTooLarge is returned when the action's proof exceeds MaxProofBytes.
+	ErrProofTooLarge = errors.Errorf("issue action proof exceeds maximum allowed size of %d bytes", MaxProofBytes)
+)
+
+// checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
+// on a deserialized issue action's metadata map.
+func checkMetadataLimits(metadata map[string][]byte) error {
+	if len(metadata) > MaxMetadataEntries {
+		return ErrTooManyMetadataEntries
+	}
+	for k, v := range metadata {
+		if len(k) > MaxMetadataKeyBytes {
+			return ErrMetadataKeyTooLarge
+		}
+		if len(v) > MaxMetadataValueBytes {
+			return ErrMetadataValueTooLarge
+		}
+	}
+
+	return nil
+}

--- a/token/core/zkatdlog/nogh/v1/issue/limits.go
+++ b/token/core/zkatdlog/nogh/v1/issue/limits.go
@@ -10,54 +10,40 @@ import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
 // Resource limits enforced while deserializing and validating an untrusted issue action.
 //
-// These constants are consensus-critical: every peer validating the same action must apply the
-// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
-// another, breaking endorsement determinism. Changing any value below is a breaking protocol
-// change and requires a coordinated upgrade of all validating peers.
-const (
-	// MaxInputs bounds the number of redeemed-token inputs in a single issue action.
-	MaxInputs = 256
-	// MaxOutputs bounds the number of newly issued outputs in a single issue action.
-	MaxOutputs = 256
-	// MaxMetadataEntries bounds the number of metadata entries attached to an issue action.
-	MaxMetadataEntries = 64
-	// MaxMetadataKeyBytes bounds the length of a single metadata key.
-	MaxMetadataKeyBytes = 256
-	// MaxMetadataValueBytes bounds the length of a single metadata value.
-	MaxMetadataValueBytes = 4 << 10 // 4 KiB
-	// MaxProofBytes bounds the length of the action's zero-knowledge proof, checked before the
-	// proof is handed to the bulletproof/CSP verifier for deserialization.
-	MaxProofBytes = 128 << 10 // 128 KiB
-)
+// The limits enforced by a given Action are configurable (see driver.ResourceLimits); every peer
+// validating the same action must be configured with the same limits, or otherwise-identical
+// actions could be accepted by one peer and rejected by another, breaking endorsement
+// determinism. Deployments that override the defaults are responsible for keeping every
+// validating peer in sync.
 
 // Typed errors returned when an issue action exceeds a configured resource limit.
 var (
-	// ErrTooManyInputs is returned when an issue action redeems more than MaxInputs inputs.
-	ErrTooManyInputs = errors.Errorf("issue action exceeds maximum allowed number of inputs [%d]", MaxInputs)
-	// ErrTooManyOutputs is returned when an issue action issues more than MaxOutputs outputs.
-	ErrTooManyOutputs = errors.Errorf("issue action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
-	// ErrTooManyMetadataEntries is returned when an issue action has more than MaxMetadataEntries metadata entries.
-	ErrTooManyMetadataEntries = errors.Errorf("issue action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
-	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
-	ErrMetadataKeyTooLarge = errors.Errorf("issue action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
-	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
-	ErrMetadataValueTooLarge = errors.Errorf("issue action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
-	// ErrProofTooLarge is returned when the action's proof exceeds MaxProofBytes.
-	ErrProofTooLarge = errors.Errorf("issue action proof exceeds maximum allowed size of %d bytes", MaxProofBytes)
+	// ErrTooManyInputs is returned when an issue action redeems more inputs than allowed.
+	ErrTooManyInputs = errors.New("issue action exceeds maximum allowed number of inputs")
+	// ErrTooManyOutputs is returned when an issue action issues more outputs than allowed.
+	ErrTooManyOutputs = errors.New("issue action exceeds maximum allowed number of outputs")
+	// ErrTooManyMetadataEntries is returned when an issue action has more metadata entries than allowed.
+	ErrTooManyMetadataEntries = errors.New("issue action exceeds maximum allowed number of metadata entries")
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds the configured limit.
+	ErrMetadataKeyTooLarge = errors.New("issue action metadata key exceeds maximum allowed size")
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds the configured limit.
+	ErrMetadataValueTooLarge = errors.New("issue action metadata value exceeds maximum allowed size")
+	// ErrProofTooLarge is returned when the action's proof exceeds the configured limit.
+	ErrProofTooLarge = errors.New("issue action proof exceeds maximum allowed size")
 )
 
 // checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
 // on a deserialized issue action's metadata map.
-func checkMetadataLimits(metadata map[string][]byte) error {
-	if len(metadata) > MaxMetadataEntries {
-		return ErrTooManyMetadataEntries
+func checkMetadataLimits(metadata map[string][]byte, maxEntries, maxKeyBytes, maxValueBytes int) error {
+	if len(metadata) > maxEntries {
+		return errors.Wrapf(ErrTooManyMetadataEntries, "limit [%d]", maxEntries)
 	}
 	for k, v := range metadata {
-		if len(k) > MaxMetadataKeyBytes {
-			return ErrMetadataKeyTooLarge
+		if len(k) > maxKeyBytes {
+			return errors.Wrapf(ErrMetadataKeyTooLarge, "limit [%d] bytes", maxKeyBytes)
 		}
-		if len(v) > MaxMetadataValueBytes {
-			return ErrMetadataValueTooLarge
+		if len(v) > maxValueBytes {
+			return errors.Wrapf(ErrMetadataValueTooLarge, "limit [%d] bytes", maxValueBytes)
 		}
 	}
 

--- a/token/core/zkatdlog/nogh/v1/issue/limits_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/limits_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/LFDT-Panurus/panurus/token/driver"
 	protosv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -39,6 +40,7 @@ func baseValidAction() *Action {
 }
 
 func TestAction_Validate_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *Action {
 		a := baseValidAction()
 		a.Inputs = make([]*ActionInput, n)
@@ -48,12 +50,30 @@ func TestAction_Validate_TooManyInputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxInputs-1).Validate())
-	require.NoError(t, mk(MaxInputs).Validate())
-	require.ErrorIs(t, mk(MaxInputs+1).Validate(), ErrTooManyInputs)
+	require.NoError(t, mk(limits.MaxInputs-1).Validate())
+	require.NoError(t, mk(limits.MaxInputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxInputs+1).Validate(), ErrTooManyInputs)
+}
+
+func TestAction_Validate_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	mk := func(n int) *Action {
+		a := baseValidAction()
+		a.Inputs = make([]*ActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &ActionInput{ID: token2.ID{TxId: "txid", Index: uint64(i)}, Token: []byte("token")}
+		}
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(2).Validate())
+	require.ErrorIs(t, mk(3).Validate(), ErrTooManyInputs)
 }
 
 func TestAction_Validate_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	curve := math.Curves[math.BN254]
 	mk := func(n int) *Action {
 		a := baseValidAction()
@@ -64,24 +84,40 @@ func TestAction_Validate_TooManyOutputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(MaxOutputs-1).Validate())
-	require.NoError(t, mk(MaxOutputs).Validate())
-	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+	require.NoError(t, mk(limits.MaxOutputs-1).Validate())
+	require.NoError(t, mk(limits.MaxOutputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxOutputs+1).Validate(), ErrTooManyOutputs)
 }
 
 func TestAction_Validate_ProofTooLarge(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *Action {
 		a := baseValidAction()
 		a.Proof = make([]byte, n)
 
 		return a
 	}
-	require.NoError(t, mk(MaxProofBytes-1).Validate())
-	require.NoError(t, mk(MaxProofBytes).Validate())
-	require.ErrorIs(t, mk(MaxProofBytes+1).Validate(), ErrProofTooLarge)
+	require.NoError(t, mk(limits.MaxProofBytes-1).Validate())
+	require.NoError(t, mk(limits.MaxProofBytes).Validate())
+	require.ErrorIs(t, mk(limits.MaxProofBytes+1).Validate(), ErrProofTooLarge)
+}
+
+func TestAction_Validate_ProofTooLarge_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxProofBytes = 16
+	mk := func(n int) *Action {
+		a := baseValidAction()
+		a.Proof = make([]byte, n)
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(16).Validate())
+	require.ErrorIs(t, mk(17).Validate(), ErrProofTooLarge)
 }
 
 func TestAction_Validate_MetadataLimits(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	t.Run("entries", func(t *testing.T) {
 		mk := func(n int) *Action {
 			a := baseValidAction()
@@ -92,9 +128,9 @@ func TestAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataEntries-1).Validate())
-		require.NoError(t, mk(MaxMetadataEntries).Validate())
-		require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+		require.NoError(t, mk(limits.MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
 	})
 	t.Run("key bytes", func(t *testing.T) {
 		mk := func(n int) *Action {
@@ -103,9 +139,9 @@ func TestAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataKeyBytes-1).Validate())
-		require.NoError(t, mk(MaxMetadataKeyBytes).Validate())
-		require.ErrorIs(t, mk(MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
 	})
 	t.Run("value bytes", func(t *testing.T) {
 		mk := func(n int) *Action {
@@ -114,9 +150,9 @@ func TestAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(MaxMetadataValueBytes-1).Validate())
-		require.NoError(t, mk(MaxMetadataValueBytes).Validate())
-		require.ErrorIs(t, mk(MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
 	})
 }
 
@@ -142,33 +178,47 @@ func marshalIssueAction(t *testing.T, inputs, outputs, proofLen int) []byte {
 }
 
 func TestAction_Deserialize_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &Action{}
-	require.NoError(t, a.Deserialize(marshalIssueAction(t, MaxInputs, 1, 1)))
-	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxInputs+1, 1, 1)), ErrTooManyInputs)
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, limits.MaxInputs, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, limits.MaxInputs+1, 1, 1)), ErrTooManyInputs)
 }
 
 func TestAction_Deserialize_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &Action{}
-	require.NoError(t, a.Deserialize(marshalIssueAction(t, 1, MaxOutputs, 1)))
-	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, MaxOutputs+1, 1)), ErrTooManyOutputs)
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, 1, limits.MaxOutputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, limits.MaxOutputs+1, 1)), ErrTooManyOutputs)
 }
 
 func TestAction_Deserialize_ProofTooLarge(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &Action{}
-	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, 1, MaxProofBytes+1)), ErrProofTooLarge)
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, 1, limits.MaxProofBytes+1)), ErrProofTooLarge)
 }
 
 func TestAction_Deserialize_ManyTinyInputs(t *testing.T) {
 	// Many minimal-size inputs should be rejected purely on count, not size.
+	limits := driver.DefaultResourceLimits()
 	a := &Action{}
-	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxInputs+1, 1, 1)), ErrTooManyInputs)
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, limits.MaxInputs+1, 1, 1)), ErrTooManyInputs)
+}
+
+func TestAction_Deserialize_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	a := &Action{}
+	a.SetLimits(custom)
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, 2, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 3, 1, 1)), ErrTooManyInputs)
 }
 
 // TestAction_Deserialize_RejectsBeforeCryptographicWork proves that an oversized proof is
 // rejected by the resource-limit check before any cryptographic verifier work would run:
 // Deserialize returns near-instantly and never reaches proof-specific unmarshalling.
 func TestAction_Deserialize_RejectsBeforeCryptographicWork(t *testing.T) {
-	raw := marshalIssueAction(t, 1, 1, MaxProofBytes+1)
+	limits := driver.DefaultResourceLimits()
+	raw := marshalIssueAction(t, 1, 1, limits.MaxProofBytes+1)
 
 	start := time.Now()
 	a := &Action{}

--- a/token/core/zkatdlog/nogh/v1/issue/limits_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/limits_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package issue
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	protosv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
+	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func baseValidAction() *Action {
+	curve := math.Curves[math.BN254]
+
+	return &Action{
+		Issuer: []byte("issuer"),
+		Inputs: []*ActionInput{
+			{ID: token2.ID{TxId: "txid1", Index: 0}, Token: []byte("token1")},
+		},
+		Outputs: []*token.Token{
+			{Owner: []byte("owner1"), Data: curve.GenG1},
+		},
+		ProofType: rp.RangeProofType,
+		Proof:     []byte("proof"),
+		Metadata:  map[string][]byte{},
+	}
+}
+
+func TestAction_Validate_TooManyInputs(t *testing.T) {
+	mk := func(n int) *Action {
+		a := baseValidAction()
+		a.Inputs = make([]*ActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &ActionInput{ID: token2.ID{TxId: "txid", Index: uint64(i)}, Token: []byte("token")}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxInputs-1).Validate())
+	require.NoError(t, mk(MaxInputs).Validate())
+	require.ErrorIs(t, mk(MaxInputs+1).Validate(), ErrTooManyInputs)
+}
+
+func TestAction_Validate_TooManyOutputs(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	mk := func(n int) *Action {
+		a := baseValidAction()
+		a.Outputs = make([]*token.Token, n)
+		for i := range a.Outputs {
+			a.Outputs[i] = &token.Token{Owner: []byte("owner"), Data: curve.GenG1}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(MaxOutputs-1).Validate())
+	require.NoError(t, mk(MaxOutputs).Validate())
+	require.ErrorIs(t, mk(MaxOutputs+1).Validate(), ErrTooManyOutputs)
+}
+
+func TestAction_Validate_ProofTooLarge(t *testing.T) {
+	mk := func(n int) *Action {
+		a := baseValidAction()
+		a.Proof = make([]byte, n)
+
+		return a
+	}
+	require.NoError(t, mk(MaxProofBytes-1).Validate())
+	require.NoError(t, mk(MaxProofBytes).Validate())
+	require.ErrorIs(t, mk(MaxProofBytes+1).Validate(), ErrProofTooLarge)
+}
+
+func TestAction_Validate_MetadataLimits(t *testing.T) {
+	t.Run("entries", func(t *testing.T) {
+		mk := func(n int) *Action {
+			a := baseValidAction()
+			a.Metadata = make(map[string][]byte, n)
+			for i := range n {
+				a.Metadata["k"+strconv.Itoa(i)] = []byte("v")
+			}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(MaxMetadataEntries+1).Validate(), ErrTooManyMetadataEntries)
+	})
+	t.Run("key bytes", func(t *testing.T) {
+		mk := func(n int) *Action {
+			a := baseValidAction()
+			a.Metadata = map[string][]byte{string(make([]byte, n)): []byte("v")}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(MaxMetadataKeyBytes+1).Validate(), ErrMetadataKeyTooLarge)
+	})
+	t.Run("value bytes", func(t *testing.T) {
+		mk := func(n int) *Action {
+			a := baseValidAction()
+			a.Metadata = map[string][]byte{"k": make([]byte, n)}
+
+			return a
+		}
+		require.NoError(t, mk(MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(MaxMetadataValueBytes+1).Validate(), ErrMetadataValueTooLarge)
+	})
+}
+
+func marshalIssueAction(t *testing.T, inputs, outputs, proofLen int) []byte {
+	t.Helper()
+	ia := &actions.IssueAction{
+		Version: ProtocolV1,
+		Issuer:  &protosv1.Identity{Raw: []byte("issuer")},
+	}
+	for range inputs {
+		ia.Inputs = append(ia.Inputs, &actions.IssueActionInput{Token: []byte("t")})
+	}
+	for range outputs {
+		ia.Outputs = append(ia.Outputs, &actions.IssueActionOutput{Token: &actions.Token{Owner: []byte("o")}})
+	}
+	if proofLen > 0 {
+		ia.Proof = &actions.Proof{ProofType: &actions.Proof_Proof{Proof: make([]byte, proofLen)}}
+	}
+	raw, err := proto.Marshal(ia)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestAction_Deserialize_TooManyInputs(t *testing.T) {
+	a := &Action{}
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, MaxInputs, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxInputs+1, 1, 1)), ErrTooManyInputs)
+}
+
+func TestAction_Deserialize_TooManyOutputs(t *testing.T) {
+	a := &Action{}
+	require.NoError(t, a.Deserialize(marshalIssueAction(t, 1, MaxOutputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, MaxOutputs+1, 1)), ErrTooManyOutputs)
+}
+
+func TestAction_Deserialize_ProofTooLarge(t *testing.T) {
+	a := &Action{}
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, 1, 1, MaxProofBytes+1)), ErrProofTooLarge)
+}
+
+func TestAction_Deserialize_ManyTinyInputs(t *testing.T) {
+	// Many minimal-size inputs should be rejected purely on count, not size.
+	a := &Action{}
+	require.ErrorIs(t, a.Deserialize(marshalIssueAction(t, MaxInputs+1, 1, 1)), ErrTooManyInputs)
+}
+
+// TestAction_Deserialize_RejectsBeforeCryptographicWork proves that an oversized proof is
+// rejected by the resource-limit check before any cryptographic verifier work would run:
+// Deserialize returns near-instantly and never reaches proof-specific unmarshalling.
+func TestAction_Deserialize_RejectsBeforeCryptographicWork(t *testing.T) {
+	raw := marshalIssueAction(t, 1, 1, MaxProofBytes+1)
+
+	start := time.Now()
+	a := &Action{}
+	err := a.Deserialize(raw)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, ErrProofTooLarge)
+	require.Less(t, elapsed, 50*time.Millisecond, "oversized proof must be rejected near-instantly, before any cryptographic work")
+}

--- a/token/core/zkatdlog/nogh/v1/regression/regression_test.go
+++ b/token/core/zkatdlog/nogh/v1/regression/regression_test.go
@@ -178,7 +178,7 @@ func testRegression(t *testing.T, configDir string) {
 }
 
 func tokenServicesFactory(bytes []byte) (tcc.PublicParameters, tcc.Validator, error) {
-	is := core.NewValidatorDriverService(fabtoken.NewValidatorDriver(), dlog.NewValidatorDriver())
+	is := core.NewValidatorDriverService(driver.DefaultResourceLimits(), fabtoken.NewValidatorDriver(), dlog.NewValidatorDriver())
 
 	ppm, err := is.PublicParametersFromBytes(bytes)
 	if err != nil {

--- a/token/core/zkatdlog/nogh/v1/testutils/env.go
+++ b/token/core/zkatdlog/nogh/v1/testutils/env.go
@@ -104,6 +104,7 @@ func NewEnv(benchCase *benchmark2.Case, configurations *benchmark.SetupConfigura
 		logging.MustGetLogger(),
 		pp,
 		deserializer,
+		driver.DefaultResourceLimits(),
 		nil,
 		nil,
 		nil,

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -335,6 +335,9 @@ func (t *Action) Validate() error {
 	if len(t.Inputs) == 0 {
 		return ErrInvalidInputs
 	}
+	if len(t.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
 	for i, in := range t.Inputs {
 		if in == nil {
 			return errors.Wrapf(ErrEmptyInput, "invalid input at index [%d], empty input", i)
@@ -361,6 +364,9 @@ func (t *Action) Validate() error {
 	if len(t.Outputs) == 0 {
 		return ErrInvalidOutputs
 	}
+	if len(t.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
 	for i, out := range t.Outputs {
 		if out == nil {
 			return errors.Wrapf(ErrEmptyOutputToken, "invalid output token at index [%d]", i)
@@ -379,6 +385,12 @@ func (t *Action) Validate() error {
 	}
 	if len(t.Proof) == 0 {
 		return ErrEmptyProof
+	}
+	if len(t.Proof) > MaxProofBytes {
+		return ErrProofTooLarge
+	}
+	if err := checkMetadataLimits(t.Metadata); err != nil {
+		return err
 	}
 
 	return nil
@@ -463,6 +475,22 @@ func (t *Action) Deserialize(raw []byte) error {
 	// assert version
 	if action.Version != ProtocolV1 {
 		return errors.Wrapf(ErrInvalidVersion, "expected [%d], got [%d]", ProtocolV1, action.Version)
+	}
+
+	// enforce resource limits before any allocation proportional to attacker-controlled counts
+	if len(action.Inputs) > MaxInputs {
+		return ErrTooManyInputs
+	}
+	if len(action.Outputs) > MaxOutputs {
+		return ErrTooManyOutputs
+	}
+	if err := checkMetadataLimits(action.Metadata); err != nil {
+		return err
+	}
+	if proof := action.GetProof(); proof != nil {
+		if len(proof.GetProof()) > MaxProofBytes || len(proof.GetCspBasedProof()) > MaxProofBytes {
+			return ErrProofTooLarge
+		}
 	}
 
 	// inputs

--- a/token/core/zkatdlog/nogh/v1/transfer/action.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/action.go
@@ -134,6 +134,22 @@ type Action struct {
 	Metadata map[string][]byte
 	// Issuer contains the identity of the issuer to sign the transfer action
 	Issuer driver.Identity
+
+	limits *driver.ResourceLimits
+}
+
+// SetLimits configures the resource limits enforced by Validate and Deserialize.
+func (t *Action) SetLimits(limits driver.ResourceLimits) {
+	t.limits = &limits
+}
+
+// effectiveLimits returns the configured limits, or the defaults if none were set.
+func (t *Action) effectiveLimits() driver.ResourceLimits {
+	if t.limits == nil {
+		return driver.DefaultResourceLimits()
+	}
+
+	return *t.limits
 }
 
 // NewAction returns the Action that matches the passed arguments
@@ -335,8 +351,9 @@ func (t *Action) Validate() error {
 	if len(t.Inputs) == 0 {
 		return ErrInvalidInputs
 	}
-	if len(t.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	limits := t.effectiveLimits()
+	if len(t.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
 	for i, in := range t.Inputs {
 		if in == nil {
@@ -364,8 +381,8 @@ func (t *Action) Validate() error {
 	if len(t.Outputs) == 0 {
 		return ErrInvalidOutputs
 	}
-	if len(t.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(t.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
 	for i, out := range t.Outputs {
 		if out == nil {
@@ -386,10 +403,10 @@ func (t *Action) Validate() error {
 	if len(t.Proof) == 0 {
 		return ErrEmptyProof
 	}
-	if len(t.Proof) > MaxProofBytes {
-		return ErrProofTooLarge
+	if len(t.Proof) > limits.MaxProofBytes {
+		return errors.Wrapf(ErrProofTooLarge, "limit [%d] bytes", limits.MaxProofBytes)
 	}
-	if err := checkMetadataLimits(t.Metadata); err != nil {
+	if err := checkMetadataLimits(t.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 
@@ -478,18 +495,19 @@ func (t *Action) Deserialize(raw []byte) error {
 	}
 
 	// enforce resource limits before any allocation proportional to attacker-controlled counts
-	if len(action.Inputs) > MaxInputs {
-		return ErrTooManyInputs
+	limits := t.effectiveLimits()
+	if len(action.Inputs) > limits.MaxInputs {
+		return errors.Wrapf(ErrTooManyInputs, "limit [%d]", limits.MaxInputs)
 	}
-	if len(action.Outputs) > MaxOutputs {
-		return ErrTooManyOutputs
+	if len(action.Outputs) > limits.MaxOutputs {
+		return errors.Wrapf(ErrTooManyOutputs, "limit [%d]", limits.MaxOutputs)
 	}
-	if err := checkMetadataLimits(action.Metadata); err != nil {
+	if err := checkMetadataLimits(action.Metadata, limits.MaxMetadataEntries, limits.MaxMetadataKeyBytes, limits.MaxMetadataValueBytes); err != nil {
 		return err
 	}
 	if proof := action.GetProof(); proof != nil {
-		if len(proof.GetProof()) > MaxProofBytes || len(proof.GetCspBasedProof()) > MaxProofBytes {
-			return ErrProofTooLarge
+		if len(proof.GetProof()) > limits.MaxProofBytes || len(proof.GetCspBasedProof()) > limits.MaxProofBytes {
+			return errors.Wrapf(ErrProofTooLarge, "limit [%d] bytes", limits.MaxProofBytes)
 		}
 	}
 

--- a/token/core/zkatdlog/nogh/v1/transfer/limits.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/limits.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transfer
+
+import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+// Resource limits enforced while deserializing and validating an untrusted transfer action.
+//
+// These constants are consensus-critical: every peer validating the same action must apply the
+// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
+// another, breaking endorsement determinism. Changing any value below is a breaking protocol
+// change and requires a coordinated upgrade of all validating peers.
+const (
+	// MaxInputs bounds the number of spent-token inputs in a single transfer action.
+	MaxInputs = 256
+	// MaxOutputs bounds the number of newly created outputs in a single transfer action.
+	MaxOutputs = 256
+	// MaxMetadataEntries bounds the number of metadata entries attached to a transfer action.
+	MaxMetadataEntries = 64
+	// MaxMetadataKeyBytes bounds the length of a single metadata key.
+	MaxMetadataKeyBytes = 256
+	// MaxMetadataValueBytes bounds the length of a single metadata value.
+	MaxMetadataValueBytes = 4 << 10 // 4 KiB
+	// MaxProofBytes bounds the length of the action's zero-knowledge proof, checked before the
+	// proof is handed to the bulletproof/CSP verifier for deserialization.
+	MaxProofBytes = 128 << 10 // 128 KiB
+)
+
+// Typed errors returned when a transfer action exceeds a configured resource limit.
+var (
+	// ErrTooManyInputs is returned when a transfer action spends more than MaxInputs inputs.
+	ErrTooManyInputs = errors.Errorf("transfer action exceeds maximum allowed number of inputs [%d]", MaxInputs)
+	// ErrTooManyOutputs is returned when a transfer action creates more than MaxOutputs outputs.
+	ErrTooManyOutputs = errors.Errorf("transfer action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
+	// ErrTooManyMetadataEntries is returned when a transfer action has more than MaxMetadataEntries metadata entries.
+	ErrTooManyMetadataEntries = errors.Errorf("transfer action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
+	ErrMetadataKeyTooLarge = errors.Errorf("transfer action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
+	ErrMetadataValueTooLarge = errors.Errorf("transfer action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
+	// ErrProofTooLarge is returned when the action's proof exceeds MaxProofBytes.
+	ErrProofTooLarge = errors.Errorf("transfer action proof exceeds maximum allowed size of %d bytes", MaxProofBytes)
+)
+
+// checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
+// on a deserialized transfer action's metadata map.
+func checkMetadataLimits(metadata map[string][]byte) error {
+	if len(metadata) > MaxMetadataEntries {
+		return ErrTooManyMetadataEntries
+	}
+	for k, v := range metadata {
+		if len(k) > MaxMetadataKeyBytes {
+			return ErrMetadataKeyTooLarge
+		}
+		if len(v) > MaxMetadataValueBytes {
+			return ErrMetadataValueTooLarge
+		}
+	}
+
+	return nil
+}

--- a/token/core/zkatdlog/nogh/v1/transfer/limits.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/limits.go
@@ -10,54 +10,40 @@ import "github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 
 // Resource limits enforced while deserializing and validating an untrusted transfer action.
 //
-// These constants are consensus-critical: every peer validating the same action must apply the
-// same limits, or otherwise-identical actions could be accepted by one peer and rejected by
-// another, breaking endorsement determinism. Changing any value below is a breaking protocol
-// change and requires a coordinated upgrade of all validating peers.
-const (
-	// MaxInputs bounds the number of spent-token inputs in a single transfer action.
-	MaxInputs = 256
-	// MaxOutputs bounds the number of newly created outputs in a single transfer action.
-	MaxOutputs = 256
-	// MaxMetadataEntries bounds the number of metadata entries attached to a transfer action.
-	MaxMetadataEntries = 64
-	// MaxMetadataKeyBytes bounds the length of a single metadata key.
-	MaxMetadataKeyBytes = 256
-	// MaxMetadataValueBytes bounds the length of a single metadata value.
-	MaxMetadataValueBytes = 4 << 10 // 4 KiB
-	// MaxProofBytes bounds the length of the action's zero-knowledge proof, checked before the
-	// proof is handed to the bulletproof/CSP verifier for deserialization.
-	MaxProofBytes = 128 << 10 // 128 KiB
-)
+// The limits enforced by a given Action are configurable (see driver.ResourceLimits); every peer
+// validating the same action must be configured with the same limits, or otherwise-identical
+// actions could be accepted by one peer and rejected by another, breaking endorsement
+// determinism. Deployments that override the defaults are responsible for keeping every
+// validating peer in sync.
 
 // Typed errors returned when a transfer action exceeds a configured resource limit.
 var (
-	// ErrTooManyInputs is returned when a transfer action spends more than MaxInputs inputs.
-	ErrTooManyInputs = errors.Errorf("transfer action exceeds maximum allowed number of inputs [%d]", MaxInputs)
-	// ErrTooManyOutputs is returned when a transfer action creates more than MaxOutputs outputs.
-	ErrTooManyOutputs = errors.Errorf("transfer action exceeds maximum allowed number of outputs [%d]", MaxOutputs)
-	// ErrTooManyMetadataEntries is returned when a transfer action has more than MaxMetadataEntries metadata entries.
-	ErrTooManyMetadataEntries = errors.Errorf("transfer action exceeds maximum allowed number of metadata entries [%d]", MaxMetadataEntries)
-	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds MaxMetadataKeyBytes.
-	ErrMetadataKeyTooLarge = errors.Errorf("transfer action metadata key exceeds maximum allowed size of %d bytes", MaxMetadataKeyBytes)
-	// ErrMetadataValueTooLarge is returned when a metadata value exceeds MaxMetadataValueBytes.
-	ErrMetadataValueTooLarge = errors.Errorf("transfer action metadata value exceeds maximum allowed size of %d bytes", MaxMetadataValueBytes)
-	// ErrProofTooLarge is returned when the action's proof exceeds MaxProofBytes.
-	ErrProofTooLarge = errors.Errorf("transfer action proof exceeds maximum allowed size of %d bytes", MaxProofBytes)
+	// ErrTooManyInputs is returned when a transfer action spends more inputs than allowed.
+	ErrTooManyInputs = errors.New("transfer action exceeds maximum allowed number of inputs")
+	// ErrTooManyOutputs is returned when a transfer action creates more outputs than allowed.
+	ErrTooManyOutputs = errors.New("transfer action exceeds maximum allowed number of outputs")
+	// ErrTooManyMetadataEntries is returned when a transfer action has more metadata entries than allowed.
+	ErrTooManyMetadataEntries = errors.New("transfer action exceeds maximum allowed number of metadata entries")
+	// ErrMetadataKeyTooLarge is returned when a metadata key exceeds the configured limit.
+	ErrMetadataKeyTooLarge = errors.New("transfer action metadata key exceeds maximum allowed size")
+	// ErrMetadataValueTooLarge is returned when a metadata value exceeds the configured limit.
+	ErrMetadataValueTooLarge = errors.New("transfer action metadata value exceeds maximum allowed size")
+	// ErrProofTooLarge is returned when the action's proof exceeds the configured limit.
+	ErrProofTooLarge = errors.New("transfer action proof exceeds maximum allowed size")
 )
 
 // checkMetadataLimits enforces MaxMetadataEntries, MaxMetadataKeyBytes and MaxMetadataValueBytes
 // on a deserialized transfer action's metadata map.
-func checkMetadataLimits(metadata map[string][]byte) error {
-	if len(metadata) > MaxMetadataEntries {
-		return ErrTooManyMetadataEntries
+func checkMetadataLimits(metadata map[string][]byte, maxEntries, maxKeyBytes, maxValueBytes int) error {
+	if len(metadata) > maxEntries {
+		return errors.Wrapf(ErrTooManyMetadataEntries, "limit [%d]", maxEntries)
 	}
 	for k, v := range metadata {
-		if len(k) > MaxMetadataKeyBytes {
-			return ErrMetadataKeyTooLarge
+		if len(k) > maxKeyBytes {
+			return errors.Wrapf(ErrMetadataKeyTooLarge, "limit [%d] bytes", maxKeyBytes)
 		}
-		if len(v) > MaxMetadataValueBytes {
-			return ErrMetadataValueTooLarge
+		if len(v) > maxValueBytes {
+			return errors.Wrapf(ErrMetadataValueTooLarge, "limit [%d] bytes", maxValueBytes)
 		}
 	}
 

--- a/token/core/zkatdlog/nogh/v1/transfer/limits_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/limits_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	token2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/transfer"
+	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
@@ -41,6 +42,7 @@ func baseValidTransferAction() *transfer.Action {
 }
 
 func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	curve := math.Curves[math.BN254]
 	mk := func(n int) *transfer.Action {
 		a := baseValidTransferAction()
@@ -54,12 +56,34 @@ func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(transfer.MaxInputs-1).Validate())
-	require.NoError(t, mk(transfer.MaxInputs).Validate())
-	require.ErrorIs(t, mk(transfer.MaxInputs+1).Validate(), transfer.ErrTooManyInputs)
+	require.NoError(t, mk(limits.MaxInputs-1).Validate())
+	require.NoError(t, mk(limits.MaxInputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxInputs+1).Validate(), transfer.ErrTooManyInputs)
+}
+
+func TestTransferAction_Validate_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	curve := math.Curves[math.BN254]
+	mk := func(n int) *transfer.Action {
+		a := baseValidTransferAction()
+		a.Inputs = make([]*transfer.ActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &transfer.ActionInput{
+				ID:    &token.ID{TxId: "txid", Index: uint64(i)},
+				Token: &token2.Token{Owner: []byte("owner"), Data: curve.GenG1},
+			}
+		}
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(2).Validate())
+	require.ErrorIs(t, mk(3).Validate(), transfer.ErrTooManyInputs)
 }
 
 func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	curve := math.Curves[math.BN254]
 	mk := func(n int) *transfer.Action {
 		a := baseValidTransferAction()
@@ -70,24 +94,40 @@ func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
 
 		return a
 	}
-	require.NoError(t, mk(transfer.MaxOutputs-1).Validate())
-	require.NoError(t, mk(transfer.MaxOutputs).Validate())
-	require.ErrorIs(t, mk(transfer.MaxOutputs+1).Validate(), transfer.ErrTooManyOutputs)
+	require.NoError(t, mk(limits.MaxOutputs-1).Validate())
+	require.NoError(t, mk(limits.MaxOutputs).Validate())
+	require.ErrorIs(t, mk(limits.MaxOutputs+1).Validate(), transfer.ErrTooManyOutputs)
 }
 
 func TestTransferAction_Validate_ProofTooLarge(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	mk := func(n int) *transfer.Action {
 		a := baseValidTransferAction()
 		a.Proof = make([]byte, n)
 
 		return a
 	}
-	require.NoError(t, mk(transfer.MaxProofBytes-1).Validate())
-	require.NoError(t, mk(transfer.MaxProofBytes).Validate())
-	require.ErrorIs(t, mk(transfer.MaxProofBytes+1).Validate(), transfer.ErrProofTooLarge)
+	require.NoError(t, mk(limits.MaxProofBytes-1).Validate())
+	require.NoError(t, mk(limits.MaxProofBytes).Validate())
+	require.ErrorIs(t, mk(limits.MaxProofBytes+1).Validate(), transfer.ErrProofTooLarge)
+}
+
+func TestTransferAction_Validate_ProofTooLarge_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxProofBytes = 16
+	mk := func(n int) *transfer.Action {
+		a := baseValidTransferAction()
+		a.Proof = make([]byte, n)
+		a.SetLimits(custom)
+
+		return a
+	}
+	require.NoError(t, mk(16).Validate())
+	require.ErrorIs(t, mk(17).Validate(), transfer.ErrProofTooLarge)
 }
 
 func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	t.Run("entries", func(t *testing.T) {
 		mk := func(n int) *transfer.Action {
 			a := baseValidTransferAction()
@@ -98,9 +138,9 @@ func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(transfer.MaxMetadataEntries-1).Validate())
-		require.NoError(t, mk(transfer.MaxMetadataEntries).Validate())
-		require.ErrorIs(t, mk(transfer.MaxMetadataEntries+1).Validate(), transfer.ErrTooManyMetadataEntries)
+		require.NoError(t, mk(limits.MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataEntries+1).Validate(), transfer.ErrTooManyMetadataEntries)
 	})
 	t.Run("key bytes", func(t *testing.T) {
 		mk := func(n int) *transfer.Action {
@@ -109,9 +149,9 @@ func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(transfer.MaxMetadataKeyBytes-1).Validate())
-		require.NoError(t, mk(transfer.MaxMetadataKeyBytes).Validate())
-		require.ErrorIs(t, mk(transfer.MaxMetadataKeyBytes+1).Validate(), transfer.ErrMetadataKeyTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataKeyBytes+1).Validate(), transfer.ErrMetadataKeyTooLarge)
 	})
 	t.Run("value bytes", func(t *testing.T) {
 		mk := func(n int) *transfer.Action {
@@ -120,9 +160,9 @@ func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
 
 			return a
 		}
-		require.NoError(t, mk(transfer.MaxMetadataValueBytes-1).Validate())
-		require.NoError(t, mk(transfer.MaxMetadataValueBytes).Validate())
-		require.ErrorIs(t, mk(transfer.MaxMetadataValueBytes+1).Validate(), transfer.ErrMetadataValueTooLarge)
+		require.NoError(t, mk(limits.MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(limits.MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(limits.MaxMetadataValueBytes+1).Validate(), transfer.ErrMetadataValueTooLarge)
 	})
 }
 
@@ -147,32 +187,46 @@ func marshalTransferAction(t *testing.T, inputs, outputs, proofLen int) []byte {
 }
 
 func TestTransferAction_Deserialize_TooManyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &transfer.Action{}
-	require.NoError(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs, 1, 1)))
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
 }
 
 func TestTransferAction_Deserialize_TooManyOutputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &transfer.Action{}
-	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, transfer.MaxOutputs, 1)))
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, transfer.MaxOutputs+1, 1)), transfer.ErrTooManyOutputs)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, limits.MaxOutputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, limits.MaxOutputs+1, 1)), transfer.ErrTooManyOutputs)
 }
 
 func TestTransferAction_Deserialize_ProofTooLarge(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &transfer.Action{}
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, 1, transfer.MaxProofBytes+1)), transfer.ErrProofTooLarge)
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, 1, limits.MaxProofBytes+1)), transfer.ErrProofTooLarge)
 }
 
 func TestTransferAction_Deserialize_ManyTinyInputs(t *testing.T) {
+	limits := driver.DefaultResourceLimits()
 	a := &transfer.Action{}
-	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, limits.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
+}
+
+func TestTransferAction_Deserialize_TooManyInputs_CustomLimit(t *testing.T) {
+	custom := driver.DefaultResourceLimits()
+	custom.MaxInputs = 2
+	a := &transfer.Action{}
+	a.SetLimits(custom)
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 2, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 3, 1, 1)), transfer.ErrTooManyInputs)
 }
 
 // TestTransferAction_Deserialize_RejectsBeforeCryptographicWork proves that an oversized
 // proof is rejected by the resource-limit check before any cryptographic verifier work would
 // run: Deserialize returns near-instantly and never reaches proof-specific unmarshalling.
 func TestTransferAction_Deserialize_RejectsBeforeCryptographicWork(t *testing.T) {
-	raw := marshalTransferAction(t, 1, 1, transfer.MaxProofBytes+1)
+	limits := driver.DefaultResourceLimits()
+	raw := marshalTransferAction(t, 1, 1, limits.MaxProofBytes+1)
 
 	start := time.Now()
 	a := &transfer.Action{}

--- a/token/core/zkatdlog/nogh/v1/transfer/limits_test.go
+++ b/token/core/zkatdlog/nogh/v1/transfer/limits_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package transfer_test
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
+	token2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/transfer"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func baseValidTransferAction() *transfer.Action {
+	curve := math.Curves[math.BN254]
+
+	return &transfer.Action{
+		Inputs: []*transfer.ActionInput{
+			{
+				ID:    &token.ID{TxId: "txid1", Index: 0},
+				Token: &token2.Token{Owner: []byte("owner1"), Data: curve.GenG1},
+			},
+		},
+		Outputs: []*token2.Token{
+			{Owner: []byte("owner2"), Data: curve.GenG1},
+		},
+		ProofType: rp.RangeProofType,
+		Proof:     []byte("proof"),
+		Metadata:  map[string][]byte{},
+	}
+}
+
+func TestTransferAction_Validate_TooManyInputs(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	mk := func(n int) *transfer.Action {
+		a := baseValidTransferAction()
+		a.Inputs = make([]*transfer.ActionInput, n)
+		for i := range a.Inputs {
+			a.Inputs[i] = &transfer.ActionInput{
+				ID:    &token.ID{TxId: "txid", Index: uint64(i)},
+				Token: &token2.Token{Owner: []byte("owner"), Data: curve.GenG1},
+			}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(transfer.MaxInputs-1).Validate())
+	require.NoError(t, mk(transfer.MaxInputs).Validate())
+	require.ErrorIs(t, mk(transfer.MaxInputs+1).Validate(), transfer.ErrTooManyInputs)
+}
+
+func TestTransferAction_Validate_TooManyOutputs(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	mk := func(n int) *transfer.Action {
+		a := baseValidTransferAction()
+		a.Outputs = make([]*token2.Token, n)
+		for i := range a.Outputs {
+			a.Outputs[i] = &token2.Token{Owner: []byte("owner"), Data: curve.GenG1}
+		}
+
+		return a
+	}
+	require.NoError(t, mk(transfer.MaxOutputs-1).Validate())
+	require.NoError(t, mk(transfer.MaxOutputs).Validate())
+	require.ErrorIs(t, mk(transfer.MaxOutputs+1).Validate(), transfer.ErrTooManyOutputs)
+}
+
+func TestTransferAction_Validate_ProofTooLarge(t *testing.T) {
+	mk := func(n int) *transfer.Action {
+		a := baseValidTransferAction()
+		a.Proof = make([]byte, n)
+
+		return a
+	}
+	require.NoError(t, mk(transfer.MaxProofBytes-1).Validate())
+	require.NoError(t, mk(transfer.MaxProofBytes).Validate())
+	require.ErrorIs(t, mk(transfer.MaxProofBytes+1).Validate(), transfer.ErrProofTooLarge)
+}
+
+func TestTransferAction_Validate_MetadataLimits(t *testing.T) {
+	t.Run("entries", func(t *testing.T) {
+		mk := func(n int) *transfer.Action {
+			a := baseValidTransferAction()
+			a.Metadata = make(map[string][]byte, n)
+			for i := range n {
+				a.Metadata["k"+strconv.Itoa(i)] = []byte("v")
+			}
+
+			return a
+		}
+		require.NoError(t, mk(transfer.MaxMetadataEntries-1).Validate())
+		require.NoError(t, mk(transfer.MaxMetadataEntries).Validate())
+		require.ErrorIs(t, mk(transfer.MaxMetadataEntries+1).Validate(), transfer.ErrTooManyMetadataEntries)
+	})
+	t.Run("key bytes", func(t *testing.T) {
+		mk := func(n int) *transfer.Action {
+			a := baseValidTransferAction()
+			a.Metadata = map[string][]byte{string(make([]byte, n)): []byte("v")}
+
+			return a
+		}
+		require.NoError(t, mk(transfer.MaxMetadataKeyBytes-1).Validate())
+		require.NoError(t, mk(transfer.MaxMetadataKeyBytes).Validate())
+		require.ErrorIs(t, mk(transfer.MaxMetadataKeyBytes+1).Validate(), transfer.ErrMetadataKeyTooLarge)
+	})
+	t.Run("value bytes", func(t *testing.T) {
+		mk := func(n int) *transfer.Action {
+			a := baseValidTransferAction()
+			a.Metadata = map[string][]byte{"k": make([]byte, n)}
+
+			return a
+		}
+		require.NoError(t, mk(transfer.MaxMetadataValueBytes-1).Validate())
+		require.NoError(t, mk(transfer.MaxMetadataValueBytes).Validate())
+		require.ErrorIs(t, mk(transfer.MaxMetadataValueBytes+1).Validate(), transfer.ErrMetadataValueTooLarge)
+	})
+}
+
+func marshalTransferAction(t *testing.T, inputs, outputs, proofLen int) []byte {
+	t.Helper()
+	ta := &actions.TransferAction{
+		Version: transfer.ProtocolV1,
+	}
+	for range inputs {
+		ta.Inputs = append(ta.Inputs, &actions.TransferActionInput{Input: &actions.Token{Owner: []byte("o")}})
+	}
+	for range outputs {
+		ta.Outputs = append(ta.Outputs, &actions.TransferActionOutput{Token: &actions.Token{Owner: []byte("o")}})
+	}
+	if proofLen > 0 {
+		ta.Proof = &actions.Proof{ProofType: &actions.Proof_Proof{Proof: make([]byte, proofLen)}}
+	}
+	raw, err := proto.Marshal(ta)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func TestTransferAction_Deserialize_TooManyInputs(t *testing.T) {
+	a := &transfer.Action{}
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs, 1, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
+}
+
+func TestTransferAction_Deserialize_TooManyOutputs(t *testing.T) {
+	a := &transfer.Action{}
+	require.NoError(t, a.Deserialize(marshalTransferAction(t, 1, transfer.MaxOutputs, 1)))
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, transfer.MaxOutputs+1, 1)), transfer.ErrTooManyOutputs)
+}
+
+func TestTransferAction_Deserialize_ProofTooLarge(t *testing.T) {
+	a := &transfer.Action{}
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, 1, 1, transfer.MaxProofBytes+1)), transfer.ErrProofTooLarge)
+}
+
+func TestTransferAction_Deserialize_ManyTinyInputs(t *testing.T) {
+	a := &transfer.Action{}
+	require.ErrorIs(t, a.Deserialize(marshalTransferAction(t, transfer.MaxInputs+1, 1, 1)), transfer.ErrTooManyInputs)
+}
+
+// TestTransferAction_Deserialize_RejectsBeforeCryptographicWork proves that an oversized
+// proof is rejected by the resource-limit check before any cryptographic verifier work would
+// run: Deserialize returns near-instantly and never reaches proof-specific unmarshalling.
+func TestTransferAction_Deserialize_RejectsBeforeCryptographicWork(t *testing.T) {
+	raw := marshalTransferAction(t, 1, 1, transfer.MaxProofBytes+1)
+
+	start := time.Now()
+	a := &transfer.Action{}
+	err := a.Deserialize(raw)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, transfer.ErrProofTooLarge)
+	require.Less(t, elapsed, 50*time.Millisecond, "oversized proof must be rejected near-instantly, before any cryptographic work")
+}

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-inputs-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-inputs-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(256)
+int(1)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-inputs-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-inputs-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(257)
+int(1)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(256)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-outputs-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(257)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-proof-bytes-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-proof-bytes-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(1)
+int(131072)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-proof-bytes-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/issue-max-proof-bytes-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(true)
+int(1)
+int(1)
+int(131073)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(256)
+int(1)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-inputs-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(257)
+int(1)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(256)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-outputs-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(257)
+int(8)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-proof-bytes-boundary
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-proof-bytes-boundary
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(1)
+int(131072)

--- a/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-proof-bytes-plus-one
+++ b/token/core/zkatdlog/nogh/v1/validator/testdata/fuzz/FuzzActionResourceLimits/transfer-max-proof-bytes-plus-one
@@ -1,0 +1,5 @@
+go test fuzz v1
+bool(false)
+int(1)
+int(1)
+int(131073)

--- a/token/core/zkatdlog/nogh/v1/validator/validator.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator.go
@@ -31,6 +31,7 @@ type Context = common.Context[*v1.PublicParams, *token.Token, *transfer.Action, 
 // ActionDeserializer is a deserializer for actions
 type ActionDeserializer struct {
 	PublicParams *v1.PublicParams
+	Limits       driver.ResourceLimits
 }
 
 // DeserializeActions deserializes the actions from the token request
@@ -39,6 +40,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*iss
 	issueActions := make([]*issue.Action, len(issues))
 	for i := range issues {
 		ia := &issue.Action{}
+		ia.SetLimits(a.Limits)
 		if err := ia.Deserialize(issues[i]); err != nil {
 			return nil, nil, err
 		}
@@ -49,6 +51,7 @@ func (a *ActionDeserializer) DeserializeActions(tr *driver.TokenRequest) ([]*iss
 	transferActions := make([]*transfer.Action, len(transfers))
 	for i := range transfers {
 		ta := &transfer.Action{}
+		ta.SetLimits(a.Limits)
 		if err := ta.Deserialize(transfers[i]); err != nil {
 			return nil, nil, err
 		}
@@ -66,6 +69,7 @@ func New(
 	logger logging.Logger,
 	pp *v1.PublicParams,
 	deserializer driver.Deserializer,
+	limits driver.ResourceLimits,
 	extraTransferValidators []ValidateTransferFunc,
 	extraIssuerValidators []ValidateIssueFunc,
 	extraAuditorValidators []ValidateAuditingFunc,
@@ -95,7 +99,8 @@ func New(
 		logger,
 		pp,
 		deserializer,
-		&ActionDeserializer{},
+		limits,
+		&ActionDeserializer{PublicParams: pp, Limits: limits},
 		transferValidators,
 		issueValidators,
 		auditingValidators,

--- a/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
@@ -10,19 +10,25 @@ import (
 	"testing"
 
 	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/core/common"
 	fv1 "github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
+	nghactions "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/issue"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/transfer"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/validator"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	driverv1 "github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1"
 	"github.com/LFDT-Panurus/panurus/token/driver/protos-go/v1/request"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
 )
 
-const maxFuzzActionBytes = 256 << 10
+// maxFuzzActionBytes mirrors common.MaxActionBytes: it is the real production limit enforced on
+// TypedAction.Raw by the common validator, so fuzzing beyond it exercises no additional code path.
+const maxFuzzActionBytes = common.MaxActionBytes
 
 // fuzzCurve is a fixed, non-nil curve used to build well-formed G1/Zr elements for the
 // seed corpus. Any curve works here: these seeds only need to survive Serialize/Deserialize,
@@ -220,5 +226,120 @@ func FuzzActionDeserializerMultiActionNoPanic(f *testing.F) {
 			}
 			require.LessOrEqual(t, len(issues)+len(transfers), 2)
 		})
+	})
+}
+
+// marshalFuzzedIssueAction builds the raw protobuf bytes of an issue action with the given
+// input/output/proof-byte counts, bypassing issue.Action.Serialize so that out-of-limit shapes
+// (which Serialize's own caller never produces) can still be exercised.
+func marshalFuzzedIssueAction(inputs, outputs, proofBytes int) []byte {
+	ia := &nghactions.IssueAction{
+		Version: issue.ProtocolV1,
+		Issuer:  &driverv1.Identity{Raw: []byte("issuer")},
+	}
+	for range inputs {
+		ia.Inputs = append(ia.Inputs, &nghactions.IssueActionInput{Token: []byte("t")})
+	}
+	for range outputs {
+		ia.Outputs = append(ia.Outputs, &nghactions.IssueActionOutput{Token: &nghactions.Token{Owner: []byte("o")}})
+	}
+	if proofBytes > 0 {
+		ia.Proof = &nghactions.Proof{ProofType: &nghactions.Proof_Proof{Proof: make([]byte, proofBytes)}}
+	}
+	raw, _ := proto.Marshal(ia)
+
+	return raw
+}
+
+// marshalFuzzedTransferAction mirrors marshalFuzzedIssueAction for transfer actions.
+func marshalFuzzedTransferAction(inputs, outputs, proofBytes int) []byte {
+	ta := &nghactions.TransferAction{
+		Version: transfer.ProtocolV1,
+	}
+	for range inputs {
+		ta.Inputs = append(ta.Inputs, &nghactions.TransferActionInput{Input: &nghactions.Token{Owner: []byte("o")}})
+	}
+	for range outputs {
+		ta.Outputs = append(ta.Outputs, &nghactions.TransferActionOutput{Token: &nghactions.Token{Owner: []byte("o")}})
+	}
+	if proofBytes > 0 {
+		ta.Proof = &nghactions.Proof{ProofType: &nghactions.Proof_Proof{Proof: make([]byte, proofBytes)}}
+	}
+	raw, _ := proto.Marshal(ta)
+
+	return raw
+}
+
+// boundInt clamps n into [lo, hi], using n's magnitude modulo the range width so that fuzzed
+// values (including negatives) still exercise the full range deterministically.
+func boundInt(n, lo, hi int) int {
+	if hi <= lo {
+		return lo
+	}
+	width := hi - lo + 1
+	if n < 0 {
+		n = -n
+	}
+
+	return lo + n%width
+}
+
+// FuzzActionResourceLimits fuzzes issue and transfer actions shaped by their resource
+// dimensions (input/output counts, proof byte length) and asserts that Deserialize never
+// panics and rejects any dimension that exceeds its configured limit with the corresponding
+// typed error. Rejection-before-cryptographic-work is a timing property and is covered
+// separately by the dedicated RejectsBeforeCryptographicWork unit tests, which run without
+// fuzz-worker CPU contention.
+func FuzzActionResourceLimits(f *testing.F) {
+	f.Add(true, 1, 1, 8)
+	f.Add(true, issue.MaxInputs, 1, 8)
+	f.Add(true, issue.MaxInputs+1, 1, 8)
+	f.Add(true, 1, issue.MaxOutputs, 8)
+	f.Add(true, 1, issue.MaxOutputs+1, 8)
+	f.Add(true, 1, 1, issue.MaxProofBytes)
+	f.Add(true, 1, 1, issue.MaxProofBytes+1)
+	f.Add(false, 1, 1, 8)
+	f.Add(false, transfer.MaxInputs, 1, 8)
+	f.Add(false, transfer.MaxInputs+1, 1, 8)
+	f.Add(false, 1, transfer.MaxOutputs, 8)
+	f.Add(false, 1, transfer.MaxOutputs+1, 8)
+	f.Add(false, 1, 1, transfer.MaxProofBytes)
+	f.Add(false, 1, 1, transfer.MaxProofBytes+1)
+
+	f.Fuzz(func(t *testing.T, isIssue bool, inputs, outputs, proofBytes int) {
+		inputs = boundInt(inputs, 1, 512)
+		outputs = boundInt(outputs, 1, 512)
+		proofBytes = boundInt(proofBytes, 1, 256<<10)
+
+		var raw []byte
+		var maxInputs, maxOutputs, maxProofBytes int
+		var errTooManyInputs, errTooManyOutputs, errProofTooLarge error
+		if isIssue {
+			raw = marshalFuzzedIssueAction(inputs, outputs, proofBytes)
+			maxInputs, maxOutputs, maxProofBytes = issue.MaxInputs, issue.MaxOutputs, issue.MaxProofBytes
+			errTooManyInputs, errTooManyOutputs, errProofTooLarge = issue.ErrTooManyInputs, issue.ErrTooManyOutputs, issue.ErrProofTooLarge
+		} else {
+			raw = marshalFuzzedTransferAction(inputs, outputs, proofBytes)
+			maxInputs, maxOutputs, maxProofBytes = transfer.MaxInputs, transfer.MaxOutputs, transfer.MaxProofBytes
+			errTooManyInputs, errTooManyOutputs, errProofTooLarge = transfer.ErrTooManyInputs, transfer.ErrTooManyOutputs, transfer.ErrProofTooLarge
+		}
+
+		var err error
+		require.NotPanics(t, func() {
+			if isIssue {
+				err = (&issue.Action{}).Deserialize(raw)
+			} else {
+				err = (&transfer.Action{}).Deserialize(raw)
+			}
+		})
+
+		switch {
+		case inputs > maxInputs:
+			require.ErrorIs(t, err, errTooManyInputs)
+		case outputs > maxOutputs:
+			require.ErrorIs(t, err, errTooManyOutputs)
+		case proofBytes > maxProofBytes:
+			require.ErrorIs(t, err, errProofTooLarge)
+		}
 	})
 }

--- a/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const maxFuzzActionBytes = 256 << 10
+
 // fuzzCurve is a fixed, non-nil curve used to build well-formed G1/Zr elements for the
 // seed corpus. Any curve works here: these seeds only need to survive Serialize/Deserialize,
 // not a real ZK verification.

--- a/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	math "github.com/IBM/mathlib"
-	"github.com/LFDT-Panurus/panurus/token/core/common"
 	fv1 "github.com/LFDT-Panurus/panurus/token/core/fabtoken/v1/actions"
 	nghactions "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
@@ -25,10 +24,6 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
 	"github.com/stretchr/testify/require"
 )
-
-// maxFuzzActionBytes mirrors common.MaxActionBytes: it is the real production limit enforced on
-// TypedAction.Raw by the common validator, so fuzzing beyond it exercises no additional code path.
-const maxFuzzActionBytes = common.MaxActionBytes
 
 // fuzzCurve is a fixed, non-nil curve used to build well-formed G1/Zr elements for the
 // seed corpus. Any curve works here: these seeds only need to survive Serialize/Deserialize,
@@ -170,15 +165,16 @@ func FuzzActionDeserializerNoPanic(f *testing.F) {
 	f.Add(uint8(0), issueRaw[:len(issueRaw)/2])
 	f.Add(uint8(1), transferRaw[:len(transferRaw)/2])
 
+	limits := driver.DefaultResourceLimits()
 	f.Fuzz(func(t *testing.T, actionKind uint8, raw []byte) {
-		if len(raw) > maxFuzzActionBytes {
+		if len(raw) > limits.MaxActionBytes {
 			t.Skip()
 		}
 		typeID := actionTypeFor(actionKind)
 		tokenRequest := &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: typeID, Raw: raw}}}
 
 		require.NotPanics(t, func() {
-			issues, transfers, err := (&validator.ActionDeserializer{}).DeserializeActions(tokenRequest)
+			issues, transfers, err := (&validator.ActionDeserializer{Limits: limits}).DeserializeActions(tokenRequest)
 			if err != nil {
 				return
 			}
@@ -210,8 +206,9 @@ func FuzzActionDeserializerMultiActionNoPanic(f *testing.F) {
 	f.Add(uint8(1), []byte("malformed"), uint8(0), issueRaw)
 	f.Add(uint8(0), issueRaw, uint8(1), []byte{})
 
+	limits := driver.DefaultResourceLimits()
 	f.Fuzz(func(t *testing.T, kind1 uint8, raw1 []byte, kind2 uint8, raw2 []byte) {
-		if len(raw1) > maxFuzzActionBytes || len(raw2) > maxFuzzActionBytes {
+		if len(raw1) > limits.MaxActionBytes || len(raw2) > limits.MaxActionBytes {
 			t.Skip()
 		}
 		tokenRequest := &driver.TokenRequest{Actions: []*driver.TypedAction{
@@ -220,7 +217,7 @@ func FuzzActionDeserializerMultiActionNoPanic(f *testing.F) {
 		}}
 
 		require.NotPanics(t, func() {
-			issues, transfers, err := (&validator.ActionDeserializer{}).DeserializeActions(tokenRequest)
+			issues, transfers, err := (&validator.ActionDeserializer{Limits: limits}).DeserializeActions(tokenRequest)
 			if err != nil {
 				return
 			}
@@ -291,20 +288,21 @@ func boundInt(n, lo, hi int) int {
 // separately by the dedicated RejectsBeforeCryptographicWork unit tests, which run without
 // fuzz-worker CPU contention.
 func FuzzActionResourceLimits(f *testing.F) {
+	limits := driver.DefaultResourceLimits()
 	f.Add(true, 1, 1, 8)
-	f.Add(true, issue.MaxInputs, 1, 8)
-	f.Add(true, issue.MaxInputs+1, 1, 8)
-	f.Add(true, 1, issue.MaxOutputs, 8)
-	f.Add(true, 1, issue.MaxOutputs+1, 8)
-	f.Add(true, 1, 1, issue.MaxProofBytes)
-	f.Add(true, 1, 1, issue.MaxProofBytes+1)
+	f.Add(true, limits.MaxInputs, 1, 8)
+	f.Add(true, limits.MaxInputs+1, 1, 8)
+	f.Add(true, 1, limits.MaxOutputs, 8)
+	f.Add(true, 1, limits.MaxOutputs+1, 8)
+	f.Add(true, 1, 1, limits.MaxProofBytes)
+	f.Add(true, 1, 1, limits.MaxProofBytes+1)
 	f.Add(false, 1, 1, 8)
-	f.Add(false, transfer.MaxInputs, 1, 8)
-	f.Add(false, transfer.MaxInputs+1, 1, 8)
-	f.Add(false, 1, transfer.MaxOutputs, 8)
-	f.Add(false, 1, transfer.MaxOutputs+1, 8)
-	f.Add(false, 1, 1, transfer.MaxProofBytes)
-	f.Add(false, 1, 1, transfer.MaxProofBytes+1)
+	f.Add(false, limits.MaxInputs, 1, 8)
+	f.Add(false, limits.MaxInputs+1, 1, 8)
+	f.Add(false, 1, limits.MaxOutputs, 8)
+	f.Add(false, 1, limits.MaxOutputs+1, 8)
+	f.Add(false, 1, 1, limits.MaxProofBytes)
+	f.Add(false, 1, 1, limits.MaxProofBytes+1)
 
 	f.Fuzz(func(t *testing.T, isIssue bool, inputs, outputs, proofBytes int) {
 		inputs = boundInt(inputs, 1, 512)
@@ -312,15 +310,13 @@ func FuzzActionResourceLimits(f *testing.F) {
 		proofBytes = boundInt(proofBytes, 1, 256<<10)
 
 		var raw []byte
-		var maxInputs, maxOutputs, maxProofBytes int
+		maxInputs, maxOutputs, maxProofBytes := limits.MaxInputs, limits.MaxOutputs, limits.MaxProofBytes
 		var errTooManyInputs, errTooManyOutputs, errProofTooLarge error
 		if isIssue {
 			raw = marshalFuzzedIssueAction(inputs, outputs, proofBytes)
-			maxInputs, maxOutputs, maxProofBytes = issue.MaxInputs, issue.MaxOutputs, issue.MaxProofBytes
 			errTooManyInputs, errTooManyOutputs, errProofTooLarge = issue.ErrTooManyInputs, issue.ErrTooManyOutputs, issue.ErrProofTooLarge
 		} else {
 			raw = marshalFuzzedTransferAction(inputs, outputs, proofBytes)
-			maxInputs, maxOutputs, maxProofBytes = transfer.MaxInputs, transfer.MaxOutputs, transfer.MaxProofBytes
 			errTooManyInputs, errTooManyOutputs, errProofTooLarge = transfer.ErrTooManyInputs, transfer.ErrTooManyOutputs, transfer.ErrProofTooLarge
 		}
 

--- a/token/core/zkatdlog/nogh/v1/validator/validator_security_extra_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_security_extra_test.go
@@ -499,7 +499,7 @@ func TestSecurityFR_Version0Rejected(t *testing.T) {
 	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
 	require.NoError(t, err)
 
-	v := validator.New(logging.MustGetLogger(), pp, nil, nil, nil, nil)
+	v := validator.New(logging.MustGetLogger(), pp, nil, driver.DefaultResourceLimits(), nil, nil, nil)
 
 	// Build a minimal TokenRequest with Version explicitly set to 0.
 	tr := &driver.TokenRequest{

--- a/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
@@ -173,6 +173,7 @@ func TestSecurityPanicAuditingContextMetadataCounter(t *testing.T) {
 		logging.MustGetLogger(),
 		pp,
 		nil,
+		driver.DefaultResourceLimits(),
 		nil,
 		nil,
 		[]validator.ValidateAuditingFunc{auditingValidator},
@@ -294,7 +295,7 @@ func TestSecurityFalseAcceptanceEmptyTokenRequest(t *testing.T) {
 	pp, err := v1.Setup(32, []byte("idemix"), math.BLS12_381_BBS_GURVY)
 	require.NoError(t, err)
 
-	v := validator.New(logging.MustGetLogger(), pp, nil, nil, nil, nil)
+	v := validator.New(logging.MustGetLogger(), pp, nil, driver.DefaultResourceLimits(), nil, nil, nil)
 
 	require.NotPanics(t, func() {
 		_, _, err = v.VerifyTokenRequestFromRaw(context.Background(), nil, "anchor", nil)
@@ -769,6 +770,7 @@ func TestSecurityFA_MultipleMetadataCountForSameKey(t *testing.T) {
 		logging.MustGetLogger(),
 		pp,
 		nil,
+		driver.DefaultResourceLimits(),
 		&validator.ActionDeserializer{},
 		[]validator.ValidateTransferFunc{doubleCounter},
 		nil,
@@ -820,6 +822,7 @@ func TestSecurityFA_UnvalidatedMetadataKey(t *testing.T) {
 		logging.MustGetLogger(),
 		pp,
 		nil,
+		driver.DefaultResourceLimits(),
 		&validator.ActionDeserializer{},
 		[]validator.ValidateTransferFunc{noopTransferValidator},
 		nil,

--- a/token/driver/driver.go
+++ b/token/driver/driver.go
@@ -20,6 +20,7 @@ type Driver interface {
 //go:generate counterfeiter -o mock/validator_driver.go -fake-name ValidatorDriver . ValidatorDriver
 type ValidatorDriver interface {
 	PPReader
-	// NewValidator returns a new Validator instance from the passed public parameters
-	NewValidator(pp PublicParameters) (Validator, error)
+	// NewValidator returns a new Validator instance from the passed public parameters, enforcing
+	// the passed resource limits on untrusted requests and actions.
+	NewValidator(pp PublicParameters, limits ResourceLimits) (Validator, error)
 }

--- a/token/driver/limits.go
+++ b/token/driver/limits.go
@@ -1,0 +1,131 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+// ResourceLimits bounds the resources a validator will spend deserializing and validating an
+// untrusted token request, before any cryptographic work is performed.
+//
+// These limits are consensus-relevant: every peer validating the same request must be configured
+// with the same values, or otherwise-identical requests could be accepted by one peer and rejected
+// by another, breaking endorsement determinism. DefaultResourceLimits returns values identical to
+// the ones this package has always enforced; deployments that override them are responsible for
+// keeping every validating peer in sync.
+type ResourceLimits struct {
+	// MaxRequestBytes bounds the raw serialized size of a token request, checked before the
+	// protobuf decode so an oversized message is rejected without allocating a parsed structure.
+	MaxRequestBytes int
+	// MaxActions bounds the number of actions (issue + transfer) in a single token request.
+	MaxActions int
+	// MaxSignatures bounds the number of request signatures (auditor + action) in a single
+	// token request.
+	MaxSignatures int
+	// MaxSignatureBytes bounds the length of a single auditor or action signature.
+	MaxSignatureBytes int
+	// MaxActionBytes bounds the length of a single action's serialized (raw) bytes.
+	MaxActionBytes int
+
+	// MaxInputs bounds the number of inputs (redeemed or spent tokens) in a single action.
+	MaxInputs int
+	// MaxOutputs bounds the number of outputs in a single action.
+	MaxOutputs int
+	// MaxMetadataEntries bounds the number of metadata entries attached to an action.
+	MaxMetadataEntries int
+	// MaxMetadataKeyBytes bounds the length of a single metadata key.
+	MaxMetadataKeyBytes int
+	// MaxMetadataValueBytes bounds the length of a single metadata value.
+	MaxMetadataValueBytes int
+
+	// MaxProofBytes bounds the length of an action's zero-knowledge proof, checked before the
+	// proof is handed to the bulletproof/CSP verifier for deserialization. Drivers without a
+	// zero-knowledge proof (e.g. fabtoken) ignore this field.
+	MaxProofBytes int
+}
+
+// DefaultResourceLimits returns the resource limits enforced when no override is configured.
+// These values are identical to the ones this package has always enforced as hardcoded
+// constants; changing them here changes the out-of-the-box behavior for every deployment that
+// does not explicitly override them.
+func DefaultResourceLimits() ResourceLimits {
+	return ResourceLimits{
+		MaxRequestBytes:   256 << 10, // 256 KiB
+		MaxActions:        256,
+		MaxSignatures:     4096,
+		MaxSignatureBytes: 4 << 10,   // 4 KiB
+		MaxActionBytes:    256 << 10, // 256 KiB
+
+		MaxInputs:             256,
+		MaxOutputs:            256,
+		MaxMetadataEntries:    64,
+		MaxMetadataKeyBytes:   256,
+		MaxMetadataValueBytes: 4 << 10, // 4 KiB
+
+		MaxProofBytes: 128 << 10, // 128 KiB
+	}
+}
+
+// WithDefaults returns a copy of l where every zero-valued field is replaced by the
+// corresponding field from DefaultResourceLimits. It lets callers accept a partially-specified
+// ResourceLimits (e.g. parsed from a config file or environment variables where most fields are
+// left unset) without ever silently disabling a limit by leaving it at zero.
+func (l ResourceLimits) WithDefaults() ResourceLimits {
+	d := DefaultResourceLimits()
+	if l.MaxRequestBytes == 0 {
+		l.MaxRequestBytes = d.MaxRequestBytes
+	}
+	if l.MaxActions == 0 {
+		l.MaxActions = d.MaxActions
+	}
+	if l.MaxSignatures == 0 {
+		l.MaxSignatures = d.MaxSignatures
+	}
+	if l.MaxSignatureBytes == 0 {
+		l.MaxSignatureBytes = d.MaxSignatureBytes
+	}
+	if l.MaxActionBytes == 0 {
+		l.MaxActionBytes = d.MaxActionBytes
+	}
+	if l.MaxInputs == 0 {
+		l.MaxInputs = d.MaxInputs
+	}
+	if l.MaxOutputs == 0 {
+		l.MaxOutputs = d.MaxOutputs
+	}
+	if l.MaxMetadataEntries == 0 {
+		l.MaxMetadataEntries = d.MaxMetadataEntries
+	}
+	if l.MaxMetadataKeyBytes == 0 {
+		l.MaxMetadataKeyBytes = d.MaxMetadataKeyBytes
+	}
+	if l.MaxMetadataValueBytes == 0 {
+		l.MaxMetadataValueBytes = d.MaxMetadataValueBytes
+	}
+	if l.MaxProofBytes == 0 {
+		l.MaxProofBytes = d.MaxProofBytes
+	}
+
+	return l
+}
+
+// ResourceLimitsProvider resolves the ResourceLimits a validator should enforce. Different
+// implementations back it with different sources (a configuration file, environment variables,
+// a static value for tests), letting the composition root choose the source while every
+// downstream consumer depends only on this interface.
+type ResourceLimitsProvider interface {
+	// ResourceLimits returns the resolved resource limits, with defaults already applied to any
+	// field the underlying source left unset.
+	ResourceLimits() (ResourceLimits, error)
+}
+
+// StaticResourceLimits is a ResourceLimitsProvider that always returns the same, pre-resolved
+// ResourceLimits value. It is the implicit provider for callers that do not need a configurable
+// source (tests, tools, callers that only need the defaults).
+type StaticResourceLimits ResourceLimits
+
+// ResourceLimits returns l as a ResourceLimits value, unchanged.
+func (l StaticResourceLimits) ResourceLimits() (ResourceLimits, error) {
+	return ResourceLimits(l), nil
+}

--- a/token/driver/limits.go
+++ b/token/driver/limits.go
@@ -67,43 +67,45 @@ func DefaultResourceLimits() ResourceLimits {
 	}
 }
 
-// WithDefaults returns a copy of l where every zero-valued field is replaced by the
-// corresponding field from DefaultResourceLimits. It lets callers accept a partially-specified
-// ResourceLimits (e.g. parsed from a config file or environment variables where most fields are
-// left unset) without ever silently disabling a limit by leaving it at zero.
+// WithDefaults returns a copy of l where every field that is not a positive value (i.e. zero or
+// negative) is replaced by the corresponding field from DefaultResourceLimits. It lets callers
+// accept a partially-specified ResourceLimits (e.g. parsed from a config file or environment
+// variables where most fields are left unset) without ever silently disabling a limit by leaving
+// it at zero, and without a negative value (e.g. a config typo) being misread as "unlimited" by
+// the comparisons in token/core/common that enforce these limits.
 func (l ResourceLimits) WithDefaults() ResourceLimits {
 	d := DefaultResourceLimits()
-	if l.MaxRequestBytes == 0 {
+	if l.MaxRequestBytes <= 0 {
 		l.MaxRequestBytes = d.MaxRequestBytes
 	}
-	if l.MaxActions == 0 {
+	if l.MaxActions <= 0 {
 		l.MaxActions = d.MaxActions
 	}
-	if l.MaxSignatures == 0 {
+	if l.MaxSignatures <= 0 {
 		l.MaxSignatures = d.MaxSignatures
 	}
-	if l.MaxSignatureBytes == 0 {
+	if l.MaxSignatureBytes <= 0 {
 		l.MaxSignatureBytes = d.MaxSignatureBytes
 	}
-	if l.MaxActionBytes == 0 {
+	if l.MaxActionBytes <= 0 {
 		l.MaxActionBytes = d.MaxActionBytes
 	}
-	if l.MaxInputs == 0 {
+	if l.MaxInputs <= 0 {
 		l.MaxInputs = d.MaxInputs
 	}
-	if l.MaxOutputs == 0 {
+	if l.MaxOutputs <= 0 {
 		l.MaxOutputs = d.MaxOutputs
 	}
-	if l.MaxMetadataEntries == 0 {
+	if l.MaxMetadataEntries <= 0 {
 		l.MaxMetadataEntries = d.MaxMetadataEntries
 	}
-	if l.MaxMetadataKeyBytes == 0 {
+	if l.MaxMetadataKeyBytes <= 0 {
 		l.MaxMetadataKeyBytes = d.MaxMetadataKeyBytes
 	}
-	if l.MaxMetadataValueBytes == 0 {
+	if l.MaxMetadataValueBytes <= 0 {
 		l.MaxMetadataValueBytes = d.MaxMetadataValueBytes
 	}
-	if l.MaxProofBytes == 0 {
+	if l.MaxProofBytes <= 0 {
 		l.MaxProofBytes = d.MaxProofBytes
 	}
 

--- a/token/driver/limits_test.go
+++ b/token/driver/limits_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResourceLimits_WithDefaults_AllUnset(t *testing.T) {
+	var l ResourceLimits
+	assert.Equal(t, DefaultResourceLimits(), l.WithDefaults())
+}
+
+func TestResourceLimits_WithDefaults_PartialOverride(t *testing.T) {
+	l := ResourceLimits{MaxActions: 2, MaxProofBytes: 1024}
+
+	want := DefaultResourceLimits()
+	want.MaxActions = 2
+	want.MaxProofBytes = 1024
+
+	assert.Equal(t, want, l.WithDefaults())
+}
+
+func TestResourceLimits_WithDefaults_FullyOverridden(t *testing.T) {
+	l := ResourceLimits{
+		MaxRequestBytes:       1,
+		MaxActions:            2,
+		MaxSignatures:         3,
+		MaxSignatureBytes:     4,
+		MaxActionBytes:        5,
+		MaxInputs:             6,
+		MaxOutputs:            7,
+		MaxMetadataEntries:    8,
+		MaxMetadataKeyBytes:   9,
+		MaxMetadataValueBytes: 10,
+		MaxProofBytes:         11,
+	}
+	assert.Equal(t, l, l.WithDefaults())
+}
+
+// Negative values (e.g. from a config typo) must fall back to the default rather than being
+// preserved, since a negative bound would compare as "always satisfied" wherever these limits are
+// enforced, effectively disabling the check.
+func TestResourceLimits_WithDefaults_NegativeValuesFallBackToDefault(t *testing.T) {
+	l := ResourceLimits{
+		MaxRequestBytes:       -1,
+		MaxActions:            -1,
+		MaxSignatures:         -1,
+		MaxSignatureBytes:     -1,
+		MaxActionBytes:        -1,
+		MaxInputs:             -1,
+		MaxOutputs:            -1,
+		MaxMetadataEntries:    -1,
+		MaxMetadataKeyBytes:   -1,
+		MaxMetadataValueBytes: -1,
+		MaxProofBytes:         -1,
+	}
+	assert.Equal(t, DefaultResourceLimits(), l.WithDefaults())
+}

--- a/token/driver/mock/validator_driver.go
+++ b/token/driver/mock/validator_driver.go
@@ -8,10 +8,11 @@ import (
 )
 
 type ValidatorDriver struct {
-	NewValidatorStub        func(driver.PublicParameters) (driver.Validator, error)
+	NewValidatorStub        func(driver.PublicParameters, driver.ResourceLimits) (driver.Validator, error)
 	newValidatorMutex       sync.RWMutex
 	newValidatorArgsForCall []struct {
 		arg1 driver.PublicParameters
+		arg2 driver.ResourceLimits
 	}
 	newValidatorReturns struct {
 		result1 driver.Validator
@@ -38,42 +39,46 @@ type ValidatorDriver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ValidatorDriver) NewValidator(arg1 driver.PublicParameters) (driver.Validator, error) {
+func (fake *ValidatorDriver) NewValidator(arg1 driver.PublicParameters, arg2 driver.ResourceLimits) (driver.Validator, error) {
 	fake.newValidatorMutex.Lock()
 	ret, specificReturn := fake.newValidatorReturnsOnCall[len(fake.newValidatorArgsForCall)]
 	fake.newValidatorArgsForCall = append(fake.newValidatorArgsForCall, struct {
 		arg1 driver.PublicParameters
-	}{arg1})
+		arg2 driver.ResourceLimits
+	}{arg1, arg2})
 	stub := fake.NewValidatorStub
 	fakeReturns := fake.newValidatorReturns
-	fake.recordInvocation("NewValidator", []interface{}{arg1})
+	fake.recordInvocation("NewValidator", []interface{}{arg1, arg2})
 	fake.newValidatorMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+
 	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ValidatorDriver) NewValidatorCallCount() int {
 	fake.newValidatorMutex.RLock()
 	defer fake.newValidatorMutex.RUnlock()
+
 	return len(fake.newValidatorArgsForCall)
 }
 
-func (fake *ValidatorDriver) NewValidatorCalls(stub func(driver.PublicParameters) (driver.Validator, error)) {
+func (fake *ValidatorDriver) NewValidatorCalls(stub func(driver.PublicParameters, driver.ResourceLimits) (driver.Validator, error)) {
 	fake.newValidatorMutex.Lock()
 	defer fake.newValidatorMutex.Unlock()
 	fake.NewValidatorStub = stub
 }
 
-func (fake *ValidatorDriver) NewValidatorArgsForCall(i int) driver.PublicParameters {
+func (fake *ValidatorDriver) NewValidatorArgsForCall(i int) (driver.PublicParameters, driver.ResourceLimits) {
 	fake.newValidatorMutex.RLock()
 	defer fake.newValidatorMutex.RUnlock()
 	argsForCall := fake.newValidatorArgsForCall[i]
-	return argsForCall.arg1
+
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *ValidatorDriver) NewValidatorReturns(result1 driver.Validator, result2 error) {
@@ -123,12 +128,14 @@ func (fake *ValidatorDriver) PublicParametersFromBytes(arg1 []byte) (driver.Publ
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+
 	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ValidatorDriver) PublicParametersFromBytesCallCount() int {
 	fake.publicParametersFromBytesMutex.RLock()
 	defer fake.publicParametersFromBytesMutex.RUnlock()
+
 	return len(fake.publicParametersFromBytesArgsForCall)
 }
 
@@ -142,6 +149,7 @@ func (fake *ValidatorDriver) PublicParametersFromBytesArgsForCall(i int) []byte 
 	fake.publicParametersFromBytesMutex.RLock()
 	defer fake.publicParametersFromBytesMutex.RUnlock()
 	argsForCall := fake.publicParametersFromBytesArgsForCall[i]
+
 	return argsForCall.arg1
 }
 
@@ -178,6 +186,7 @@ func (fake *ValidatorDriver) Invocations() map[string][][]interface{} {
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
+
 	return copiedInvocations
 }
 

--- a/token/sdk/dig/providers.go
+++ b/token/sdk/dig/providers.go
@@ -9,8 +9,10 @@ package sdk
 import (
 	"github.com/LFDT-Panurus/panurus/token/core"
 	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/config"
 	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/multiplexed"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	driver2 "github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
 	"go.uber.org/dig"
 )
@@ -38,8 +40,14 @@ func newTokenDriverService(in struct {
 
 func newValidatorDriverService(in struct {
 	dig.In
-	Drivers []core.NamedFactory[driver.ValidatorDriver] `group:"validator-drivers"`
+	Drivers        []core.NamedFactory[driver.ValidatorDriver] `group:"validator-drivers"`
+	ConfigProvider config.Provider
 },
-) *core.ValidatorDriverService {
-	return core.NewValidatorDriverService(in.Drivers...)
+) (*core.ValidatorDriverService, error) {
+	limits, err := config.NewResourceLimitsProvider(in.ConfigProvider).ResourceLimits()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed resolving validation resource limits")
+	}
+
+	return core.NewValidatorDriverService(limits, in.Drivers...), nil
 }

--- a/token/services/config/limits.go
+++ b/token/services/config/limits.go
@@ -1,0 +1,81 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+)
+
+// ResourceLimitsPath is the configuration key holding the process-wide validator resource
+// limits. It is deliberately not scoped under a TMS (unlike TMSPath): the composition roots that
+// need it (the validator driver service used both by the FSC/DI runtime and by the standalone
+// Fabric chaincode process) only ever have public parameters in scope, never a TMS identifier.
+var ResourceLimitsPath = config.Join(RootKey, "validation", "limits")
+
+// resourceLimitsConfig is the yaml-facing shape of ResourceLimitsPath. Any field left unset (its
+// zero value) is replaced by the corresponding driver.DefaultResourceLimits() value.
+type resourceLimitsConfig struct {
+	MaxRequestBytes   int `yaml:"maxRequestBytes,omitempty"`
+	MaxActions        int `yaml:"maxActions,omitempty"`
+	MaxSignatures     int `yaml:"maxSignatures,omitempty"`
+	MaxSignatureBytes int `yaml:"maxSignatureBytes,omitempty"`
+	MaxActionBytes    int `yaml:"maxActionBytes,omitempty"`
+
+	MaxInputs             int `yaml:"maxInputs,omitempty"`
+	MaxOutputs            int `yaml:"maxOutputs,omitempty"`
+	MaxMetadataEntries    int `yaml:"maxMetadataEntries,omitempty"`
+	MaxMetadataKeyBytes   int `yaml:"maxMetadataKeyBytes,omitempty"`
+	MaxMetadataValueBytes int `yaml:"maxMetadataValueBytes,omitempty"`
+
+	MaxProofBytes int `yaml:"maxProofBytes,omitempty"`
+}
+
+func (c resourceLimitsConfig) toResourceLimits() driver.ResourceLimits {
+	return driver.ResourceLimits{
+		MaxRequestBytes:   c.MaxRequestBytes,
+		MaxActions:        c.MaxActions,
+		MaxSignatures:     c.MaxSignatures,
+		MaxSignatureBytes: c.MaxSignatureBytes,
+		MaxActionBytes:    c.MaxActionBytes,
+
+		MaxInputs:             c.MaxInputs,
+		MaxOutputs:            c.MaxOutputs,
+		MaxMetadataEntries:    c.MaxMetadataEntries,
+		MaxMetadataKeyBytes:   c.MaxMetadataKeyBytes,
+		MaxMetadataValueBytes: c.MaxMetadataValueBytes,
+
+		MaxProofBytes: c.MaxProofBytes,
+	}
+}
+
+// ResourceLimitsProvider resolves driver.ResourceLimits from key ResourceLimitsPath, overlaying
+// driver.DefaultResourceLimits() onto any field the configuration leaves unset. It is the
+// config-service-backed implementation of driver.ResourceLimitsProvider used by the FSC/DI
+// runtime.
+type ResourceLimitsProvider struct {
+	cp Provider
+}
+
+// NewResourceLimitsProvider returns a driver.ResourceLimitsProvider backed by the passed
+// configuration provider.
+func NewResourceLimitsProvider(cp Provider) *ResourceLimitsProvider {
+	return &ResourceLimitsProvider{cp: cp}
+}
+
+// ResourceLimits implements driver.ResourceLimitsProvider.
+func (p *ResourceLimitsProvider) ResourceLimits() (driver.ResourceLimits, error) {
+	c := resourceLimitsConfig{}
+	if p.cp.IsSet(ResourceLimitsPath) {
+		if err := p.cp.UnmarshalKey(ResourceLimitsPath, &c); err != nil {
+			return driver.ResourceLimits{}, errors.Wrapf(err, "invalid configuration for key [%s]", ResourceLimitsPath)
+		}
+	}
+
+	return c.toResourceLimits().WithDefaults(), nil
+}

--- a/token/services/config/limits_unit_test.go
+++ b/token/services/config/limits_unit_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/LFDT-Panurus/panurus/token/services/config"
+	"github.com/LFDT-Panurus/panurus/token/services/config/mocks"
+	fscconfig "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceLimitsProvider_Unset(t *testing.T) {
+	cp := &mocks.Provider{}
+	cp.IsSetReturns(false)
+
+	p := config.NewResourceLimitsProvider(cp)
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+	assert.Equal(t, driver.DefaultResourceLimits(), limits)
+}
+
+func TestResourceLimitsProvider_PartialOverride(t *testing.T) {
+	cp, err := fscconfig.NewProvider("./testdata/token0")
+	require.NoError(t, err)
+	require.NoError(t, cp.MergeConfig([]byte("token:\n  validation:\n    limits:\n      maxActions: 2\n      maxProofBytes: 1024\n")))
+
+	p := config.NewResourceLimitsProvider(cp)
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+
+	want := driver.DefaultResourceLimits()
+	want.MaxActions = 2
+	want.MaxProofBytes = 1024
+	assert.Equal(t, want, limits)
+}
+
+func TestResourceLimitsProvider_UnmarshalError(t *testing.T) {
+	cp := &mocks.Provider{}
+	cp.IsSetReturns(true)
+	cp.UnmarshalKeyReturns(assert.AnError)
+
+	p := config.NewResourceLimitsProvider(cp)
+	_, err := p.ResourceLimits()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid configuration")
+}

--- a/token/services/network/fabric/tcc/limits.go
+++ b/token/services/network/fabric/tcc/limits.go
@@ -1,0 +1,87 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tcc
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// Environment variables read by EnvResourceLimitsProvider. Each is optional; an unset variable
+// leaves the corresponding driver.ResourceLimits field at zero, which WithDefaults then replaces
+// with driver.DefaultResourceLimits().
+const (
+	EnvMaxRequestBytes   = "TOKEN_VALIDATION_MAX_REQUEST_BYTES"
+	EnvMaxActions        = "TOKEN_VALIDATION_MAX_ACTIONS"
+	EnvMaxSignatures     = "TOKEN_VALIDATION_MAX_SIGNATURES"
+	EnvMaxSignatureBytes = "TOKEN_VALIDATION_MAX_SIGNATURE_BYTES"
+	EnvMaxActionBytes    = "TOKEN_VALIDATION_MAX_ACTION_BYTES"
+
+	EnvMaxInputs             = "TOKEN_VALIDATION_MAX_INPUTS"
+	EnvMaxOutputs            = "TOKEN_VALIDATION_MAX_OUTPUTS"
+	EnvMaxMetadataEntries    = "TOKEN_VALIDATION_MAX_METADATA_ENTRIES"
+	EnvMaxMetadataKeyBytes   = "TOKEN_VALIDATION_MAX_METADATA_KEY_BYTES"
+	EnvMaxMetadataValueBytes = "TOKEN_VALIDATION_MAX_METADATA_VALUE_BYTES"
+
+	EnvMaxProofBytes = "TOKEN_VALIDATION_MAX_PROOF_BYTES"
+)
+
+// EnvResourceLimitsProvider resolves driver.ResourceLimits from environment variables, overlaying
+// driver.DefaultResourceLimits() onto any variable that is unset. It is the implementation used
+// by the standalone Fabric chaincode process (cmd/main.go), which has no config service wired.
+type EnvResourceLimitsProvider struct {
+	// Getenv defaults to os.Getenv; overridable for tests.
+	Getenv func(key string) string
+}
+
+// NewEnvResourceLimitsProvider returns a driver.ResourceLimitsProvider backed by environment
+// variables.
+func NewEnvResourceLimitsProvider() *EnvResourceLimitsProvider {
+	return &EnvResourceLimitsProvider{Getenv: os.Getenv}
+}
+
+// ResourceLimits implements driver.ResourceLimitsProvider.
+func (p *EnvResourceLimitsProvider) ResourceLimits() (driver.ResourceLimits, error) {
+	getenv := p.Getenv
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+
+	var l driver.ResourceLimits
+	fields := []struct {
+		env string
+		dst *int
+	}{
+		{EnvMaxRequestBytes, &l.MaxRequestBytes},
+		{EnvMaxActions, &l.MaxActions},
+		{EnvMaxSignatures, &l.MaxSignatures},
+		{EnvMaxSignatureBytes, &l.MaxSignatureBytes},
+		{EnvMaxActionBytes, &l.MaxActionBytes},
+		{EnvMaxInputs, &l.MaxInputs},
+		{EnvMaxOutputs, &l.MaxOutputs},
+		{EnvMaxMetadataEntries, &l.MaxMetadataEntries},
+		{EnvMaxMetadataKeyBytes, &l.MaxMetadataKeyBytes},
+		{EnvMaxMetadataValueBytes, &l.MaxMetadataValueBytes},
+		{EnvMaxProofBytes, &l.MaxProofBytes},
+	}
+	for _, f := range fields {
+		raw := getenv(f.env)
+		if raw == "" {
+			continue
+		}
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			return driver.ResourceLimits{}, errors.Wrapf(err, "invalid value [%s] for environment variable [%s]", raw, f.env)
+		}
+		*f.dst = v
+	}
+
+	return l.WithDefaults(), nil
+}

--- a/token/services/network/fabric/tcc/limits_test.go
+++ b/token/services/network/fabric/tcc/limits_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package tcc
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvResourceLimitsProvider_Unset(t *testing.T) {
+	p := &EnvResourceLimitsProvider{Getenv: func(string) string { return "" }}
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+	assert.Equal(t, driver.DefaultResourceLimits(), limits)
+}
+
+func TestEnvResourceLimitsProvider_PartialOverride(t *testing.T) {
+	env := map[string]string{
+		EnvMaxActions:    "2",
+		EnvMaxProofBytes: "1024",
+	}
+	p := &EnvResourceLimitsProvider{Getenv: func(key string) string { return env[key] }}
+
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+
+	want := driver.DefaultResourceLimits()
+	want.MaxActions = 2
+	want.MaxProofBytes = 1024
+	assert.Equal(t, want, limits)
+}
+
+func TestEnvResourceLimitsProvider_AllOverridden(t *testing.T) {
+	env := map[string]string{
+		EnvMaxRequestBytes:       "1",
+		EnvMaxActions:            "2",
+		EnvMaxSignatures:         "3",
+		EnvMaxSignatureBytes:     "4",
+		EnvMaxActionBytes:        "5",
+		EnvMaxInputs:             "6",
+		EnvMaxOutputs:            "7",
+		EnvMaxMetadataEntries:    "8",
+		EnvMaxMetadataKeyBytes:   "9",
+		EnvMaxMetadataValueBytes: "10",
+		EnvMaxProofBytes:         "11",
+	}
+	p := &EnvResourceLimitsProvider{Getenv: func(key string) string { return env[key] }}
+
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+	assert.Equal(t, driver.ResourceLimits{
+		MaxRequestBytes:       1,
+		MaxActions:            2,
+		MaxSignatures:         3,
+		MaxSignatureBytes:     4,
+		MaxActionBytes:        5,
+		MaxInputs:             6,
+		MaxOutputs:            7,
+		MaxMetadataEntries:    8,
+		MaxMetadataKeyBytes:   9,
+		MaxMetadataValueBytes: 10,
+		MaxProofBytes:         11,
+	}, limits)
+}
+
+func TestEnvResourceLimitsProvider_InvalidValue(t *testing.T) {
+	p := &EnvResourceLimitsProvider{Getenv: func(key string) string {
+		if key == EnvMaxActions {
+			return "not-a-number"
+		}
+
+		return ""
+	}}
+
+	_, err := p.ResourceLimits()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), EnvMaxActions)
+	var numErr *strconv.NumError
+	assert.ErrorAs(t, err, &numErr)
+}
+
+func TestNewEnvResourceLimitsProvider_DefaultsToOsGetenv(t *testing.T) {
+	p := NewEnvResourceLimitsProvider()
+	require.NotNil(t, p.Getenv)
+	limits, err := p.ResourceLimits()
+	require.NoError(t, err)
+	assert.Equal(t, driver.DefaultResourceLimits(), limits)
+}

--- a/token/services/network/fabric/tcc/main/main.go
+++ b/token/services/network/fabric/tcc/main/main.go
@@ -58,7 +58,11 @@ func main() {
 		Writer:  os.Stderr,
 	})
 
+	limits, err := tcc.NewEnvResourceLimitsProvider().ResourceLimits()
+	assertNoError(err, "cannot resolve validation resource limits")
+
 	is := core.NewValidatorDriverService(
+		limits,
 		fabtoken.NewValidatorDriver(),
 		dlog.NewValidatorDriver(),
 	)


### PR DESCRIPTION
## Summary
- Add a common resource-limit gate (`token/core/common/limits.go`) enforced in `VerifyTokenRequestFromRaw`, rejecting oversized raw requests, and requests with too many actions/signatures or oversized actions/signatures, before any protobuf parsing or cryptographic work.
- Add driver-specific action limits for fabtoken (`token/core/fabtoken/v1/actions/limits.go`) and zkatdlog/nogh (`token/core/zkatdlog/nogh/v1/issue/limits.go`, `.../transfer/limits.go`) bounding input/output/metadata counts and sizes, plus proof size for zkatdlog, enforced during action `Deserialize`/`Validate` before allocation and cryptographic verification.
- All limits are fixed package constants (not `PublicParameters` fields) so every validating peer applies identical bounds deterministically — a binary-version-scoped, consensus-safe policy that needs no protocol/PP migration.
- Exact-boundary unit tests (`limit`/`limit+1`) for every new constant across all three packages.
- New fuzz targets (`FuzzRequestResourceLimits`, `FuzzActionResourceLimits` x2) with persisted seed corpora, wired into the nightly fuzz workflow matrix; existing fuzz harness caps now reference the production limit constants instead of local ad-hoc values.
- New doc page `docs/drivers/validation-resource-limits.md` describing the policy and its consensus-safety contract, linked from `docs/driverapi.md`.

## Test plan
- [x] `make checks`
- [x] `make lint-auto-fix`
- [x] `make unit-tests` (full suite, no failures)
- [x] Targeted package tests: `token/core/common/...`, `token/core/fabtoken/v1/...`, `token/core/zkatdlog/nogh/v1/...`
- [x] Live fuzz campaigns on all three new targets (clean, no crashes)
- [ ] Fabric integration tests — not run in this environment (no `FAB_BINS` configured); no currently-valid request exercised by the unit/regression suites trips any new limit.

Fixes #1928