### PR TITLE
fsc setup responder: enforce validation invariants on new public parameters

### DIFF
--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -178,7 +178,10 @@ initiator/responder pair handles this:
 The two initiator/responder pairs are distinguished by chaincode function name and
 transient key: the token-request flow uses the `invoke` function, while the PP flow
 uses a dedicated `setup` function and carries the raw parameters under a dedicated
-`public_params` transient key (in addition to the `tmsID` key used by both).
+`public_params` transient key (in addition to the `tmsID` key used by both). On
+re-setup of a namespace that already has a TMS, a third transient key,
+`public_params_sig`, carries a detached signature (JSON-encoded signer identity plus
+signature bytes) authorizing the change — see below.
 
 Both responders share a common `receive` step that only checks that the proposal's
 `tmsID` transient carries a non-empty network, channel, and namespace — it does not
@@ -202,9 +205,29 @@ The responder enforces the following before writing:
    proposal.
 2. The raw PP must be deserializable (`PublicParametersFromBytes`) and pass
    `PublicParameters.Validate()`.
-3. If a TMS with existing public parameters is already present for the namespace, the
-   submitted PP's driver name and version must match the existing ones. This check is
-   skipped for first-time setup, when no PP exists yet.
+3. First-time setup (no TMS found for the namespace yet) stops here — an empty
+   issuer list is allowed, matching the permissive "anyone can issue" default some
+   drivers (e.g. fabtoken) use out of the box.
+4. Re-setup (a TMS already exists) additionally requires:
+   - the *current* PP declares at least one issuer (otherwise no identity could ever
+     be authorized to change it) — the submitted PP is not required to declare any
+     issuers itself;
+   - the proposal carries a `public_params_sig` transient: a detached signature over
+     the raw PP bytes, produced by one of the *current* PP's issuers;
+   - that signer identity is verified against the current TMS's `Deserializer`
+     (`SigService().IssuerVerifier`).
+
+   Driver name, version, and `CertificationDriver()` are all allowed to change freely
+   on re-setup — the only gate is the current-issuer signature above, there is no
+   equality check against the previous PP. There is likewise no monotonicity or
+   replay protection beyond what Fabric's own transaction anti-replay already
+   provides.
+
+The signature itself is produced entirely on the initiator side, without changing the
+public `SetupPublicParams` API: `fsc.EndorsementService` resolves the current TMS via
+its `TokenManagementSystemProvider`, iterates the current PP's issuers, and signs the
+raw PP bytes with the first one it holds a local wallet/signer for. On first-time setup
+(no current TMS) it submits no signature, matching the responder's tolerance above.
 
 There is no separate "init" vs. "update" API: the write is an unconditional overwrite
 of the setup key, mirroring the semantics of the chaincode `Init` path. Endorser

--- a/token/services/network/fabric/endorsement/fsc/errors.go
+++ b/token/services/network/fabric/endorsement/fsc/errors.go
@@ -21,4 +21,7 @@ var (
 	ErrValidateProposal = errors.New("failed to validate proposal")
 	// ErrEndorseProposal signals a failure in endorsing the proposal
 	ErrEndorseProposal = errors.New("failed to endorse proposal")
+	// ErrValidatePublicParams signals that the submitted public parameters failed
+	// authorization or consistency checks
+	ErrValidatePublicParams = errors.New("invalid public parameters")
 )

--- a/token/services/network/fabric/endorsement/fsc/responder.go
+++ b/token/services/network/fabric/endorsement/fsc/responder.go
@@ -9,6 +9,7 @@ package fsc
 import (
 	"context"
 	"encoding/json"
+	"slices"
 
 	token2 "github.com/LFDT-Panurus/panurus/token"
 	"github.com/LFDT-Panurus/panurus/token/core/common"
@@ -50,6 +51,9 @@ type Request struct {
 
 	// setup-specific fields, populated by setupBehaviour
 	PublicParamsRaw []byte
+	// PublicParamsSig is the detached issuer signature over PublicParamsRaw, present only
+	// on re-setup (i.e. when Tms is non-nil).
+	PublicParamsSig *PublicParamsSignature
 }
 
 // responderBehaviour models the protocol-specific steps of ResponderView. ResponderView
@@ -469,9 +473,9 @@ type setupBehaviour struct {
 func (b *setupBehaviour) function() string { return SetupFunction }
 
 func (b *setupBehaviour) checkTransientCount(tx *endorser.Transaction) error {
-	// 2 required (tmsID + public_params)
-	if n := len(tx.Transaction.Transient()); n != 2 {
-		return errors.Wrapf(ErrInvalidTransient, "invalid number of transient fields, expected 2, got %d", n)
+	// 2 required (tmsID + public_params) plus 1 optional (public_params_sig, on re-setup)
+	if n := len(tx.Transaction.Transient()); n < 2 || n > 3 {
+		return errors.Wrapf(ErrInvalidTransient, "invalid number of transient fields, expected 2 or 3, got %d", n)
 	}
 
 	return nil
@@ -483,18 +487,32 @@ func (b *setupBehaviour) extractTransient(tx *endorser.Transaction, request *Req
 	if len(publicParamsRaw) == 0 {
 		return errors.Wrapf(ErrInvalidTransient, "empty public params")
 	}
-
 	request.PublicParamsRaw = publicParamsRaw
+
+	// public parameters signature (optional, present only on re-setup)
+	if sigRaw := tx.GetTransient(TransientPublicParamsSigKey); len(sigRaw) > 0 {
+		var sig PublicParamsSignature
+		if err := json.Unmarshal(sigRaw, &sig); err != nil {
+			return errors.Wrapf(ErrInvalidTransient, "failed to unmarshal public params signature")
+		}
+		if len(sig.SignerIdentity) == 0 || len(sig.Signature) == 0 {
+			return errors.Wrapf(ErrInvalidTransient, "incomplete public params signature")
+		}
+		request.PublicParamsSig = &sig
+	}
 
 	return nil
 }
 
-// validate looks up the TMS for request.TMSID, if any, and checks that it matches the
-// requested TMS ID. Validating the submitted public parameters themselves (parsing,
-// internal consistency, and driver compatibility against an existing TMS) is left for
-// https://github.com/LFDT-Panurus/panurus/issues/1943, since at this point we don't know
-// enough to make that call yet.
-func (b *setupBehaviour) validate(_ view.Context, request *Request) error {
+// validate looks up the TMS for request.TMSID, if any, and enforces the setup invariants:
+// the submitted public parameters must always parse and pass driver-level Validate(); on
+// re-setup of a namespace that already has a TMS, the current public parameters must declare
+// at least one issuer, and the submission must carry a detached signature over the raw public
+// parameters bytes produced by one of the current issuers. The new public parameters are not
+// required to declare any issuers themselves. Driver name, version, and certification driver
+// are allowed to change freely on re-setup: they are gated only by that signature, not by
+// equality checks.
+func (b *setupBehaviour) validate(ctx view.Context, request *Request) error {
 	tms, err := b.tokenManagementSystemProvider.GetManagementService(token2.WithTMSID(request.TMSID))
 	if err != nil {
 		if !errors.Is(err, token2.ErrTMSNotFound) {
@@ -507,7 +525,42 @@ func (b *setupBehaviour) validate(_ view.Context, request *Request) error {
 		request.Tms = tms
 	}
 
-	// TODO: need to add validation logic...to be addressed in #1943
+	pp, err := b.ppValidator.PublicParametersFromBytes(request.PublicParamsRaw)
+	if err != nil {
+		return errors.Join(ErrValidatePublicParams, errors.Wrapf(err, "failed to unmarshal public params"))
+	}
+	if err := pp.Validate(); err != nil {
+		return errors.Join(ErrValidatePublicParams, errors.Wrapf(err, "failed to validate public params"))
+	}
+
+	if request.Tms == nil {
+		// first-time setup: empty issuers are allowed, no authorization signature required
+		return nil
+	}
+
+	currentPP := request.Tms.PublicParameters()
+	if currentPP == nil {
+		return errors.Join(ErrValidatePublicParams, errors.Errorf("no current public parameters found for [%s]", request.TMSID))
+	}
+	currentIssuers := currentPP.Issuers()
+	if len(currentIssuers) == 0 {
+		return errors.Join(ErrValidatePublicParams, errors.Errorf("current public parameters for [%s] declare no issuers", request.TMSID))
+	}
+
+	if request.PublicParamsSig == nil {
+		return errors.Join(ErrValidatePublicParams, errors.Errorf("missing public params signature for re-setup of [%s]", request.TMSID))
+	}
+	if !slices.ContainsFunc(currentIssuers, request.PublicParamsSig.SignerIdentity.Equal) {
+		return errors.Join(ErrValidatePublicParams, errors.Errorf("signer [%s] is not a current issuer of [%s]", request.PublicParamsSig.SignerIdentity, request.TMSID))
+	}
+
+	verifier, err := request.Tms.SigService().IssuerVerifier(ctx.Context(), request.PublicParamsSig.SignerIdentity)
+	if err != nil {
+		return errors.Join(ErrValidatePublicParams, errors.Wrapf(err, "failed to get issuer verifier for [%s]", request.PublicParamsSig.SignerIdentity))
+	}
+	if err := verifier.Verify(request.PublicParamsRaw, request.PublicParamsSig.Signature); err != nil {
+		return errors.Join(ErrValidatePublicParams, errors.Wrapf(err, "public params signature verification failed for [%s]", request.TMSID))
+	}
 
 	return nil
 }

--- a/token/services/network/fabric/endorsement/fsc/service.go
+++ b/token/services/network/fabric/endorsement/fsc/service.go
@@ -33,12 +33,13 @@ const (
 )
 
 type EndorsementService struct {
-	TmsID            token.TMSID
-	Endorsers        []view.Identity
-	ViewManager      ViewManager
-	PolicyType       string
-	EndorserService  EndorserService
-	EndorserSelector EndorserSelector
+	TmsID                         token.TMSID
+	Endorsers                     []view.Identity
+	ViewManager                   ViewManager
+	PolicyType                    string
+	EndorserService               EndorserService
+	EndorserSelector              EndorserSelector
+	TokenManagementSystemProvider TokenManagementSystemProvider
 }
 
 func NewEndorsementService(
@@ -105,12 +106,13 @@ func NewEndorsementService(
 	}
 
 	return &EndorsementService{
-		Endorsers:        endorsers,
-		TmsID:            tmsID,
-		ViewManager:      viewManager,
-		PolicyType:       policyType,
-		EndorserService:  endorserService,
-		EndorserSelector: endorserSelector,
+		Endorsers:                     endorsers,
+		TmsID:                         tmsID,
+		ViewManager:                   viewManager,
+		PolicyType:                    policyType,
+		EndorserService:               endorserService,
+		EndorserSelector:              endorserSelector,
+		TokenManagementSystemProvider: tokenManagementSystemProvider,
 	}, nil
 }
 
@@ -161,7 +163,9 @@ func (e *EndorsementService) Endorse(context view.Context, requestRaw []byte, si
 }
 
 // SetupPublicParams submits new/updated public parameters for endorsement, following the same
-// endorser-selection policy used by Endorse.
+// endorser-selection policy used by Endorse. On re-setup of a namespace that already has a TMS,
+// the submission is signed with a locally-held current-issuer wallet, so the responder can
+// authorize the change; first-time setup carries no signature.
 func (e *EndorsementService) SetupPublicParams(context view.Context, publicParamsRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
 	endorsers, err := e.selectEndorsers(context)
 	if err != nil {
@@ -169,10 +173,25 @@ func (e *EndorsementService) SetupPublicParams(context view.Context, publicParam
 	}
 	logger.DebugfContext(context.Context(), "request public params setup via panurus endorsers with policy [%s]: [%d]...", e.PolicyType, len(endorsers))
 
+	var ppSig *PublicParamsSignature
+	tms, err := e.TokenManagementSystemProvider.GetManagementService(token.WithTMSID(e.TmsID))
+	switch {
+	case err == nil:
+		ppSig, err = signPublicParamsWithCurrentIssuer(context, tms, publicParamsRaw)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "failed to sign public parameters for re-setup of [%s]", e.TmsID)
+		}
+	case errors.Is(err, token.ErrTMSNotFound):
+		// first-time setup: no existing TMS to be authorized by, no signature needed
+	default:
+		return nil, errors.WithMessagef(err, "failed to look up tms [%s] for public params setup", e.TmsID)
+	}
+
 	envBoxed, err := e.ViewManager.InitiateView(context.Context(), NewSetupPublicParamsView(
 		e.TmsID,
 		txID,
 		publicParamsRaw,
+		ppSig,
 		endorsers,
 		e.EndorserService,
 	))
@@ -185,4 +204,37 @@ func (e *EndorsementService) SetupPublicParams(context view.Context, publicParam
 	}
 
 	return env, nil
+}
+
+// signPublicParamsWithCurrentIssuer produces a detached signature over ppRaw using a locally
+// held signer for one of the current public parameters' issuers, authorizing a re-setup.
+func signPublicParamsWithCurrentIssuer(context view.Context, tms *token.ManagementService, ppRaw []byte) (*PublicParamsSignature, error) {
+	issuers := tms.PublicParameters().Issuers()
+	if len(issuers) == 0 {
+		return nil, errors.Errorf("no issuers defined in current public parameters for [%s]", tms.ID())
+	}
+
+	var lastErr error
+	for _, id := range issuers {
+		wallet, err := tms.WalletManager().IssuerWallet(context.Context(), id)
+		if err != nil {
+			lastErr = err
+
+			continue
+		}
+		signer, err := wallet.GetSigner(context.Context(), id)
+		if err != nil {
+			lastErr = err
+
+			continue
+		}
+		sigma, err := signer.Sign(ppRaw)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "failed to sign public parameters with issuer [%s]", id)
+		}
+
+		return &PublicParamsSignature{SignerIdentity: id, Signature: sigma}, nil
+	}
+
+	return nil, errors.WithMessagef(lastErr, "no local signer found for any current issuer of [%s]", tms.ID())
 }

--- a/token/services/network/fabric/endorsement/fsc/service_test.go
+++ b/token/services/network/fabric/endorsement/fsc/service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/token"
 	mock2 "github.com/LFDT-Panurus/panurus/token/driver/mock"
+	tokenmock "github.com/LFDT-Panurus/panurus/token/mock"
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/endorsement/fsc"
 	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/endorsement/fsc/mock"
@@ -564,6 +565,13 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		Namespace: "test_namespace",
 	}
 
+	firstTimeSetupTMSP := func() *mock.TokenManagementSystemProvider {
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(nil, token.ErrTMSNotFound)
+
+		return tmsp
+	}
+
 	t.Run("success - AllPolicy", func(t *testing.T) {
 		ctx := &mock.Context{}
 		ctx.ContextReturns(context.Background())
@@ -579,9 +587,10 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 				[]byte("endorser1"),
 				[]byte("endorser2"),
 			},
-			ViewManager:     viewManager,
-			PolicyType:      fsc.AllPolicy,
-			EndorserService: &mock.EndorserService{},
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		env, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -607,9 +616,10 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 				[]byte("endorser2"),
 				[]byte("endorser3"),
 			},
-			ViewManager:     viewManager,
-			PolicyType:      fsc.OneOutNPolicy,
-			EndorserService: &mock.EndorserService{},
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.OneOutNPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		env, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -628,11 +638,12 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		}
 
 		service := &fsc.EndorsementService{
-			TmsID:           tmsID,
-			Endorsers:       []view.Identity{[]byte("endorser1")},
-			ViewManager:     viewManager,
-			PolicyType:      "unknown",
-			EndorserService: &mock.EndorserService{},
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   viewManager,
+			PolicyType:                    "unknown",
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		env, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -659,10 +670,11 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 				[]byte("endorser1"),
 				[]byte("endorser2"),
 			},
-			ViewManager:      viewManager,
-			PolicyType:       fsc.NamespacePolicy,
-			EndorserService:  &mock.EndorserService{},
-			EndorserSelector: selector,
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.NamespacePolicy,
+			EndorserService:               &mock.EndorserService{},
+			EndorserSelector:              selector,
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		env, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -683,12 +695,13 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		selector.SelectEndorsersReturns(nil, errors.New("no covering subset"))
 
 		service := &fsc.EndorsementService{
-			TmsID:            tmsID,
-			Endorsers:        []view.Identity{[]byte("endorser1")},
-			ViewManager:      &mockViewManager{},
-			PolicyType:       fsc.NamespacePolicy,
-			EndorserService:  &mock.EndorserService{},
-			EndorserSelector: selector,
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.NamespacePolicy,
+			EndorserService:               &mock.EndorserService{},
+			EndorserSelector:              selector,
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -706,11 +719,12 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		}
 
 		service := &fsc.EndorsementService{
-			TmsID:           tmsID,
-			Endorsers:       []view.Identity{[]byte("endorser1")},
-			ViewManager:     viewManager,
-			PolicyType:      fsc.AllPolicy,
-			EndorserService: &mock.EndorserService{},
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -728,11 +742,12 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		}
 
 		service := &fsc.EndorsementService{
-			TmsID:           tmsID,
-			Endorsers:       []view.Identity{[]byte("endorser1")},
-			ViewManager:     viewManager,
-			PolicyType:      fsc.AllPolicy,
-			EndorserService: &mock.EndorserService{},
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: firstTimeSetupTMSP(),
 		}
 
 		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
@@ -740,6 +755,210 @@ func TestEndorsementService_SetupPublicParams(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected driver.Envelope")
 	})
+
+	t.Run("failed to look up tms", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(nil, errors.New("lookup failed"))
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to look up tms")
+	})
+
+	t.Run("success - re-setup signs with current issuer", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		issuer := token.Identity("current_issuer")
+		signature := []byte("issuer_signature")
+		signer := &mock2.Signer{}
+		signer.SignReturns(signature, nil)
+		issuerWallet := &mock2.IssuerWallet{}
+		issuerWallet.GetSignerReturns(signer, nil)
+		ws := &mock2.WalletService{}
+		ws.IssuerWalletReturns(issuerWallet, nil)
+		tms := newResetupManagementService(t, tmsID, []token.Identity{issuer}, ws)
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(tms, nil)
+
+		mockEnv := &mock.Envelope{}
+		viewManager := &mockViewManager{
+			initiateViewResult: mockEnv,
+		}
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   viewManager,
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		ppRaw := []byte("public_params")
+		env, err := service.SetupPublicParams(ctx, ppRaw, []byte("signer"), driver.TxID{})
+
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		require.NotNil(t, viewManager.initiateViewArg)
+		setupView, ok := viewManager.initiateViewArg.(*fsc.SetupPublicParamsView)
+		require.True(t, ok)
+		require.NotNil(t, setupView.PublicParamsSig)
+		assert.Equal(t, issuer, setupView.PublicParamsSig.SignerIdentity)
+		assert.Equal(t, signature, setupView.PublicParamsSig.Signature)
+		require.Equal(t, 1, signer.SignCallCount())
+		assert.Equal(t, ppRaw, signer.SignArgsForCall(0))
+	})
+
+	t.Run("failed - re-setup current public params have no issuers", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		tms := newResetupManagementService(t, tmsID, nil, &mock2.WalletService{})
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(tms, nil)
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to sign public parameters for re-setup")
+		assert.Contains(t, err.Error(), "no issuers defined")
+	})
+
+	t.Run("failed - re-setup no local signer for any current issuer", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		issuer := token.Identity("current_issuer")
+		ws := &mock2.WalletService{}
+		ws.IssuerWalletReturns(nil, errors.New("no wallet for issuer"))
+		tms := newResetupManagementService(t, tmsID, []token.Identity{issuer}, ws)
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(tms, nil)
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to sign public parameters for re-setup")
+		assert.Contains(t, err.Error(), "no local signer found for any current issuer")
+		assert.Contains(t, err.Error(), "no wallet for issuer")
+	})
+
+	t.Run("failed - re-setup GetSigner fails for all current issuers", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		issuer := token.Identity("current_issuer")
+		issuerWallet := &mock2.IssuerWallet{}
+		issuerWallet.GetSignerReturns(nil, errors.New("no signer registered"))
+		ws := &mock2.WalletService{}
+		ws.IssuerWalletReturns(issuerWallet, nil)
+		tms := newResetupManagementService(t, tmsID, []token.Identity{issuer}, ws)
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(tms, nil)
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to sign public parameters for re-setup")
+		assert.Contains(t, err.Error(), "no local signer found for any current issuer")
+		assert.Contains(t, err.Error(), "no signer registered")
+	})
+
+	t.Run("failed - re-setup signing fails", func(t *testing.T) {
+		ctx := &mock.Context{}
+		ctx.ContextReturns(context.Background())
+
+		issuer := token.Identity("current_issuer")
+		signer := &mock2.Signer{}
+		signer.SignReturns(nil, errors.New("signing device unavailable"))
+		issuerWallet := &mock2.IssuerWallet{}
+		issuerWallet.GetSignerReturns(signer, nil)
+		ws := &mock2.WalletService{}
+		ws.IssuerWalletReturns(issuerWallet, nil)
+		tms := newResetupManagementService(t, tmsID, []token.Identity{issuer}, ws)
+		tmsp := &mock.TokenManagementSystemProvider{}
+		tmsp.GetManagementServiceReturns(tms, nil)
+
+		service := &fsc.EndorsementService{
+			TmsID:                         tmsID,
+			Endorsers:                     []view.Identity{[]byte("endorser1")},
+			ViewManager:                   &mockViewManager{},
+			PolicyType:                    fsc.AllPolicy,
+			EndorserService:               &mock.EndorserService{},
+			TokenManagementSystemProvider: tmsp,
+		}
+
+		_, err := service.SetupPublicParams(ctx, []byte("public_params"), []byte("signer"), driver.TxID{})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to sign public parameters for re-setup")
+		assert.Contains(t, err.Error(), "signing device unavailable")
+	})
+}
+
+// newResetupManagementService returns a mocked token.ManagementService whose current public
+// parameters report the given issuers and whose wallet manager resolves issuer wallets via ws,
+// so tests can control the outcome of signPublicParamsWithCurrentIssuer.
+func newResetupManagementService(t *testing.T, tmsID token.TMSID, issuers []token.Identity, ws *mock2.WalletService) *token.ManagementService {
+	t.Helper()
+	tms := &mock2.TokenManagerService{}
+	pp := &mock2.PublicParameters{}
+	pp.IssuersReturns(issuers)
+	ppm := &mock2.PublicParamsManager{}
+	ppm.PublicParametersReturns(pp)
+	tms.PublicParamsManagerReturns(ppm)
+	tms.WalletServiceReturns(ws)
+	vp := &tokenmock.VaultProvider{}
+	vault := &mock2.Vault{}
+	qe := &mock2.QueryEngine{}
+	vault.QueryEngineReturns(qe)
+	vp.VaultReturns(vault, nil)
+
+	res, err := token.NewManagementService(tmsID, tms, nil, vp, nil, nil)
+	require.NoError(t, err)
+
+	return res
 }
 
 // Mock implementations
@@ -783,10 +1002,12 @@ type mockViewManager struct {
 	initiateViewCalled bool
 	initiateViewResult any
 	initiateViewError  error
+	initiateViewArg    view.View
 }
 
 func (m *mockViewManager) InitiateView(ctx context.Context, view view.View) (any, error) {
 	m.initiateViewCalled = true
+	m.initiateViewArg = view
 
 	return m.initiateViewResult, m.initiateViewError
 }

--- a/token/services/network/fabric/endorsement/fsc/setup_initiator.go
+++ b/token/services/network/fabric/endorsement/fsc/setup_initiator.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package fsc
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -19,11 +20,29 @@ import (
 // from the initiator to the responder.
 const TransientPublicParamsKey = "public_params"
 
+// TransientPublicParamsSigKey is the transient map key used to carry the detached issuer
+// signature over the raw public parameters bytes. It is present only on re-setup, when a
+// TMS already exists for the namespace and the setup responder requires proof that the
+// submission is authorized by a current issuer.
+const TransientPublicParamsSigKey = "public_params_sig"
+
+// PublicParamsSignature is a detached signature over the raw public parameters bytes,
+// produced by a current issuer to authorize a re-setup.
+type PublicParamsSignature struct {
+	// SignerIdentity is the identity of the issuer that produced Signature.
+	SignerIdentity view.Identity `json:"signer_identity"`
+	// Signature is the detached signature over the raw public parameters bytes.
+	Signature []byte `json:"signature"`
+}
+
 // SetupPublicParamsView is the initiator of the public parameters setup/update protocol.
 type SetupPublicParamsView struct {
 	TMSID           token.TMSID
 	TxID            driver.TxID
 	PublicParamsRaw []byte
+	// PublicParamsSig is the detached issuer signature over PublicParamsRaw, required on
+	// re-setup and nil on first-time setup.
+	PublicParamsSig *PublicParamsSignature
 	// Endorsers are the identities of the FSC node that play the role of endorser
 	Endorsers []view.Identity
 
@@ -36,6 +55,7 @@ func NewSetupPublicParamsView(
 	TMSID token.TMSID,
 	txID driver.TxID,
 	publicParamsRaw []byte,
+	ppSig *PublicParamsSignature,
 	endorsers []view.Identity,
 	endorserService EndorserService,
 ) *SetupPublicParamsView {
@@ -43,6 +63,7 @@ func NewSetupPublicParamsView(
 		TMSID:           TMSID,
 		TxID:            txID,
 		PublicParamsRaw: publicParamsRaw,
+		PublicParamsSig: ppSig,
 		Endorsers:       endorsers,
 		EndorserService: endorserService,
 	}
@@ -71,6 +92,15 @@ func (s *SetupPublicParamsView) Call(ctx view.Context) (any, error) {
 	}
 	if err := tx.SetTransient(TransientPublicParamsKey, s.PublicParamsRaw); err != nil {
 		return nil, errors.WithMessagef(err, "failed to set public params transient")
+	}
+	if s.PublicParamsSig != nil {
+		sigRaw, err := json.Marshal(s.PublicParamsSig)
+		if err != nil {
+			return nil, errors.WithMessagef(err, "failed to marshal public params signature")
+		}
+		if err := tx.SetTransient(TransientPublicParamsSigKey, sigRaw); err != nil {
+			return nil, errors.WithMessagef(err, "failed to set public params signature transient")
+		}
 	}
 
 	logger.DebugfContext(ctx.Context(), "request endorsement on tx [%s] to [%v]...", tx.ID(), s.Endorsers)

--- a/token/services/network/fabric/endorsement/fsc/setup_initiator_test.go
+++ b/token/services/network/fabric/endorsement/fsc/setup_initiator_test.go
@@ -32,7 +32,7 @@ type MockNewSetupPublicParamsView struct {
 	env             *fabric.Envelope
 }
 
-func mockNewSetupPublicParamsView(t *testing.T, overrideTMSID *token.TMSID) *MockNewSetupPublicParamsView {
+func mockNewSetupPublicParamsView(t *testing.T, overrideTMSID *token.TMSID, ppSig *fsc.PublicParamsSignature) *MockNewSetupPublicParamsView {
 	t.Helper()
 
 	ctx := &mock.Context{}
@@ -66,6 +66,7 @@ func mockNewSetupPublicParamsView(t *testing.T, overrideTMSID *token.TMSID) *Moc
 		tmsID,
 		driver.TxID{},
 		publicParamsRaw,
+		ppSig,
 		nil,
 		es,
 	)
@@ -96,7 +97,7 @@ func TestSetupPublicParamsView(t *testing.T) {
 		{
 			name: "Success",
 			setup: func() *MockNewSetupPublicParamsView {
-				m := mockNewSetupPublicParamsView(t, nil)
+				m := mockNewSetupPublicParamsView(t, nil, nil)
 
 				return m
 			},
@@ -116,9 +117,31 @@ func TestSetupPublicParamsView(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Success with public params signature",
+			setup: func() *MockNewSetupPublicParamsView {
+				m := mockNewSetupPublicParamsView(t, nil, &fsc.PublicParamsSignature{
+					SignerIdentity: token.Identity("an_issuer"),
+					Signature:      []byte("a_signature"),
+				})
+
+				return m
+			},
+			verify: func(m *MockNewSetupPublicParamsView, res any) {
+				assert.Len(t, m.transientMap, 3)
+				assert.Equal(t, m.tmsIDRaw, m.transientMap[fsc.TransientTMSIDKey])
+				assert.Equal(t, m.publicParamsRaw, m.transientMap[fsc.TransientPublicParamsKey])
+				var sig fsc.PublicParamsSignature
+				require.NoError(t, json.Unmarshal(m.transientMap[fsc.TransientPublicParamsSigKey], &sig))
+				assert.Equal(t, token.Identity("an_issuer"), sig.SignerIdentity)
+				assert.Equal(t, []byte("a_signature"), sig.Signature)
+				assert.Equal(t, m.env, res)
+			},
+			expectError: false,
+		},
+		{
 			name: "failed NewTransaction",
 			setup: func() *MockNewSetupPublicParamsView {
-				m := mockNewSetupPublicParamsView(t, nil)
+				m := mockNewSetupPublicParamsView(t, nil, nil)
 				m.es.NewTransactionReturns(nil, errors.New("failed NewTransaction"))
 
 				return m
@@ -129,7 +152,7 @@ func TestSetupPublicParamsView(t *testing.T) {
 		{
 			name: "failed EndorseProposal",
 			setup: func() *MockNewSetupPublicParamsView {
-				m := mockNewSetupPublicParamsView(t, nil)
+				m := mockNewSetupPublicParamsView(t, nil, nil)
 				m.fabricTx.EndorseProposalReturns(errors.New("failed EndorseProposal"))
 
 				return m
@@ -140,7 +163,7 @@ func TestSetupPublicParamsView(t *testing.T) {
 		{
 			name: "failed CollectEndorsements",
 			setup: func() *MockNewSetupPublicParamsView {
-				m := mockNewSetupPublicParamsView(t, nil)
+				m := mockNewSetupPublicParamsView(t, nil, nil)
 				m.es.CollectEndorsementsReturns(errors.New("failed CollectEndorsements"))
 
 				return m

--- a/token/services/network/fabric/endorsement/fsc/setup_responder_test.go
+++ b/token/services/network/fabric/endorsement/fsc/setup_responder_test.go
@@ -36,7 +36,13 @@ type MockNewSetupPublicParamsResponderView struct {
 	ppValidator     *mock.PublicParamsValidator
 	pp              *mock2.PublicParameters
 	tms             *token.ManagementService
+	currentPP       *mock2.PublicParameters
+	deserializer    *mock2.Deserializer
 }
+
+// currentIssuer is the identity used as the sole current issuer in the mocked TMS returned by
+// mockNewSetupPublicParamsResponderView; it is also the default valid signer for re-setup cases.
+var currentIssuer = token.Identity("current_issuer_identity")
 
 func mockNewSetupPublicParamsResponderView(t *testing.T, overrideTMSID *token.TMSID) *MockNewSetupPublicParamsResponderView {
 	t.Helper()
@@ -67,9 +73,15 @@ func mockNewSetupPublicParamsResponderView(t *testing.T, overrideTMSID *token.TM
 	tmsIDRaw, err := json.Marshal(tmsID)
 	require.NoError(t, err)
 	publicParamsRaw := []byte("a_public_params")
+	sigRaw, err := json.Marshal(&fsc.PublicParamsSignature{
+		SignerIdentity: currentIssuer,
+		Signature:      []byte("a_valid_signature"),
+	})
+	require.NoError(t, err)
 	fabricTx.TransientReturns(map[string][]byte{
-		fsc.TransientTMSIDKey:        tmsIDRaw,
-		fsc.TransientPublicParamsKey: publicParamsRaw,
+		fsc.TransientTMSIDKey:           tmsIDRaw,
+		fsc.TransientPublicParamsKey:    publicParamsRaw,
+		fsc.TransientPublicParamsSigKey: sigRaw,
 	})
 	rws := &mock.FabricRWSet{}
 	fabricTx.GetRWSetReturns(rws, nil)
@@ -82,7 +94,8 @@ func mockNewSetupPublicParamsResponderView(t *testing.T, overrideTMSID *token.TM
 		Transaction: fabric.NewTransaction(nil, fabricTx),
 	}, nil)
 	tmsp := &mock.TokenManagementSystemProvider{}
-	tms := tokenapi.NewMockedManagementService(t, tmsID)
+	tms, currentPP, deserializer := tokenapi.NewMockedManagementServiceWithIssuers(t, tmsID, []token.Identity{currentIssuer})
+	deserializer.GetIssuerVerifierReturns(&alwaysValidVerifier{}, nil)
 	tmsp.GetManagementServiceReturns(tms, nil)
 
 	mspManager := &mock.MSPManager{}
@@ -100,6 +113,8 @@ func mockNewSetupPublicParamsResponderView(t *testing.T, overrideTMSID *token.TM
 
 	ppValidator := &mock.PublicParamsValidator{}
 	pp := &mock2.PublicParameters{}
+	pp.IssuersReturns([]token.Identity{currentIssuer})
+	pp.ValidateReturns(nil)
 	ppValidator.PublicParametersFromBytesReturns(pp, nil)
 
 	view := fsc.NewResponderView(
@@ -128,6 +143,8 @@ func mockNewSetupPublicParamsResponderView(t *testing.T, overrideTMSID *token.TM
 		ppValidator:     ppValidator,
 		pp:              pp,
 		tms:             tms,
+		currentPP:       currentPP,
+		deserializer:    deserializer,
 	}
 }
 
@@ -158,7 +175,7 @@ func TestSetupPublicParamsResponderView(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid number of transient fields",
+			name: "invalid number of transient fields (too few)",
 			setup: func() *MockNewSetupPublicParamsResponderView {
 				m := mockNewSetupPublicParamsResponderView(t, nil)
 				m.fabricTx.TransientReturns(map[string][]byte{
@@ -169,7 +186,70 @@ func TestSetupPublicParamsResponderView(t *testing.T) {
 			},
 			expectError:      true,
 			expectErrorType:  fsc.ErrReceivedProposal,
-			expectErrContain: "invalid number of transient fields, expected 2, got 1",
+			expectErrContain: "invalid number of transient fields, expected 2 or 3, got 1",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 0, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "invalid number of transient fields (too many)",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					"transient":  []byte("transient"),
+					"transient2": []byte("transient2"),
+					"transient3": []byte("transient3"),
+					"transient4": []byte("transient4"),
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrReceivedProposal,
+			expectErrContain: "invalid number of transient fields, expected 2 or 3, got 4",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 0, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "malformed public params signature transient",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:           m.tmsIDRaw,
+					fsc.TransientPublicParamsKey:    []byte("a_public_params"),
+					fsc.TransientPublicParamsSigKey: []byte("not_json"),
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrReceivedProposal,
+			expectErrContain: "failed to unmarshal public params signature",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 0, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "incomplete public params signature envelope",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				sigRaw, err := json.Marshal(&fsc.PublicParamsSignature{
+					SignerIdentity: currentIssuer,
+					Signature:      nil,
+				})
+				require.NoError(t, err)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:           m.tmsIDRaw,
+					fsc.TransientPublicParamsKey:    []byte("a_public_params"),
+					fsc.TransientPublicParamsSigKey: sigRaw,
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrReceivedProposal,
+			expectErrContain: "incomplete public params signature",
 			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
 				assert.Equal(t, 0, m.rws.DoneCallCount())
 			},
@@ -369,6 +449,158 @@ func TestSetupPublicParamsResponderView(t *testing.T) {
 			expectErrContain: "tms ids do not match",
 			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
 				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "failed to parse public params",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.ppValidator.PublicParametersFromBytesReturns(nil, errors.New("cannot parse"))
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "failed to unmarshal public params",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "public params fail Validate",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.pp.ValidateReturns(errors.New("internally inconsistent"))
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "failed to validate public params",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "re-setup with new public params declaring no issuers succeeds",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.pp.IssuersReturns(nil)
+
+				return m
+			},
+			expectError: false,
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+				assert.Equal(t, 1, m.translator.WriteCallCount())
+			},
+		},
+		{
+			name: "re-setup with current public params declaring no issuers",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.currentPP.IssuersReturns(nil)
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "current public parameters",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "re-setup missing public params signature",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:        m.tmsIDRaw,
+					fsc.TransientPublicParamsKey: []byte("a_public_params"),
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "missing public params signature",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "re-setup signed by a non-issuer",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				sigRaw, err := json.Marshal(&fsc.PublicParamsSignature{
+					SignerIdentity: token.Identity("not_an_issuer"),
+					Signature:      []byte("a_signature"),
+				})
+				require.NoError(t, err)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:           m.tmsIDRaw,
+					fsc.TransientPublicParamsKey:    []byte("a_public_params"),
+					fsc.TransientPublicParamsSigKey: sigRaw,
+				})
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "is not a current issuer",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "re-setup issuer verifier lookup fails",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.deserializer.GetIssuerVerifierReturns(nil, errors.New("no verifier"))
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "failed to get issuer verifier",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "re-setup signature verification fails",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.deserializer.GetIssuerVerifierReturns(&rejectingVerifier{}, nil)
+
+				return m
+			},
+			expectError:      true,
+			expectErrorType:  fsc.ErrValidateProposal,
+			expectErrContain: "public params signature verification failed",
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+			},
+		},
+		{
+			name: "first-time setup with empty issuers succeeds",
+			setup: func() *MockNewSetupPublicParamsResponderView {
+				m := mockNewSetupPublicParamsResponderView(t, nil)
+				m.tmsp.GetManagementServiceReturns(nil, token.ErrTMSNotFound)
+				m.pp.IssuersReturns(nil)
+				m.fabricTx.TransientReturns(map[string][]byte{
+					fsc.TransientTMSIDKey:        m.tmsIDRaw,
+					fsc.TransientPublicParamsKey: []byte("a_public_params"),
+				})
+
+				return m
+			},
+			expectError: false,
+			verify: func(m *MockNewSetupPublicParamsResponderView, res any) {
+				assert.Equal(t, 1, m.rws.DoneCallCount())
+				assert.Equal(t, 1, m.translator.WriteCallCount())
+				assert.Equal(t, 1, m.ppValidator.PublicParametersFromBytesCallCount())
+				assert.Equal(t, 1, m.pp.ValidateCallCount())
 			},
 		},
 		{

--- a/token/services/ttx/dep/tokenapi/tms.go
+++ b/token/services/ttx/dep/tokenapi/tms.go
@@ -35,6 +35,33 @@ func NewMockedManagementService(t *testing.T, tmsID token.TMSID) *token.Manageme
 	return res
 }
 
+// NewMockedManagementServiceWithIssuers returns a mocked token.ManagementService whose public
+// parameters report the given issuers and whose Deserializer resolves issuer verifiers via the
+// returned mock.Deserializer, so tests can control signature verification outcomes with
+// deserializer.GetIssuerVerifierReturns. The returned mock.PublicParameters lets tests further
+// adjust the current public parameters (e.g. pp.IssuersReturns(nil) to simulate no issuers).
+func NewMockedManagementServiceWithIssuers(t *testing.T, tmsID token.TMSID, issuers []token.Identity) (*token.ManagementService, *mock.PublicParameters, *mock.Deserializer) {
+	t.Helper()
+	tms := &mock.TokenManagerService{}
+	pp := &mock.PublicParameters{}
+	pp.IssuersReturns(issuers)
+	ppm := &mock.PublicParamsManager{}
+	ppm.PublicParametersReturns(pp)
+	tms.PublicParamsManagerReturns(ppm)
+	deserializer := &mock.Deserializer{}
+	tms.DeserializerReturns(deserializer)
+	vp := &mock2.VaultProvider{}
+	vault := &mock.Vault{}
+	qe := &mock.QueryEngine{}
+	vault.QueryEngineReturns(qe)
+	vp.VaultReturns(vault, nil)
+
+	res, err := token.NewManagementService(tmsID, tms, nil, vp, nil, nil)
+	require.NoError(t, err)
+
+	return res, pp, deserializer
+}
+
 // NewMockedManagementServiceWithValidation returns a mocked token.ManagementService and a validator
 func NewMockedManagementServiceWithValidation(t *testing.T, tmsID token.TMSID) (*token.ManagementService, *mock.Validator) {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Parses incoming public parameters and calls `Validate()` before accepting a setup/re-setup request.
- On re-setup of a namespace that already has a TMS, requires a detached signature over the raw public parameters bytes produced by a current issuer (from `PublicParameters.Issuers()`), carried via an optional `public_params_sig` transient, so setup changes can't be pushed by an unauthorized party.
- `fsc.EndorsementService.SetupPublicParams` looks up the existing TMS (if any) and signs on behalf of the initiator using a locally-held issuer wallet, so callers don't need to change.
- First-time setup (no existing TMS) is unaffected and requires no signature; empty issuer sets remain allowed (drivers support "anyone can issue" mode).
- Driver name/version and `CertificationDriver()` are allowed to change freely on re-setup — gated only by the issuer signature, per the driver implementations' existing design.

Fixes #1943

## Test plan
- [x] `go test ./token/services/network/fabric/endorsement/fsc/...` — accept/reject cases for validate/parse failures, missing signature, non-issuer signer, verifier lookup failure, signature verification failure, and the initiator-side signing paths (success, no current issuers, no local signer available, signer lookup failure, signing failure)
- [x] `signPublicParamsWithCurrentIssuer` at 100% coverage (previously untested)
- [x] `make checks` (license, gofmt, goimports, go vet, misspell, ineffassign, staticcheck, tidy)
- [x] `make unit-tests` (full suite, no failures)
- [x] `golangci-lint run` on the changed package — 0 issues
- [x] `docs/services/network-fabric.md` updated to describe the new invariants and the initiator-side signing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)