### PR TITLE
feat(nwo): enable token platform on FSC nodes without a TMS

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -171,6 +171,30 @@ To run the `dlog-fabric-t1` test:
 make integration-tests-dlog-fabric-t1
 ```
 
+### Enabling the Token Platform Without a TMS
+
+By default, an FSC node only gets `token: enabled: true` written into its generated
+`core.yaml` if it belongs to at least one TMS (`Topology.AddTMS`). `Topology.EnableTokenPlatform`
+(`integration/nwo/token/topology.go`) lets a topology install and start the token platform on
+every node of an `fsc.Topology` with **no TMS defined at all**:
+
+```go
+tokenTopology := token.NewTopology()
+tokenTopology.EnableTokenPlatform(fscTopology)
+```
+
+This only affects configuration generation — the base `token:` stanza from the extension
+template, without any TMS-specific selector or driver configuration. It does not attach the
+token Go SDK to the nodes; do that separately with `Topology.SetSDK` or
+`fscTopology.AddSDK(...)`, as usual.
+
+The token SDK starts up cleanly with zero TMS configs (all its dependencies are lazily
+provided and `network.Provider.Connect()` is a no-op with no configured networks), but
+`GetManagementService(...)` still returns "no token management service configs found" until a
+TMS is registered. `EnableTokenPlatform` is meant as the config-generation groundwork for
+bringing up nodes that will have a TMS registered dynamically at runtime, once that
+capability exists — it is not itself a way to use tokens.
+
 ## Fabric-X Tests
 
 For tests involving Fabric-X (starts with `fabricx`), you need additional setup:

--- a/integration/nwo/token/platform.go
+++ b/integration/nwo/token/platform.go
@@ -142,6 +142,20 @@ func (p *Platform) GenerateArtifacts() {
 			}
 		}
 	}
+
+	// Enable the base token platform on nodes requested independently of any TMS.
+	covered := map[string]struct{}{}
+	for _, tms := range p.Topology.TMSs {
+		for _, n := range tms.FSCNodes {
+			covered[n.Name] = struct{}{}
+		}
+	}
+	for _, n := range p.Topology.TokenPlatformNodes {
+		if _, ok := covered[n.Name]; ok {
+			continue
+		}
+		p.GenerateExtension(n)
+	}
 }
 
 func (p *Platform) Load() {

--- a/integration/nwo/token/topology.go
+++ b/integration/nwo/token/topology.go
@@ -37,6 +37,10 @@ type Topology struct {
 
 	TokenSelector string
 	TMSs          []*topology.TMS
+
+	// TokenPlatformNodes lists FSC nodes that should have the token platform
+	// enabled independently of any TMS. Populated via EnableTokenPlatform.
+	TokenPlatformNodes []*node.Node `yaml:"-"`
 }
 
 func NewTopology() *Topology {
@@ -88,6 +92,16 @@ func (t *Topology) SetSDK(fscTopology *fsc.Topology, sdk nodepkg.SDK) {
 	for _, node := range fscTopology.Nodes {
 		node.AddSDK(sdk)
 	}
+}
+
+// EnableTokenPlatform marks every FSC node in the given topology as
+// token-platform-enabled (token.enabled: true in core.yaml) without
+// requiring any TMS to be defined. This is useful to bring up nodes that
+// will have a TMS registered dynamically at runtime. It only affects
+// configuration generation; attaching the token SDK to the nodes is the
+// caller's responsibility (see SetSDK).
+func (t *Topology) EnableTokenPlatform(fscTopology *fsc.Topology) {
+	t.TokenPlatformNodes = append(t.TokenPlatformNodes, fscTopology.ListNodes()...)
 }
 
 func (t *Topology) GetTMSs() []*topology.TMS {

--- a/integration/nwo/token/topology_test.go
+++ b/integration/nwo/token/topology_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token
+
+import (
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnableTokenPlatform(t *testing.T) {
+	fscTopology := fsc.NewTopology()
+	fscTopology.AddNodeByName("alice")
+	fscTopology.AddNodeByName("bob")
+
+	tokenTopology := NewTopology()
+	tokenTopology.EnableTokenPlatform(fscTopology)
+
+	require.Empty(t, tokenTopology.TMSs)
+	require.Len(t, tokenTopology.TokenPlatformNodes, 2)
+
+	var names []string
+	for _, n := range tokenTopology.TokenPlatformNodes {
+		names = append(names, n.Name)
+	}
+	require.ElementsMatch(t, []string{"alice", "bob"}, names)
+}


### PR DESCRIPTION
## Summary
- Add `Topology.EnableTokenPlatform(fscTopology)` to mark all FSC nodes in an `fsc.Topology` as token-platform-enabled (`token: enabled: true` in `core.yaml`) independently of any TMS.
- `Platform.GenerateArtifacts()` writes the base extension to those nodes (deduped against nodes already covered by a TMS).
- Add a unit test for `EnableTokenPlatform` and document the new method in `docs/development/testing.md`.

This is config-generation groundwork for bringing up nodes that will have a TMS registered dynamically at runtime; it does not itself add a runtime TMS-registration API, and `GetManagementService(...)` still requires a TMS to be registered before use.

Fixes #1974

## Test plan
- [x] `go build ./...` (root module)
- [x] `cd integration && go build ./...`
- [x] `cd integration && go test ./nwo/token/... -v` — new `TestEnableTokenPlatform` passes
- [x] `make checks`
- [x] `make lint-auto-fix`