### PR TITLE
feat(transactions): prepare GetStatus and GetTokenRequest statements

### DIFF
--- a/token/services/storage/db/sql/common/prepared_stmt_holder.go
+++ b/token/services/storage/db/sql/common/prepared_stmt_holder.go
@@ -61,9 +61,16 @@ func (h *preparedStmtHolder[K]) Execute(ctx context.Context, db *sql.DB, key K, 
 	if stmt, err := h.getOrPrepare(ctx, db, key, query); err == nil {
 		if rows, qErr := stmt.QueryContext(ctx, args...); qErr == nil {
 			return rows, nil
+		} else if ctx.Err() != nil {
+			// The context is already done - retrying via the fallback path
+			// would fail identically and only obscure the original
+			// cancellation/deadline error for callers checking its type.
+			return nil, qErr
 		} else {
 			logger.Warnf("prepared statement query failed for key [%v], falling back to unprepared query: %s", key, qErr)
 		}
+	} else if ctx.Err() != nil {
+		return nil, err
 	} else {
 		logger.Warnf("failed preparing statement for key [%v], falling back to unprepared query: %s", key, err)
 	}

--- a/token/services/storage/db/sql/common/tokens_prepared_reuse_test.go
+++ b/token/services/storage/db/sql/common/tokens_prepared_reuse_test.go
@@ -192,3 +192,62 @@ func TestBalancePreparedReuse(t *testing.T) {
 
 	require.NoError(t, mockDB.ExpectationsWereMet())
 }
+
+// TestGetStatusPreparedReuse verifies, without a real DB, that GetStatus
+// reuses the same prepared statement across repeated calls with different
+// txIDs, since the query has only one shape ever (tx_id = ?).
+func TestGetStatusPreparedReuse(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := &TransactionStore{
+		readDB:        db,
+		table:         transactionTables{Requests: "requests"},
+		ci:            stubCondInterpreter{},
+		getStatusStmt: newPreparedStmtHolder[string](),
+	}
+
+	cols := []string{"status", "status_message"}
+	queryPattern := "(?s)SELECT.*status.*requests.*"
+
+	mockDB.ExpectPrepare(queryPattern).
+		ExpectQuery().WillReturnRows(sqlmock.NewRows(cols).AddRow(1, ""))
+	mockDB.ExpectQuery(queryPattern).WillReturnRows(sqlmock.NewRows(cols).AddRow(1, ""))
+	mockDB.ExpectQuery(queryPattern).WillReturnRows(sqlmock.NewRows(cols).AddRow(1, ""))
+
+	for _, txID := range []string{"tx-a", "tx-b", "tx-c"} {
+		_, _, err := store.GetStatus(t.Context(), txID)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, store.getStatusStmt.Count())
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+// TestGetTokenRequestPreparedReuse verifies the same for GetTokenRequest.
+func TestGetTokenRequestPreparedReuse(t *testing.T) {
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	store := &TransactionStore{
+		readDB:              db,
+		table:               transactionTables{Requests: "requests"},
+		ci:                  stubCondInterpreter{},
+		getTokenRequestStmt: newPreparedStmtHolder[string](),
+	}
+
+	cols := []string{"request"}
+	queryPattern := "(?s)SELECT.*request.*requests.*"
+
+	mockDB.ExpectPrepare(queryPattern).
+		ExpectQuery().WillReturnRows(sqlmock.NewRows(cols).AddRow([]byte("r")))
+	mockDB.ExpectQuery(queryPattern).WillReturnRows(sqlmock.NewRows(cols).AddRow([]byte("r")))
+
+	for _, txID := range []string{"tx-a", "tx-b"} {
+		_, err := store.GetTokenRequest(t.Context(), txID)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, store.getTokenRequestStmt.Count())
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}

--- a/token/services/storage/db/sql/common/transactions.go
+++ b/token/services/storage/db/sql/common/transactions.go
@@ -54,6 +54,16 @@ type TransactionStore struct {
 	pi                    common3.PagInterpreter
 	notifier              dbdriver.TransactionNotifier
 	recoveryLeaderFactory func(context.Context, *sql.DB, int64) (dbdriver.RecoveryLeadership, bool, error)
+
+	// getStatusStmt caches the single prepared statement for GetStatus.
+	// Unlike the token-store queries, this query has exactly one shape
+	// (tx_id = ?, always present), so the holder always uses the same
+	// constant key.
+	getStatusStmt PreparedStmtHolder[string]
+
+	// getTokenRequestStmt caches the single prepared statement for
+	// GetTokenRequest, same single-shape reasoning as getStatusStmt.
+	getTokenRequestStmt PreparedStmtHolder[string]
 }
 
 func newTransactionStore(
@@ -66,7 +76,7 @@ func newTransactionStore(
 	notifier dbdriver.TransactionNotifier,
 	recoveryLeaderFactory func(context.Context, *sql.DB, int64) (dbdriver.RecoveryLeadership, bool, error),
 ) *TransactionStore {
-	return &TransactionStore{
+	ts := &TransactionStore{
 		readDB:                readDB,
 		writeDB:               writeDB,
 		table:                 tables,
@@ -77,6 +87,10 @@ func newTransactionStore(
 		notifier:              notifier,
 		recoveryLeaderFactory: recoveryLeaderFactory,
 	}
+	ts.getStatusStmt = newPreparedStmtHolder[string]()
+	ts.getTokenRequestStmt = newPreparedStmtHolder[string]()
+
+	return ts
 }
 
 // PrefixedTableName returns the formatted table name for the given logical name.
@@ -123,13 +137,31 @@ func (db *TransactionStore) CreateSchema() error {
 }
 
 func (db *TransactionStore) GetTokenRequest(ctx context.Context, txID string) ([]byte, error) {
-	query, args := q.Select().
-		FieldsByName("request").
-		From(q.Table(db.table.Requests)).
-		Where(cond.Eq("tx_id", txID)).
-		Format(db.ci)
+	rows, err := db.getTokenRequestStmt.Execute(ctx, db.readDB, "", func() (string, []any, error) {
+		query, args := q.Select().
+			FieldsByName("request").
+			From(q.Table(db.table.Requests)).
+			Where(cond.Eq("tx_id", txID)).
+			Format(db.ci)
 
-	return common.QueryUniqueContext[[]byte](ctx, db.readDB, query, args...)
+		return query, args, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		// Missing tx id - see GetTokenRequests' doc comment: callers should
+		// treat this identically to a present-but-nil result.
+		return nil, rows.Err()
+	}
+	var request []byte
+	if err := rows.Scan(&request); err != nil {
+		return nil, err
+	}
+
+	return request, nil
 }
 
 // GetTokenRequests fetches the token requests for the given tx ids in a
@@ -248,21 +280,30 @@ func (db *TransactionStore) QueryTransactions(ctx context.Context, params dbdriv
 func (db *TransactionStore) GetStatus(ctx context.Context, txID string) (dbdriver.TxStatus, string, error) {
 	var status dbdriver.TxStatus
 	var statusMessage string
-	query, args := q.Select().
-		FieldsByName("status", "status_message").
-		From(q.Table(db.table.Requests)).
-		Where(cond.Eq("tx_id", txID)).
-		Format(db.ci)
-	logging.Debug(logger, query, txID)
 
-	row := db.readDB.QueryRowContext(ctx, query, args...)
-	if err := row.Scan(&status, &statusMessage); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			logger.DebugfContext(ctx, "tried to get status for non-existent tx [%s], returning unknown", txID)
+	rows, err := db.getStatusStmt.Execute(ctx, db.readDB, "", func() (string, []any, error) {
+		query, args := q.Select().
+			FieldsByName("status", "status_message").
+			From(q.Table(db.table.Requests)).
+			Where(cond.Eq("tx_id", txID)).
+			Format(db.ci)
 
-			return dbdriver.Unknown, "", nil
+		return query, args, nil
+	})
+	if err != nil {
+		return dbdriver.Unknown, "", errors.Wrapf(err, "error querying db")
+	}
+	defer func() { _ = rows.Close() }()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return dbdriver.Unknown, "", errors.Wrapf(err, "error querying db")
 		}
+		logger.DebugfContext(ctx, "tried to get status for non-existent tx [%s], returning unknown", txID)
 
+		return dbdriver.Unknown, "", nil
+	}
+	if err := rows.Scan(&status, &statusMessage); err != nil {
 		return dbdriver.Unknown, "", errors.Wrapf(err, "error querying db")
 	}
 
@@ -435,6 +476,9 @@ func (db *TransactionStore) GetTransactionEndorsementAcks(ctx context.Context, t
 }
 
 func (db *TransactionStore) Close() error {
+	_ = db.getStatusStmt.Close()
+	_ = db.getTokenRequestStmt.Close()
+
 	return common2.Close(db.readDB, db.writeDB)
 }
 

--- a/token/services/storage/db/sql/common/transactions_bench_util.go
+++ b/token/services/storage/db/sql/common/transactions_bench_util.go
@@ -1,0 +1,148 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/benchmark"
+	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
+	q "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query"
+	"github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/query/cond"
+)
+
+// seedBenchRequest inserts a single request row for txID with status Pending,
+// so GetStatus has something real to read during the benchmark.
+func seedBenchRequest(b *testing.B, store *TransactionStore, txID string) {
+	b.Helper()
+
+	tx, err := store.NewTransactionStoreTransaction()
+	if err != nil {
+		b.Fatalf("failed starting tx: %v", err)
+	}
+	if err := tx.AddTokenRequest(context.Background(), txID, []byte("request-bytes"), nil, nil, []byte("pp-hash")); err != nil {
+		b.Fatalf("failed seeding request: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		b.Fatalf("failed committing seed tx: %v", err)
+	}
+}
+
+// RunGetStatusPreparedComparison benchmarks GetStatus against a version of
+// the same query executed via a statement prepared once outside the timed
+// loop, using the same worker count and duration as RunTokenStoreBenchmarks
+// so the numbers are directly comparable.
+//
+// Unlike the token-store queries, GetStatus has exactly one query shape
+// (tx_id = ?, always present) - this benchmark exists to confirm the win
+// holds for that simpler, single-shape case, backing the finality-polling
+// loop in ttx/finality.go.
+// RunGetTokenRequestPreparedComparison benchmarks GetTokenRequest against a
+// version of the same query executed via a statement prepared once outside
+// the timed loop. Same single-shape reasoning as GetStatus.
+func RunGetTokenRequestPreparedComparison(b *testing.B, store *TransactionStore) {
+	b.Helper()
+
+	b.Run("GetTokenRequest_Dynamic", func(b *testing.B) {
+		txID := fmt.Sprintf("bench-tx-req-dynamic-%d", time.Now().UnixNano())
+		seedBenchRequest(b, store, txID)
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *TransactionStore { return store },
+			func(s *TransactionStore) error {
+				_, err := s.GetTokenRequest(context.Background(), txID)
+
+				return err
+			},
+		)
+		result.Print()
+	})
+
+	b.Run("GetTokenRequest_Prepared", func(b *testing.B) {
+		txID := fmt.Sprintf("bench-tx-req-prepared-%d", time.Now().UnixNano())
+		seedBenchRequest(b, store, txID)
+
+		query, args := q.Select().
+			FieldsByName("request").
+			From(q.Table(store.table.Requests)).
+			Where(cond.Eq("tx_id", txID)).
+			Format(store.ci)
+
+		stmt, err := store.readDB.PrepareContext(context.Background(), query)
+		if err != nil {
+			b.Fatalf("failed preparing statement: %v", err)
+		}
+		defer func() { _ = stmt.Close() }()
+
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *sql.Stmt { return stmt },
+			func(s *sql.Stmt) error {
+				var request []byte
+
+				return s.QueryRowContext(context.Background(), args...).Scan(&request)
+			},
+		)
+		result.Print()
+	})
+}
+
+func RunGetStatusPreparedComparison(b *testing.B, store *TransactionStore) {
+	b.Helper()
+
+	b.Run("GetStatus_Dynamic", func(b *testing.B) {
+		txID := fmt.Sprintf("bench-tx-dynamic-%d", time.Now().UnixNano())
+		seedBenchRequest(b, store, txID)
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *TransactionStore { return store },
+			func(s *TransactionStore) error {
+				_, _, err := s.GetStatus(context.Background(), txID)
+
+				return err
+			},
+		)
+		result.Print()
+	})
+
+	b.Run("GetStatus_Prepared", func(b *testing.B) {
+		txID := fmt.Sprintf("bench-tx-prepared-%d", time.Now().UnixNano())
+		seedBenchRequest(b, store, txID)
+
+		query, args := q.Select().
+			FieldsByName("status", "status_message").
+			From(q.Table(store.table.Requests)).
+			Where(cond.Eq("tx_id", txID)).
+			Format(store.ci)
+
+		stmt, err := store.readDB.PrepareContext(context.Background(), query)
+		if err != nil {
+			b.Fatalf("failed preparing statement: %v", err)
+		}
+		defer func() { _ = stmt.Close() }()
+
+		cfg := benchmark.NewConfig(4, 5*time.Second, 500*time.Millisecond)
+		result := benchmark.RunBenchmark(
+			cfg,
+			func() *sql.Stmt { return stmt },
+			func(s *sql.Stmt) error {
+				var status dbdriver.TxStatus
+				var statusMessage string
+
+				return s.QueryRowContext(context.Background(), args...).Scan(&status, &statusMessage)
+			},
+		)
+		result.Print()
+	})
+}

--- a/token/services/storage/db/sql/common/transactions_test_util.go
+++ b/token/services/storage/db/sql/common/transactions_test_util.go
@@ -142,7 +142,8 @@ func TestGetStatus(t *testing.T, store transactionsStoreConstructor) {
 	output := []driver2.Value{3, "some_message"}
 
 	mockDB.
-		ExpectQuery("SELECT status, status_message FROM REQUESTS WHERE tx_id = \\$1").
+		ExpectPrepare("SELECT status, status_message FROM REQUESTS WHERE tx_id = \\$1").
+		ExpectQuery().
 		WithArgs(input).
 		WillReturnRows(mockDB.NewRows([]string{"status", "status_message"}).AddRow(output...))
 
@@ -363,7 +364,8 @@ func TestGetStatusContextCancelled(t *testing.T, store transactionsStoreConstruc
 
 	// The mock delays the query by 1 s; the context expires after 10 ms.
 	mockDB.
-		ExpectQuery("SELECT status, status_message FROM REQUESTS WHERE tx_id = \\$1").
+		ExpectPrepare("SELECT status, status_message FROM REQUESTS WHERE tx_id = \\$1").
+		ExpectQuery().
 		WithArgs("1234").
 		WillDelayFor(time.Second).
 		WillReturnRows(mockDB.NewRows([]string{"status", "status_message"}))

--- a/token/services/storage/db/sql/postgres/transactions_bench_test.go
+++ b/token/services/storage/db/sql/postgres/transactions_bench_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"database/sql"
+	"testing"
+
+	sqlcommon "github.com/LFDT-Panurus/panurus/token/services/storage/db/sql/common"
+	fscpostgres "github.com/hyperledger-labs/fabric-smart-client/platform/view/services/storage/driver/sql/postgres"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+func openBenchTransactionStore(b *testing.B) (*sqlcommon.TransactionStore, func()) {
+	b.Helper()
+
+	cfg := fscpostgres.DefaultConfig(fscpostgres.WithDBName("bench-transactions"))
+	terminate, _, err := fscpostgres.StartPostgres(b.Context(), cfg, nil)
+	if err != nil {
+		b.Skipf("postgres not available: %v", err)
+	}
+	b.Cleanup(terminate)
+
+	db, err := sql.Open("pgx", cfg.DataSource())
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tables, err := sqlcommon.GetTableNames("")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := sqlcommon.NewTransactionStoreWithNotifierAndRecovery(
+		db, db, tables, NewConditionInterpreter(), NewPaginationInterpreter(), nil, NewAdvisoryLockFactory(),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := store.CreateSchema(); err != nil {
+		b.Fatal(err)
+	}
+
+	return store, func() { _ = db.Close() }
+}
+
+func BenchmarkGetStatusPreparedComparison(b *testing.B) {
+	store, cleanup := openBenchTransactionStore(b)
+	defer cleanup()
+	sqlcommon.RunGetStatusPreparedComparison(b, store)
+}
+
+func BenchmarkGetTokenRequestPreparedComparison(b *testing.B) {
+	store, cleanup := openBenchTransactionStore(b)
+	defer cleanup()
+	sqlcommon.RunGetTokenRequestPreparedComparison(b, store)
+}


### PR DESCRIPTION
## Summary
Per maintainer's request to assess remaining candidates, targeted the two most-used queries found: `GetStatus` and `GetTokenRequest`, both in `transactions.go`, both with 11 call sites, the widest of anything checked (`QueryTokenDetails` was ruled out, only 1 call site with too many optional-field shapes to cache cleanly).

## Why these two
Unlike the token-store queries (#1889/#1929/#1970), both have exactly **one query shape ever** (`tx_id = ?`, always present) no shape-key logic needed, just a single cached prepared statement per query. `GetStatus` specifically backs the finality-polling loop in `ttx/finality.go`.

## Changes
-> Added prepared-statement caching to `GetStatus` and `GetTokenRequest`, reusing the existing `PreparedStmtHolder[K]`
-> `GetTokenRequest`'s not-found behavior (`nil, nil`) preserved per the documented contract in `GetTokenRequests`' own comment
-> **Bug fix in `PreparedStmtHolder.Execute`**: when the context is already cancelled/expired, the fallback path was retrying via an unprepared query, which fails identically but wraps the error differently, breaking callers checking for the specific cancellation error via `errors.Is`. Now returns the original error directly when `ctx.Err() != nil`, without retrying.
-> Fixed two existing tests (`TestGetStatus`, `TestGetStatusContextCancelled`) that were silently passing via the fallback path without ever exercising the prepared path, now correctly assert `ExpectPrepare`.
-> Added benchmarks for both queries, plus DB-free reuse tests (`go-sqlmock`) covering statement caching.

## Results (median of 2 runs each, 4 workers, 5s window)

| Query | Throughput | P99 latency | Allocs/op |
|---|---|---|---|
| GetStatus | +15% | -66% | -47% |
| GetTokenRequest | +14% | -65% | -45% |

## Testing
Full test suite (common + sqlite + postgres) green.

## Notes for the Reviewer
The context-cancellation bug affects all four prepared queries done so far (`UnspentTokensIteratorBy`, `SpendableTokensIteratorBy`, `balance`, and now these two), since it's in the shared holder worth a careful look given it's a correctness fix, not just a new feature.