### PR TITLE
Aligning Benchmarks with FSC Changes

### DIFF
--- a/cmd/token_validation_service/api_bench_test.go
+++ b/cmd/token_validation_service/api_bench_test.go
@@ -18,14 +18,16 @@ func BenchmarkAPI(b *testing.B) {
 	testdataPath := b.TempDir()
 	nodeConfPath := path.Join(testdataPath, "fsc", "nodes", "test-node.0")
 
-	err := node.GenerateConfig(testdataPath)
+	err := generateConfigWS(testdataPath)
 	require.NoError(b, err)
 
-	n, err := node.SetupNode(nodeConfPath, node.NamedFactory{
+	n, err := setupNodeP2P(nodeConfPath, node.NamedFactory{
 		Name:    "token-validation-service",
 		Factory: &TokenValidationServiceViewFactory{},
 	})
+
 	require.NoError(b, err)
+
 	defer n.Stop()
 
 	vm, err := viewregistry.GetManager(n)

--- a/cmd/token_validation_service/api_bench_test.go
+++ b/cmd/token_validation_service/api_bench_test.go
@@ -18,10 +18,10 @@ func BenchmarkAPI(b *testing.B) {
 	testdataPath := b.TempDir()
 	nodeConfPath := path.Join(testdataPath, "fsc", "nodes", "test-node.0")
 
-	err := generateConfigWS(testdataPath)
+	err := GenerateConfigWS(testdataPath)
 	require.NoError(b, err)
 
-	n, err := setupNodeP2P(nodeConfPath, node.NamedFactory{
+	n, err := SetupNodeP2P(nodeConfPath, node.NamedFactory{
 		Name:    "token-validation-service",
 		Factory: &TokenValidationServiceViewFactory{},
 	})

--- a/cmd/token_validation_service/api_grpc_bench_test.go
+++ b/cmd/token_validation_service/api_grpc_bench_test.go
@@ -25,10 +25,10 @@ func BenchmarkAPIGRPC(b *testing.B) {
 	nodeConfPath := path.Join(testdataPath, "fsc", "nodes", "test-node.0")
 	clientConfPath := path.Join(nodeConfPath, "client-config.yaml")
 
-	err := generateConfigWS(testdataPath)
+	err := GenerateConfigWS(testdataPath)
 	require.NoError(b, err)
 
-	n, err := setupNodeP2P(nodeConfPath, node.NamedFactory{
+	n, err := SetupNodeP2P(nodeConfPath, node.NamedFactory{
 		Name:    "token-validation-service",
 		Factory: &TokenValidationServiceViewFactory{},
 	})

--- a/cmd/token_validation_service/api_grpc_bench_test.go
+++ b/cmd/token_validation_service/api_grpc_bench_test.go
@@ -25,15 +25,16 @@ func BenchmarkAPIGRPC(b *testing.B) {
 	nodeConfPath := path.Join(testdataPath, "fsc", "nodes", "test-node.0")
 	clientConfPath := path.Join(nodeConfPath, "client-config.yaml")
 
-	err := node.GenerateConfig(testdataPath)
+	err := generateConfigWS(testdataPath)
 	require.NoError(b, err)
 
-	n, err := node.SetupNode(nodeConfPath, node.NamedFactory{
+	n, err := setupNodeP2P(nodeConfPath, node.NamedFactory{
 		Name:    "token-validation-service",
 		Factory: &TokenValidationServiceViewFactory{},
 	})
 
 	require.NoError(b, err)
+
 	defer n.Stop()
 
 	paramsSlice, err := NewTokenValidationParamsSlice(DefaultTestRoot)

--- a/cmd/token_validation_service/bench_setup.go
+++ b/cmd/token_validation_service/bench_setup.go
@@ -15,9 +15,9 @@ import (
 	viewregistry "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
 )
 
-// generateConfigWS mirrors node.GenerateConfig but uses websocket transport.
+// GenerateConfigWS mirrors node.GenerateConfig but uses websocket transport.
 // (node.GenerateConfig uses default LibP2P)
-func generateConfigWS(testdataDir string) error {
+func GenerateConfigWS(testdataDir string) error {
 	fscTopology := fsc.NewTopology()
 	fscTopology.P2PCommunicationType = fsc.WebSocket
 	fscTopology.SetLogging("error", "")
@@ -27,8 +27,8 @@ func generateConfigWS(testdataDir string) error {
 	return err
 }
 
-// setupNodeP2P mirrors node.SetupNode and uses the default websocket transport.
-func setupNodeP2P(confPath string, factories ...node.NamedFactory) (*fscnode.Node, error) {
+// SetupNodeP2P mirrors node.SetupNode and uses the default websocket transport.
+func SetupNodeP2P(confPath string, factories ...node.NamedFactory) (*fscnode.Node, error) {
 	n := fscnode.NewWithConfPath(confPath)
 
 	if err := n.InstallSDK(viewsdk.NewSDK(n)); err != nil {

--- a/cmd/token_validation_service/bench_setup.go
+++ b/cmd/token_validation_service/bench_setup.go
@@ -24,6 +24,7 @@ func GenerateConfigWS(testdataDir string) error {
 	fscTopology.AddNodeByName("test-node")
 
 	_, err := integration.GenerateAt(8099, testdataDir, false, fscTopology)
+
 	return err
 }
 

--- a/cmd/token_validation_service/bench_setup_test.go
+++ b/cmd/token_validation_service/bench_setup_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bench
+
+import (
+	"github.com/hyperledger-labs/fabric-smart-client/integration"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/benchmark/node"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	fscnode "github.com/hyperledger-labs/fabric-smart-client/node"
+	viewsdk "github.com/hyperledger-labs/fabric-smart-client/platform/view/sdk/dig"
+	viewregistry "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/view"
+)
+
+// generateConfigWS mirrors node.GenerateConfig but uses websocket transport.
+// (node.GenerateConfig uses default LibP2P)
+func generateConfigWS(testdataDir string) error {
+	fscTopology := fsc.NewTopology()
+	fscTopology.P2PCommunicationType = fsc.WebSocket
+	fscTopology.SetLogging("error", "")
+	fscTopology.AddNodeByName("test-node")
+
+	_, err := integration.GenerateAt(8099, testdataDir, false, fscTopology)
+	return err
+}
+
+// setupNodeP2P mirrors node.SetupNode and uses the default websocket transport.
+func setupNodeP2P(confPath string, factories ...node.NamedFactory) (*fscnode.Node, error) {
+	n := fscnode.NewWithConfPath(confPath)
+
+	if err := n.InstallSDK(viewsdk.NewSDK(n)); err != nil {
+		return nil, err
+	}
+
+	if err := n.Start(); err != nil {
+		return nil, err
+	}
+
+	reg := viewregistry.GetRegistry(n)
+	for _, f := range factories {
+		if err := reg.RegisterFactory(f.Name, f.Factory); err != nil {
+			return nil, err
+		}
+	}
+
+	return n, nil
+}

--- a/cmd/token_validation_service/server/main.go
+++ b/cmd/token_validation_service/server/main.go
@@ -13,6 +13,7 @@ import (
 	"path"
 
 	bench "github.com/LFDT-Panurus/panurus/cmd/token_validation_service"
+
 	"github.com/hyperledger-labs/fabric-smart-client/integration/benchmark/node"
 )
 
@@ -21,14 +22,14 @@ func main() {
 	nodeConfPath := path.Join(testdataPath, "fsc", "nodes", "test-node.0")
 
 	// we generate our testdata
-	err := node.GenerateConfig(testdataPath)
+	err := bench.GenerateConfigWS(testdataPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate config: %v\n", err)
 		os.Exit(1)
 	}
 
 	// create server
-	n, err := node.SetupNode(nodeConfPath, node.NamedFactory{
+	n, err := bench.SetupNodeP2P(nodeConfPath, node.NamedFactory{
 		Name:    "token-validation-service",
 		Factory: &bench.TokenValidationServiceViewFactory{},
 	})

--- a/cmd/token_validation_service/token_validation_service_bench.go
+++ b/cmd/token_validation_service/token_validation_service_bench.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,7 +32,8 @@ import (
 
 const (
 	// DefaultTestRoot is the default path to test data for token transfer verification
-	DefaultTestRoot = "../../token/core/zkatdlog/nogh/v1/validator/regression/testdata/32-BLS12_381_BBS_GURVY/transfers_i2_o2"
+	DefaultTestRoot   = "../../token/core/zkatdlog/nogh/v1/regression/testdata/zero/32-BLS12_381_BBS_GURVY"
+	defaultCasePrefix = "transfers_i2_o2_"
 )
 
 var (
@@ -102,55 +104,51 @@ func NewTokenValidationParamsSlice(TestRootPath string) ([]*transferServiceParam
 	if TestRootPath == "" {
 		return nil, errors.New("TestRootPath cannot be empty")
 	}
-	paramsTxt := filepath.Join(filepath.Dir(TestRootPath), "params.txt")
 
-	paramsRaw, err := os.ReadFile(paramsTxt)
+	testdataPath := filepath.Join(TestRootPath, "testdata.json")
+	testdataRaw, err := os.ReadFile(testdataPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read params file %s: %w", paramsTxt, err)
+		return nil, fmt.Errorf("failed to read testdata file %s: %w", testdataPath, err)
 	}
 
-	ppRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(paramsRaw)))
-	if err != nil {
-		return nil, fmt.Errorf("failed to base64-decode params.txt: %w", err)
+	var allCases map[string]struct {
+		ReqRaw string `json:"req_raw"`
+		TXID   string `json:"txid"`
+	}
+	if err := json.Unmarshal(testdataRaw, &allCases); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal testdata file: %w", err)
 	}
 
-	outPaths, err := os.ReadDir(TestRootPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read directory %s: %w", TestRootPath, err)
-	}
-	ret := make([]*transferServiceParams, len(outPaths))
-	for i, outPath := range outPaths {
-		params, err := newTokenValidationParams(filepath.Join(TestRootPath, outPath.Name()), ppRaw)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create params for %s: %w", outPath.Name(), err)
+	keys := make([]string, 0, len(allCases))
+	for key := range allCases {
+		if strings.HasPrefix(key, defaultCasePrefix) {
+			keys = append(keys, key)
 		}
-		ret[i] = params
+	}
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("no test cases with prefix %q found in %s", defaultCasePrefix, testdataPath)
+	}
+	sort.Strings(keys)
+
+	caseFamily := strings.TrimSuffix(defaultCasePrefix, "_")
+	ret := make([]*transferServiceParams, 0, len(keys))
+	for _, key := range keys {
+		tokenCase := allCases[key]
+		reqRaw, err := base64.StdEncoding.DecodeString(tokenCase.ReqRaw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to base64-decode req_raw for %s: %w", key, err)
+		}
+		ret = append(ret, &transferServiceParams{
+			// Synthetic path: <configDir>/<caseFamily>/<idx> for path-based helpers.
+			OutputPath: filepath.Join(TestRootPath, caseFamily, strings.TrimPrefix(key, defaultCasePrefix)),
+			TokenData: &TokenData{
+				TokenRequestRaw: reqRaw,
+				TxID:            tokenCase.TXID,
+			},
+		})
 	}
 
 	return ret, nil
-}
-
-func newTokenValidationParams(outputPath string, ppRaw []byte) (*transferServiceParams, error) {
-	outputRaw, err := os.ReadFile(outputPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read %s: %w", outputPath, err)
-	}
-
-	var tokenData struct {
-		ReqRaw []byte `json:"req_raw"`
-		TXID   string `json:"txid"`
-	}
-	if err := json.Unmarshal(outputRaw, &tokenData); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal output file: %w", err)
-	}
-
-	return &transferServiceParams{
-		OutputPath: outputPath,
-		TokenData: &TokenData{
-			TokenRequestRaw: tokenData.ReqRaw,
-			TxID:            tokenData.TXID,
-		},
-	}, nil
 }
 
 type fakeLedger struct{}

--- a/docs/drivers/benchmark/token_validation_service_benchmark.md
+++ b/docs/drivers/benchmark/token_validation_service_benchmark.md
@@ -38,17 +38,17 @@ The Token Validation Service benchmarks serve several critical purposes:
 Panurus comes pre-equipped with test data containing cryptographic parameters and sample token transfers located at:
 
 ```
-token/core/zkatdlog/nogh/v1/validator/regression/testdata/
+token/core/zkatdlog/nogh/v1/validator/regression/testdata/zero
 ```
 
 This directory includes:
 - Public parameters for zero-knowledge proofs (e.g., `32-BLS12_381_BBS_GURVY/params.txt`)
-- Pre-generated token transfer test cases in subdirectories like `transfers_i2_o2/`
+- Pre-generated token transfer test cases in `testdata/`
 
 **Note**: The test data is already included in the repository. You only need to regenerate it if you want to create custom test cases with different parameters or token configurations. To regenerate test data on demand:
 
 ```bash
-cd token/core/zkatdlog/nogh/v1/validator
+cd token/core/zkatdlog/nogh/v1/regression
 go test -run TestRegression -v
 ```
 - Sample token commitments and metadata


### PR DESCRIPTION
### Motivation

We need to align the benchmarks with recent structural changes
Benchmarks break without this

### Overview:
1. In `cmd/token_validation_service/bench_setup.go`  we handle setting up FSC nodes with WebSocket as P2P service 
    The benchmarks then all use this instead of `node` directly. 
2. Benchmarks also read from testdata files instead of the old way (from the folder structure)

 ### Scope 
 limited to `cmd/token_validation_service`