### PR TITLE
ci: add nightly job to build against fabric-smart-client main

### DIFF
--- a/.claude/skills/update-fsc/SKILL.md
+++ b/.claude/skills/update-fsc/SKILL.md
@@ -1,0 +1,1 @@
+../../../docs/development/update-fsc.md

--- a/.github/actions/bump-fsc/action.yml
+++ b/.github/actions/bump-fsc/action.yml
@@ -1,0 +1,18 @@
+name: Bump FSC dependency
+description: >
+  Resolves the latest fabric-smart-client main commit and bumps it (and its
+  /integration submodule) across every Go module in the repo via `make update-dep`.
+runs:
+  using: composite
+  steps:
+    - name: Bump fabric-smart-client to latest main
+      shell: bash
+      run: |
+        SHA=$(git ls-remote https://github.com/hyperledger-labs/fabric-smart-client.git refs/heads/main | cut -f1)
+        if [ -z "$SHA" ]; then
+          echo "Failed to resolve fabric-smart-client main SHA" >&2
+          exit 1
+        fi
+        echo "Bumping fabric-smart-client to $SHA"
+        make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client VER=$SHA
+        make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client/integration VER=$SHA

--- a/.github/workflows/nightly-fsc.yml
+++ b/.github/workflows/nightly-fsc.yml
@@ -1,0 +1,244 @@
+name: Nightly FSC Update
+
+on:
+  schedule:
+    - cron: '23 3 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  GOFLAGS: -mod=mod
+
+jobs:
+
+  checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Bump FSC dependency
+        uses: ./.github/actions/bump-fsc
+
+      - name: Set up tools
+        run: make install-tools
+
+      - name: Run checks
+        run: make checks
+
+      - name: Run linter
+        run: make lint
+
+  utest:
+    needs: checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tests: [unit-tests-race, unit-tests-regression]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Bump FSC dependency
+        uses: ./.github/actions/bump-fsc
+
+      - name: Set up tools
+        run: make install-tools
+
+      - name: Install Testing Docker Images
+        run: make testing-docker-images
+
+      - name: Unit Tests with Coverage
+        run: |
+          make unit-tests
+          ./ci/scripts/filter-coverage.sh profile.cov profile.cov
+
+      - name: Send coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: profile.cov
+          flag-name: utest-nightly-${{ matrix.tests }}
+          parallel: true
+          fail-on-error: false
+
+      - name: Run ${{ matrix.tests }}
+        run: make ${{ matrix.tests }}
+
+  itest:
+    needs: checks
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tests: [
+          dlog-fabric-t1,
+          dlog-fabric-t2,
+          dlog-fabric-t2.1,
+          dlog-fabric-t3,
+          dlog-fabric-t4,
+          dlog-fabric-t5,
+          dlog-fabric-t6,
+          dlog-fabric-t7,
+          dlog-fabric-t8,
+          dlog-fabric-t9,
+          dlog-fabric-t10,
+          dlog-fabric-t11,
+          dlog-fabric-t12,
+          dlog-fabric-t13,
+#          dlog-fabric-t14,
+          fabricx-dlog-t1,
+#          fabricx-dlog-t2,
+#          fabricx-dlog-t2.1,
+          fabricx-dlog-t3,
+          fabricx-dlog-t4,
+          fabricx-dlog-t5,
+          fabricx-dlog-t6,
+#          fabricx-dlog-t7,
+#          fabricx-dlog-t9,
+          fabricx-dlog-t11,
+#          fabricx-dlog-t12,
+          fabricx-dlog-t13,
+#          fabricx-dlog-t14,
+          fabricx-dlog-t16,
+          fabtoken-dlog-fabric,
+          dloghsm-fabric-t1,
+          dloghsm-fabric-t2,
+          fabtoken-fabric-t1,
+          fabtoken-fabric-t2,
+          fabtoken-fabric-t3,
+          fabtoken-fabric-t4,
+          fabtoken-fabric-t5,
+          update-t1,
+          update-t2,
+          update-t3,
+          nft-dlog,
+          nft-fabtoken,
+          dvp-fabtoken,
+          dvp-dlog,
+          interop-fabtoken-t1,
+          interop-fabtoken-t3,
+          interop-fabtoken-t4,
+          interop-fabtoken-t5,
+          interop-dlog-t1,
+          interop-dlog-t3,
+          interop-dlog-t4,
+          interop-dlog-t5,
+          dlogstress-t1,
+        ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Bump FSC dependency
+        uses: ./.github/actions/bump-fsc
+
+      - name: Set up tools
+        run: make install-tools
+
+      - name: Download fabric binaries
+        run: make download-fabric
+
+      - name: Docker
+        run: make docker-images
+
+      - name: Fabric-x setup
+        if: startsWith(matrix.tests, 'fabricx')
+        run: |
+          make fxconfig configtxgen fabricx-docker-images
+
+      - name: Run ${{ matrix.tests }}
+        run: |
+          mkdir -p covdata
+          GOCOVERDIR=$(realpath covdata) make integration-tests-${{ matrix.tests }}
+          go tool covdata textfmt -i=covdata -o coverage.profile
+          ./ci/scripts/filter-coverage.sh coverage.profile coverage.profile
+
+      - name: Send coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage.profile
+          flag-name: itest-nightly-${{ matrix.tests }}
+          parallel: true
+          fail-on-error: false
+
+  publish-coverage:
+    needs: [ utest, itest ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finish coverage report
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true
+          fail-on-error: false
+
+  bench-check:
+    needs: checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Bump FSC dependency
+        uses: ./.github/actions/bump-fsc
+
+      - name: Compile benchmarks (do not run)
+        run: go test ./... -run=^$ -bench=^$
+
+  cgo-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Bump FSC dependency
+        uses: ./.github/actions/bump-fsc
+
+      - name: Build tokengen without cgo
+        env:
+          CGO_ENABLED: "0"
+        run: cd ./cmd/tokengen; go build -o /dev/null .
+
+      - name: Build artifactgen without cgo
+        env:
+          CGO_ENABLED: "0"
+        run: cd ./cmd/artifactgen; go build -o /dev/null .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,18 @@ Before marking a task complete, update or create the relevant documentation unde
 - New `docs/` pages must follow the existing style (Markdown, same heading hierarchy as neighbouring files).
 - If no existing doc page covers the changed area, create `docs/<subsystem>/<topic>.md` and add a link from the nearest index or README.
 
+### Automation Runbooks (Workflow Rule)
+Reusable, agent-agnostic step-by-step procedures live under `docs/development/` and are
+readable by any agent that reads this file — not just Claude Code. When Claude Code also
+needs a `/slash-command` trigger for one, add a symlink at
+`.claude/skills/<name>/SKILL.md` pointing back at the doc, so there is one source of truth.
+
+- **Update `fabric-smart-client` to latest `main`**: [docs/development/update-fsc.md](docs/development/update-fsc.md)
+  (Claude Code: `/update-fsc`). Bumps the FSC dependency across every Go module, resolves
+  API/lint breakage until `make checks` and `make lint-auto-fix` are clean, then stops and
+  waits for the user's go-ahead before pushing a branch or opening the PR — the "never push
+  or open a PR without explicit go-ahead" rule above still applies to this runbook.
+
 ## 🔍 Debugging & Advanced Testing
 
 ### Log Locations

--- a/docs/development/ai_agents.md
+++ b/docs/development/ai_agents.md
@@ -45,6 +45,17 @@ Keep changes focused and minimal.
 - **Feature Addition:** Research -> Design -> Strategy -> Implement -> Test -> Validate.
 - **Documentation:** Research -> Draft -> Review -> Refine.
 
+## Runbooks
+
+Some recurring maintenance chores are captured as standalone, agent-agnostic runbooks
+under `docs/development/`, so any agent that has read `AGENTS.md` can execute them
+without re-deriving the steps each time:
+
+- **[Update `fabric-smart-client` to latest `main`](./update-fsc.md)** — bumps the FSC
+  dependency across all Go modules, resolves resulting API/lint breakage until
+  `make checks` is clean, then pauses for user confirmation before pushing or opening
+  a PR. Also available in Claude Code as `/update-fsc`.
+
 ## Issue & PR Submission
 
 Non-trivial fixes/features should have a GitHub Issue before implementation (describing

--- a/docs/development/update-fsc.md
+++ b/docs/development/update-fsc.md
@@ -1,0 +1,149 @@
+---
+name: update-fsc
+description: "Upgrade Panurus's fabric-smart-client dependency to the latest main commit, resolve API/lint breakage until `make checks` is clean, then open a PR. Trigger: /update-fsc"
+trigger: /update-fsc
+---
+
+# Update `fabric-smart-client` to latest `main`
+
+Panurus depends on `github.com/hyperledger-labs/fabric-smart-client` (FSC) across
+every Go module in the repo, pinned to a main-branch pseudo-version (e.g.
+`v0.14.3-0.20260716152906-60a85d843ab6`). This runbook is a reusable, agent-agnostic
+procedure — for a human or an AI agent — to bump that dependency to the latest FSC
+`main` commit, absorb any resulting API changes, and get the repo's checks green.
+
+This doc is the single source of truth. In Claude Code it is also exposed as the
+`/update-fsc` skill via a symlink at `.claude/skills/update-fsc/SKILL.md`.
+
+## Preconditions
+
+- Working tree is clean: `git status` shows nothing to commit. If not, stash
+  (`git stash -u`) or commit first — do not discard existing work.
+- `gh` is authenticated (`gh auth status`) — needed only at the very end, to open the PR.
+- Network access to `github.com/hyperledger-labs/fabric-smart-client`.
+
+## Procedure
+
+### 1. Pick the target commit and branch off `main`
+
+```bash
+git fetch origin
+SHA=$(git ls-remote https://github.com/hyperledger-labs/fabric-smart-client.git refs/heads/main | cut -f1)
+git checkout -b fsc-update-${SHA:0:12} origin/main
+```
+
+### 2. Bump the dependency in every module
+
+Use the existing `update-dep` Makefile target (`Makefile:304`). It walks every
+non-vendor `go.mod` in the repo, runs `go get <DEP>@<VER>` wherever that module is a
+dependency, and finishes with `make tidy`.
+
+```bash
+make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client VER=$SHA
+make update-dep DEP=github.com/hyperledger-labs/fabric-smart-client/integration VER=$SHA
+```
+
+Both runs are required: `/integration` is a **separate Go module path** inside the FSC
+repo, and `update-dep`'s matching (`go list -m all | grep "^$(DEP) "`) only catches
+modules whose require line starts with the exact `DEP` string. `go get module@<sha>`
+resolves the commit hash into the correct pseudo-version automatically.
+
+Leave the `replace`-pinned FSC sub-modules alone:
+
+- `github.com/hyperledger-labs/fabric-smart-client/platform/fabric/services/state/cc/query`
+- `github.com/hyperledger-labs/fabric-smart-client/platform/view/services/comm/host/libp2p`
+
+These are independently tagged releases (currently `v0.14.2`), not tracked to FSC
+`main`. Only touch them if a later step's build error specifically demands it.
+
+### 3. Detect API breakage
+
+For every module in `GO_MODULES` (see `Makefile:36` for the current list — today:
+`. integration token/services/storage/db/kvs/hashicorp cmd/artifactgen cmd/tokengen
+cmd/token_validation_service cmd/profiler cmd/skicleanup cmd/node`):
+
+```bash
+(cd <module-dir> && go build ./... && go vet -all ./...)
+```
+
+`go vet` also type-checks `_test.go` files, catching test-only breakage that `go build`
+misses.
+
+### 4. Resolve compile errors from API changes
+
+For each error:
+
+- Read the FSC symbol's new signature/doc: `go doc <package>.<Symbol>`, or read the
+  source directly under `$(go env GOMODCACHE)/github.com/hyperledger-labs/fabric-smart-client@<pseudo-version>/...`.
+  `go env GOMODCACHE` is the read-only module cache; do not edit files there — update
+  the call site in this repo instead.
+- Make the **minimal, surgical** change needed at the call site — do not refactor
+  unrelated code (project convention, see `AGENTS.md`).
+- If an FSC interface used by a `counterfeiter` mock changed shape, regenerate mocks:
+  `go generate ./...`.
+- Re-run step 3 until `go build` and `go vet` are clean in every module.
+
+### 5. Lint and static checks
+
+```bash
+make lint-auto-fix
+make checks
+```
+
+`make checks` runs: `licensecheck gofmt goimports govet gofix misspell ineffassign
+staticcheck protos-lint buf-format tidy-check` (see `checks.mk`). Fix whatever it
+flags and re-run until it passes cleanly. Do not skip or silence individual checks.
+
+### 6. Tests
+
+```bash
+make unit-tests
+make unit-tests-race   # preferred when time allows
+```
+
+Fix any regression the dependency bump introduced. Integration tests
+(`make integration-tests-*`) are heavy (Docker, Fabric binaries) and CI-gated — run
+them locally only if the environment (`FAB_BINS`, Docker images) is already set up;
+otherwise note in the PR that they're expected to run in CI.
+
+### 7. Commit
+
+One signed-off commit:
+
+```bash
+git add -A
+git commit -s -m "chore(deps): bump fabric-smart-client to ${SHA:0:12}"
+```
+
+Include the old → new pseudo-version in the commit body. Never introduce
+`fmt.Errorf`/`fmt` for error construction in any file you touch — use
+`github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors` per project
+convention.
+
+### 8. Stop and confirm before any remote action
+
+**Do not push or open a PR without the user's explicit go-ahead**, per `AGENTS.md`.
+Report what changed and that `make checks` / `make unit-tests` are green, and wait for
+confirmation.
+
+If `make checks` (or the build) cannot be made clean, **do not open a PR** — report the
+remaining blockers to the user instead of pushing broken state.
+
+### 9. Push and open the PR (after confirmation)
+
+```bash
+git push -u origin fsc-update-${SHA:0:12}
+gh pr create --base main \
+  --title "chore(deps): bump fabric-smart-client to ${SHA:0:12}" \
+  --assignee @me \
+  --label "dep update" \
+  --milestone "$(gh api repos/LFDT-Panurus/panurus/milestones --jq '.[] | select(.state=="open") | .title' | head -1)" \
+  --project "Panurus" \
+  --body "Updates github.com/hyperledger-labs/fabric-smart-client to the latest main commit (${SHA}).
+
+- Ran \`make checks\` and \`make unit-tests\` — both clean.
+- <call out any notable API-adaptation changes here>"
+```
+
+Routine dependency bumps in this repo have shipped both with and without a linked
+issue — open one only if the maintainer wants extra tracking for this run.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,5 +121,6 @@ nav:
       - Tools: development/tools.md
       - Versioning: development/versioning.md
       - AI Agents: development/ai_agents.md
+      - Update FSC Dependency: development/update-fsc.md
       - Documentation: development/documentation.md
   - Evolution: evolution_summary.md


### PR DESCRIPTION
## Summary
- Adds `.github/actions/bump-fsc`, a reusable composite action that resolves the latest `fabric-smart-client` `main` commit and bumps it (plus its `/integration` submodule) across every Go module via `make update-dep`.
- Adds `.github/workflows/nightly-fsc.yml`, a nightly (03:23 UTC) + manually-dispatchable workflow that applies that bump and then runs `make checks`/`make lint`, unit tests (race + regression, with Coveralls), the full integration test matrix, a benchmark-compile sanity check, and cgo-free builds of `tokengen`/`artifactgen` — all against FSC's current `main` instead of the pinned pseudo-version.
- Adds `docs/development/update-fsc.md`, an agent-agnostic runbook for manually bumping the FSC dependency (also exposed to Claude Code as the `/update-fsc` skill via a symlink added in a prior commit on this branch).

## Why
Panurus pins FSC to a manually-bumped pseudo-version, so upstream breakage only surfaces whenever someone next attempts a bump — by then a lot of drift has accumulated. This closes that gap with a continuous nightly signal, per #1961 (a follow-up to the previously-closed #345).

Fixes #1961

## Test plan
- [x] `make checks` — clean
- [x] CI: checks / lint / unit / integration matrix on this PR
- [ ] First nightly run on `main` after merge (verify the composite action resolves FSC's SHA and the full matrix stays green)