### PR TITLE
fix(token): instantiate validators with limits resolved from configuration

### DIFF
--- a/docs/drivers/validation-resource-limits.md
+++ b/docs/drivers/validation-resource-limits.md
@@ -51,12 +51,25 @@ A `driver.StaticResourceLimits` provider (a trivial wrapper returning a fixed va
 tests, tools, and any caller that only needs the defaults (e.g.
 `cmd/token_validation_service`, the zkatdlog regression suite).
 
-The resolved `driver.ResourceLimits` flows: composition root → `core.NewValidatorDriverService(limits, ...)`
-→ `driver.ValidatorDriver.NewValidator(pp, limits)` → the per-driver `common.NewValidator(..., limits, ...)`
-→ `ActionDeserializer.DeserializeActions`, which calls `action.SetLimits(limits)` on every
-deserialized action before `Deserialize` runs. Any action constructed without `SetLimits` (e.g. in
-tests or other non-validator call sites) falls back to `DefaultResourceLimits()` via an internal
-`effectiveLimits()` helper — never more permissive than the historical behavior.
+The FSC/DI runtime (`token/sdk/dig/sdk.go`) registers exactly one `driver.ResourceLimitsProvider` in
+the dig container — the config-backed implementation above — and injects it into **both** validator
+construction paths, so they always enforce the same configured limits:
+
+- The per-TMS token manager service: each driver's `NewTokenDriver` constructor
+  (`token/core/fabtoken/v1/driver/driver.go`, `token/core/zkatdlog/nogh/v1/driver/driver.go`) takes a
+  `driver.ResourceLimitsProvider` and resolves it inside `NewTokenService`, immediately before
+  constructing that TMS's validator.
+- The standalone validator-driver service: `newValidatorDriverService`
+  (`token/sdk/dig/providers.go`) takes the same injected `driver.ResourceLimitsProvider` and resolves
+  it once when building `core.ValidatorDriverService`.
+
+The resolved `driver.ResourceLimits` flows: provider → (`Driver.NewTokenService` /
+`core.NewValidatorDriverService(limits, ...)` → `driver.ValidatorDriver.NewValidator(pp, limits)`) →
+the per-driver `common.NewValidator(..., limits, ...)` → `ActionDeserializer.DeserializeActions`,
+which calls `action.SetLimits(limits)` on every deserialized action before `Deserialize` runs. Any
+action constructed without `SetLimits` (e.g. in tests or other non-validator call sites) falls back
+to `DefaultResourceLimits()` via an internal `effectiveLimits()` helper — never more permissive than
+the historical behavior.
 
 ## Consensus-safety contract
 

--- a/token/core/fabtoken/v1/driver/driver.go
+++ b/token/core/fabtoken/v1/driver/driver.go
@@ -26,14 +26,15 @@ import (
 // Driver contains the non-static logic of the fabtoken driver (including services).
 type Driver struct {
 	BaseWalletServiceFactory
-	metricsProvider  cdriver.MetricsProvider
-	tracerProvider   cdriver.TracerProvider
-	configService    cdriver.ConfigService
-	storageProvider  cdriver.StorageProvider
-	identityProvider cdriver.IdentityProvider
-	endpointService  cdriver.NetworkBinderService
-	networkProvider  cdriver.NetworkProvider
-	vaultProvider    cdriver.VaultProvider
+	metricsProvider        cdriver.MetricsProvider
+	tracerProvider         cdriver.TracerProvider
+	configService          cdriver.ConfigService
+	storageProvider        cdriver.StorageProvider
+	identityProvider       cdriver.IdentityProvider
+	endpointService        cdriver.NetworkBinderService
+	networkProvider        cdriver.NetworkProvider
+	vaultProvider          cdriver.VaultProvider
+	resourceLimitsProvider driver.ResourceLimitsProvider
 }
 
 // NewTokenDriver returns a new factory for the fabtoken driver.
@@ -46,6 +47,7 @@ func NewTokenDriver(
 	endpointService cdriver.NetworkBinderService,
 	networkProvider cdriver.NetworkProvider,
 	vaultProvider cdriver.VaultProvider,
+	resourceLimitsProvider driver.ResourceLimitsProvider,
 ) core.NamedFactory[driver.Driver] {
 	return core.NamedFactory[driver.Driver]{
 		Name: core.DriverIdentifier(v1setup.FabTokenDriverName, 1),
@@ -58,6 +60,7 @@ func NewTokenDriver(
 			endpointService,
 			networkProvider,
 			vaultProvider,
+			resourceLimitsProvider,
 		),
 	}
 }
@@ -71,16 +74,18 @@ func newTokenDriver(
 	endpointService cdriver.NetworkBinderService,
 	networkProvider cdriver.NetworkProvider,
 	vaultProvider cdriver.VaultProvider,
+	resourceLimitsProvider driver.ResourceLimitsProvider,
 ) *Driver {
 	return &Driver{
-		metricsProvider:  metricsProvider,
-		tracerProvider:   tracerProvider,
-		configService:    configService,
-		storageProvider:  storageProvider,
-		identityProvider: identityProvider,
-		endpointService:  endpointService,
-		networkProvider:  networkProvider,
-		vaultProvider:    vaultProvider,
+		metricsProvider:        metricsProvider,
+		tracerProvider:         tracerProvider,
+		configService:          configService,
+		storageProvider:        storageProvider,
+		identityProvider:       identityProvider,
+		endpointService:        endpointService,
+		networkProvider:        networkProvider,
+		vaultProvider:          vaultProvider,
+		resourceLimitsProvider: resourceLimitsProvider,
 	}
 }
 
@@ -155,11 +160,15 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initialize token service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}
+	limits, err := d.resourceLimitsProvider.ResourceLimits()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed resolving validator resource limits")
+	}
 	validator := validator.NewValidator(
 		logger,
 		publicParamsManager.PublicParams(),
 		deserializer,
-		driver.DefaultResourceLimits(),
+		limits,
 		nil,
 		nil,
 		nil,

--- a/token/core/fabtoken/v1/driver/driver_test.go
+++ b/token/core/fabtoken/v1/driver/driver_test.go
@@ -45,6 +45,7 @@ func TestNewDriver(t *testing.T) {
 		endpointService,
 		networkProvider,
 		vaultProvider,
+		tdriver.StaticResourceLimits(tdriver.DefaultResourceLimits()),
 	)
 
 	assert.NotNil(t, factory.Driver)
@@ -70,6 +71,7 @@ func TestNewTokenService(t *testing.T) {
 		endpointService,
 		networkProvider,
 		vaultProvider,
+		tdriver.StaticResourceLimits(tdriver.DefaultResourceLimits()),
 	).Driver.(*driver.Driver)
 
 	tmsID := tdriver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"}

--- a/token/core/zkatdlog/nogh/v1/driver/driver.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver.go
@@ -28,14 +28,15 @@ import (
 // Driver contains the non-static logic of the zkatdlog driver (including services).
 type Driver struct {
 	BaseWalletServiceFactory
-	metricsProvider  cdriver.MetricsProvider
-	tracerProvider   cdriver.TracerProvider
-	configService    cdriver.ConfigService
-	storageProvider  cdriver.StorageProvider
-	identityProvider cdriver.IdentityProvider
-	endpointService  cdriver.NetworkBinderService
-	networkProvider  cdriver.NetworkProvider
-	vaultProvider    cdriver.VaultProvider
+	metricsProvider        cdriver.MetricsProvider
+	tracerProvider         cdriver.TracerProvider
+	configService          cdriver.ConfigService
+	storageProvider        cdriver.StorageProvider
+	identityProvider       cdriver.IdentityProvider
+	endpointService        cdriver.NetworkBinderService
+	networkProvider        cdriver.NetworkProvider
+	vaultProvider          cdriver.VaultProvider
+	resourceLimitsProvider driver.ResourceLimitsProvider
 }
 
 // NewTokenDriver returns a new factory for the zkatdlog driver.
@@ -48,6 +49,7 @@ func NewTokenDriver(
 	endpointService cdriver.NetworkBinderService,
 	networkProvider cdriver.NetworkProvider,
 	vaultProvider cdriver.VaultProvider,
+	resourceLimitsProvider driver.ResourceLimitsProvider,
 ) core.NamedFactory[driver.Driver] {
 	return core.NamedFactory[driver.Driver]{
 		Name: core.DriverIdentifier(v1setup.DLogNoGHDriverName, v1setup.ProtocolV1),
@@ -60,6 +62,7 @@ func NewTokenDriver(
 			endpointService,
 			networkProvider,
 			vaultProvider,
+			resourceLimitsProvider,
 		),
 	}
 }
@@ -73,16 +76,18 @@ func newTokenDriver(
 	endpointService cdriver.NetworkBinderService,
 	networkProvider cdriver.NetworkProvider,
 	vaultProvider cdriver.VaultProvider,
+	resourceLimitsProvider driver.ResourceLimitsProvider,
 ) *Driver {
 	return &Driver{
-		metricsProvider:  metricsProvider,
-		tracerProvider:   tracerProvider,
-		configService:    configService,
-		storageProvider:  storageProvider,
-		identityProvider: identityProvider,
-		endpointService:  endpointService,
-		networkProvider:  networkProvider,
-		vaultProvider:    vaultProvider,
+		metricsProvider:        metricsProvider,
+		tracerProvider:         tracerProvider,
+		configService:          configService,
+		storageProvider:        storageProvider,
+		identityProvider:       identityProvider,
+		endpointService:        endpointService,
+		networkProvider:        networkProvider,
+		vaultProvider:          vaultProvider,
+		resourceLimitsProvider: resourceLimitsProvider,
 	}
 }
 
@@ -162,11 +167,15 @@ func (d *Driver) NewTokenService(tmsID driver.TMSID, publicParams []byte) (drive
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to initiliaze token upgrade service for [%s:%s]", tmsID.Network, tmsID.Namespace)
 	}
+	limits, err := d.resourceLimitsProvider.ResourceLimits()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed resolving validator resource limits")
+	}
 	validator := validator.New(
 		logger,
 		ppm.PublicParams(),
 		deserializer,
-		driver.DefaultResourceLimits(),
+		limits,
 		nil,
 		nil,
 		nil,

--- a/token/core/zkatdlog/nogh/v1/driver/driver_test.go
+++ b/token/core/zkatdlog/nogh/v1/driver/driver_test.go
@@ -63,6 +63,7 @@ func TestNewDriver(t *testing.T) {
 		endpointService,
 		networkProvider,
 		vaultProvider,
+		tdriver.StaticResourceLimits(tdriver.DefaultResourceLimits()),
 	)
 
 	assert.NotNil(t, factory.Driver)
@@ -88,6 +89,7 @@ func TestNewTokenService(t *testing.T) {
 		endpointService,
 		networkProvider,
 		vaultProvider,
+		tdriver.StaticResourceLimits(tdriver.DefaultResourceLimits()),
 	).Driver.(*driver.Driver)
 
 	tmsID := tdriver.TMSID{Network: "n1", Channel: "c1", Namespace: "ns1"}

--- a/token/sdk/dig/providers.go
+++ b/token/sdk/dig/providers.go
@@ -9,7 +9,6 @@ package sdk
 import (
 	"github.com/LFDT-Panurus/panurus/token/core"
 	"github.com/LFDT-Panurus/panurus/token/driver"
-	"github.com/LFDT-Panurus/panurus/token/services/config"
 	dbdriver "github.com/LFDT-Panurus/panurus/token/services/storage/db/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/storage/db/multiplexed"
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
@@ -40,11 +39,11 @@ func newTokenDriverService(in struct {
 
 func newValidatorDriverService(in struct {
 	dig.In
-	Drivers        []core.NamedFactory[driver.ValidatorDriver] `group:"validator-drivers"`
-	ConfigProvider config.Provider
+	Drivers                []core.NamedFactory[driver.ValidatorDriver] `group:"validator-drivers"`
+	ResourceLimitsProvider driver.ResourceLimitsProvider
 },
 ) (*core.ValidatorDriverService, error) {
-	limits, err := config.NewResourceLimitsProvider(in.ConfigProvider).ResourceLimits()
+	limits, err := in.ResourceLimitsProvider.ResourceLimits()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed resolving validation resource limits")
 	}

--- a/token/sdk/dig/sdk.go
+++ b/token/sdk/dig/sdk.go
@@ -122,6 +122,7 @@ func (p *SDK) Install() error {
 			digutils.Identity[*tms.ConfigServiceWrapper](),
 			dig.As(new(ftscore.ConfigService), new(db2.ConfigService), new(tms.ConfigService)),
 		),
+		p.Container().Provide(ftsconfig.NewResourceLimitsProvider, dig.As(new(ftsdriver.ResourceLimitsProvider))),
 
 		// network service
 		p.Container().Provide(network.NewProvider),


### PR DESCRIPTION
## Summary
- Both the fabtoken and zkatdlog drivers built their per-TMS validator with a hardcoded `driver.DefaultResourceLimits()`, silently ignoring any `token.validation.limits` the operator configured — while the separate validator-driver-service path already honored it.
- Register a single `driver.ResourceLimitsProvider` (config-backed) in dig and inject it into both drivers' `NewTokenService` and into `newValidatorDriverService`, so every validator-construction path resolves the same configured limits.
- Updated `docs/drivers/validation-resource-limits.md` to describe the unified flow.

Fixes #1978

## Test plan
- [x] `make checks`
- [x] `make lint-auto-fix`
- [x] `go test ./token/core/fabtoken/v1/driver/... ./token/core/zkatdlog/nogh/v1/driver/... ./token/sdk/dig/... ./token/core/... ./token/services/config/...`
- [x] `go test -race` on the same packages (includes `TestFabricWiring` dig dry-run)