### PR TITLE
perf(ttx/finality): push confirmed status events and replace per-waiter fallback polling with a shared batch poller

### DIFF
--- a/docs/services/ttx.md
+++ b/docs/services/ttx.md
@@ -497,6 +497,8 @@ Once fully endorsed, the transaction metadata is distributed to all recipients s
 
 The `FinalityView` allows applications to wait for a transaction to be committed to the ledger. Internally, Panurus's **Network Service** listens for ledger events. When a transaction reaches finality, the Network Service notifies Panurus, which then updates the local `Transactions DB` and `Tokens DB` to reflect the new state.
 
+Waiting is push-first: each waiter registers a status listener on the local database (`TTXDB` or `AuditDB`), checks the status once to cover the registration race, and then blocks until a status event arrives. Status writes — including the confirmed commit path — push the event in-process. As a safety net for lost push events, a single fallback poller per database batch-fetches the statuses of all waited-on transactions (`GetStatuses`) and re-publishes terminal ones; it sweeps at the smallest polling interval among the active waiters (`WithPollingTimeout`, default 1s) and stops when no waiter remains. There is no per-transaction polling.
+
 ### Transaction Recovery
 
 Panurus includes an automatic recovery mechanism to handle pending transactions that may have lost their finality listeners due to node restarts, network interruptions, or other failures. 

--- a/token/services/network/fabric/network.go
+++ b/token/services/network/fabric/network.go
@@ -649,6 +649,7 @@ type transactionDB interface {
 	NewTransaction() (storage.TransactionStoreTransaction, error)
 	GetTokenRequest(ctx context.Context, txID string) ([]byte, error)
 	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
+	NotifyStatus(ctx context.Context, txID string, status storage.TxStatus, message string)
 	AcquireRecoveryLeadership(ctx context.Context, lockID int64) (recovery2.Leadership, bool, error)
 	ClaimPendingTransactions(ctx context.Context, olderThan time.Duration, leaseDuration time.Duration, limit int, owner string) ([]*ttxdb.RecoveryClaim, error)
 	ReleaseRecoveryClaim(ctx context.Context, txID string, owner string, message string) error

--- a/token/services/storage/auditdb/store.go
+++ b/token/services/storage/auditdb/store.go
@@ -290,14 +290,17 @@ func (d *StoreService) SetStatus(ctx context.Context, txID string, status dbdriv
 	}
 
 	// notify the listeners
-	d.Notify(common.StatusEvent{
-		Ctx:            ctx,
-		TxID:           txID,
-		ValidationCode: status,
-	})
+	d.NotifyStatus(ctx, txID, status, message)
 	logger.DebugfContext(ctx, "set status [%s][%s]...done without errors", txID, dbdriver.TxStatusMessage[status])
 
 	return nil
+}
+
+// NotifyStatus pushes a status event to the in-process listeners without
+// touching the database. Used after a transaction-scoped status update,
+// which bypasses SetStatus.
+func (d *StoreService) NotifyStatus(ctx context.Context, txID string, status dbdriver.TxStatus, message string) {
+	d.Notify(common.StatusEvent{Ctx: ctx, TxID: txID, ValidationCode: status, ValidationMessage: message})
 }
 
 // GetStatus return the status of the given transaction id.

--- a/token/services/storage/db/common/status.go
+++ b/token/services/storage/db/common/status.go
@@ -47,6 +47,21 @@ func (c *StatusSupport) AddStatusListener(txID string, ch chan StatusEvent) {
 	c.listeners[txID] = ls
 }
 
+// ListenerTxIDs returns the tx ids that currently have at least one
+// registered status listener. Used by fallback pollers to scope batch
+// status lookups to transactions someone is actually waiting on.
+func (c *StatusSupport) ListenerTxIDs() []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	txIDs := make([]string, 0, len(c.listeners))
+	for txID := range c.listeners {
+		txIDs = append(txIDs, txID)
+	}
+
+	return txIDs
+}
+
 func (c *StatusSupport) DeleteStatusListener(txID string, ch chan StatusEvent) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/token/services/storage/ttxdb/store.go
+++ b/token/services/storage/ttxdb/store.go
@@ -250,14 +250,17 @@ func (d *StoreService) SetStatus(ctx context.Context, txID string, status dbdriv
 	}
 
 	// notify the listeners
-	d.Notify(common.StatusEvent{
-		Ctx:            ctx,
-		TxID:           txID,
-		ValidationCode: status,
-	})
+	d.NotifyStatus(ctx, txID, status, message)
 	logger.DebugfContext(ctx, "set status [%s][%s] done", txID, dbdriver.TxStatusMessage[status])
 
 	return nil
+}
+
+// NotifyStatus pushes a status event to the in-process listeners without
+// touching the database. Used after a transaction-scoped status update,
+// which bypasses SetStatus.
+func (d *StoreService) NotifyStatus(ctx context.Context, txID string, status dbdriver.TxStatus, message string) {
+	d.Notify(common.StatusEvent{Ctx: ctx, TxID: txID, ValidationCode: status, ValidationMessage: message})
 }
 
 // GetStatus return the status of the given transaction id.

--- a/token/services/ttx/dep/mock/audit_db.go
+++ b/token/services/ttx/dep/mock/audit_db.go
@@ -39,6 +39,38 @@ type AuditDB struct {
 		result2 string
 		result3 error
 	}
+	GetStatusesStub        func(context.Context, []string) (map[string]token.TxStatus, error)
+	getStatusesMutex       sync.RWMutex
+	getStatusesArgsForCall []struct {
+		arg1 context.Context
+		arg2 []string
+	}
+	getStatusesReturns struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}
+	getStatusesReturnsOnCall map[int]struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}
+	ListenerTxIDsStub        func() []string
+	listenerTxIDsMutex       sync.RWMutex
+	listenerTxIDsArgsForCall []struct {
+	}
+	listenerTxIDsReturns struct {
+		result1 []string
+	}
+	listenerTxIDsReturnsOnCall map[int]struct {
+		result1 []string
+	}
+	NotifyStatusStub        func(context.Context, string, token.TxStatus, string)
+	notifyStatusMutex       sync.RWMutex
+	notifyStatusArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 token.TxStatus
+		arg4 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -175,6 +207,164 @@ func (fake *AuditDB) GetStatusReturnsOnCall(i int, result1 token.TxStatus, resul
 		result2 string
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *AuditDB) GetStatuses(arg1 context.Context, arg2 []string) (map[string]token.TxStatus, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.getStatusesMutex.Lock()
+	ret, specificReturn := fake.getStatusesReturnsOnCall[len(fake.getStatusesArgsForCall)]
+	fake.getStatusesArgsForCall = append(fake.getStatusesArgsForCall, struct {
+		arg1 context.Context
+		arg2 []string
+	}{arg1, arg2Copy})
+	stub := fake.GetStatusesStub
+	fakeReturns := fake.getStatusesReturns
+	fake.recordInvocation("GetStatuses", []interface{}{arg1, arg2Copy})
+	fake.getStatusesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *AuditDB) GetStatusesCallCount() int {
+	fake.getStatusesMutex.RLock()
+	defer fake.getStatusesMutex.RUnlock()
+	return len(fake.getStatusesArgsForCall)
+}
+
+func (fake *AuditDB) GetStatusesCalls(stub func(context.Context, []string) (map[string]token.TxStatus, error)) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = stub
+}
+
+func (fake *AuditDB) GetStatusesArgsForCall(i int) (context.Context, []string) {
+	fake.getStatusesMutex.RLock()
+	defer fake.getStatusesMutex.RUnlock()
+	argsForCall := fake.getStatusesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *AuditDB) GetStatusesReturns(result1 map[string]token.TxStatus, result2 error) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = nil
+	fake.getStatusesReturns = struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *AuditDB) GetStatusesReturnsOnCall(i int, result1 map[string]token.TxStatus, result2 error) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = nil
+	if fake.getStatusesReturnsOnCall == nil {
+		fake.getStatusesReturnsOnCall = make(map[int]struct {
+			result1 map[string]token.TxStatus
+			result2 error
+		})
+	}
+	fake.getStatusesReturnsOnCall[i] = struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *AuditDB) ListenerTxIDs() []string {
+	fake.listenerTxIDsMutex.Lock()
+	ret, specificReturn := fake.listenerTxIDsReturnsOnCall[len(fake.listenerTxIDsArgsForCall)]
+	fake.listenerTxIDsArgsForCall = append(fake.listenerTxIDsArgsForCall, struct {
+	}{})
+	stub := fake.ListenerTxIDsStub
+	fakeReturns := fake.listenerTxIDsReturns
+	fake.recordInvocation("ListenerTxIDs", []interface{}{})
+	fake.listenerTxIDsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *AuditDB) ListenerTxIDsCallCount() int {
+	fake.listenerTxIDsMutex.RLock()
+	defer fake.listenerTxIDsMutex.RUnlock()
+	return len(fake.listenerTxIDsArgsForCall)
+}
+
+func (fake *AuditDB) ListenerTxIDsCalls(stub func() []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = stub
+}
+
+func (fake *AuditDB) ListenerTxIDsReturns(result1 []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = nil
+	fake.listenerTxIDsReturns = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *AuditDB) ListenerTxIDsReturnsOnCall(i int, result1 []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = nil
+	if fake.listenerTxIDsReturnsOnCall == nil {
+		fake.listenerTxIDsReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.listenerTxIDsReturnsOnCall[i] = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *AuditDB) NotifyStatus(arg1 context.Context, arg2 string, arg3 token.TxStatus, arg4 string) {
+	fake.notifyStatusMutex.Lock()
+	fake.notifyStatusArgsForCall = append(fake.notifyStatusArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 token.TxStatus
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.NotifyStatusStub
+	fake.recordInvocation("NotifyStatus", []interface{}{arg1, arg2, arg3, arg4})
+	fake.notifyStatusMutex.Unlock()
+	if stub != nil {
+		fake.NotifyStatusStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *AuditDB) NotifyStatusCallCount() int {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	return len(fake.notifyStatusArgsForCall)
+}
+
+func (fake *AuditDB) NotifyStatusCalls(stub func(context.Context, string, token.TxStatus, string)) {
+	fake.notifyStatusMutex.Lock()
+	defer fake.notifyStatusMutex.Unlock()
+	fake.NotifyStatusStub = stub
+}
+
+func (fake *AuditDB) NotifyStatusArgsForCall(i int) (context.Context, string, token.TxStatus, string) {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	argsForCall := fake.notifyStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *AuditDB) Invocations() map[string][][]interface{} {

--- a/token/services/ttx/dep/mock/transaction_db.go
+++ b/token/services/ttx/dep/mock/transaction_db.go
@@ -39,6 +39,38 @@ type TransactionDB struct {
 		result2 string
 		result3 error
 	}
+	GetStatusesStub        func(context.Context, []string) (map[string]token.TxStatus, error)
+	getStatusesMutex       sync.RWMutex
+	getStatusesArgsForCall []struct {
+		arg1 context.Context
+		arg2 []string
+	}
+	getStatusesReturns struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}
+	getStatusesReturnsOnCall map[int]struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}
+	ListenerTxIDsStub        func() []string
+	listenerTxIDsMutex       sync.RWMutex
+	listenerTxIDsArgsForCall []struct {
+	}
+	listenerTxIDsReturns struct {
+		result1 []string
+	}
+	listenerTxIDsReturnsOnCall map[int]struct {
+		result1 []string
+	}
+	NotifyStatusStub        func(context.Context, string, token.TxStatus, string)
+	notifyStatusMutex       sync.RWMutex
+	notifyStatusArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 token.TxStatus
+		arg4 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -175,6 +207,164 @@ func (fake *TransactionDB) GetStatusReturnsOnCall(i int, result1 token.TxStatus,
 		result2 string
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *TransactionDB) GetStatuses(arg1 context.Context, arg2 []string) (map[string]token.TxStatus, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.getStatusesMutex.Lock()
+	ret, specificReturn := fake.getStatusesReturnsOnCall[len(fake.getStatusesArgsForCall)]
+	fake.getStatusesArgsForCall = append(fake.getStatusesArgsForCall, struct {
+		arg1 context.Context
+		arg2 []string
+	}{arg1, arg2Copy})
+	stub := fake.GetStatusesStub
+	fakeReturns := fake.getStatusesReturns
+	fake.recordInvocation("GetStatuses", []interface{}{arg1, arg2Copy})
+	fake.getStatusesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *TransactionDB) GetStatusesCallCount() int {
+	fake.getStatusesMutex.RLock()
+	defer fake.getStatusesMutex.RUnlock()
+	return len(fake.getStatusesArgsForCall)
+}
+
+func (fake *TransactionDB) GetStatusesCalls(stub func(context.Context, []string) (map[string]token.TxStatus, error)) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = stub
+}
+
+func (fake *TransactionDB) GetStatusesArgsForCall(i int) (context.Context, []string) {
+	fake.getStatusesMutex.RLock()
+	defer fake.getStatusesMutex.RUnlock()
+	argsForCall := fake.getStatusesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *TransactionDB) GetStatusesReturns(result1 map[string]token.TxStatus, result2 error) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = nil
+	fake.getStatusesReturns = struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TransactionDB) GetStatusesReturnsOnCall(i int, result1 map[string]token.TxStatus, result2 error) {
+	fake.getStatusesMutex.Lock()
+	defer fake.getStatusesMutex.Unlock()
+	fake.GetStatusesStub = nil
+	if fake.getStatusesReturnsOnCall == nil {
+		fake.getStatusesReturnsOnCall = make(map[int]struct {
+			result1 map[string]token.TxStatus
+			result2 error
+		})
+	}
+	fake.getStatusesReturnsOnCall[i] = struct {
+		result1 map[string]token.TxStatus
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *TransactionDB) ListenerTxIDs() []string {
+	fake.listenerTxIDsMutex.Lock()
+	ret, specificReturn := fake.listenerTxIDsReturnsOnCall[len(fake.listenerTxIDsArgsForCall)]
+	fake.listenerTxIDsArgsForCall = append(fake.listenerTxIDsArgsForCall, struct {
+	}{})
+	stub := fake.ListenerTxIDsStub
+	fakeReturns := fake.listenerTxIDsReturns
+	fake.recordInvocation("ListenerTxIDs", []interface{}{})
+	fake.listenerTxIDsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *TransactionDB) ListenerTxIDsCallCount() int {
+	fake.listenerTxIDsMutex.RLock()
+	defer fake.listenerTxIDsMutex.RUnlock()
+	return len(fake.listenerTxIDsArgsForCall)
+}
+
+func (fake *TransactionDB) ListenerTxIDsCalls(stub func() []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = stub
+}
+
+func (fake *TransactionDB) ListenerTxIDsReturns(result1 []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = nil
+	fake.listenerTxIDsReturns = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *TransactionDB) ListenerTxIDsReturnsOnCall(i int, result1 []string) {
+	fake.listenerTxIDsMutex.Lock()
+	defer fake.listenerTxIDsMutex.Unlock()
+	fake.ListenerTxIDsStub = nil
+	if fake.listenerTxIDsReturnsOnCall == nil {
+		fake.listenerTxIDsReturnsOnCall = make(map[int]struct {
+			result1 []string
+		})
+	}
+	fake.listenerTxIDsReturnsOnCall[i] = struct {
+		result1 []string
+	}{result1}
+}
+
+func (fake *TransactionDB) NotifyStatus(arg1 context.Context, arg2 string, arg3 token.TxStatus, arg4 string) {
+	fake.notifyStatusMutex.Lock()
+	fake.notifyStatusArgsForCall = append(fake.notifyStatusArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 token.TxStatus
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.NotifyStatusStub
+	fake.recordInvocation("NotifyStatus", []interface{}{arg1, arg2, arg3, arg4})
+	fake.notifyStatusMutex.Unlock()
+	if stub != nil {
+		fake.NotifyStatusStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *TransactionDB) NotifyStatusCallCount() int {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	return len(fake.notifyStatusArgsForCall)
+}
+
+func (fake *TransactionDB) NotifyStatusCalls(stub func(context.Context, string, token.TxStatus, string)) {
+	fake.notifyStatusMutex.Lock()
+	defer fake.notifyStatusMutex.Unlock()
+	fake.NotifyStatusStub = stub
+}
+
+func (fake *TransactionDB) NotifyStatusArgsForCall(i int) (context.Context, string, token.TxStatus, string) {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	argsForCall := fake.notifyStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *TransactionDB) Invocations() map[string][][]interface{} {

--- a/token/services/ttx/dep/providers.go
+++ b/token/services/ttx/dep/providers.go
@@ -139,8 +139,11 @@ func GetNetworkIdentityProvider(sp token.ServiceProvider) (NetworkIdentityProvid
 //go:generate counterfeiter -o mock/transaction_db.go -fake-name TransactionDB . TransactionDB
 type TransactionDB interface {
 	GetStatus(ctx context.Context, txID string) (token.TxStatus, string, error)
+	GetStatuses(ctx context.Context, txIDs []string) (map[string]token.TxStatus, error)
 	AddStatusListener(txID string, ch chan db.TransactionStatusEvent)
 	DeleteStatusListener(txID string, ch chan db.TransactionStatusEvent)
+	ListenerTxIDs() []string
+	NotifyStatus(ctx context.Context, txID string, status token.TxStatus, message string)
 }
 
 // TransactionDBProvider is used to retrieves instances of TransactionDB
@@ -170,8 +173,11 @@ func GetTransactionDB(sp token.ServiceProvider, tmsID token.TMSID) (TransactionD
 //go:generate counterfeiter -o mock/audit_db.go -fake-name AuditDB . AuditDB
 type AuditDB interface {
 	GetStatus(ctx context.Context, txID string) (token.TxStatus, string, error)
+	GetStatuses(ctx context.Context, txIDs []string) (map[string]token.TxStatus, error)
 	AddStatusListener(txID string, ch chan db.TransactionStatusEvent)
 	DeleteStatusListener(txID string, ch chan db.TransactionStatusEvent)
+	ListenerTxIDs() []string
+	NotifyStatus(ctx context.Context, txID string, status token.TxStatus, message string)
 }
 
 // AuditDBProvider is used to retrieves instances of AuditDB

--- a/token/services/ttx/dep/wrapper/dbs.go
+++ b/token/services/ttx/dep/wrapper/dbs.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/services"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/auditdb"
+	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/dep"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/dep/db"
@@ -20,11 +21,14 @@ import (
 
 // statusStore is the subset of a transaction/audit store service needed by
 // the batching decorator: the batched status lookup plus the status
-// listener registry, which is passed through untouched.
+// listener registry and notification surface, which are passed through
+// untouched.
 type statusStore interface {
 	statusFetcher
 	AddStatusListener(txID string, ch chan db.TransactionStatusEvent)
 	DeleteStatusListener(txID string, ch chan db.TransactionStatusEvent)
+	ListenerTxIDs() []string
+	NotifyStatus(ctx context.Context, txID string, status dbdriver.TxStatus, message string)
 }
 
 // batchingStatusDB wraps a transaction/audit store service so that
@@ -48,12 +52,26 @@ func (b *batchingStatusDB) GetStatus(ctx context.Context, txID string) (token.Tx
 	return status, "", err
 }
 
+// GetStatuses is already a batch operation, so it goes straight to the store
+// without passing through the single-tx batcher.
+func (b *batchingStatusDB) GetStatuses(ctx context.Context, txIDs []string) (map[string]dbdriver.TxStatus, error) {
+	return b.store.GetStatuses(ctx, txIDs)
+}
+
 func (b *batchingStatusDB) AddStatusListener(txID string, ch chan db.TransactionStatusEvent) {
 	b.store.AddStatusListener(txID, ch)
 }
 
 func (b *batchingStatusDB) DeleteStatusListener(txID string, ch chan db.TransactionStatusEvent) {
 	b.store.DeleteStatusListener(txID, ch)
+}
+
+func (b *batchingStatusDB) ListenerTxIDs() []string {
+	return b.store.ListenerTxIDs()
+}
+
+func (b *batchingStatusDB) NotifyStatus(ctx context.Context, txID string, status dbdriver.TxStatus, message string) {
+	b.store.NotifyStatus(ctx, txID, status, message)
 }
 
 type TransactionDBProvider struct {

--- a/token/services/ttx/dep/wrapper/dbs_test.go
+++ b/token/services/ttx/dep/wrapper/dbs_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package wrapper
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -21,8 +22,9 @@ import (
 
 type fakeStatusStore struct {
 	fakeStatusFetcher
-	added   []string
-	deleted []string
+	added    []string
+	deleted  []string
+	notified []string
 }
 
 func (f *fakeStatusStore) AddStatusListener(txID string, _ chan db.TransactionStatusEvent) {
@@ -35,6 +37,19 @@ func (f *fakeStatusStore) DeleteStatusListener(txID string, _ chan db.Transactio
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.deleted = append(f.deleted, txID)
+}
+
+func (f *fakeStatusStore) ListenerTxIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([]string(nil), f.added...)
+}
+
+func (f *fakeStatusStore) NotifyStatus(_ context.Context, txID string, _ dbdriver.TxStatus, _ string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.notified = append(f.notified, txID)
 }
 
 func TestBatchingStatusDB_CoalescesConcurrentGetStatus(t *testing.T) {
@@ -82,6 +97,22 @@ func TestBatchingStatusDB_ListenersPassThrough(t *testing.T) {
 
 	assert.Equal(t, []string{"tx1"}, store.added)
 	assert.Equal(t, []string{"tx1"}, store.deleted)
+	assert.Equal(t, []string{"tx1"}, d.ListenerTxIDs())
+
+	d.NotifyStatus(t.Context(), "tx1", dbdriver.Confirmed, "")
+	assert.Equal(t, []string{"tx1"}, store.notified)
+}
+
+func TestBatchingStatusDB_GetStatusesBypassesBatcher(t *testing.T) {
+	store := &fakeStatusStore{fakeStatusFetcher: fakeStatusFetcher{responses: map[string]dbdriver.TxStatus{
+		"tx1": dbdriver.Confirmed,
+	}}}
+	d := newBatchingStatusDB(store)
+
+	statuses, err := d.GetStatuses(t.Context(), []string{"tx1"})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]dbdriver.TxStatus{"tx1": dbdriver.Confirmed}, statuses)
+	assert.Equal(t, 1, store.callCount(), "a batch lookup goes straight to the store")
 }
 
 func TestTransactionDBProvider_CachesPerTMS(t *testing.T) {

--- a/token/services/ttx/finality.go
+++ b/token/services/ttx/finality.go
@@ -22,7 +22,10 @@ import (
 type finalityDB interface {
 	AddStatusListener(txID string, ch chan db.TransactionStatusEvent)
 	DeleteStatusListener(txID string, ch chan db.TransactionStatusEvent)
+	ListenerTxIDs() []string
+	NotifyStatus(ctx context.Context, txID string, status TxStatus, message string)
 	GetStatus(ctx context.Context, txID string) (TxStatus, string, error)
+	GetStatuses(ctx context.Context, txIDs []string) (map[string]TxStatus, error)
 }
 
 type finalityView struct {
@@ -116,23 +119,15 @@ func (f *finalityView) call(ctx view.Context, txID string, tmsID token.TMSID, ti
 	}
 
 	logger.DebugfContext(ctx.Context(), "Listen for DB finality")
-	// Calculate iterations using ceiling division to avoid precision loss
-	iterations := int((timeout + f.pollingTimeout - 1) / f.pollingTimeout)
-	if iterations == 0 {
-		iterations = 1
-	}
-	index := 0
 	if knownInTTXDB {
 		logger.DebugfContext(ctx.Context(), "Request TTXDB finality")
-		index, err = f.dbFinality(c, txID, transactionDB, index, iterations)
-		if err != nil {
+		if err := f.dbFinality(c, txID, transactionDB); err != nil {
 			return nil, err
 		}
 	}
 	if knownInAuditDB {
 		logger.DebugfContext(ctx.Context(), "Request AuditDB finality")
-		_, err = f.dbFinality(c, txID, auditDB, index, iterations)
-		if err != nil {
+		if err := f.dbFinality(c, txID, auditDB); err != nil {
 			return nil, err
 		}
 	}
@@ -141,22 +136,21 @@ func (f *finalityView) call(ctx view.Context, txID string, tmsID token.TMSID, ti
 }
 
 // dbFinality waits for a transaction to reach finality in a specific database.
-// It polls the database at regular intervals (pollingTimeout) up to a maximum
-// number of iterations calculated from the timeout.
+// Detection is push-first: SetStatus on the database notifies the registered
+// listener channel in-process. A shared per-database poller batch-checks every
+// waited-on transaction (pollingTimeout interval) as a fallback for lost push
+// events, so no per-transaction polling happens here.
 //
 // Parameters:
 //   - ctx: Context for cancellation and timeout
 //   - txID: Transaction ID to monitor
 //   - finalityDB: Database to monitor for finality
-//   - startCounter: Starting iteration counter (for logging/debugging)
-//   - iterations: Maximum number of polling iterations
 //
 // Returns:
-//   - int: The iteration number when finality was reached or error occurred
 //   - error: Error if transaction is invalid or timeout occurs
-func (f *finalityView) dbFinality(ctx context.Context, txID string, finalityDB finalityDB, startCounter, iterations int) (int, error) {
+func (f *finalityView) dbFinality(ctx context.Context, txID string, finalityDB finalityDB) error {
 	// notice that adding the listener can happen after the event we are looking for has already happened
-	// therefore we need to check more often before the timeout happens
+	// therefore we need to check the status right after registering
 	dbChannel := make(chan db.TransactionStatusEvent, 1)
 
 	logger.DebugfContext(ctx, "Add status listener")
@@ -169,63 +163,36 @@ func (f *finalityView) dbFinality(ctx context.Context, txID string, finalityDB f
 		logger.DebugfContext(ctx, "Removed status listener and closed channel")
 	}()
 
+	unregister := registerStatusWaiter(finalityDB, f.pollingTimeout)
+	defer unregister()
+
 	logger.DebugfContext(ctx, "Get status")
 	status, _, err := finalityDB.GetStatus(ctx, txID)
 	if err == nil {
 		if status == ttxdb.Confirmed {
-			return startCounter, nil
+			return nil
 		}
 		if status == ttxdb.Deleted {
 			logger.ErrorfContext(ctx, "Deleted tx")
 
-			return startCounter, errors.Wrapf(ErrFinalityInvalidTransaction, "transaction [%s] is not valid", txID)
+			return errors.Wrapf(ErrFinalityInvalidTransaction, "transaction [%s] is not valid", txID)
 		}
 	}
 
 	logger.DebugfContext(ctx, "Listen DB channels")
-	for i := startCounter; i < iterations; i++ {
-		logger.DebugfContext(ctx, "Start iteration [%d]", i)
-		timeout := time.NewTimer(f.pollingTimeout)
+	select {
+	case <-ctx.Done():
+		logger.ErrorfContext(ctx, "Is [%s] final? Failed to listen to transaction for timeout", txID)
 
-		select {
-		case <-ctx.Done():
-			timeout.Stop()
-
-			return i, errors.Wrapf(ErrFinalityTimeout, "failed to listen to transaction [%s] for timeout", txID)
-		case event := <-dbChannel:
-
-			trace.SpanFromContext(ctx).AddLink(trace.LinkFromContext(event.Ctx))
-			logger.DebugfContext(ctx, "Got an answer to finality of [%s]: [%s]", txID, event)
-			timeout.Stop()
-			if event.ValidationCode == ttxdb.Confirmed {
-				return i, nil
-			}
-			logger.ErrorfContext(ctx, "transaction [%s] is not valid [%s]", txID, TxStatusMessage[event.ValidationCode])
-
-			return i, errors.Wrapf(ErrFinalityInvalidTransaction, "transaction [%s] is not valid [%s]", txID, TxStatusMessage[event.ValidationCode])
-		case <-timeout.C:
-			timeout.Stop()
-			logger.DebugfContext(ctx, "Got a timeout for finality of [%s], check the status", txID)
-			vd, _, err := finalityDB.GetStatus(ctx, txID)
-			if err != nil {
-				logger.DebugfContext(ctx, "Is [%s] final? not available yet, wait [err:%s, vc:%d]", txID, err, vd)
-
-				break
-			}
-			switch vd {
-			case ttxdb.Confirmed:
-				logger.DebugfContext(ctx, "Listen to finality of [%s]. VALID", txID)
-
-				return i, nil
-			case ttxdb.Deleted:
-				logger.ErrorfContext(ctx, "Listen to finality of [%s]. NOT VALID", txID)
-
-				return i, errors.Wrapf(ErrFinalityInvalidTransaction, "transaction [%s] is not valid", txID)
-			}
+		return errors.Wrapf(ErrFinalityTimeout, "failed to listen to transaction [%s] for timeout", txID)
+	case event := <-dbChannel:
+		trace.SpanFromContext(ctx).AddLink(trace.LinkFromContext(event.Ctx))
+		logger.DebugfContext(ctx, "Got an answer to finality of [%s]: [%s]", txID, event)
+		if event.ValidationCode == ttxdb.Confirmed {
+			return nil
 		}
+		logger.ErrorfContext(ctx, "transaction [%s] is not valid [%s]", txID, TxStatusMessage[event.ValidationCode])
+
+		return errors.Wrapf(ErrFinalityInvalidTransaction, "transaction [%s] is not valid [%s]", txID, TxStatusMessage[event.ValidationCode])
 	}
-
-	logger.ErrorfContext(ctx, "Is [%s] final? Failed to listen to transaction for timeout", txID)
-
-	return iterations, errors.Wrapf(ErrFinalityTimeout, "failed to listen to transaction [%s] for timeout", txID)
 }

--- a/token/services/ttx/finality/listener.go
+++ b/token/services/ttx/finality/listener.go
@@ -31,6 +31,7 @@ type transactionDB interface {
 	NewTransaction() (dbdriver.TransactionStoreTransaction, error)
 	GetTokenRequest(ctx context.Context, txID string) ([]byte, error)
 	SetStatus(ctx context.Context, txID string, status storage.TxStatus, message string) error
+	NotifyStatus(ctx context.Context, txID string, status storage.TxStatus, message string)
 }
 
 // tokenRequestHasher defines the interface for processing token requests from raw bytes
@@ -223,6 +224,11 @@ func Commit(
 	}
 
 	tx = nil
+
+	// The transactional SetStatus above bypasses the store service, so push
+	// the status event explicitly — otherwise finality waiters only wake on
+	// the fallback polling.
+	ttxDB.NotifyStatus(ctx, txID, driver.Confirmed, "")
 
 	return nil
 }

--- a/token/services/ttx/finality/listener_test.go
+++ b/token/services/ttx/finality/listener_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network"
 	"github.com/LFDT-Panurus/panurus/token/services/storage"
+	drivermock "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver/mock"
 	depmock "github.com/LFDT-Panurus/panurus/token/services/ttx/dep/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/finality"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/finality/mock"
@@ -212,6 +213,40 @@ func TestOnStatus_StatusSetToDeletedForInvalidTx(t *testing.T) {
 
 	require.Equal(t, storage.Deleted, capturedStatus,
 		"an Invalid network status should map to Deleted in local storage")
+}
+
+// TestCommit_NotifiesConfirmed verifies that the confirmed path pushes the
+// status event to waiters after the store transaction commits: the
+// transactional SetStatus bypasses the store service, so without an explicit
+// NotifyStatus the finality waiters would only wake on the fallback polling.
+func TestCommit_NotifiesConfirmed(t *testing.T) {
+	db := &mock.TransactionDB{}
+	storeTx := &drivermock.TransactionStoreTransaction{}
+	db.NewTransactionReturns(storeTx, nil)
+
+	require.NoError(t, finality.Commit(t.Context(), logging.MustGetLogger(), &mock.TokensService{}, db, "tx1", nil))
+
+	require.Equal(t, 1, storeTx.SetStatusCallCount())
+	_, _, txStatus, _ := storeTx.SetStatusArgsForCall(0)
+	assert.Equal(t, storage.Confirmed, txStatus)
+	require.Equal(t, 1, storeTx.CommitCallCount())
+
+	require.Equal(t, 1, db.NotifyStatusCallCount(), "commit must push the Confirmed event to waiters")
+	_, notifiedTxID, notifiedStatus, _ := db.NotifyStatusArgsForCall(0)
+	assert.Equal(t, "tx1", notifiedTxID)
+	assert.Equal(t, storage.Confirmed, notifiedStatus)
+}
+
+// TestCommit_NoNotifyOnCommitFailure verifies no status event is pushed when
+// the store transaction fails to commit.
+func TestCommit_NoNotifyOnCommitFailure(t *testing.T) {
+	db := &mock.TransactionDB{}
+	storeTx := &drivermock.TransactionStoreTransaction{}
+	storeTx.CommitReturns(errors.New("commit failed"))
+	db.NewTransactionReturns(storeTx, nil)
+
+	require.Error(t, finality.Commit(t.Context(), logging.MustGetLogger(), &mock.TokensService{}, db, "tx1", nil))
+	assert.Equal(t, 0, db.NotifyStatusCallCount(), "a failed commit must not wake waiters")
 }
 
 // TestOnError tests the OnError callback

--- a/token/services/ttx/finality/mock/transaction_db.go
+++ b/token/services/ttx/finality/mock/transaction_db.go
@@ -36,6 +36,14 @@ type TransactionDB struct {
 		result1 driver.TransactionStoreTransaction
 		result2 error
 	}
+	NotifyStatusStub        func(context.Context, string, storage.TxStatus, string)
+	notifyStatusMutex       sync.RWMutex
+	notifyStatusArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 storage.TxStatus
+		arg4 string
+	}
 	SetStatusStub        func(context.Context, string, storage.TxStatus, string) error
 	setStatusMutex       sync.RWMutex
 	setStatusArgsForCall []struct {
@@ -173,6 +181,41 @@ func (fake *TransactionDB) NewTransactionReturnsOnCall(i int, result1 driver.Tra
 		result1 driver.TransactionStoreTransaction
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *TransactionDB) NotifyStatus(arg1 context.Context, arg2 string, arg3 storage.TxStatus, arg4 string) {
+	fake.notifyStatusMutex.Lock()
+	fake.notifyStatusArgsForCall = append(fake.notifyStatusArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 storage.TxStatus
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.NotifyStatusStub
+	fake.recordInvocation("NotifyStatus", []interface{}{arg1, arg2, arg3, arg4})
+	fake.notifyStatusMutex.Unlock()
+	if stub != nil {
+		fake.NotifyStatusStub(arg1, arg2, arg3, arg4)
+	}
+}
+
+func (fake *TransactionDB) NotifyStatusCallCount() int {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	return len(fake.notifyStatusArgsForCall)
+}
+
+func (fake *TransactionDB) NotifyStatusCalls(stub func(context.Context, string, storage.TxStatus, string)) {
+	fake.notifyStatusMutex.Lock()
+	defer fake.notifyStatusMutex.Unlock()
+	fake.NotifyStatusStub = stub
+}
+
+func (fake *TransactionDB) NotifyStatusArgsForCall(i int) (context.Context, string, storage.TxStatus, string) {
+	fake.notifyStatusMutex.RLock()
+	defer fake.notifyStatusMutex.RUnlock()
+	argsForCall := fake.notifyStatusArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *TransactionDB) SetStatus(arg1 context.Context, arg2 string, arg3 storage.TxStatus, arg4 string) error {

--- a/token/services/ttx/finality_poller.go
+++ b/token/services/ttx/finality_poller.go
@@ -1,0 +1,184 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ttx
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+)
+
+const (
+	// statusPollerChunk bounds the number of tx ids per batch status query.
+	statusPollerChunk = 1000
+	// statusPollerSweepTimeout bounds a single sweep so a stalled database
+	// cannot wedge the poller loop.
+	statusPollerSweepTimeout = 30 * time.Second
+)
+
+// statusPollers holds one statusPoller per finality database instance.
+// Finality databases are per-TMS process-level singletons, so entries are
+// few and kept for the process lifetime; a poller's goroutine only runs
+// while waiters are registered.
+var statusPollers sync.Map // finalityDB -> *statusPoller
+
+// statusPoller is the shared fallback poller behind dbFinality: instead of
+// every waiter polling GetStatus on its own timer, a single goroutine per
+// database batch-fetches the statuses of all waited-on transactions and
+// re-publishes terminal ones through the database's listener notification,
+// waking the registered waiters. It sweeps at the smallest polling interval
+// among the active waiters and stops when none remain.
+type statusPoller struct {
+	db finalityDB
+
+	mu        sync.Mutex
+	intervals map[time.Duration]int // active waiters per requested interval
+	running   bool
+	wake      chan struct{} // tells the loop to re-evaluate its interval
+}
+
+func newStatusPoller(fdb finalityDB) *statusPoller {
+	return &statusPoller{db: fdb, intervals: map[time.Duration]int{}, wake: make(chan struct{}, 1)}
+}
+
+// registerStatusWaiter registers a waiter polling at the given interval with
+// the shared poller of the given database and returns an idempotent
+// unregister function.
+func registerStatusWaiter(fdb finalityDB, interval time.Duration) func() {
+	v, ok := statusPollers.Load(fdb)
+	if !ok {
+		v, _ = statusPollers.LoadOrStore(fdb, newStatusPoller(fdb))
+	}
+	p := v.(*statusPoller)
+	p.add(interval)
+
+	var once sync.Once
+
+	return func() { once.Do(func() { p.remove(interval) }) }
+}
+
+func (p *statusPoller) add(interval time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	oldMin, had := p.minIntervalLocked()
+	p.intervals[interval]++
+	if !p.running {
+		p.running = true
+		go p.run()
+
+		return
+	}
+	// wake the sleeping loop only when the sweep interval must shrink; waking
+	// on every registration would keep resetting the timer and starve sweeps
+	// under sustained load
+	if !had || interval < oldMin {
+		p.signalWake()
+	}
+}
+
+func (p *statusPoller) remove(interval time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	oldMin, _ := p.minIntervalLocked()
+	if p.intervals[interval]--; p.intervals[interval] <= 0 {
+		delete(p.intervals, interval)
+	}
+	// wake the sleeping loop when the last waiter left (prompt shutdown) or
+	// the smallest interval grew (adopt the new one instead of the old timer)
+	if newMin, has := p.minIntervalLocked(); !has || newMin > oldMin {
+		p.signalWake()
+	}
+}
+
+// minIntervalLocked returns the smallest interval among the active waiters,
+// or false when none is registered. The caller must hold p.mu.
+func (p *statusPoller) minIntervalLocked() (time.Duration, bool) {
+	var interval time.Duration
+	for i := range p.intervals {
+		if interval == 0 || i < interval {
+			interval = i
+		}
+	}
+
+	return interval, interval != 0
+}
+
+func (p *statusPoller) signalWake() {
+	select {
+	case p.wake <- struct{}{}:
+	default:
+	}
+}
+
+// nextInterval returns the current sweep interval; when no waiter remains it
+// marks the poller as stopped and returns false, and the loop must exit.
+func (p *statusPoller) nextInterval() (time.Duration, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	interval, ok := p.minIntervalLocked()
+	if !ok {
+		p.running = false
+	}
+
+	return interval, ok
+}
+
+func (p *statusPoller) run() {
+	for {
+		interval, ok := p.nextInterval()
+		if !ok {
+			return
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-timer.C:
+			p.sweep()
+		case <-p.wake:
+			timer.Stop()
+		}
+	}
+}
+
+// sweep batch-fetches the statuses of every transaction someone is waiting on
+// and notifies the terminal ones (Confirmed/Deleted), mirroring what the
+// per-waiter poll used to detect. A failing chunk is skipped — the next chunk
+// may still succeed and the next sweep retries — unless the sweep context is
+// done. Fallback events carry no status message; the live push path does.
+func (p *statusPoller) sweep() {
+	txIDs := p.db.ListenerTxIDs()
+	if len(txIDs) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), statusPollerSweepTimeout)
+	defer cancel()
+
+	for chunk := range slices.Chunk(txIDs, statusPollerChunk) {
+		statuses, err := p.db.GetStatuses(ctx, chunk)
+		if err != nil {
+			logger.Warnf("status poller: batch status query failed (%d tx ids): %v", len(chunk), err)
+			if ctx.Err() != nil {
+				return
+			}
+
+			continue
+		}
+		for txID, status := range statuses {
+			if status != ttxdb.Confirmed && status != ttxdb.Deleted {
+				continue
+			}
+			p.db.NotifyStatus(ctx, txID, status, "")
+		}
+	}
+}

--- a/token/services/ttx/finality_poller_test.go
+++ b/token/services/ttx/finality_poller_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ttx
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/common"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeFinalityDB is a finalityDB backed by a real StatusSupport (listener
+// registry and notification), with a stubbable batch status lookup.
+type fakeFinalityDB struct {
+	*common.StatusSupport
+
+	mu               sync.Mutex
+	getStatusesStub  func(txIDs []string) (map[string]TxStatus, error)
+	getStatusesCalls [][]string
+}
+
+func newFakeFinalityDB(stub func(txIDs []string) (map[string]TxStatus, error)) *fakeFinalityDB {
+	return &fakeFinalityDB{StatusSupport: common.NewStatusSupport(), getStatusesStub: stub}
+}
+
+func (f *fakeFinalityDB) GetStatus(context.Context, string) (TxStatus, string, error) {
+	return ttxdb.Pending, "", nil
+}
+
+func (f *fakeFinalityDB) GetStatuses(_ context.Context, txIDs []string) (map[string]TxStatus, error) {
+	f.mu.Lock()
+	f.getStatusesCalls = append(f.getStatusesCalls, append([]string(nil), txIDs...))
+	stub := f.getStatusesStub
+	f.mu.Unlock()
+
+	return stub(txIDs)
+}
+
+func (f *fakeFinalityDB) NotifyStatus(ctx context.Context, txID string, status TxStatus, message string) {
+	f.Notify(common.StatusEvent{Ctx: ctx, TxID: txID, ValidationCode: status, ValidationMessage: message})
+}
+
+func (f *fakeFinalityDB) calls() [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	return append([][]string(nil), f.getStatusesCalls...)
+}
+
+// confirmAll resolves every requested tx id as Confirmed.
+func confirmAll(txIDs []string) (map[string]TxStatus, error) {
+	out := make(map[string]TxStatus, len(txIDs))
+	for _, id := range txIDs {
+		out[id] = ttxdb.Confirmed
+	}
+
+	return out, nil
+}
+
+// TestStatusPoller_SweepCoalescesWaiters verifies that one sweep resolves all
+// waited-on transactions with a single batched query and wakes every waiter.
+func TestStatusPoller_SweepCoalescesWaiters(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+	ch1 := make(chan common.StatusEvent, 1)
+	ch2 := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch1)
+	fdb.AddStatusListener("tx2", ch2)
+
+	newStatusPoller(fdb).sweep()
+
+	calls := fdb.calls()
+	require.Len(t, calls, 1, "one sweep over two waiters must issue a single batched query")
+	assert.ElementsMatch(t, []string{"tx1", "tx2"}, calls[0])
+	for _, ch := range []chan common.StatusEvent{ch1, ch2} {
+		select {
+		case event := <-ch:
+			assert.Equal(t, ttxdb.Confirmed, event.ValidationCode)
+		default:
+			t.Fatal("waiter not notified by the sweep")
+		}
+	}
+}
+
+// TestStatusPoller_ChunkFailureDoesNotSkipRemainingChunks verifies that a
+// failing chunk does not abort the sweep: the remaining chunks are still
+// queried and their waiters notified.
+func TestStatusPoller_ChunkFailureDoesNotSkipRemainingChunks(t *testing.T) {
+	var stubMu sync.Mutex
+	call := 0
+	fdb := newFakeFinalityDB(nil)
+	fdb.getStatusesStub = func(txIDs []string) (map[string]TxStatus, error) {
+		stubMu.Lock()
+		call++
+		failing := call == 1
+		stubMu.Unlock()
+		if failing {
+			return nil, errors.New("transient db error")
+		}
+
+		return confirmAll(txIDs)
+	}
+
+	const n = statusPollerChunk + 500
+	channels := make([]chan common.StatusEvent, n)
+	for i := range channels {
+		channels[i] = make(chan common.StatusEvent, 1)
+		fdb.AddStatusListener(fmt.Sprintf("tx-%d", i), channels[i])
+	}
+
+	newStatusPoller(fdb).sweep()
+
+	calls := fdb.calls()
+	require.Len(t, calls, 2, "the chunk after the failing one must still be queried")
+	require.Len(t, calls[0], statusPollerChunk)
+	require.Len(t, calls[1], n-statusPollerChunk)
+
+	notified := 0
+	for _, ch := range channels {
+		select {
+		case <-ch:
+			notified++
+		default:
+		}
+	}
+	assert.Equal(t, len(calls[1]), notified, "every waiter of the successful chunk must be notified")
+}
+
+// TestStatusPoller_UsesSmallestActiveWaiterInterval verifies that the poller
+// interval is not fixed by the first caller: a later waiter with a smaller
+// polling interval takes effect immediately.
+func TestStatusPoller_UsesSmallestActiveWaiterInterval(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+
+	// the first waiter registers a very slow interval
+	unregisterSlow := registerStatusWaiter(fdb, 10*time.Second)
+	defer unregisterSlow()
+
+	// a second waiter with a fast interval joins
+	ch := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch)
+	defer fdb.DeleteStatusListener("tx1", ch)
+	unregisterFast := registerStatusWaiter(fdb, 20*time.Millisecond)
+	defer unregisterFast()
+
+	select {
+	case event := <-ch:
+		assert.Equal(t, ttxdb.Confirmed, event.ValidationCode)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter not woken: the poller is stuck on the first caller's interval")
+	}
+}
+
+// settleOnSlowInterval drives the poller of fdb into a long timer wait: a
+// fast waiter is registered next to the caller's slow one, a sweep is
+// observed on ch (the loop is demonstrably cycling), the fast waiter is
+// unregistered and the sweeps are seen to quiesce — the loop has adopted the
+// slow interval and is parked in its timer select.
+func settleOnSlowInterval(t *testing.T, fdb *fakeFinalityDB, ch chan common.StatusEvent) {
+	t.Helper()
+
+	unregisterFast := registerStatusWaiter(fdb, 10*time.Millisecond)
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller never swept at the fast interval")
+	}
+	unregisterFast()
+
+	// sweeps must quiesce: at the fast cadence the call count would keep
+	// growing, so a stable count proves the larger interval took over
+	require.Eventually(t, func() bool {
+		before := len(fdb.calls())
+		time.Sleep(100 * time.Millisecond)
+
+		return len(fdb.calls()) == before
+	}, 2*time.Second, time.Millisecond, "poller must adopt the larger interval once the fastest waiter leaves")
+}
+
+// TestStatusPoller_AdoptsLargerIntervalWhenSmallestLeaves covers the
+// re-scheduling branch on unregistration: when the fastest waiter leaves
+// while the loop is parked on its timer, the wake-up must abort that timer —
+// not a single sweep may fire once only the hour-long waiter remains.
+func TestStatusPoller_AdoptsLargerIntervalWhenSmallestLeaves(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+
+	ch := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch)
+	defer fdb.DeleteStatusListener("tx1", ch)
+
+	unregisterSlow := registerStatusWaiter(fdb, time.Hour)
+	defer unregisterSlow()
+	unregisterFast := registerStatusWaiter(fdb, 200*time.Millisecond)
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller never swept at the fast interval")
+	}
+	// give the loop time to re-arm and park in the select on the next fast
+	// timer, so the unregistration below hits a sleeping loop
+	time.Sleep(50 * time.Millisecond)
+
+	before := len(fdb.calls())
+	unregisterFast()
+
+	time.Sleep(400 * time.Millisecond)
+	assert.Len(t, fdb.calls(), before,
+		"pending fast timer fired after the fast waiter left: the poller kept the old cadence instead of adopting the larger interval")
+}
+
+// TestStatusPoller_StopsWhenIdleAndRestarts verifies that the poller
+// goroutine exits promptly once the last waiter unregisters even while it is
+// parked in a long timer wait — the exit is driven by the unregister wake-up,
+// not by the timer expiring — and starts again when a new waiter registers.
+func TestStatusPoller_StopsWhenIdleAndRestarts(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+
+	ch := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch)
+	defer fdb.DeleteStatusListener("tx1", ch)
+
+	unregisterSlow := registerStatusWaiter(fdb, time.Hour)
+	settleOnSlowInterval(t, fdb, ch)
+
+	// the loop is waiting on the hour-long timer; unregistering the last
+	// waiter must stop it promptly
+	unregisterSlow()
+
+	v, ok := statusPollers.Load(fdb)
+	require.True(t, ok)
+	p := v.(*statusPoller)
+	require.Eventually(t, func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		return !p.running
+	}, 2*time.Second, 10*time.Millisecond, "poller must stop when the last waiter unregisters, without waiting out its timer")
+
+	// drain a possibly buffered event from the settle phase, then verify the
+	// poller restarts for a new waiter
+	select {
+	case <-ch:
+	default:
+	}
+	unregister := registerStatusWaiter(fdb, 10*time.Millisecond)
+	defer unregister()
+
+	select {
+	case event := <-ch:
+		assert.Equal(t, ttxdb.Confirmed, event.ValidationCode)
+	case <-time.After(2 * time.Second):
+		t.Fatal("poller did not restart after going idle")
+	}
+}
+
+// TestStatusPoller_SustainedRegistrationsDoNotStarveSweep verifies that a
+// steady stream of registrations at the same interval does not keep resetting
+// the sweep timer: an already-waiting listener must still be notified.
+func TestStatusPoller_SustainedRegistrationsDoNotStarveSweep(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+
+	ch := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch)
+	defer fdb.DeleteStatusListener("tx1", ch)
+	unregister := registerStatusWaiter(fdb, 50*time.Millisecond)
+	defer unregister()
+
+	// churn: new same-interval waiters keep arriving faster than the sweep
+	// interval, like sustained transaction load
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(5 * time.Millisecond):
+				registerStatusWaiter(fdb, 50*time.Millisecond)()
+			}
+		}
+	}()
+	defer func() { close(stop); <-done }()
+
+	select {
+	case event := <-ch:
+		assert.Equal(t, ttxdb.Confirmed, event.ValidationCode)
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweep starved: continuous registrations kept resetting the poller timer")
+	}
+}
+
+// TestStatusPoller_UnregisterIsIdempotent verifies that calling the same
+// unregister function twice does not steal the registration of another
+// waiter sharing the interval.
+func TestStatusPoller_UnregisterIsIdempotent(t *testing.T) {
+	fdb := newFakeFinalityDB(confirmAll)
+
+	unregisterA := registerStatusWaiter(fdb, 10*time.Millisecond)
+
+	ch := make(chan common.StatusEvent, 1)
+	fdb.AddStatusListener("tx1", ch)
+	defer fdb.DeleteStatusListener("tx1", ch)
+	unregisterB := registerStatusWaiter(fdb, 10*time.Millisecond)
+	defer unregisterB()
+
+	unregisterA()
+	unregisterA() // must be a no-op, not decrement B's registration
+
+	select {
+	case event := <-ch:
+		assert.Equal(t, ttxdb.Confirmed, event.ValidationCode)
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter B lost its registration to a double unregister of waiter A")
+	}
+}
+
+// TestStatusPoller_IsolatedPerDatabase verifies that each database gets its
+// own poller: sweeping one database never queries another.
+func TestStatusPoller_IsolatedPerDatabase(t *testing.T) {
+	fdb1 := newFakeFinalityDB(confirmAll)
+	fdb2 := newFakeFinalityDB(confirmAll)
+
+	ch := make(chan common.StatusEvent, 1)
+	fdb1.AddStatusListener("tx1", ch)
+	defer fdb1.DeleteStatusListener("tx1", ch)
+	unregister := registerStatusWaiter(fdb1, 10*time.Millisecond)
+	defer unregister()
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter on fdb1 not notified")
+	}
+	assert.Empty(t, fdb2.calls(), "the poller of one database must not query another")
+}

--- a/token/services/ttx/finality_test.go
+++ b/token/services/ttx/finality_test.go
@@ -7,10 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package ttx_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/common"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx"
 	"github.com/LFDT-Panurus/panurus/token/services/ttx/dep/db"
@@ -19,6 +21,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// notifyStatusVia adapts the flat NotifyStatus mock signature to a
+// StatusSupport's event-based Notify, so poller pushes reach the channels the
+// view registered on the same support.
+func notifyStatusVia(support *common.StatusSupport) func(context.Context, string, token.TxStatus, string) {
+	return func(ctx context.Context, txID string, status token.TxStatus, message string) {
+		support.Notify(common.StatusEvent{Ctx: ctx, TxID: txID, ValidationCode: status, ValidationMessage: message})
+	}
+}
 
 type testFinalityViewContext struct {
 	ctx                   *mock.Context
@@ -34,11 +45,25 @@ func newTestFinalityViewContext(t *testing.T) *testFinalityViewContext {
 	ctx := &mock.Context{}
 	ctx.ContextReturns(t.Context())
 
+	// Back the listener methods with a real StatusSupport so the shared
+	// fallback poller sees the registrations the view makes and its
+	// NotifyStatus reaches the view's channel, like the production store
+	// services.
 	transactionDB := &mock.TransactionDB{}
+	transactionDBSupport := common.NewStatusSupport()
+	transactionDB.AddStatusListenerStub = transactionDBSupport.AddStatusListener
+	transactionDB.DeleteStatusListenerStub = transactionDBSupport.DeleteStatusListener
+	transactionDB.ListenerTxIDsStub = transactionDBSupport.ListenerTxIDs
+	transactionDB.NotifyStatusStub = notifyStatusVia(transactionDBSupport)
 	transactionDBProvider := &mock.TransactionDBProvider{}
 	transactionDBProvider.TransactionDBReturns(transactionDB, nil)
 
 	auditDB := &mock.AuditDB{}
+	auditDBSupport := common.NewStatusSupport()
+	auditDB.AddStatusListenerStub = auditDBSupport.AddStatusListener
+	auditDB.DeleteStatusListenerStub = auditDBSupport.DeleteStatusListener
+	auditDB.ListenerTxIDsStub = auditDBSupport.ListenerTxIDs
+	auditDB.NotifyStatusStub = notifyStatusVia(auditDBSupport)
 	auditDBProvider := &mock.AuditDBProvider{}
 	auditDBProvider.AuditDBReturns(auditDB, nil)
 
@@ -183,50 +208,67 @@ func TestFinalityView(t *testing.T) {
 			errorContains: "db error",
 		},
 		{
-			name: "timeout tick then confirmed",
+			name: "poller fallback confirmed",
 			prepare: func(c *testFinalityViewContext) {
-				c.transactionDB.GetStatusReturnsOnCall(0, ttxdb.Pending, "", nil)   // call check
-				c.transactionDB.GetStatusReturnsOnCall(1, ttxdb.Pending, "", nil)   // dbFinality initial check
-				c.transactionDB.GetStatusReturnsOnCall(2, ttxdb.Confirmed, "", nil) // dbFinality timeout check
+				c.transactionDB.GetStatusReturns(ttxdb.Pending, "", nil)
 				c.auditDB.GetStatusReturns(ttxdb.Unknown, "", nil)
+				c.transactionDB.GetStatusesReturns(map[string]token.TxStatus{
+					"tx_id": ttxdb.Confirmed,
+				}, nil)
 			},
-			opts:        []ttx.TxOption{ttx.WithTimeout(1500 * time.Millisecond)},
+			opts: []ttx.TxOption{
+				ttx.WithTimeout(2 * time.Second),
+				ttx.WithPollingTimeout(100 * time.Millisecond),
+			},
 			expectError: false,
 		},
 		{
-			name: "timeout tick then deleted",
+			name: "poller fallback deleted",
 			prepare: func(c *testFinalityViewContext) {
-				c.transactionDB.GetStatusReturnsOnCall(0, ttxdb.Pending, "", nil) // call check
-				c.transactionDB.GetStatusReturnsOnCall(1, ttxdb.Pending, "", nil) // dbFinality initial check
-				c.transactionDB.GetStatusReturnsOnCall(2, ttxdb.Deleted, "", nil) // dbFinality timeout check
+				c.transactionDB.GetStatusReturns(ttxdb.Pending, "", nil)
 				c.auditDB.GetStatusReturns(ttxdb.Unknown, "", nil)
+				c.transactionDB.GetStatusesReturns(map[string]token.TxStatus{
+					"tx_id": ttxdb.Deleted,
+				}, nil)
 			},
-			opts:          []ttx.TxOption{ttx.WithTimeout(1500 * time.Millisecond)},
+			opts: []ttx.TxOption{
+				ttx.WithTimeout(2 * time.Second),
+				ttx.WithPollingTimeout(100 * time.Millisecond),
+			},
 			expectError:   true,
 			errorContains: "transaction [tx_id] is not valid",
 			expectErr:     ttx.ErrFinalityInvalidTransaction,
 		},
 		{
-			name: "timeout tick then error then confirmed",
+			name: "poller fallback error then confirmed",
 			prepare: func(c *testFinalityViewContext) {
-				c.transactionDB.GetStatusReturnsOnCall(0, ttxdb.Pending, "", nil)                           // call check
-				c.transactionDB.GetStatusReturnsOnCall(1, ttxdb.Pending, "", nil)                           // dbFinality initial check
-				c.transactionDB.GetStatusReturnsOnCall(2, ttxdb.Unknown, "", errors.New("transient error")) // dbFinality timeout check 1
-				c.transactionDB.GetStatusReturnsOnCall(3, ttxdb.Confirmed, "", nil)                         // dbFinality timeout check 2
+				c.transactionDB.GetStatusReturns(ttxdb.Pending, "", nil)
 				c.auditDB.GetStatusReturns(ttxdb.Unknown, "", nil)
+				c.transactionDB.GetStatusesReturnsOnCall(0, nil, errors.New("transient error"))
+				c.transactionDB.GetStatusesReturns(map[string]token.TxStatus{
+					"tx_id": ttxdb.Confirmed,
+				}, nil)
 			},
-			opts:        []ttx.TxOption{ttx.WithTimeout(2500 * time.Millisecond)},
+			opts: []ttx.TxOption{
+				ttx.WithTimeout(2 * time.Second),
+				ttx.WithPollingTimeout(100 * time.Millisecond),
+			},
 			expectError: false,
 		},
 		{
-			name: "initial get status error then confirmed",
+			name: "initial get status error then poller confirmed",
 			prepare: func(c *testFinalityViewContext) {
 				c.transactionDB.GetStatusReturnsOnCall(0, ttxdb.Pending, "", nil)                         // call check
 				c.transactionDB.GetStatusReturnsOnCall(1, ttxdb.Unknown, "", errors.New("initial error")) // dbFinality initial check
-				c.transactionDB.GetStatusReturnsOnCall(2, ttxdb.Confirmed, "", nil)                       // dbFinality timeout check
 				c.auditDB.GetStatusReturns(ttxdb.Unknown, "", nil)
+				c.transactionDB.GetStatusesReturns(map[string]token.TxStatus{
+					"tx_id": ttxdb.Confirmed,
+				}, nil)
 			},
-			opts:        []ttx.TxOption{ttx.WithTimeout(1500 * time.Millisecond)},
+			opts: []ttx.TxOption{
+				ttx.WithTimeout(2 * time.Second),
+				ttx.WithPollingTimeout(100 * time.Millisecond),
+			},
 			expectError: false,
 		},
 		{


### PR DESCRIPTION
Fixes #1956

### Motivation

`FinalityView` waiters are designed to be woken by push (the store's status listener) with polling as a fallback, but today the push channel never fires for confirmed transactions: the confirmed path writes its status through the store transaction (`tx.SetStatus` inside `finality.Commit`), bypassing `StoreService.SetStatus` and its listener notification — only the Deleted path pushes. Every confirmed transaction therefore resolves through the fallback polling, paying up to one polling interval of extra latency.

That also makes the per-waiter polling load structural: with tens of thousands of in-flight waiters in our test environments under sustained load, the per-waiter `GetStatus` queries (~3.5k/s plus setup checks at high concurrency) queued thousands of goroutines on the `database/sql` pool mutex. The batching decorator from #1896 coalesces concurrent lookups into fewer round trips, but every waiter still wakes up each interval to issue one.

### Changes

**fix(ttx/finality): notify status waiters on the confirmed commit path**

- ttxdb/auditdb `StoreService` gains `NotifyStatus`, which pushes a status event to the in-process listeners without touching the database; `SetStatus` routes through it, so status events now also carry the status message.
- `finality.Commit` pushes the Confirmed event through `NotifyStatus` after the transaction commits, waking waiters through the same path as a Deleted push. This covers both the live finality listener and the recovery handler, which share `Commit`.

**perf(ttx/finality): replace per-waiter fallback polling with a shared batch poller**

- `dbFinality` now registers the listener, checks the status once (covering the registration race), and blocks on the push channel — no per-transaction polling loop.
- A shared `statusPoller` per finality database batch-fetches the statuses of all waited-on transactions through `GetStatuses` (#1896), in chunks of 1000 (a failing chunk is skipped, not the whole sweep), and re-publishes terminal ones through the store's `NotifyStatus`, waking the registered waiters through the same path as a live push.
- The poller sweeps at the smallest polling interval among the active waiters, so `WithPollingTimeout` keeps its per-view meaning. Its loop is only woken when the sweep interval must shrink, when the smallest interval grew, or when the last waiter left — waking on every registration would keep resetting the timer and starve sweeps under sustained load. The goroutine stops when no waiter remains and restarts on the next registration.
- The batching decorator from #1896 keeps serving the remaining single-tx lookups (the known-check at view setup and the initial check after registration); the batch lookup, the listener registry and the notification surface pass through it untouched.

### Testing

- New unit tests for the poller (registration/unregistration, interval shrink/grow, stop/restart, sweep notification of terminal statuses) and for the Confirmed push on the commit path.
- Existing finality view tests adapted to the push-first flow.
- `go build ./token/...`, `go vet`, `go test -race` on the affected packages, and golangci-lint v2.12.2 with the repo configuration all pass locally.
