### PR TITLE
perf(selector): shard simple selector's in-memory locker by owner and jitter retries

### DIFF
--- a/token/services/selector/benchmark_test.go
+++ b/token/services/selector/benchmark_test.go
@@ -27,8 +27,8 @@ import (
 type WalletIDByRawIdentityFunc func(rawIdentity []byte) string
 
 type Locker interface {
-	Lock(ctx context.Context, id *token2.ID, txID string, reclaim bool) (string, error)
-	UnlockIDs(ctx context.Context, ids ...*token2.ID) []*token2.ID
+	Lock(ctx context.Context, owner string, id *token2.ID, txID string, reclaim bool) (string, error)
+	UnlockIDs(ctx context.Context, owner string, ids ...*token2.ID) []*token2.ID
 	UnlockByTxID(ctx context.Context, txID string)
 	IsLocked(id *token2.ID) bool
 }
@@ -43,9 +43,9 @@ func (s *extendedSelector) Select(ctx context.Context, ownerFilter token.OwnerFi
 }
 func (s *extendedSelector) Close() error { return s.Selector.Close() }
 
-func (s *extendedSelector) Unselect(id ...*token2.ID) {
+func (s *extendedSelector) Unselect(owner string, id ...*token2.ID) {
 	if s.Lock != nil {
-		s.Lock.UnlockIDs(context.Background(), id...)
+		s.Lock.UnlockIDs(context.Background(), owner, id...)
 	}
 }
 
@@ -72,7 +72,7 @@ func BenchmarkSelectorSingle(b *testing.B) {
 				wg.Add(1)
 				go func(ids []*token2.ID) {
 					defer wg.Done()
-					s.selector.Unselect(ids...)
+					s.selector.Unselect(s.filter.ID(), ids...)
 				}(ids)
 			}
 		})
@@ -110,7 +110,7 @@ func BenchmarkSelectorParallel(b *testing.B) {
 					wg.Add(1)
 					go func(ids []*token2.ID) {
 						defer wg.Done()
-						s.selector.Unselect(ids...)
+						s.selector.Unselect(s.filter.ID(), ids...)
 					}(ids)
 				}
 			})
@@ -199,7 +199,7 @@ type LockerProviderFunction func() selector.Locker
 
 type ExtendedSelector interface {
 	token.Selector
-	Unselect(id ...*token2.ID)
+	Unselect(owner string, id ...*token2.ID)
 }
 
 type MockTokenIterator struct {

--- a/token/services/selector/sherdlock/inmemory/locker.go
+++ b/token/services/selector/sherdlock/inmemory/locker.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Locker interface {
-	Lock(ctx context.Context, id *token.ID, txID string, reclaim bool) (string, error)
+	Lock(ctx context.Context, owner string, id *token.ID, txID string, reclaim bool) (string, error)
 	UnlockByTxID(ctx context.Context, txID string)
 }
 
@@ -32,7 +32,8 @@ func NewLocker(l Locker) *locker {
 }
 
 func (l *locker) Lock(ctx context.Context, tokenID *token.ID, consumerTxID transaction.ID) error {
-	_, err := l.Locker.Lock(ctx, tokenID, consumerTxID, false)
+	// this adapter has no owner context; the empty owner shares one default shard
+	_, err := l.Locker.Lock(ctx, "", tokenID, consumerTxID, false)
 
 	return err
 }

--- a/token/services/selector/simple/inmemory/locker.go
+++ b/token/services/selector/simple/inmemory/locker.go
@@ -47,10 +47,18 @@ func (l lockEntry) String() string {
 	return fmt.Sprintf("[[%s] since [%s], last access [%s]]", l.TxID, l.Created, l.LastAccess)
 }
 
+// shard holds the lock state for the tokens of a single owner. A token has
+// exactly one owner, so operations on different owners can never contend
+// for the same token and each shard can be guarded independently.
+type shard struct {
+	mu     sync.Mutex
+	locked map[token2.ID]*lockEntry
+}
+
 type locker struct {
 	ttxdb                  TXStatusProvider
-	lock                   *sync.RWMutex
-	locked                 map[token2.ID]*lockEntry
+	shardsMu               sync.RWMutex
+	shards                 map[string]*shard
 	sleepTimeout           time.Duration
 	validTxEvictionTimeout time.Duration
 	cancel                 context.CancelFunc
@@ -63,8 +71,7 @@ func NewLocker(ttxdb TXStatusProvider, timeout time.Duration, validTxEvictionTim
 	r := &locker{
 		ttxdb:                  ttxdb,
 		sleepTimeout:           timeout,
-		lock:                   &sync.RWMutex{},
-		locked:                 map[token2.ID]*lockEntry{},
+		shards:                 map[string]*shard{},
 		validTxEvictionTimeout: validTxEvictionTimeout,
 		cancel:                 cancel,
 		scanDone:               make(chan struct{}),
@@ -91,30 +98,54 @@ func (d *locker) Stop() error {
 	return err
 }
 
-func (d *locker) Lock(ctx context.Context, id *token2.ID, txID string, reclaim bool) (string, error) {
-	k := *id
-
-	// check quickly if the token is locked
-	d.lock.RLock()
-	if _, ok := d.locked[k]; ok && !reclaim {
-		// return immediately
-		d.lock.RUnlock()
-
-		return "", AlreadyLockedError
+// shard returns the shard for the given owner, creating it on first use.
+// The empty owner is a valid key: callers without owner context share one
+// default shard, which degrades to the pre-sharding single-map behavior.
+func (d *locker) shard(owner string) *shard {
+	d.shardsMu.RLock()
+	s, ok := d.shards[owner]
+	d.shardsMu.RUnlock()
+	if ok {
+		return s
 	}
-	d.lock.RUnlock()
 
-	// it is either not locked or we are reclaiming
-	d.lock.Lock()
-	defer d.lock.Unlock()
-	e, ok := d.locked[k]
+	d.shardsMu.Lock()
+	defer d.shardsMu.Unlock()
+	if s, ok := d.shards[owner]; ok {
+		return s
+	}
+	s = &shard{locked: map[token2.ID]*lockEntry{}}
+	d.shards[owner] = s
+
+	return s
+}
+
+// allShards returns a snapshot of the current shards.
+func (d *locker) allShards() []*shard {
+	d.shardsMu.RLock()
+	defer d.shardsMu.RUnlock()
+	shards := make([]*shard, 0, len(d.shards))
+	for _, s := range d.shards {
+		shards = append(shards, s)
+	}
+
+	return shards
+}
+
+func (d *locker) Lock(ctx context.Context, owner string, id *token2.ID, txID string, reclaim bool) (string, error) {
+	k := *id
+	s := d.shard(owner)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.locked[k]
 	if ok {
 		e.LastAccess = time.Now()
 
 		if reclaim {
 			// Second chance
 			logger.DebugfContext(ctx, "[%s] already locked by [%s], try to reclaim...", id, e)
-			reclaimed, status := d.reclaim(ctx, id, e.TxID)
+			reclaimed, status := d.reclaim(ctx, s, id, e.TxID)
 			if !reclaimed {
 				logger.DebugfContext(ctx, "[%s] already locked by [%s], reclaim failed, tx status [%s]", id, e, ttxdb.TxStatusMessage[status])
 				if logger.IsEnabledFor(zapcore.DebugLevel) {
@@ -135,22 +166,23 @@ func (d *locker) Lock(ctx context.Context, id *token2.ID, txID string, reclaim b
 	}
 	logger.DebugfContext(ctx, "locking [%s] for [%s]", id, txID)
 	now := time.Now()
-	d.locked[k] = &lockEntry{TxID: txID, Created: now, LastAccess: now}
+	s.locked[k] = &lockEntry{TxID: txID, Created: now, LastAccess: now}
 
 	return "", nil
 }
 
-// UnlockIDs unlocks the passed IDS. It returns the list of tokens that were not locked in the first place among
-// those passed.
-func (d *locker) UnlockIDs(ctx context.Context, ids ...*token2.ID) []*token2.ID {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+// UnlockIDs unlocks the passed IDS of the given owner. It returns the list of tokens that were
+// not locked in the first place among those passed.
+func (d *locker) UnlockIDs(ctx context.Context, owner string, ids ...*token2.ID) []*token2.ID {
+	s := d.shard(owner)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	logger.DebugfContext(ctx, "unlocking tokens [%v]", ids)
 	var notFound []*token2.ID
 	for _, id := range ids {
 		k := *id
-		entry, ok := d.locked[k]
+		entry, ok := s.locked[k]
 		if !ok {
 			notFound = append(notFound, &k)
 			logger.Warnf("unlocking [%s] hold by no one, skipping [%s]", id, entry)
@@ -158,42 +190,51 @@ func (d *locker) UnlockIDs(ctx context.Context, ids ...*token2.ID) []*token2.ID 
 			continue
 		}
 		logger.DebugfContext(ctx, "unlocking [%s] hold by [%s]", id, entry)
-		delete(d.locked, k)
+		delete(s.locked, k)
 	}
 
 	return notFound
 }
 
+// UnlockByTxID unlocks all tokens locked by the given transaction. The owner
+// is unknown at this point, so every shard is visited, each locked briefly.
 func (d *locker) UnlockByTxID(ctx context.Context, txID string) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-
 	logger.DebugfContext(ctx, "unlocking tokens hold by [%s]", txID)
-	for id, entry := range d.locked {
-		if entry.TxID == txID {
-			logger.DebugfContext(ctx, "unlocking [%s] hold by [%s]", id, entry)
-			delete(d.locked, id)
+	for _, s := range d.allShards() {
+		s.mu.Lock()
+		for id, entry := range s.locked {
+			if entry.TxID == txID {
+				logger.DebugfContext(ctx, "unlocking [%s] hold by [%s]", id, entry)
+				delete(s.locked, id)
+			}
 		}
+		s.mu.Unlock()
 	}
 }
 
 func (d *locker) IsLocked(id *token2.ID) bool {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+	k := *id
+	for _, s := range d.allShards() {
+		s.mu.Lock()
+		_, ok := s.locked[k]
+		s.mu.Unlock()
+		if ok {
+			return true
+		}
+	}
 
-	_, ok := d.locked[*id]
-
-	return ok
+	return false
 }
 
-func (d *locker) reclaim(ctx context.Context, id *token2.ID, txID string) (bool, int) {
+// reclaim must be called while holding the shard's mutex.
+func (d *locker) reclaim(ctx context.Context, s *shard, id *token2.ID, txID string) (bool, int) {
 	status, _, err := d.ttxdb.GetStatus(ctx, txID)
 	if err != nil {
 		return false, status
 	}
 	switch status {
 	case ttxdb.Deleted:
-		delete(d.locked, *id)
+		delete(s.locked, *id)
 
 		return true, status
 	default:
@@ -203,6 +244,18 @@ func (d *locker) reclaim(ctx context.Context, id *token2.ID, txID string) (bool,
 
 func (d *locker) start(ctx context.Context) {
 	go d.scan(ctx)
+}
+
+// lockedCount returns the total number of locked tokens across all shards.
+func (d *locker) lockedCount() int {
+	total := 0
+	for _, s := range d.allShards() {
+		s.mu.Lock()
+		total += len(s.locked)
+		s.mu.Unlock()
+	}
+
+	return total
 }
 
 func (d *locker) scan(ctx context.Context) {
@@ -217,50 +270,7 @@ func (d *locker) scan(ctx context.Context) {
 		default:
 		}
 		logger.DebugfContext(ctx, "token collector: scan locked tokens")
-		// Track both token ID and the txID that was observed during the scan,
-		// so we can re-validate before deleting (prevents TOCTOU race with Lock/reclaim).
-		type removeEntry struct {
-			id   token2.ID
-			txID string
-		}
-		var removeList []removeEntry
-		d.lock.RLock()
-		for id, entry := range d.locked {
-			status, _, err := d.ttxdb.GetStatus(ctx, entry.TxID)
-			if err != nil {
-				logger.Warnf("failed getting status for token [%s] locked by [%s], remove", id, entry)
-				removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-
-				continue
-			}
-			switch status {
-			case ttxdb.Confirmed:
-				// remove only if elapsed enough time from last access, to avoid concurrency issue
-				if time.Since(entry.LastAccess) > d.validTxEvictionTimeout {
-					removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-					logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], time elapsed, remove", id, entry, ttxdb.TxStatusMessage[status])
-				}
-			case ttxdb.Deleted:
-				removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-				logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], remove", id, entry, ttxdb.TxStatusMessage[status])
-			default:
-				logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], skip", id, entry, ttxdb.TxStatusMessage[status])
-			}
-		}
-		d.lock.RUnlock()
-
-		d.lock.Lock()
-		logger.DebugfContext(ctx, "token collector: freeing [%d] items", len(removeList))
-		for _, s := range removeList {
-			// Re-validate: only delete if the entry still belongs to the same
-			// transaction that was inspected during the RLock scan phase.
-			// Between RUnlock and Lock, a Lock(reclaim=true) call may have
-			// reclaimed this token and re-locked it for a new transaction.
-			if entry, ok := d.locked[s.id]; ok && entry.TxID == s.txID {
-				delete(d.locked, s.id)
-			}
-		}
-		d.lock.Unlock()
+		d.scanShards(ctx)
 
 		for {
 			logger.DebugfContext(ctx, "token collector: sleep for some time...")
@@ -271,15 +281,84 @@ func (d *locker) scan(ctx context.Context) {
 
 				return
 			}
-			d.lock.RLock()
-			l := len(d.locked)
-			d.lock.RUnlock()
-			if l > 0 {
+			if l := d.lockedCount(); l > 0 {
 				// time to do some token collection
 				logger.DebugfContext(ctx, "token collector: time to do some token collection, [%d] locked", l)
 
 				break
 			}
 		}
+	}
+}
+
+// scanShards runs one collection cycle over every shard. For each shard it
+// snapshots the entries under the shard lock, resolves their transaction
+// statuses without holding any lock, and then deletes stale entries under
+// the shard lock again — re-validating that each entry still belongs to the
+// transaction observed during the snapshot, since a concurrent
+// Lock(reclaim=true) may have re-locked the token for a new transaction in
+// the meantime (TOCTOU).
+func (d *locker) scanShards(ctx context.Context) {
+	type scannedEntry struct {
+		id         token2.ID
+		txID       string
+		lastAccess time.Time
+	}
+	type removeEntry struct {
+		id        token2.ID
+		txID      string
+		confirmed bool
+	}
+
+	for _, s := range d.allShards() {
+		// Phase 1: snapshot the shard's entries.
+		s.mu.Lock()
+		entries := make([]scannedEntry, 0, len(s.locked))
+		for id, entry := range s.locked {
+			entries = append(entries, scannedEntry{id: id, txID: entry.TxID, lastAccess: entry.LastAccess})
+		}
+		s.mu.Unlock()
+
+		// Phase 2: resolve statuses without holding the shard lock, so the
+		// owner's Lock/Unlock operations are not blocked behind status lookups.
+		var removeList []removeEntry
+		for _, entry := range entries {
+			status, _, err := d.ttxdb.GetStatus(ctx, entry.txID)
+			if err != nil {
+				logger.Warnf("failed getting status for token [%s] locked by [%s], remove", entry.id, entry.txID)
+				removeList = append(removeList, removeEntry{id: entry.id, txID: entry.txID})
+
+				continue
+			}
+			switch status {
+			case ttxdb.Confirmed:
+				// remove only if elapsed enough time from last access, to avoid concurrency issue
+				if time.Since(entry.lastAccess) > d.validTxEvictionTimeout {
+					removeList = append(removeList, removeEntry{id: entry.id, txID: entry.txID, confirmed: true})
+					logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], time elapsed, remove", entry.id, entry.txID, ttxdb.TxStatusMessage[status])
+				}
+			case ttxdb.Deleted:
+				removeList = append(removeList, removeEntry{id: entry.id, txID: entry.txID})
+				logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], remove", entry.id, entry.txID, ttxdb.TxStatusMessage[status])
+			default:
+				logger.DebugfContext(ctx, "token [%s] locked by [%s] in status [%s], skip", entry.id, entry.txID, ttxdb.TxStatusMessage[status])
+			}
+		}
+
+		// Phase 3: delete, re-validating each entry.
+		s.mu.Lock()
+		logger.DebugfContext(ctx, "token collector: freeing [%d] items", len(removeList))
+		for _, r := range removeList {
+			entry, ok := s.locked[r.id]
+			if !ok || entry.TxID != r.txID {
+				continue
+			}
+			if r.confirmed && time.Since(entry.LastAccess) <= d.validTxEvictionTimeout {
+				// the entry was accessed again after the snapshot; keep it
+				continue
+			}
+			delete(s.locked, r.id)
+		}
+		s.mu.Unlock()
 	}
 }

--- a/token/services/selector/simple/inmemory/locker.go
+++ b/token/services/selector/simple/inmemory/locker.go
@@ -9,6 +9,7 @@ package inmemory
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sync"
 	"time"
 
@@ -53,6 +54,10 @@ func (l lockEntry) String() string {
 type shard struct {
 	mu     sync.Mutex
 	locked map[token2.ID]*lockEntry
+	// dead is set (under mu) when the scanner prunes this empty shard from
+	// the registry; a caller that raced the pruning and still holds a
+	// reference must retry the registry lookup instead of using it.
+	dead bool
 }
 
 type locker struct {
@@ -120,23 +125,33 @@ func (d *locker) shard(owner string) *shard {
 	return s
 }
 
-// allShards returns a snapshot of the current shards.
-func (d *locker) allShards() []*shard {
+// lockShard returns the owner's shard with its mutex held. If the shard was
+// pruned between the registry lookup and acquiring its mutex, the lookup is
+// retried, so callers never operate on a shard that left the registry.
+func (d *locker) lockShard(owner string) *shard {
+	for {
+		s := d.shard(owner)
+		s.mu.Lock()
+		if !s.dead {
+			return s
+		}
+		s.mu.Unlock()
+	}
+}
+
+// allShards returns a snapshot of the current shards keyed by owner.
+func (d *locker) allShards() map[string]*shard {
 	d.shardsMu.RLock()
 	defer d.shardsMu.RUnlock()
-	shards := make([]*shard, 0, len(d.shards))
-	for _, s := range d.shards {
-		shards = append(shards, s)
-	}
+	shards := make(map[string]*shard, len(d.shards))
+	maps.Copy(shards, d.shards)
 
 	return shards
 }
 
 func (d *locker) Lock(ctx context.Context, owner string, id *token2.ID, txID string, reclaim bool) (string, error) {
 	k := *id
-	s := d.shard(owner)
-
-	s.mu.Lock()
+	s := d.lockShard(owner)
 	defer s.mu.Unlock()
 	e, ok := s.locked[k]
 	if ok {
@@ -174,8 +189,7 @@ func (d *locker) Lock(ctx context.Context, owner string, id *token2.ID, txID str
 // UnlockIDs unlocks the passed IDS of the given owner. It returns the list of tokens that were
 // not locked in the first place among those passed.
 func (d *locker) UnlockIDs(ctx context.Context, owner string, ids ...*token2.ID) []*token2.ID {
-	s := d.shard(owner)
-	s.mu.Lock()
+	s := d.lockShard(owner)
 	defer s.mu.Unlock()
 
 	logger.DebugfContext(ctx, "unlocking tokens [%v]", ids)
@@ -310,7 +324,7 @@ func (d *locker) scanShards(ctx context.Context) {
 		confirmed bool
 	}
 
-	for _, s := range d.allShards() {
+	for owner, s := range d.allShards() {
 		// Phase 1: snapshot the shard's entries.
 		s.mu.Lock()
 		entries := make([]scannedEntry, 0, len(s.locked))
@@ -360,5 +374,31 @@ func (d *locker) scanShards(ctx context.Context) {
 			delete(s.locked, r.id)
 		}
 		s.mu.Unlock()
+
+		d.pruneIfEmpty(owner, s)
+	}
+}
+
+// pruneIfEmpty removes the owner's shard from the registry when it holds no
+// locks. Both the registry lock and the shard lock are held while re-checking
+// emptiness and marking the shard dead, so a concurrent Lock either finds the
+// shard still registered or observes dead and retries the registry lookup —
+// a live lock can never end up in a pruned shard.
+func (d *locker) pruneIfEmpty(owner string, s *shard) {
+	s.mu.Lock()
+	empty := len(s.locked) == 0
+	s.mu.Unlock()
+	if !empty {
+		// common case: skip the exclusive registry lock entirely
+		return
+	}
+
+	d.shardsMu.Lock()
+	defer d.shardsMu.Unlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.locked) == 0 && d.shards[owner] == s {
+		s.dead = true
+		delete(d.shards, owner)
 	}
 }

--- a/token/services/selector/simple/inmemory/locker_bench_test.go
+++ b/token/services/selector/simple/inmemory/locker_bench_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+	"github.com/LFDT-Panurus/panurus/token/token"
+)
+
+// BenchmarkLockerContention measures lock/unlock throughput under concurrent
+// load. Workers are spread over a varying number of owners: owners=1 puts
+// every worker on one shard — approximating the old single global mutex —
+// while owners=workers gives every worker its own shard.
+func BenchmarkLockerContention(b *testing.B) {
+	const workers = 32
+	for _, owners := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("workers=%d/owners=%d", workers, owners), func(b *testing.B) {
+			mock := newMockTXStatusProvider()
+			d := NewLocker(mock, 10*time.Minute, time.Minute).(*locker)
+			b.Cleanup(func() { _ = d.Stop() })
+
+			var next atomic.Int64
+			b.ResetTimer()
+			var wg sync.WaitGroup
+			for w := range workers {
+				owner := fmt.Sprintf("owner-%d", w%owners)
+				wg.Go(func() {
+					ctx := context.Background()
+					for {
+						i := next.Add(1) - 1
+						if i >= int64(b.N) {
+							return
+						}
+						id := &token.ID{TxId: fmt.Sprintf("tok-%s-%d", owner, i), Index: 0}
+						txID := fmt.Sprintf("tx-%d", i)
+						if _, err := d.Lock(ctx, owner, id, txID, false); err != nil {
+							b.Error(err)
+
+							return
+						}
+						d.UnlockIDs(ctx, owner, id)
+					}
+				})
+			}
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkLockerContentionWithSlowReclaim is the scenario the sharding
+// targets: one owner is stuck in a reclaim whose status lookup is slow
+// (e.g. a database round trip), while other owners keep locking. With one
+// shared lock, everybody waits behind the slow reclaim; with per-owner
+// shards, only the slow owner does.
+func BenchmarkLockerContentionWithSlowReclaim(b *testing.B) {
+	const workers = 8
+	const statusDelay = 100 * time.Microsecond
+	for _, owners := range []int{1, workers} {
+		b.Run(fmt.Sprintf("workers=%d/owners=%d", workers, owners), func(b *testing.B) {
+			mock := newMockTXStatusProvider()
+			mock.getStatusHook = func(string) { time.Sleep(statusDelay) }
+			d := NewLocker(mock, 10*time.Minute, time.Minute).(*locker)
+			b.Cleanup(func() { _ = d.Stop() })
+
+			// Every worker's tokens are pre-locked by a Pending tx, so each
+			// Lock attempt takes the reclaim path and pays the status lookup.
+			mock.setStatus("tx-holder", ttxdb.Pending)
+			ids := make([]*token.ID, workers)
+			ownersOf := make([]string, workers)
+			for w := range workers {
+				ownersOf[w] = fmt.Sprintf("owner-%d", w%owners)
+				ids[w] = &token.ID{TxId: fmt.Sprintf("tok-%d", w), Index: 0}
+				if _, err := d.Lock(context.Background(), ownersOf[w], ids[w], "tx-holder", false); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			var next atomic.Int64
+			b.ResetTimer()
+			var wg sync.WaitGroup
+			for w := range workers {
+				wg.Go(func() {
+					ctx := context.Background()
+					for {
+						i := next.Add(1) - 1
+						if i >= int64(b.N) {
+							return
+						}
+						// reclaim fails (holder is Pending) after paying the
+						// status lookup under the shard lock
+						_, _ = d.Lock(ctx, ownersOf[w], ids[w], fmt.Sprintf("tx-%d", i), true)
+					}
+				})
+			}
+			wg.Wait()
+		})
+	}
+}

--- a/token/services/selector/simple/inmemory/locker_prune_test.go
+++ b/token/services/selector/simple/inmemory/locker_prune_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/stretchr/testify/require"
+)
+
+func (d *locker) hasShard(owner string) bool {
+	d.shardsMu.RLock()
+	defer d.shardsMu.RUnlock()
+	_, ok := d.shards[owner]
+
+	return ok
+}
+
+// TestScannerPrunesEmptyShards verifies that once the scanner has evicted a
+// shard's last entry, the shard itself is removed from the registry, while
+// shards that still hold locks stay; a pruned owner can lock again afterwards.
+func TestScannerPrunesEmptyShards(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	d := NewLocker(mock, 20*time.Millisecond, time.Minute).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+	tokenB := &token.ID{TxId: "tok-b", Index: 0}
+	mock.setStatus("tx-a", ttxdb.Pending)
+	mock.setStatus("tx-b", ttxdb.Pending)
+	_, err := d.Lock(context.Background(), "alice", tokenA, "tx-a", false)
+	require.NoError(t, err)
+	_, err = d.Lock(context.Background(), "bob", tokenB, "tx-b", false)
+	require.NoError(t, err)
+	require.True(t, d.hasShard("alice"))
+	require.True(t, d.hasShard("bob"))
+
+	// tx-a is Deleted: the scanner evicts alice's entry and must then drop
+	// alice's now-empty shard, keeping bob's.
+	mock.setStatus("tx-a", ttxdb.Deleted)
+	require.Eventually(t, func() bool {
+		return !d.hasShard("alice")
+	}, 2*time.Second, 20*time.Millisecond, "empty shard must be pruned by the scanner")
+	require.True(t, d.hasShard("bob"), "shard with live locks must not be pruned")
+
+	// The pruned owner keeps working: a fresh Lock creates a fresh shard.
+	mock.setStatus("tx-c", ttxdb.Pending)
+	_, err = d.Lock(context.Background(), "alice", tokenA, "tx-c", false)
+	require.NoError(t, err)
+	require.True(t, d.IsLocked(tokenA))
+}
+
+// TestPruningDoesNotLoseConcurrentLocks stresses the race between the
+// scanner pruning an empty shard and a concurrent Lock on the same owner:
+// a lock taken through a stale shard reference must never end up in an
+// orphaned shard invisible to IsLocked/UnlockIDs.
+func TestPruningDoesNotLoseConcurrentLocks(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	// aggressive scan cadence so pruning races with the workers below
+	d := NewLocker(mock, time.Millisecond, time.Minute).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+
+	const workers = 4
+	const iterations = 500
+	var wg sync.WaitGroup
+	for w := range workers {
+		owner := fmt.Sprintf("owner-%d", w)
+		wg.Go(func() {
+			ctx := context.Background()
+			for i := range iterations {
+				id := &token.ID{TxId: fmt.Sprintf("tok-%s-%d", owner, i), Index: 0}
+				txID := fmt.Sprintf("tx-%s-%d", owner, i)
+				mock.setStatus(txID, ttxdb.Pending)
+				if _, err := d.Lock(ctx, owner, id, txID, false); err != nil {
+					t.Errorf("lock failed: %v", err)
+
+					return
+				}
+				// The invariant pruning must not break: a token locked a
+				// moment ago is visible as locked. An orphaned shard would
+				// make IsLocked return false here.
+				if !d.IsLocked(id) {
+					t.Errorf("lock for %s lost: shard was pruned while holding a live lock", id)
+
+					return
+				}
+				if notFound := d.UnlockIDs(ctx, owner, id); len(notFound) != 0 {
+					t.Errorf("unlock missed %v: lock ended up in an orphaned shard", notFound)
+
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+}

--- a/token/services/selector/simple/inmemory/locker_sharding_test.go
+++ b/token/services/selector/simple/inmemory/locker_sharding_test.go
@@ -37,15 +37,21 @@ func TestLockDifferentOwnersDoNotBlock(t *testing.T) {
 	mock := newMockTXStatusProvider()
 	entered := make(chan struct{})
 	release := make(chan struct{})
-	var once sync.Once
+	var enteredOnce, releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+	defer releaseAll()
+	// The hook blocks every tx-a1 status lookup: the reclaim below, and —
+	// on a slow machine — possibly the background scanner's too. The
+	// scanner never holds a shard lock during lookups, so a blocked
+	// scanner is harmless, and releaseAll (close, not a single send)
+	// wakes every blocked lookup regardless of how many there are.
 	mock.getStatusHook = func(txID string) {
 		if txID == "tx-a1" {
-			once.Do(func() { close(entered) })
+			enteredOnce.Do(func() { close(entered) })
 			<-release
 		}
 	}
 	d := quietLocker(t, mock)
-	defer close(release)
 
 	tokenA := &token.ID{TxId: "tok-a", Index: 0}
 	tokenB := &token.ID{TxId: "tok-b", Index: 0}
@@ -78,8 +84,8 @@ func TestLockDifferentOwnersDoNotBlock(t *testing.T) {
 		t.Fatal("bob's Lock blocked behind alice's in-flight reclaim: owners are serializing on a shared lock")
 	}
 
-	// Cleanup: unblock the reclaim and wait for it to finish.
-	release <- struct{}{}
+	// Cleanup: unblock every blocked status lookup and wait for the reclaim.
+	releaseAll()
 	<-reclaimDone
 }
 

--- a/token/services/selector/simple/inmemory/locker_sharding_test.go
+++ b/token/services/selector/simple/inmemory/locker_sharding_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package inmemory
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LFDT-Panurus/panurus/token/services/storage/ttxdb"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// quietLocker returns a locker whose background scanner effectively never
+// wakes up during a test, so tests interact with the locker deterministically.
+func quietLocker(t *testing.T, mock *mockTXStatusProvider) *locker {
+	t.Helper()
+	d := NewLocker(mock, 10*time.Minute, time.Minute).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+
+	return d
+}
+
+// TestLockDifferentOwnersDoNotBlock is the core regression test for the
+// per-owner sharding: a Lock for owner A that is stuck mid-reclaim (blocked
+// inside the status lookup, holding A's lock state) must not prevent a Lock
+// for owner B from completing. With the old single global mutex, B blocks
+// until A's reclaim finishes.
+func TestLockDifferentOwnersDoNotBlock(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	mock.getStatusHook = func(txID string) {
+		if txID == "tx-a1" {
+			once.Do(func() { close(entered) })
+			<-release
+		}
+	}
+	d := quietLocker(t, mock)
+	defer close(release)
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+	tokenB := &token.ID{TxId: "tok-b", Index: 0}
+
+	// Owner alice locks tokenA for tx-a1.
+	mock.setStatus("tx-a1", ttxdb.Pending)
+	_, err := d.Lock(context.Background(), "alice", tokenA, "tx-a1", false)
+	require.NoError(t, err)
+
+	// A second transaction tries to reclaim alice's token; the reclaim's
+	// status lookup blocks, keeping alice's lock state busy.
+	reclaimDone := make(chan struct{})
+	go func() {
+		defer close(reclaimDone)
+		_, _ = d.Lock(context.Background(), "alice", tokenA, "tx-a2", true)
+	}()
+	<-entered
+
+	// While alice's reclaim is stuck, bob's Lock must still complete.
+	bobDone := make(chan error, 1)
+	go func() {
+		_, err := d.Lock(context.Background(), "bob", tokenB, "tx-b1", false)
+		bobDone <- err
+	}()
+
+	select {
+	case err := <-bobDone:
+		require.NoError(t, err, "bob's lock must succeed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("bob's Lock blocked behind alice's in-flight reclaim: owners are serializing on a shared lock")
+	}
+
+	// Cleanup: unblock the reclaim and wait for it to finish.
+	release <- struct{}{}
+	<-reclaimDone
+}
+
+// TestUnlockByTxIDAcrossOwners verifies that unlocking by transaction ID
+// still finds and removes that transaction's locks under every owner, and
+// leaves other transactions' locks alone.
+func TestUnlockByTxIDAcrossOwners(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	d := quietLocker(t, mock)
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+	tokenB := &token.ID{TxId: "tok-b", Index: 0}
+	tokenC := &token.ID{TxId: "tok-c", Index: 0}
+
+	mock.setStatus("tx-1", ttxdb.Pending)
+	mock.setStatus("tx-2", ttxdb.Pending)
+	_, err := d.Lock(context.Background(), "alice", tokenA, "tx-1", false)
+	require.NoError(t, err)
+	_, err = d.Lock(context.Background(), "bob", tokenB, "tx-1", false)
+	require.NoError(t, err)
+	_, err = d.Lock(context.Background(), "alice", tokenC, "tx-2", false)
+	require.NoError(t, err)
+
+	d.UnlockByTxID(context.Background(), "tx-1")
+
+	assert.False(t, d.IsLocked(tokenA), "tx-1's token under alice must be unlocked")
+	assert.False(t, d.IsLocked(tokenB), "tx-1's token under bob must be unlocked")
+	assert.True(t, d.IsLocked(tokenC), "tx-2's token must remain locked")
+}
+
+// TestUnlockIDsIsOwnerScoped verifies UnlockIDs removes the given tokens
+// from the owner's lock state and reports tokens that were not locked.
+func TestUnlockIDsIsOwnerScoped(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	d := quietLocker(t, mock)
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+	tokenB := &token.ID{TxId: "tok-b", Index: 0}
+
+	mock.setStatus("tx-1", ttxdb.Pending)
+	_, err := d.Lock(context.Background(), "alice", tokenA, "tx-1", false)
+	require.NoError(t, err)
+
+	notFound := d.UnlockIDs(context.Background(), "alice", tokenA, tokenB)
+	require.Len(t, notFound, 1)
+	assert.Equal(t, *tokenB, *notFound[0], "tokenB was never locked and must be reported")
+	assert.False(t, d.IsLocked(tokenA))
+}
+
+// TestEmptyOwnerFallback verifies that callers without owner context (empty
+// owner) keep the full lock/relock/reclaim/unlock semantics of the old
+// single-map locker.
+func TestEmptyOwnerFallback(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	d := quietLocker(t, mock)
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+
+	// Lock, then a second lock for another tx must fail.
+	mock.setStatus("tx-1", ttxdb.Pending)
+	_, err := d.Lock(context.Background(), "", tokenA, "tx-1", false)
+	require.NoError(t, err)
+	holder, err := d.Lock(context.Background(), "", tokenA, "tx-2", false)
+	require.ErrorIs(t, err, AlreadyLockedError)
+	assert.Equal(t, "tx-1", holder)
+	assert.True(t, d.IsLocked(tokenA))
+
+	// Reclaim succeeds once the holding tx is Deleted.
+	mock.setStatus("tx-1", ttxdb.Deleted)
+	mock.setStatus("tx-2", ttxdb.Pending)
+	_, err = d.Lock(context.Background(), "", tokenA, "tx-2", true)
+	require.NoError(t, err)
+
+	// Unlock and lock again.
+	notFound := d.UnlockIDs(context.Background(), "", tokenA)
+	require.Empty(t, notFound)
+	assert.False(t, d.IsLocked(tokenA))
+	_, err = d.Lock(context.Background(), "", tokenA, "tx-3", false)
+	require.NoError(t, err)
+}
+
+// TestSameOwnerStillSerializes verifies sharding did not weaken safety
+// within one owner: two transactions racing for the same token under the
+// same owner — one wins, the other gets AlreadyLockedError.
+func TestSameOwnerStillSerializes(t *testing.T) {
+	mock := newMockTXStatusProvider()
+	d := quietLocker(t, mock)
+
+	tokenA := &token.ID{TxId: "tok-a", Index: 0}
+	mock.setStatus("tx-1", ttxdb.Pending)
+	mock.setStatus("tx-2", ttxdb.Pending)
+
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, txID := range []string{"tx-1", "tx-2"} {
+		wg.Go(func() {
+			_, err := d.Lock(context.Background(), "alice", tokenA, txID, false)
+			errs <- err
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	var failures int
+	for err := range errs {
+		if err != nil {
+			require.ErrorIs(t, err, AlreadyLockedError)
+			failures++
+		}
+	}
+	assert.Equal(t, 1, failures, "exactly one of two racing locks for the same token must fail")
+	assert.True(t, d.IsLocked(tokenA))
+}

--- a/token/services/selector/simple/inmemory/locker_shutdown_test.go
+++ b/token/services/selector/simple/inmemory/locker_shutdown_test.go
@@ -29,7 +29,7 @@ func TestLocker_Stop(t *testing.T) {
 
 		d := NewLocker(mock, 20*time.Millisecond, time.Minute)
 
-		_, err := d.Lock(context.Background(), tokenID, txA, false)
+		_, err := d.Lock(context.Background(), "alice", tokenID, txA, false)
 		if err != nil {
 			t.Fatalf("unexpected lock error: %v", err)
 		}
@@ -113,7 +113,7 @@ func TestLocker_StopDuringActiveScan(t *testing.T) {
 	d := NewLocker(mock, 20*time.Millisecond, time.Minute).(*locker)
 
 	for _, id := range ids {
-		_, _ = d.Lock(context.Background(), id, "stop-scan-tx", false)
+		_, _ = d.Lock(context.Background(), "alice", id, "stop-scan-tx", false)
 	}
 
 	// Give the scan goroutine a moment to start iterating.
@@ -147,7 +147,7 @@ func TestLocker_ConcurrentStopAndLock(t *testing.T) {
 			defer wg.Done()
 			id := &token.ID{TxId: "conc", Index: uint64(i)} //nolint:gosec // G115: i is in [0,5), no overflow
 			mock.setStatus("conc", ttxdb.Pending)
-			_, _ = d.Lock(context.Background(), id, "conc", false)
+			_, _ = d.Lock(context.Background(), "alice", id, "conc", false)
 		}(i)
 	}
 

--- a/token/services/selector/simple/inmemory/locker_test.go
+++ b/token/services/selector/simple/inmemory/locker_test.go
@@ -38,12 +38,12 @@ func TestLockEntry(t *testing.T) {
 }
 
 // mockTXStatusProvider is a thread-safe mock that allows tests to control
-// the status returned for each txID and to inject delays.
+// the status returned for each txID and to inject hooks.
 type mockTXStatusProvider struct {
 	mu       sync.Mutex
 	statuses map[string]ttxdb.TxStatus
-	// getStatusHook is called inside GetStatus while the scanner holds RLock.
-	// Tests use it to inject a reclaim between the scan's RUnlock and Lock.
+	// getStatusHook, if set, is called at the beginning of every GetStatus.
+	// Tests use it to synchronize with (or block) status lookups.
 	getStatusHook func(txID string)
 }
 
@@ -57,104 +57,86 @@ func (m *mockTXStatusProvider) setStatus(txID string, status ttxdb.TxStatus) {
 	m.statuses[txID] = status
 }
 
-func (m *mockTXStatusProvider) GetStatus(_ context.Context, txID string) (ttxdb.TxStatus, string, error) {
-	if m.getStatusHook != nil {
-		m.getStatusHook(txID)
-	}
+func (m *mockTXStatusProvider) status(txID string) ttxdb.TxStatus {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	status, ok := m.statuses[txID]
 	if !ok {
-		return ttxdb.Pending, "", nil
+		return ttxdb.Pending
 	}
 
-	return status, "", nil
+	return status
 }
 
-// TestScannerDoesNotDeleteReclaimed verifies the TOCTOU fix:
-// when the scanner collects a token for removal and a concurrent
-// Lock(reclaim=true) re-locks that token for a new transaction,
-// the scanner must NOT delete the new entry.
+func (m *mockTXStatusProvider) GetStatus(_ context.Context, txID string) (ttxdb.TxStatus, string, error) {
+	m.mu.Lock()
+	hook := m.getStatusHook
+	m.mu.Unlock()
+	if hook != nil {
+		hook(txID)
+	}
+
+	return m.status(txID), "", nil
+}
+
+// TestScannerDoesNotDeleteReclaimed verifies the TOCTOU protection in the
+// scanner: when the scanner has observed a token as removable (its tx is
+// Deleted) and a concurrent Lock(reclaim=true) re-locks that token for a new
+// transaction before the scanner deletes, the scanner must NOT delete the
+// new entry. The test drives the real scan loop and blocks the scanner's
+// status lookup to open the race window deterministically.
 func TestScannerDoesNotDeleteReclaimed(t *testing.T) {
 	mock := newMockTXStatusProvider()
 	tokenID := &token.ID{TxId: "tok1", Index: 0}
 	txA := "tx-A"
 	txB := "tx-B"
 
-	// Use a short sleep timeout so the scanner loop iterates quickly.
-	d := &locker{
-		ttxdb:                  mock,
-		sleepTimeout:           50 * time.Millisecond,
-		lock:                   &sync.RWMutex{},
-		locked:                 map[token.ID]*lockEntry{},
-		validTxEvictionTimeout: 0, // immediate eviction for Confirmed
-	}
-
-	// Step 1: Lock the token for tx-A.
+	// Lock the token for tx-A while it is still Pending.
 	mock.setStatus(txA, ttxdb.Pending)
-	_, err := d.Lock(context.Background(), tokenID, txA, false)
+	d := NewLocker(mock, 20*time.Millisecond, time.Minute).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+	_, err := d.Lock(context.Background(), "alice", tokenID, txA, false)
 	require.NoError(t, err)
 
-	// Step 2: Mark tx-A as Deleted so the scanner will collect it.
+	// Arm a one-shot hook: the next status lookup that observes tx-A as
+	// Deleted blocks — that is the scanner mid-evaluation, before its
+	// delete phase.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	mock.getStatusHook = func(txID string) {
+		if txID == txA && mock.status(txA) == ttxdb.Deleted {
+			first := false
+			once.Do(func() { first = true })
+			if !first {
+				return
+			}
+			// only the first observer (the scanner) blocks; later lookups
+			// (the reclaim's) must pass through or they would deadlock
+			close(entered)
+			<-release
+		}
+	}
 	mock.setStatus(txA, ttxdb.Deleted)
 
-	// Step 3: Run the scan manually instead of in a goroutine so we
-	// can control timing. We simulate the race by using getStatusHook:
-	// while the scanner reads statuses under RLock, we prepare to reclaim
-	// right after RUnlock.
-	//
-	// We replicate the scan logic inline to inject the reclaim at the
-	// exact right moment (between RUnlock and Lock).
-	type removeEntry struct {
-		id   token.ID
-		txID string
-	}
-	var removeList []removeEntry
-
-	// Scan phase (RLock)
-	d.lock.RLock()
-	for id, entry := range d.locked {
-		status, _, _ := d.ttxdb.GetStatus(context.Background(), entry.TxID)
-		switch status {
-		case ttxdb.Deleted:
-			removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-		case ttxdb.Confirmed:
-			if time.Since(entry.LastAccess) > d.validTxEvictionTimeout {
-				removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-			}
-		}
-	}
-	d.lock.RUnlock()
-
-	// --- RACE WINDOW: scanner has released RLock but hasn't acquired Lock yet ---
-
-	// Simulate Lock(reclaim=true) for tx-B: tx-A is Deleted so reclaim succeeds.
+	// The scanner is now stuck between observing tx-A as removable and
+	// deleting it. Reclaim the token for tx-B in that window.
+	<-entered
 	mock.setStatus(txB, ttxdb.Pending)
-	_, err = d.Lock(context.Background(), tokenID, txB, true)
+	_, err = d.Lock(context.Background(), "alice", tokenID, txB, true)
 	require.NoError(t, err)
 
-	// Verify the token is now locked by tx-B.
-	d.lock.RLock()
-	entry := d.locked[*tokenID]
-	assert.Equal(t, txB, entry.TxID, "token should be locked by tx-B after reclaim")
-	d.lock.RUnlock()
+	// Let the scanner finish its delete phase.
+	close(release)
 
-	// Delete phase (Lock) — this is the code under test from scan().
-	d.lock.Lock()
-	for _, s := range removeList {
-		// The fix: re-validate before deleting.
-		if entry, ok := d.locked[s.id]; ok && entry.TxID == s.txID {
-			delete(d.locked, s.id)
-		}
-	}
-	d.lock.Unlock()
-
-	// Step 4: Assert the token is still locked by tx-B (not deleted).
-	d.lock.RLock()
-	entry, ok := d.locked[*tokenID]
-	d.lock.RUnlock()
-	assert.True(t, ok, "token entry must still exist after scanner runs")
-	assert.Equal(t, txB, entry.TxID, "token must remain locked by tx-B, not deleted by scanner")
+	// The token must remain locked by tx-B: the scanner's re-validation
+	// must notice the entry changed hands.
+	require.Never(t, func() bool {
+		return !d.IsLocked(tokenID)
+	}, 300*time.Millisecond, 10*time.Millisecond, "scanner must not delete a reclaimed entry")
+	holder, err := d.Lock(context.Background(), "alice", tokenID, "tx-C", false)
+	require.ErrorIs(t, err, AlreadyLockedError)
+	assert.Equal(t, txB, holder, "token must remain locked by tx-B")
 }
 
 // TestScannerDeletesStaleEntry verifies that the scanner still correctly
@@ -164,47 +146,17 @@ func TestScannerDeletesStaleEntry(t *testing.T) {
 	tokenID := &token.ID{TxId: "tok2", Index: 0}
 	txA := "tx-A"
 
-	d := &locker{
-		ttxdb:                  mock,
-		sleepTimeout:           50 * time.Millisecond,
-		lock:                   &sync.RWMutex{},
-		locked:                 map[token.ID]*lockEntry{},
-		validTxEvictionTimeout: 0,
-	}
-
-	// Lock the token for tx-A, then mark it Deleted.
 	mock.setStatus(txA, ttxdb.Pending)
-	_, err := d.Lock(context.Background(), tokenID, txA, false)
+	d := NewLocker(mock, 20*time.Millisecond, time.Minute).(*locker)
+	t.Cleanup(func() { _ = d.Stop() })
+
+	_, err := d.Lock(context.Background(), "alice", tokenID, txA, false)
 	require.NoError(t, err)
+	require.True(t, d.IsLocked(tokenID))
+
+	// Once the transaction is Deleted, the scanner must evict the lock.
 	mock.setStatus(txA, ttxdb.Deleted)
-
-	// Scan phase
-	type removeEntry struct {
-		id   token.ID
-		txID string
-	}
-	var removeList []removeEntry
-
-	d.lock.RLock()
-	for id, entry := range d.locked {
-		status, _, _ := d.ttxdb.GetStatus(context.Background(), entry.TxID)
-		if status == ttxdb.Deleted {
-			removeList = append(removeList, removeEntry{id: id, txID: entry.TxID})
-		}
-	}
-	d.lock.RUnlock()
-
-	// No reclaim happens — delete phase should remove the entry.
-	d.lock.Lock()
-	for _, s := range removeList {
-		if entry, ok := d.locked[s.id]; ok && entry.TxID == s.txID {
-			delete(d.locked, s.id)
-		}
-	}
-	d.lock.Unlock()
-
-	d.lock.RLock()
-	_, ok := d.locked[*tokenID]
-	d.lock.RUnlock()
-	assert.False(t, ok, "stale entry should have been removed by scanner")
+	require.Eventually(t, func() bool {
+		return !d.IsLocked(tokenID)
+	}, 2*time.Second, 20*time.Millisecond, "stale entry should have been removed by scanner")
 }

--- a/token/services/selector/simple/selector.go
+++ b/token/services/selector/simple/selector.go
@@ -8,6 +8,7 @@ package simple
 
 import (
 	"context"
+	"math/rand/v2"
 	"time"
 
 	"github.com/LFDT-Panurus/panurus/token"
@@ -23,10 +24,12 @@ type QueryService interface {
 }
 
 type Locker interface {
-	Lock(ctx context.Context, id *token2.ID, txID string, reclaim bool) (string, error)
-	// UnlockIDs unlocks the passed IDS. It returns the list of tokens that were not locked in the first place among
-	// those passed.
-	UnlockIDs(ctx context.Context, ids ...*token2.ID) []*token2.ID
+	// Lock locks the given token of the given owner for the given transaction.
+	// The owner scopes the lock state: locks of different owners never contend.
+	Lock(ctx context.Context, owner string, id *token2.ID, txID string, reclaim bool) (string, error)
+	// UnlockIDs unlocks the passed IDS of the given owner. It returns the list of tokens that were not locked
+	// in the first place among those passed.
+	UnlockIDs(ctx context.Context, owner string, ids ...*token2.ID) []*token2.ID
 	UnlockByTxID(ctx context.Context, txID string)
 	IsLocked(id *token2.ID) bool
 }
@@ -107,19 +110,19 @@ func (s *selector) selectByID(ctx context.Context, ownerFilter token.OwnerFilter
 
 			q, err := token2.ToQuantity(t.Quantity, s.precision)
 			if err != nil {
-				s.locker.UnlockIDs(ctx, toBeSpent...)
-				s.locker.UnlockIDs(ctx, toBeCertified...)
+				s.locker.UnlockIDs(ctx, id, toBeSpent...)
+				s.locker.UnlockIDs(ctx, id, toBeCertified...)
 
 				return nil, nil, errors.Wrap(err, "failed to convert quantity")
 			}
 
 			// lock the token
-			if _, lockErr := s.locker.Lock(ctx, &t.Id, s.txID, reclaim); lockErr != nil {
+			if _, lockErr := s.locker.Lock(ctx, id, &t.Id, s.txID, reclaim); lockErr != nil {
 				var addErr error
 				potentialSumWithLocked, addErr = potentialSumWithLocked.Add(q)
 				if addErr != nil {
-					s.locker.UnlockIDs(ctx, toBeSpent...)
-					s.locker.UnlockIDs(ctx, toBeCertified...)
+					s.locker.UnlockIDs(ctx, id, toBeSpent...)
+					s.locker.UnlockIDs(ctx, id, toBeCertified...)
 
 					return nil, nil, errors.Wrap(addErr, "failed to add locked quantity")
 				}
@@ -134,15 +137,15 @@ func (s *selector) selectByID(ctx context.Context, ownerFilter token.OwnerFilter
 			toBeSpent = append(toBeSpent, &t.Id)
 			sum, err = sum.Add(q)
 			if err != nil {
-				s.locker.UnlockIDs(ctx, toBeSpent...)
-				s.locker.UnlockIDs(ctx, toBeCertified...)
+				s.locker.UnlockIDs(ctx, id, toBeSpent...)
+				s.locker.UnlockIDs(ctx, id, toBeCertified...)
 
 				return nil, nil, errors.Wrap(err, "failed to add quantity")
 			}
 			potentialSumWithLocked, err = potentialSumWithLocked.Add(q)
 			if err != nil {
-				s.locker.UnlockIDs(ctx, toBeSpent...)
-				s.locker.UnlockIDs(ctx, toBeCertified...)
+				s.locker.UnlockIDs(ctx, id, toBeSpent...)
+				s.locker.UnlockIDs(ctx, id, toBeCertified...)
 
 				return nil, nil, errors.Wrap(err, "failed to add quantity")
 			}
@@ -163,8 +166,8 @@ func (s *selector) selectByID(ctx context.Context, ownerFilter token.OwnerFilter
 		}
 
 		// Unlock and check the conditions for a retry
-		s.locker.UnlockIDs(ctx, toBeSpent...)
-		s.locker.UnlockIDs(ctx, toBeCertified...)
+		s.locker.UnlockIDs(ctx, id, toBeSpent...)
+		s.locker.UnlockIDs(ctx, id, toBeCertified...)
 
 		if target.Cmp(potentialSumWithLocked) <= 0 && potentialSumWithLocked.Cmp(sum) != 0 {
 			// funds are potentially enough but they are locked
@@ -202,7 +205,19 @@ func (s *selector) selectByID(ctx context.Context, ownerFilter token.OwnerFilter
 			)
 		}
 
-		logger.DebugfContext(ctx, "token selection: let's wait [%v] before retry...", s.timeout)
-		time.Sleep(s.timeout)
+		backoff := s.retryBackoff()
+		logger.DebugfContext(ctx, "token selection: let's wait [%v] before retry...", backoff)
+		time.Sleep(backoff)
 	}
+}
+
+// retryBackoff returns a random duration in [0, timeout), so transactions
+// that lost a race for the same funds don't all retry at the same instant
+// (same jittering pattern as sherdlock's selector).
+func (s *selector) retryBackoff() time.Duration {
+	if s.timeout <= 0 {
+		return 0
+	}
+
+	return time.Duration(rand.Int64N(int64(s.timeout)))
 }

--- a/token/services/selector/simple/selector_test.go
+++ b/token/services/selector/simple/selector_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package simple
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryBackoffIsJittered verifies the retry backoff is randomized over
+// [0, timeout) instead of a constant sleep, so transactions that lost a race
+// for the same funds don't all retry at the same instant.
+func TestRetryBackoffIsJittered(t *testing.T) {
+	timeout := 5 * time.Second
+	s := &selector{timeout: timeout}
+
+	seen := map[time.Duration]struct{}{}
+	for range 100 {
+		d := s.retryBackoff()
+		require.GreaterOrEqual(t, d, time.Duration(0))
+		require.Less(t, d, timeout)
+		seen[d] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "backoff must vary across retries, not be a constant")
+}

--- a/token/services/selector/testutils/testutils.go
+++ b/token/services/selector/testutils/testutils.go
@@ -169,11 +169,11 @@ func (q *MockQueryService) GetStatus(ctx context.Context, txID string) (token.Tx
 type NoLock struct {
 }
 
-func (n *NoLock) Lock(ctx context.Context, id *token2.ID, txID string, reclaim bool) (string, error) {
+func (n *NoLock) Lock(ctx context.Context, owner string, id *token2.ID, txID string, reclaim bool) (string, error) {
 	return "", nil
 }
 
-func (n *NoLock) UnlockIDs(ctx context.Context, ids ...*token2.ID) []*token2.ID {
+func (n *NoLock) UnlockIDs(ctx context.Context, owner string, ids ...*token2.ID) []*token2.ID {
 	return ids
 }
 


### PR DESCRIPTION
The simple selector's in-memory locker guarded all tokens with one global mutex, so transactions locking tokens of unrelated owners serialized on a single lock — worst when a reclaim held it across a status lookup, freezing every other owner's selection.

Changes:
- The locker keeps a lazily-created shard per owner; `Lock`/`UnlockIDs` take the owner (already in scope in `selectByID`). `UnlockByTxID`/`IsLocked` keep their signatures and visit each shard briefly. The empty owner is a valid shard key for callers without owner context.
- The background scan now snapshots entries per shard and resolves statuses without holding any lock, re-validating before deleting (TxID match + LastAccess re-check for Confirmed evictions), so status lookups no longer block an owner's operations.
- The fixed retry sleep is replaced with a random backoff in [0, timeout), the same jittering pattern as sherdlock's selector.

Breaking: `simple.Locker`'s `Lock`/`UnlockIDs` (and the mirrored interfaces in `sherdlock/inmemory` and `testutils`) gain an owner parameter; the single-lock-per-token guarantee is now scoped to the owner namespace. `inmemory.NewLocker`'s signature is unchanged.

Benchmarks (`locker_bench_test.go`, Apple M4 Pro): 8 workers reclaiming under a 100µs status lookup run 8.1x faster with per-owner shards (linear scaling); pure lock/unlock under 32 workers is 2.3–2.5x faster. Tests cover shard independence (deterministic, no timing), cross-shard UnlockByTxID, empty-owner fallback, same-owner race safety, scanner TOCTOU protection, and backoff jitter; all with `-race` clean.

Closes #1875