### PR TITLE
fix(zkatdlog): close unauthenticated validator DoS in issue path (#1954)

### DIFF
--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp_test.go
@@ -164,9 +164,21 @@ func TestRangeProofOutOfRange(t *testing.T) {
 			prover.WithTranscriptHeader([]byte("transcript-header"))
 
 			// the proof is still generated, the verification will fail though
-			_, err = prover.Prove()
+			proof, err := prover.Prove()
 			require.NoError(t, err)
-			// require.Contains(t, err.Error(), "does not fit")
+
+			verifier := &rangeVerifier{
+				VGenerators:  vGens,
+				AGenerators:  aGens,
+				BGenerators:  bGens,
+				VCommitment:  vComm,
+				NumberOfBits: n,
+				Curve:        curve,
+			}
+			verifier.WithTranscriptHeader([]byte("transcript-header"))
+
+			err = verifier.Verify(proof)
+			require.Error(t, err, "out-of-range value must be rejected by verifier")
 		})
 	}
 }

--- a/token/core/zkatdlog/nogh/v1/issue/action.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action.go
@@ -204,6 +204,9 @@ func (i *Action) Validate() error {
 		if output == nil {
 			return ErrNilOutput
 		}
+		if err := output.Validate(false); err != nil {
+			return errors.Join(ErrInvalidOutput, err)
+		}
 	}
 	if i.ProofType != rp.RangeProofType && i.ProofType != rp.CSPRangeProofType {
 		return ErrInvalidProofType
@@ -343,6 +346,9 @@ func (i *Action) GetCommitments() ([]*math.G1, error) {
 	for j := range com {
 		if i.Outputs[j] == nil {
 			return nil, ErrNilOutput
+		}
+		if i.Outputs[j].Data == nil {
+			return nil, ErrNilOutputData
 		}
 		com[j] = i.Outputs[j].Data
 	}

--- a/token/core/zkatdlog/nogh/v1/issue/action_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/action_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/json"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/protos-go/v1/actions"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
+	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/proto"
@@ -236,4 +237,43 @@ func TestValidate(t *testing.T) {
 
 	// Valid action again
 	require.NoError(t, action.Validate())
+}
+
+// TestValidateRejectsNilOutputCommitment guards against a nil output commitment
+// (e.g. an attacker-supplied G1 proto with empty Raw bytes, which deserializes to
+// nil without error) reaching zero-knowledge verification, where it previously
+// caused a nil-pointer-dereference panic in mathlib.G1.Copy inside the verifier
+// (issue/verifier.go), before any issuer-authorization or signature check runs.
+func TestValidateRejectsNilOutputCommitment(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	pp, err := v1.Setup(32, nil, math.BN254)
+	require.NoError(t, err)
+
+	tokens, tw, err := token.GetTokensWithWitness([]uint64{10}, "ABC", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+	prover, err := NewProver(tw, tokens, pp)
+	require.NoError(t, err)
+	proofBytes, err := prover.Prove()
+	require.NoError(t, err)
+
+	action := &Action{
+		Issuer: []byte("issuer"),
+		Outputs: []*token.Token{
+			{Owner: []byte("alice"), Data: nil},
+		},
+		ProofType: rp.RangeProofType,
+		Proof:     proofBytes,
+	}
+
+	err = action.Validate()
+	require.ErrorIs(t, err, ErrInvalidOutput)
+
+	_, err = action.GetCommitments()
+	require.ErrorIs(t, err, ErrNilOutputData)
+
+	require.NotPanics(t, func() {
+		verifier, verr := NewVerifier(tokens, pp, action.ProofType)
+		require.NoError(t, verr)
+		_ = verifier.Verify(action.GetProof())
+	})
 }

--- a/token/core/zkatdlog/nogh/v1/issue/errors.go
+++ b/token/core/zkatdlog/nogh/v1/issue/errors.go
@@ -13,6 +13,10 @@ var (
 	ErrOwnerTokenMismatch = errors.New("number of owners does not match number of tokens")
 	// ErrNilOutput is returned when there is a nil output in an issue action
 	ErrNilOutput = errors.New("nil output in issue action")
+	// ErrNilOutputData is returned when an issue action output has a nil commitment
+	ErrNilOutputData = errors.New("nil output commitment in issue action")
+	// ErrInvalidOutput is returned when an issue action output fails structural validation
+	ErrInvalidOutput = errors.New("invalid output in issue action")
 	// ErrInvalidProtocolVersion is returned when the protocol version is invalid
 	ErrInvalidProtocolVersion = errors.New("invalid protocol version")
 	// ErrIssuerNotSet is returned when the issuer is not set

--- a/token/core/zkatdlog/nogh/v1/issue/sametype.go
+++ b/token/core/zkatdlog/nogh/v1/issue/sametype.go
@@ -10,6 +10,7 @@ import (
 	math "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/asn1"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/common"
+	math2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/math"
 	token2 "github.com/LFDT-Panurus/panurus/token/token"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 )
@@ -58,6 +59,26 @@ func (stp *SameType) Deserialize(bytes []byte) error {
 	stp.CommitmentToType, err = unmarshaller.NextG1()
 	if err != nil {
 		return errors.Join(ErrDeserializeCommitmentToTypeFailed, err)
+	}
+
+	return nil
+}
+
+// Validate ensures the proof elements are valid for the given curve, rejecting nil or
+// otherwise malformed fields before they are used in verification (Copy/Mul/Sub), so
+// that a proof deserialized from truncated attacker-supplied bytes cannot panic.
+func (stp *SameType) Validate(curveID math.CurveID) error {
+	if err := math2.CheckBaseElement(stp.Type, curveID); err != nil {
+		return errors.Join(ErrInvalidSameTypeProof, errors.Wrap(err, "invalid type"))
+	}
+	if err := math2.CheckBaseElement(stp.BlindingFactor, curveID); err != nil {
+		return errors.Join(ErrInvalidSameTypeProof, errors.Wrap(err, "invalid blinding factor"))
+	}
+	if err := math2.CheckBaseElement(stp.Challenge, curveID); err != nil {
+		return errors.Join(ErrInvalidSameTypeProof, errors.Wrap(err, "invalid challenge"))
+	}
+	if err := math2.CheckElement(stp.CommitmentToType, curveID); err != nil {
+		return errors.Join(ErrInvalidSameTypeProof, errors.Wrap(err, "invalid commitment to type"))
 	}
 
 	return nil

--- a/token/core/zkatdlog/nogh/v1/issue/sametype_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/sametype_test.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 
 	math "github.com/IBM/mathlib"
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/asn1"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/issue"
+	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,4 +163,56 @@ func TestSameTypeVerify_ForgedCommitmentToType(t *testing.T) {
 	proof.CommitmentToType = originalCommitment
 	err = verifier.Verify(proof)
 	require.NoError(t, err, "T-GAP-C5: restored proof must still pass verification")
+}
+
+// rawSerializer wraps pre-marshalled bytes to satisfy asn1.Serializer, letting the
+// test inject an already-corrupted SameType sub-proof into a BulletProof envelope.
+type rawSerializer struct {
+	raw []byte
+}
+
+func (r *rawSerializer) Serialize() ([]byte, error) { return r.raw, nil }
+func (r *rawSerializer) Deserialize([]byte) error   { return nil }
+
+// TestBulletProofVerifierRejectsTruncatedSameTypeProof guards against a BulletProof
+// whose SameType sub-proof was serialized with missing trailing ASN.1 elements. In
+// that case Deserialize leaves Challenge/CommitmentToType nil without returning an
+// error (asn1.NextZr/NextG1 return (nil, nil) past the end of the encoded values),
+// and previously the missing SameType.Validate step let those nil fields reach
+// SameTypeVerifier.Verify's Mul/Sub calls and BulletProofVerifier.Verify's
+// CommitmentToType.Copy(), panicking instead of returning an error.
+func TestBulletProofVerifierRejectsTruncatedSameTypeProof(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	pp, err := v1.Setup(32, nil, math.BN254)
+	require.NoError(t, err)
+
+	tokens, tw, err := token.GetTokensWithWitness([]uint64{10}, "ABC", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+	prover, err := issue.NewProver(tw, tokens, pp)
+	require.NoError(t, err)
+	proofBytes, err := prover.Prove()
+	require.NoError(t, err)
+
+	bp := &issue.BulletProof{}
+	require.NoError(t, bp.Deserialize(proofBytes))
+
+	// Truncate the SameType sub-proof to only its first 2 of 4 elements.
+	truncatedSameType, err := asn1.MarshalMath(bp.SameType.Type, bp.SameType.BlindingFactor)
+	require.NoError(t, err)
+
+	corrupted, err := asn1.Marshal[asn1.Serializer](
+		&rawSerializer{truncatedSameType},
+		bp.RangeCorrectness,
+	)
+	require.NoError(t, err)
+
+	verifier, err := issue.NewVerifier(tokens, pp, rp.RangeProofType)
+	require.NoError(t, err)
+
+	var verifyErr error
+	require.NotPanics(t, func() {
+		verifyErr = verifier.Verify(corrupted)
+	})
+	require.Error(t, verifyErr)
+	require.ErrorIs(t, verifyErr, issue.ErrInvalidIssueProof)
 }

--- a/token/core/zkatdlog/nogh/v1/issue/verifier.go
+++ b/token/core/zkatdlog/nogh/v1/issue/verifier.go
@@ -19,11 +19,13 @@ type BulletProofVerifier struct {
 	SameType *SameTypeVerifier
 	// RangeCorrectness is the verifier for the range correctness property.
 	RangeCorrectness *bulletproof.RangeCorrectnessVerifier
+	// curveID is the curve the proof elements are expected to belong to.
+	curveID math.CurveID
 }
 
 // NewBulletProofVerifier instantiates a BulletProofVerifier for the given token commitments and public parameters.
 func NewBulletProofVerifier(tokens []*math.G1, pp *v1.PublicParams) *BulletProofVerifier {
-	v := &BulletProofVerifier{}
+	v := &BulletProofVerifier{curveID: pp.Curve}
 	v.SameType = NewSameTypeVerifier(tokens, pp.PedersenGenerators, math.Curves[pp.Curve])
 	v.RangeCorrectness = bulletproof.NewRangeCorrectnessVerifier(pp.PedersenGenerators[1:], pp.RangeProofParams.LeftGenerators, pp.RangeProofParams.RightGenerators, pp.RangeProofParams.P, pp.RangeProofParams.Q, pp.RangeProofParams.BitLength, pp.RangeProofParams.NumberOfRounds, math.Curves[pp.Curve], pp.ExecutorProvider)
 
@@ -38,6 +40,12 @@ func (v *BulletProofVerifier) Verify(proof []byte) error {
 	err := tp.Deserialize(proof)
 	if err != nil {
 		return errors.Join(ErrDeserializeProofFailed, err)
+	}
+	// Validate the same-type proof structurally before it is used: a proof deserialized
+	// from truncated bytes can have nil fields, which would otherwise panic below
+	// (e.g. CommitmentToType.Copy()) or inside SameType.Verify's Mul/Sub calls.
+	if err := tp.SameType.Validate(v.curveID); err != nil {
+		return errors.Join(ErrInvalidIssueProof, err)
 	}
 	// Verify the same-type proof.
 	err = v.SameType.Verify(tp.SameType)

--- a/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_fuzz_test.go
@@ -81,6 +81,57 @@ func validTransferRaw(tb testing.TB, proofType rp.ProofType, redeem bool) []byte
 	return raw
 }
 
+// issueRawWithNilOutputData returns the serialized bytes of an issue action whose sole
+// output commitment is nil. Action.Serialize encodes a nil Data as a G1 proto with an
+// empty Raw field (utils.ToProtoG1), which utils.FromG1Proto then decodes back to nil
+// without error on the other side (empty Raw is treated as "absent", not malformed).
+// This is exactly the wire shape that let a nil commitment reach ZK verification and
+// panic before issue/action.go's Validate/GetCommitments guards were added.
+func issueRawWithNilOutputData(tb testing.TB) []byte {
+	tb.Helper()
+	raw, err := (&issue.Action{
+		Issuer: []byte("issuer"),
+		Outputs: []*token.Token{
+			{Owner: []byte("owner-1"), Data: nil},
+		},
+		ProofType: rp.RangeProofType,
+		Proof:     []byte("proof"),
+	}).Serialize()
+	require.NoError(tb, err)
+
+	return raw
+}
+
+// FuzzIssueActionValidateNoPanic fuzzes issue.Action.Deserialize followed by Validate
+// and GetCommitments on arbitrary bytes. These are the exact calls IssueValidate makes
+// before any issuer-authorization or signature check runs, so a nil-deref anywhere in
+// this chain is an unauthenticated validator DoS. The seed corpus includes a
+// nil-output-commitment action (the fixed bug) so a regression is caught immediately.
+func FuzzIssueActionValidateNoPanic(f *testing.F) {
+	f.Add(validIssueRaw(f, rp.RangeProofType))
+	f.Add(validIssueRaw(f, rp.CSPRangeProofType))
+	f.Add(issueRawWithNilOutputData(f))
+	f.Add([]byte{})
+	f.Add([]byte("malformed"))
+
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		if len(raw) > maxFuzzActionBytes {
+			t.Skip()
+		}
+
+		require.NotPanics(t, func() {
+			action := &issue.Action{}
+			if err := action.Deserialize(raw); err != nil {
+				return
+			}
+			if err := action.Validate(); err != nil {
+				return
+			}
+			_, _ = action.GetCommitments()
+		})
+	})
+}
+
 func actionTypeFor(kind uint8) request.ActionType {
 	if kind%2 == 1 {
 		return request.ActionType_ACTION_TYPE_TRANSFER

--- a/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
+++ b/token/core/zkatdlog/nogh/v1/validator/validator_security_test.go
@@ -20,8 +20,10 @@ import (
 
 	math "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/token/core/common"
+	"github.com/LFDT-Panurus/panurus/token/core/common/encoding/asn1"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/benchmark"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/issue"
 	v1 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
 	testing2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/testutils"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
@@ -1080,3 +1082,110 @@ func TestSecurityAuditing_OneValidOneBadSignature(t *testing.T) {
 	require.Error(t, err, "T-GAP-8: forged auditor signature must cause rejection")
 	assert.Contains(t, err.Error(), "failed to verify auditor's signature")
 }
+
+// ===========================================================================
+// ISSUE-ACTION DoS REGRESSION TESTS (validator entry point)
+// ===========================================================================
+
+// tamperIssueAction deserializes the sole issue action carried by env.TRWithIssue,
+// applies mutate to it, re-serializes it back into env.TRWithIssue.Actions[0].Raw,
+// and neutralizes the auditing gate so the tampered request reaches IssueValidate's
+// ZK-verification code path instead of being rejected earlier for a stale auditor
+// signature. Tampering the action's raw bytes changes the message that was
+// originally signed (TokenRequest.MarshalToMessageToSign covers all Actions), so any
+// signature computed over the original bytes no longer verifies; the auditor check
+// runs before IssueValidate in the pipeline, so it must be disabled explicitly. The
+// stale action signature is left in place: IssueValidate runs action.Validate,
+// action.GetCommitments and zkVerifier.Verify before the issuer/signature checks, so
+// the intended error surfaces first regardless.
+func tamperIssueAction(t *testing.T, env *testing2.Env, mutate func(*issue.Action)) []byte {
+	t.Helper()
+
+	env.Engine.PublicParams.AuditorIDs = nil
+	var stripped []*driver.RequestSignature
+	for _, sig := range env.TRWithIssue.Signatures {
+		if sig != nil && sig.Auditor == nil {
+			stripped = append(stripped, sig)
+		}
+	}
+	env.TRWithIssue.Signatures = stripped
+
+	require.Len(t, env.TRWithIssue.Actions, 1)
+	action := &issue.Action{}
+	require.NoError(t, action.Deserialize(env.TRWithIssue.Actions[0].Raw))
+
+	mutate(action)
+
+	raw, err := action.Serialize()
+	require.NoError(t, err)
+	env.TRWithIssue.Actions[0].Raw = raw
+
+	trRaw, err := env.TRWithIssue.Bytes()
+	require.NoError(t, err)
+
+	return trRaw
+}
+
+// TestSecurityValidatorRejectsNilOutputCommitmentInIssueRequest guards against the
+// nil-output-commitment DoS (fixed in issue/action.go) at the real validator entry
+// point, not just at the unit level. An attacker-supplied issue action whose output
+// commitment (Data) is nil must be rejected by Engine.VerifyTokenRequestFromRaw with
+// an error, never a panic.
+func TestSecurityValidatorRejectsNilOutputCommitmentInIssueRequest(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw := tamperIssueAction(t, env, func(action *issue.Action) {
+		require.NotEmpty(t, action.Outputs)
+		action.Outputs[0].Data = nil
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	})
+	require.Error(t, err)
+}
+
+// TestSecurityValidatorRejectsTruncatedSameTypeProofInIssueRequest guards against the
+// SameType-proof-missing-Validate DoS (fixed in issue/sametype.go and
+// issue/verifier.go) at the real validator entry point. An attacker-supplied issue
+// action whose BulletProof.SameType sub-proof was truncated to fewer ASN.1 elements
+// deserializes without error (nil trailing fields), and must be rejected by
+// Engine.VerifyTokenRequestFromRaw with an error, never a panic.
+func TestSecurityValidatorRejectsTruncatedSameTypeProofInIssueRequest(t *testing.T) {
+	env := newSecurityTestEnv(t)
+
+	raw := tamperIssueAction(t, env, func(action *issue.Action) {
+		require.Equal(t, rp.RangeProofType, action.ProofType)
+
+		bp := &issue.BulletProof{}
+		require.NoError(t, bp.Deserialize(action.Proof))
+
+		truncatedSameType, err := asn1.MarshalMath(bp.SameType.Type, bp.SameType.BlindingFactor)
+		require.NoError(t, err)
+
+		corrupted, err := asn1.Marshal[asn1.Serializer](
+			&rawIssueProofSerializer{truncatedSameType},
+			bp.RangeCorrectness,
+		)
+		require.NoError(t, err)
+
+		action.Proof = corrupted
+	})
+
+	var err error
+	require.NotPanics(t, func() {
+		_, _, err = env.Engine.VerifyTokenRequestFromRaw(context.Background(), nil, "1", raw)
+	})
+	require.Error(t, err)
+}
+
+// rawIssueProofSerializer wraps pre-marshalled bytes to satisfy asn1.Serializer,
+// letting the test inject an already-corrupted SameType sub-proof into a BulletProof
+// envelope (mirrors issue/sametype_test.go's rawSerializer).
+type rawIssueProofSerializer struct {
+	raw []byte
+}
+
+func (r *rawIssueProofSerializer) Serialize() ([]byte, error) { return r.raw, nil }
+func (r *rawIssueProofSerializer) Deserialize([]byte) error   { return nil }


### PR DESCRIPTION
Fixes #1954

## Problem

Two unauthenticated denial-of-service vectors existed in the zkatdlog/nogh/v1 issue-action validation path. A crafted issue action reaching `IssueValidate` could trigger a nil-pointer-dereference panic during zero-knowledge verification, **before** issuer authorization or signature checks run — so no valid issuer credential or signature was required to crash the validating goroutine.

1. **Nil output commitment.** `utils.FromG1Proto` returns `(nil, nil)` for an empty proto `Raw` field, so an output with an empty commitment deserializes cleanly with `Outputs[j].Data == nil`. Neither `Action.Validate` nor `Action.GetCommitments` checked for this, and `issue.Verifier.Verify` panicked calling `.Copy()` on the nil element.
2. **Truncated SameType sub-proof.** ASN.1 decoding (`asn1.NextG1`/`NextZr`) returns `(nil, nil)` — not an error — for elements past the end of the encoded values. `SameType` had no `Validate` method (unlike its transfer-side sibling `TypeAndSumProof.Validate`), so a proof with missing trailing elements deserialized with nil fields that later panicked in `.Mul()`/`.Sub()`/`.Copy()` calls.

The transfer path was already protected against the first case (`transfer.Action.Validate` calls `token.Token.Validate(false)`); the issue path never called the equivalent guard.

## Fix

- `issue.Action.Validate`/`GetCommitments` now reject nil output commitments, mirroring the transfer path's guard.
- Added `issue.SameType.Validate`, mirroring `transfer.TypeAndSumProof.Validate`, invoked in `BulletProofVerifier.Verify` immediately after deserialization and before any field is used.

## Testing

- Unit tests for both vectors in the `issue` package (`action_test.go`, `sametype_test.go`), asserting an error is returned (not a panic).
- Validator-entry-point regression tests in `validator/validator_security_test.go` exercising `Engine.VerifyTokenRequestFromRaw` end-to-end for both vectors.
- New fuzz target `FuzzIssueActionValidateNoPanic` in `validator/validator_fuzz_test.go` driving `issue.Action.Deserialize` → `Validate` → `GetCommitments` under `require.NotPanics`, seeded with the nil-commitment wire shape. Ran 30s locally (677k executions, 0 crashes) with no new corpus entries.
- Promoted a scratch positive-regression test for the CSP range-verifier's out-of-range rejection into `crypto/rp/csp/rp_test.go` (unrelated to the DoS fix, but was sitting uncommitted in the same investigation).
- Full suite green with `-race`: `validator`, `issue`, `transfer`, `crypto/rp/{bulletproof,csp,executor}`.
- `make lint-auto-fix && make checks` clean.

## Investigated, no change needed

The CSP range-proof verifier's `expectedRounds` (in `validateRangeProof`) is derived from the proof's own `Left` slice length rather than from a verifier-side parameter. Traced this through `rangeVerifier.Verify`: the round count actually used for indexing (`cspRounds`) is computed independently from `NumberOfBits` (a public parameter), and the inner CSP verifier re-validates the proof's lengths against that correct value before any indexing occurs. A self-consistent-but-wrong-length proof is safely rejected there, so this is not exploitable — no fix applied.
