### PR TITLE
feat(zkatsnark): add orchestrator and action builder

### DIFF
--- a/x/token/core/zkatsnark/prover/binding.go
+++ b/x/token/core/zkatsnark/prover/binding.go
@@ -1,0 +1,190 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package prover
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"math/big"
+	"sort"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards"
+)
+
+// domainSeparator prevents a binding signature produced by this scheme from
+// being valid in, or confused with, any other protocol context.
+const domainSeparator = "zkatsnark-action-binding-v1"
+
+// ProofResult holds everything one input or output token contributes to an
+// action's binding signature.
+type ProofResult struct {
+	Commitment  fr.Element
+	ValueCommit twistededwards.PointAffine
+	RCV         fr.Element
+}
+
+// sortedByCommitment returns results sorted lexicographically by
+// Commitment bytes. This makes ComputeActionHash canonical regardless of
+// which order the Orchestrator's goroutines happen to complete in — two
+// runs proving the same logical action, in any goroutine completion order,
+// must produce the same hash.
+func sortedByCommitment(results []ProofResult) []ProofResult {
+	sorted := make([]ProofResult, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool {
+		a := sorted[i].Commitment.Bytes()
+		b := sorted[j].Commitment.Bytes()
+		for k := range a {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+
+		return false
+	})
+
+	return sorted
+}
+
+// writeLengthPrefixed writes an 8-byte big-endian length followed by the
+// bytes. Used for actionType and tokenType, which are variable-length
+// strings — without a length prefix, concatenating two variable-length
+// strings back-to-back is ambiguous (e.g. "a"+"bc" and "ab"+"c" would hash
+// identically under naive concatenation). Fixed-length fields (commitments,
+// coordinates) don't need this.
+func writeLengthPrefixed(h hash.Hash, b []byte) {
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(b)))
+	h.Write(lenBuf[:])
+	h.Write(b)
+}
+
+// ComputeActionHash computes the canonical, deterministic message the
+// binding signature is produced over. Must be computed byte-identically by
+// the prover (when signing) and eventually the validator (when verifying) —
+// any divergence in sorting, encoding, or field ordering causes every
+// legitimate binding signature to fail verification with no useful
+// diagnostic.
+func ComputeActionHash(actionType string, tokenType string, inputs, outputs []ProofResult) []byte {
+	h := sha256.New()
+	h.Write([]byte(domainSeparator))
+	writeLengthPrefixed(h, []byte(actionType))
+	writeLengthPrefixed(h, []byte(tokenType))
+
+	for _, r := range sortedByCommitment(inputs) {
+		cm := r.Commitment.Bytes()
+		cmx := r.ValueCommit.X.Bytes()
+		cmy := r.ValueCommit.Y.Bytes()
+
+		h.Write(cm[:])
+		h.Write(cmx[:])
+		h.Write(cmy[:])
+	}
+
+	for _, r := range sortedByCommitment(outputs) {
+		cm := r.Commitment.Bytes()
+		cmx := r.ValueCommit.X.Bytes()
+		cmy := r.ValueCommit.Y.Bytes()
+
+		h.Write(cm[:])
+		h.Write(cmx[:])
+		h.Write(cmy[:])
+	}
+
+	return h.Sum(nil)
+}
+
+// ComputeBVK computes the binding verification key:
+//
+//	bvk = Σcv_in − Σcv_out + valueBalance·V
+//
+// valueBalance corrects for non-conserved value flows, following the
+// ZCash Sapling binding signature convention:
+//
+//   - Transfer (conserved values): valueBalance = 0
+//   - Issuance (no inputs):        valueBalance = Σv_out
+//
+// When values are conserved the V-terms in Σcv_in and Σcv_out cancel,
+// leaving bvk = bsk·R. For issuance the V-terms do NOT cancel;
+// adding valueBalance·V restores the equality bvk = bsk·R so the
+// Schnorr verification succeeds.
+//
+// Exposed here because it is a pure function of public data that the
+// eventual validator will need to compute independently.
+func ComputeBVK(inputs, outputs []ProofResult, valueBalance uint64) twistededwards.PointAffine {
+	points := make([]twistededwards.PointAffine, 0, len(inputs)+len(outputs)+1)
+
+	for _, r := range inputs {
+		points = append(points, r.ValueCommit)
+	}
+
+	for _, r := range outputs {
+		points = append(points, jubjub.NegatePoint(r.ValueCommit))
+	}
+
+	if valueBalance != 0 {
+		var vbScalar fr.Element
+		vbScalar.SetUint64(valueBalance)
+		vbBig := vbScalar.BigInt(new(big.Int))
+
+		var vbPoint twistededwards.PointAffine
+		vbPoint.ScalarMultiplication(&jubjub.V, vbBig)
+		points = append(points, vbPoint)
+	}
+
+	return jubjub.ValueCommitSum(points)
+}
+
+// ComputeBindingSignature computes the per-action binding signature proving
+// value conservation: Σvalue_in == Σvalue_out.
+//
+// bsk = Σrcv_in − Σrcv_out is the private signing key, computable only
+// because the caller collected every RCV used across this action's proofs.
+// Signing uses jubjub.R as the group base point, matching the ZCash
+// Sapling convention: bvk = Σcv_in − Σcv_out reduces to exactly bsk·R when
+// values are conserved, and to something else entirely (unreachable by the
+// prover, since nobody knows log_R(V)) when they are not
+//
+// For issuance (empty inputs), bsk becomes −Σrcv_out. There is no
+// conservation requirement for issuance, the signature instead attests
+// that the published output value commitments are correctly formed.
+func ComputeBindingSignature(actionType string, tokenType string, inputs, outputs []ProofResult) (jubjub.Signature, error) {
+	// bsk must be computed modulo the Jubjub subgroup order, NOT the
+	// BLS12-381 scalar field modulus. fr.Element.Add/Sub reduce mod r
+	// (the BLS12-381 scalar field), but the Schnorr signature scheme
+	// operates over the Jubjub curve whose subgroup order is different.
+	params := twistededwards.GetEdwardsCurve()
+	order := &params.Order
+
+	bskBig := new(big.Int)
+
+	for _, r := range inputs {
+		bskBig.Add(bskBig, r.RCV.BigInt(new(big.Int)))
+	}
+
+	for _, r := range outputs {
+		bskBig.Sub(bskBig, r.RCV.BigInt(new(big.Int)))
+	}
+
+	bskBig.Mod(bskBig, order)
+
+	var bsk fr.Element
+	bsk.SetBigInt(bskBig)
+
+	actionHash := ComputeActionHash(actionType, tokenType, inputs, outputs)
+
+	sig, err := jubjub.Sign(bsk, actionHash, jubjub.R)
+	if err != nil {
+		return jubjub.Signature{}, fmt.Errorf("prover: binding signature generation failed: %w", err)
+	}
+
+	return sig, nil
+}

--- a/x/token/core/zkatsnark/prover/binding_test.go
+++ b/x/token/core/zkatsnark/prover/binding_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package prover_test
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/prover"
+)
+
+func mustProofResult(t *testing.T, value uint64) prover.ProofResult {
+	t.Helper()
+	var rcv fr.Element
+	_, err := rcv.SetRandom()
+	require.NoError(t, err)
+
+	cv, err := jubjub.ValueCommit(value, rcv)
+	require.NoError(t, err)
+
+	// Commitment field is irrelevant to binding-signature math directly,
+	// but is used for sorting
+	var cm fr.Element
+	_, err = cm.SetRandom()
+	require.NoError(t, err)
+
+	return prover.ProofResult{Commitment: cm, ValueCommit: cv, RCV: rcv}
+}
+
+func TestActionHashDeterminism(t *testing.T) {
+	in := []prover.ProofResult{mustProofResult(t, 100)}
+	out := []prover.ProofResult{mustProofResult(t, 100)}
+
+	h1 := prover.ComputeActionHash("transfer", "USD", in, out)
+	h2 := prover.ComputeActionHash("transfer", "USD", in, out)
+
+	require.Equal(t, h1, h2)
+}
+
+func TestActionHashOrderIndependence(t *testing.T) {
+	pr1 := mustProofResult(t, 50)
+	pr2 := mustProofResult(t, 100)
+
+	h1 := prover.ComputeActionHash("transfer", "USD", []prover.ProofResult{pr1, pr2}, nil)
+	h2 := prover.ComputeActionHash("transfer", "USD", []prover.ProofResult{pr2, pr1}, nil)
+
+	require.Equal(t, h1, h2, "hash must be independent of input slice order — this is what makes "+
+		"the hash canonical regardless of goroutine completion order")
+}
+
+func TestActionHashSensitivity(t *testing.T) {
+	in := []prover.ProofResult{mustProofResult(t, 100)}
+	out := []prover.ProofResult{mustProofResult(t, 100)}
+
+	h := prover.ComputeActionHash("transfer", "USD", in, out)
+
+	withDifferentActionType := prover.ComputeActionHash("issue", "USD", in, out)
+	require.NotEqual(t, h, withDifferentActionType)
+
+	withDifferentTokenType := prover.ComputeActionHash("transfer", "EUR", in, out)
+	require.NotEqual(t, h, withDifferentTokenType)
+
+	differentOut := []prover.ProofResult{mustProofResult(t, 999)}
+	withDifferentOutputs := prover.ComputeActionHash("transfer", "USD", in, differentOut)
+	require.NotEqual(t, h, withDifferentOutputs)
+}
+
+// TestComputeBindingSignatureValid is the standard success case: conserved
+// values, sign, independently recompute bvk from public data alone, verify.
+func TestComputeBindingSignatureValid(t *testing.T) {
+	in := []prover.ProofResult{mustProofResult(t, 100), mustProofResult(t, 50)}
+	out := []prover.ProofResult{mustProofResult(t, 120), mustProofResult(t, 30)}
+
+	h := prover.ComputeActionHash("transfer", "USD", in, out)
+
+	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	require.NoError(t, err)
+
+	bvk := prover.ComputeBVK(in, out, 0)
+	err = jubjub.Verify(bvk, h, sig, jubjub.R)
+
+	require.NoError(t, err, "binding signature must verify against independently computed bvk")
+}
+
+// TestComputeBindingSignatureRejectsNonConservation is the core security
+// property test. It does NOT special-case the mismatch, it demonstrates
+// that the same verification code path used for the honest case correctly
+// rejects a bundle where values do not balance, purely as a mathematical
+// consequence of V and R being independent generators (nobody knows
+// log_R(V)).
+func TestComputeBindingSignatureRejectsNonConservation(t *testing.T) {
+	in := []prover.ProofResult{mustProofResult(t, 100), mustProofResult(t, 50)}
+	out := []prover.ProofResult{mustProofResult(t, 120), mustProofResult(t, 40)}
+
+	h := prover.ComputeActionHash("transfer", "USD", in, out)
+
+	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	require.NoError(t, err)
+
+	bvk := prover.ComputeBVK(in, out, 0)
+	err = jubjub.Verify(bvk, h, sig, jubjub.R)
+
+	require.Error(t, err,
+		"CRITICAL: a binding signature for non-conserved values must fail verification — "+
+			"if this passes, the conservation proof is fundamentally broken")
+}
+
+func TestComputeBindingSignatureIssuance(t *testing.T) {
+	out := []prover.ProofResult{mustProofResult(t, 500)}
+
+	sig, err := prover.ComputeBindingSignature("issue", "USD", nil, out)
+	require.NoError(t, err)
+
+	bvk := prover.ComputeBVK(nil, out, 500)
+	actionHash := prover.ComputeActionHash("issue", "USD", nil, out)
+
+	err = jubjub.Verify(bvk, actionHash, sig, jubjub.R)
+	require.NoError(t, err, "issuance binding signature (zero inputs) must verify")
+}
+
+func TestComputeBindingSignatureRejectsWrongTokenTypeAtVerification(t *testing.T) {
+	in := []prover.ProofResult{mustProofResult(t, 100)}
+	out := []prover.ProofResult{mustProofResult(t, 100)}
+
+	sig, err := prover.ComputeBindingSignature("transfer", "USD", in, out)
+	require.NoError(t, err)
+
+	bvk := prover.ComputeBVK(in, out, 0)
+	h := prover.ComputeActionHash("transfer", "EUR", in, out)
+
+	err = jubjub.Verify(bvk, h, sig, jubjub.R)
+	require.Error(t, err,
+		"verifying against a hash computed with the wrong token type must fail, "+
+			"this confirms token type really is bound into the signed message")
+}

--- a/x/token/core/zkatsnark/prover/orchestrator.go
+++ b/x/token/core/zkatsnark/prover/orchestrator.go
@@ -1,0 +1,283 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package prover
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/setup"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
+)
+
+// Orchestrator drives parallel proof generation for a single action and
+// assembles the resulting wire-format Action. Construct once at driver
+// startup, holding already-loaded provers, and reuse across every
+// transaction.
+type Orchestrator struct {
+	spendProver  *SpendProver
+	outputProver *OutputProver
+}
+
+func NewOrchestrator(spendProver *SpendProver, outputProver *OutputProver) *Orchestrator {
+	return &Orchestrator{spendProver: spendProver, outputProver: outputProver}
+}
+
+type SpendRequest struct {
+	Note *snarktoken.Note
+}
+
+type OutputRequest struct {
+	Value     uint64
+	TokenType string
+	Recipient []byte
+}
+
+type spendOutcome struct {
+	index  int
+	result ProofResult
+	desc   snarktoken.SpendDescription
+	err    error
+}
+
+type outputOutcome struct {
+	index  int
+	result ProofResult
+	desc   snarktoken.OutputDescription
+	note   *snarktoken.Note
+	err    error
+}
+
+// BuildTransferAction generates every Spend and Output proof concurrently,
+// computes the per-action binding signature, and assembles the resulting
+// TransferAction. Returns the newly created output Notes alongside the
+// action, persisting or transmitting them is the caller's responsibility.
+// All inputs and outputs must share tokenType
+func (o *Orchestrator) BuildTransferAction(
+	ctx context.Context,
+	inputs []SpendRequest,
+	outputs []OutputRequest,
+	tokenType string,
+	publicParams *pp.PublicParams,
+) (*snarktoken.TransferAction, []*snarktoken.Note, error) {
+	if len(inputs) == 0 && len(outputs) == 0 {
+		return nil, nil, errors.New("orchestrator: transfer action requires at least one input or output")
+	}
+
+	spendCh := make(chan spendOutcome, len(inputs))
+	outputCh := make(chan outputOutcome, len(outputs))
+
+	for i, req := range inputs {
+		go o.proveSpend(i, req, spendCh)
+	}
+
+	for j, req := range outputs {
+		go o.proveOutput(j, req, publicParams, outputCh)
+	}
+
+	spendOutcomes := make([]spendOutcome, len(inputs))
+	for range inputs {
+		r := <-spendCh
+		if r.err != nil {
+			return nil, nil, fmt.Errorf("orchestrator: spend proof %d failed: %w", r.index, r.err)
+		}
+		spendOutcomes[r.index] = r
+	}
+
+	outputOutcomes := make([]outputOutcome, len(outputs))
+	for range outputs {
+		r := <-outputCh
+		if r.err != nil {
+			return nil, nil, fmt.Errorf("orchestrator: output proof %d failed: %w", r.index, r.err)
+		}
+		outputOutcomes[r.index] = r
+	}
+
+	inputResults := make([]ProofResult, len(spendOutcomes))
+	inputDescs := make([]snarktoken.SpendDescription, len(spendOutcomes))
+	for i, oc := range spendOutcomes {
+		inputResults[i] = oc.result
+		inputDescs[i] = oc.desc
+	}
+
+	outputResults := make([]ProofResult, len(outputOutcomes))
+	outputDescs := make([]snarktoken.OutputDescription, len(outputOutcomes))
+	newNotes := make([]*snarktoken.Note, len(outputOutcomes))
+	for j, oc := range outputOutcomes {
+		outputResults[j] = oc.result
+		outputDescs[j] = oc.desc
+		newNotes[j] = oc.note
+	}
+
+	sig, err := ComputeBindingSignature(snarktoken.ActionTypeTransfer, tokenType, inputResults, outputResults)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: binding signature failed: %w", err)
+	}
+	sigBytes, err := jubjub.SerializeSignature(sig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: binding signature serialization failed: %w", err)
+	}
+
+	action := &snarktoken.TransferAction{
+		TokenType:        tokenType,
+		Inputs:           inputDescs,
+		Outputs:          outputDescs,
+		BindingSignature: sigBytes,
+	}
+
+	return action, newNotes, nil
+}
+
+// BuildIssueAction generates proofs for a set of newly issued tokens and
+// assembles the resulting IssueAction. Structurally identical to
+// BuildTransferAction with zero inputs.
+func (o *Orchestrator) BuildIssueAction(
+	ctx context.Context,
+	issuer []byte,
+	outputs []OutputRequest,
+	tokenType string,
+	publicParams *pp.PublicParams,
+) (*snarktoken.IssueAction, []*snarktoken.Note, error) {
+	if len(outputs) == 0 {
+		return nil, nil, errors.New("orchestrator: issue action requires at least one output")
+	}
+
+	outputCh := make(chan outputOutcome, len(outputs))
+	for j, req := range outputs {
+		go o.proveOutput(j, req, publicParams, outputCh)
+	}
+
+	outputOutcomes := make([]outputOutcome, len(outputs))
+	for range outputs {
+		r := <-outputCh
+		if r.err != nil {
+			return nil, nil, fmt.Errorf("orchestrator: output proof %d failed: %w", r.index, r.err)
+		}
+		outputOutcomes[r.index] = r
+	}
+
+	outputResults := make([]ProofResult, len(outputOutcomes))
+	outputDescs := make([]snarktoken.OutputDescription, len(outputOutcomes))
+	newNotes := make([]*snarktoken.Note, len(outputOutcomes))
+	for j, oc := range outputOutcomes {
+		outputResults[j] = oc.result
+		outputDescs[j] = oc.desc
+		newNotes[j] = oc.note
+	}
+
+	sig, err := ComputeBindingSignature(snarktoken.ActionTypeIssue, tokenType, nil, outputResults)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: binding signature failed: %w", err)
+	}
+	sigBytes, err := jubjub.SerializeSignature(sig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("orchestrator: binding signature serialization failed: %w", err)
+	}
+
+	action := &snarktoken.IssueAction{
+		Issuer:           issuer,
+		TokenType:        tokenType,
+		Outputs:          outputDescs,
+		BindingSignature: sigBytes,
+	}
+
+	return action, newNotes, nil
+}
+
+func (o *Orchestrator) proveSpend(index int, req SpendRequest, out chan<- spendOutcome) {
+	witnessRes, err := BuildSpendWitness(req.Note)
+	if err != nil {
+		out <- spendOutcome{index: index, err: err}
+
+		return
+	}
+
+	proof, err := o.spendProver.Prove(witnessRes.Assignment)
+	if err != nil {
+		out <- spendOutcome{index: index, err: err}
+
+		return
+	}
+
+	proofBytes, err := setup.SerializeProof(proof)
+	if err != nil {
+		out <- spendOutcome{index: index, err: err}
+
+		return
+	}
+
+	cm := witnessRes.Commitment.Bytes()
+	cx := witnessRes.ValueCommitment.X.Bytes()
+	cy := witnessRes.ValueCommitment.Y.Bytes()
+	tokenTypeField := snarktoken.EncodeTokenType(req.Note.TokenType)
+	tb := tokenTypeField.Bytes()
+
+	out <- spendOutcome{
+		index: index,
+		result: ProofResult{
+			Commitment:  witnessRes.Commitment,
+			ValueCommit: witnessRes.ValueCommitment,
+			RCV:         witnessRes.RCV,
+		},
+		desc: snarktoken.SpendDescription{
+			CommitmentIn:   cm[:],
+			ValueCommitInX: cx[:],
+			ValueCommitInY: cy[:],
+			TokenType:      tb[:],
+			SpendProof:     proofBytes,
+		},
+	}
+}
+
+func (o *Orchestrator) proveOutput(index int, req OutputRequest, publicParams *pp.PublicParams, out chan<- outputOutcome) {
+	witnessRes, err := BuildOutputWitness(req.Value, req.TokenType, publicParams)
+	if err != nil {
+		out <- outputOutcome{index: index, err: err}
+
+		return
+	}
+
+	proof, err := o.outputProver.Prove(witnessRes.Assignment)
+	if err != nil {
+		out <- outputOutcome{index: index, err: err}
+
+		return
+	}
+
+	proofBytes, err := setup.SerializeProof(proof)
+	if err != nil {
+		out <- outputOutcome{index: index, err: err}
+
+		return
+	}
+
+	cm := witnessRes.Commitment.Bytes()
+	cx := witnessRes.ValueCommitment.X.Bytes()
+	cy := witnessRes.ValueCommitment.Y.Bytes()
+	tokenTypeField := snarktoken.EncodeTokenType(req.TokenType)
+	tb := tokenTypeField.Bytes()
+
+	out <- outputOutcome{
+		index: index,
+		result: ProofResult{
+			Commitment:  witnessRes.Commitment,
+			ValueCommit: witnessRes.ValueCommitment,
+			RCV:         witnessRes.RCV,
+		},
+		desc: snarktoken.OutputDescription{
+			CommitmentOut:   cm[:],
+			ValueCommitOutX: cx[:],
+			ValueCommitOutY: cy[:],
+			TokenType:       tb[:],
+			OutputProof:     proofBytes,
+			Recipient:       req.Recipient,
+		},
+		note: witnessRes.Note,
+	}
+}

--- a/x/token/core/zkatsnark/prover/orchestrator_test.go
+++ b/x/token/core/zkatsnark/prover/orchestrator_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package prover_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/twistededwards"
+	"github.com/consensys/gnark/backend/groth16"
+	"github.com/consensys/gnark/backend/witness"
+	"github.com/consensys/gnark/frontend"
+
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/prover"
+	"github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/setup"
+	snarktoken "github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token"
+)
+
+// publicWitnessFromSpendDescription reconstructs a public-only witness for
+// SpendCircuit directly from wire-format bytes — exactly what the eventual
+// Validator does when it receives a SpendDescription over the network and
+// has no access to the private Value/Randomness/RCV that produced it.
+func publicWitnessFromSpendDescription(t *testing.T, desc snarktoken.SpendDescription) witness.Witness {
+	t.Helper()
+
+	var cm, cx, cy, tt fr.Element
+	require.NoError(t, cm.SetBytesCanonical(desc.CommitmentIn), "CommitmentIn")
+	require.NoError(t, cx.SetBytesCanonical(desc.ValueCommitInX), "ValueCommitInX")
+	require.NoError(t, cy.SetBytesCanonical(desc.ValueCommitInY), "ValueCommitInY")
+	require.NoError(t, tt.SetBytesCanonical(desc.TokenType), "TokenType")
+
+	assignment := &circuit.SpendCircuit{
+		CommitmentIn:   cm,
+		ValueCommitInX: cx,
+		ValueCommitInY: cy,
+		TokenType:      tt,
+		// Private fields left as zero values, PublicOnly() below only
+		// extracts the gnark:",public" fields, so these are never read.
+	}
+
+	w, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField(), frontend.PublicOnly())
+	require.NoError(t, err, "building public witness from SpendDescription")
+
+	return w
+}
+
+// publicWitnessFromOutputDescription is the OutputCircuit equivalent.
+func publicWitnessFromOutputDescription(t *testing.T, desc snarktoken.OutputDescription) witness.Witness {
+	t.Helper()
+
+	var cm, cx, cy, tt fr.Element
+	require.NoError(t, cm.SetBytesCanonical(desc.CommitmentOut), "CommitmentOut")
+	require.NoError(t, cx.SetBytesCanonical(desc.ValueCommitOutX), "ValueCommitOutX")
+	require.NoError(t, cy.SetBytesCanonical(desc.ValueCommitOutY), "ValueCommitOutY")
+	require.NoError(t, tt.SetBytesCanonical(desc.TokenType), "TokenType")
+
+	assignment := &circuit.OutputCircuit{
+		CommitmentOut:   cm,
+		ValueCommitOutX: cx,
+		ValueCommitOutY: cy,
+		TokenType:       tt,
+		MaxBits:         testPP.MaxBits, // MaxBits is a plain
+		// int, not a frontend.Variable, so frontend.NewWitness never reads
+		// it; it only matters at compile time, already baked into outputVK.
+	}
+
+	w, err := frontend.NewWitness(assignment, ecc.BLS12_381.ScalarField(), frontend.PublicOnly())
+	require.NoError(t, err, "building public witness from OutputDescription")
+
+	return w
+}
+
+func TestBuildTransferAction_Valid(t *testing.T) {
+	setupProvers(t)
+
+	o := prover.NewOrchestrator(spendProver, outputProver)
+
+	note1, err := snarktoken.NewRandomNote(100, "USD")
+	require.NoError(t, err)
+	note2, err := snarktoken.NewRandomNote(50, "USD")
+	require.NoError(t, err)
+
+	action, outputs, err := o.BuildTransferAction(
+		context.Background(),
+		[]prover.SpendRequest{{Note: note1}, {Note: note2}},
+		[]prover.OutputRequest{
+			{Value: 80, TokenType: "USD", Recipient: []byte("bob")},
+			{Value: 70, TokenType: "USD", Recipient: []byte("alice-change")},
+		},
+		"USD",
+		testPP,
+	)
+	require.NoError(t, err)
+	require.Len(t, action.Inputs, 2)
+	require.Len(t, action.Outputs, 2)
+	require.Len(t, outputs, 2)
+
+	// Every proof must independently verify.
+	for i, input := range action.Inputs {
+		proof, err := setup.DeserializeProof(input.SpendProof, testPP.Curve)
+		require.NoError(t, err, "input %d", i)
+
+		pw := publicWitnessFromSpendDescription(t, input)
+
+		err = groth16.Verify(proof, spendVK, pw)
+		require.NoError(t, err, "input %d: proof does not verify", i)
+	}
+
+	for j, output := range action.Outputs {
+		proof, err := setup.DeserializeProof(output.OutputProof, testPP.Curve)
+		require.NoError(t, err, "output %d: proof deserialize", j)
+
+		pw := publicWitnessFromOutputDescription(t, output)
+
+		err = groth16.Verify(proof, outputVK, pw)
+		require.NoError(t, err, "output %d: proof does not verify", j)
+	}
+
+	// Binding signature must verify against a bvk independently recomputed
+	// from the assembled action's own public descriptions, simulating what
+	// a validator will eventually do.
+	var inResults, outResults []prover.ProofResult
+
+	for _, input := range action.Inputs {
+		var cm, cx, cy fr.Element
+		require.NoError(t, cm.SetBytesCanonical(input.CommitmentIn))
+		require.NoError(t, cx.SetBytesCanonical(input.ValueCommitInX))
+		require.NoError(t, cy.SetBytesCanonical(input.ValueCommitInY))
+
+		inResults = append(inResults, prover.ProofResult{
+			Commitment:  cm,
+			ValueCommit: twistededwards.PointAffine{X: cx, Y: cy},
+		})
+	}
+
+	for _, output := range action.Outputs {
+		var cm, cx, cy fr.Element
+		require.NoError(t, cm.SetBytesCanonical(output.CommitmentOut))
+		require.NoError(t, cx.SetBytesCanonical(output.ValueCommitOutX))
+		require.NoError(t, cy.SetBytesCanonical(output.ValueCommitOutY))
+
+		outResults = append(outResults, prover.ProofResult{
+			Commitment:  cm,
+			ValueCommit: twistededwards.PointAffine{X: cx, Y: cy},
+		})
+	}
+
+	bvk := prover.ComputeBVK(inResults, outResults, 0)
+	actionHash := prover.ComputeActionHash(snarktoken.ActionTypeTransfer, action.TokenType, inResults, outResults)
+
+	sig, err := jubjub.DeserializeSignature(action.BindingSignature)
+	require.NoError(t, err)
+
+	err = jubjub.Verify(bvk, actionHash, sig, jubjub.R)
+	require.NoError(t, err, "binding signature reconstructed from wire-format bytes must verify")
+}

--- a/x/token/core/zkatsnark/token/issue.go
+++ b/x/token/core/zkatsnark/token/issue.go
@@ -1,0 +1,38 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token
+
+// OutputDescription is the public wire-format record for one newly created
+// token. Everything here is safe to publish, the note secrets (value,
+// type, randomness) that this commitment opens to are never included.
+type OutputDescription struct {
+	CommitmentOut   []byte // 32 bytes: MiMC(value, type, randomness)
+	ValueCommitOutX []byte // 32 bytes: Jubjub X coordinate of cv
+	ValueCommitOutY []byte // 32 bytes: Jubjub Y coordinate of cv
+	TokenType       []byte // 32 bytes: canonical field-element encoding of type
+	OutputProof     []byte // 192 bytes: Groth16 proof for OutputCircuit
+	Recipient       []byte // intended recipient identity
+}
+
+// IssueAction represents the creation of one or more new tokens.
+//
+// There are no SpendDescriptions — issuance consumes nothing. The binding
+// signature's signing key is bsk = −Σrcv_out (no input RCVs to add), and it
+// attests that every output's value commitment is correctly formed, not
+// that any conservation equation holds — there is nothing to conserve
+// against for freshly minted tokens.
+//
+// Issuance authorization itself (who is allowed to mint tokens of this
+// type) is not represented here — that is expected to come from whatever
+// Panurus's existing issuer-authorization mechanism is (Issuers() on
+// PublicParameters, or an equivalent endorsement-policy check at the
+// network layer), not from anything in this struct.
+type IssueAction struct {
+	Issuer           []byte
+	TokenType        string
+	Outputs          []OutputDescription
+	BindingSignature []byte // 96 bytes: R.X || R.Y || S
+}

--- a/x/token/core/zkatsnark/token/transfer.go
+++ b/x/token/core/zkatsnark/token/transfer.go
@@ -1,0 +1,36 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token
+
+// SpendDescription is the public wire-format record for one token being
+// consumed as an input. The commitment being spent, its value commitment,
+// and its type are all public; the value, randomness, and value-commitment
+// randomness that open them are not.
+type SpendDescription struct {
+	CommitmentIn   []byte // 32 bytes
+	ValueCommitInX []byte // 32 bytes
+	ValueCommitInY []byte // 32 bytes
+	TokenType      []byte // 32 bytes
+	SpendProof     []byte // 192 bytes: Groth16 proof for SpendCircuit
+}
+
+// TransferAction represents consuming one or more existing tokens and
+// creating one or more new tokens, with value conserved across the two
+// sets.
+//
+// This layer does not yet know whether TransferAction needs to satisfy a
+// broader Panurus driver.Action interface, or whether the entity that
+// produces BindingSignature needs to be registered through an existing
+// "extra signer" mechanism (per Angelo's review comment) rather than simply
+// being a byte slice on this struct. Both are open integration questions —
+// everything else here is complete and correct independent of how they
+// resolve.
+type TransferAction struct {
+	TokenType        string
+	Inputs           []SpendDescription
+	Outputs          []OutputDescription
+	BindingSignature []byte // 96 bytes: R.X || R.Y || S
+}


### PR DESCRIPTION
## Description

This PR introduces the **Orchestrator** and **Action Builder** layers for the ZKAT-SNARK driver. It handles concurrent generation of zero-knowledge proofs and assembles the final wire-format cryptographic actions (`TransferAction`, `IssueAction`).

## Key Features
- **Concurrent Proof Generation**: The `Orchestrator` uses goroutines to concurrently build witnesses and generate Groth16 proofs for both `Spend` (inputs) and `Output` (outputs) requests, maximizing throughput.
- **Value Conservation Binding Signatures**: 
  - Implemented the ZCash Sapling-style binding signature scheme over the Jubjub twisted Edwards curve.
  - Ensures `sum(value_in) == sum(value_out)` for transfers by producing a Schnorr signature where the public key is dynamically computed from public value commitments (`bvk = Σcv_in - Σcv_out`).
  - Added value balance correction for `IssueAction`s to allow non-conserved value flows while still proving that the output commitments are correctly formed.
- **Canonical Action Hashing**: Implemented a deterministic, order-independent hashing mechanism to ensure that the action hash remains canonical regardless of the order in which the concurrent proof generation goroutines complete.
- **Wire-Format Assembly**: Added definitions for `TransferAction` and `IssueAction` along with standard wire-format serializers for the generated proofs and commitments.

## Testing

All unit-tests pass:
```
go test ./...
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark  [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit  (cached)
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/circuit/gadgets  [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/jubjub    (cached)
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/mimc      (cached)
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/crypto/params    [no test files]
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/pp       [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/prover   0.762s
?       github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/setup    [no test files]
ok      github.com/LFDT-Panurus/panurus/x/token/core/zkatsnark/token    (cached)
```

Next steps:
Implement `MigrationCircuit` and integrate with the proving layer