### PR TITLE
fix(ci): exclude Fabric Smart Client dependency code from coverage report

### DIFF
--- a/ci/scripts/filter-coverage.sh
+++ b/ci/scripts/filter-coverage.sh
@@ -45,6 +45,9 @@ awk '
   # Exclude integration
   /\/integration\// { next }
 
+  # Exclude Fabric Smart Client dependency code (not part of this module)
+  /hyperledger-labs\/fabric-smart-client\// { next }
+
   # Exclude tools and docs
   /\/tools\// { next }
   /\/docs\// { next }


### PR DESCRIPTION
Coverage dropped **~82.6% → ~53%** after #1933 (https://coveralls.io/builds/80658631).

**Cause:** #1933 bumped `fabric-smart-client/integration` to v0.14.3, whose node builder now hardcodes `-coverpkg=github.com/hyperledger-labs/fabric-smart-client/...`. That overrides the `-coverpkg` we set via `GOFLAGS`, so integration tests instrument FSC's own `platform/*`/`pkg/*` (~17k lines, ~0.8% covered here) instead of our packages — flooding the report.

**Fix:** drop FSC-module lines in `filter-coverage.sh`.

Recovers the denominator (~71%). Full recovery to ~82% needs an upstream FSC change to make `-coverpkg` configurable.
