### PR TITLE
feat(evm): NWO backend skeleton in the evm module

### DIFF
--- a/x/token/services/network/evm/nwo/backend.go
+++ b/x/token/services/network/evm/nwo/backend.go
@@ -1,0 +1,54 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package nwo
+
+import (
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// TMSRef identifies the token management system a backend operation targets. It is the evm module's
+// own minimal reference (network, channel, namespace), so this package needs no panurus token types.
+type TMSRef struct {
+	Network   string
+	Channel   string
+	Namespace string
+}
+
+// DeploySpec is the input to standing up one TMS's on-chain state: the endorser set and threshold the
+// EndorsementVerifier is seeded with, the driver mode (graphHiding selects the spentRefs semantics),
+// and the initial public parameters (version 0). Endorsers are Ethereum addresses here; the address
+// to FSC identity binding the driver's config carries is assembled by the harness alongside this.
+type DeploySpec struct {
+	TMS          TMSRef
+	Endorsers    []client.Address
+	Threshold    uint
+	GraphHiding  bool
+	PublicParams []byte
+}
+
+// Deployment is the result of Deploy: the contract addresses a node's evm config block points at
+// (services.network.evm.contracts.*).
+type Deployment struct {
+	TokenState          client.Address
+	EndorsementVerifier client.Address
+}
+
+// Backend stands up and maintains the EVM on-chain state a TMS needs during integration tests. It is
+// the driver-owned NWO surface: a test harness deploys the contracts through Deploy and seeds or
+// updates public parameters through UpdatePublicParams. Standing up the node itself (Besu vs the
+// fabricx+EVM gateway) is the concrete backend's concern and is not part of this contract, so the two
+// backends share this shape and differ only in how the node is provisioned underneath.
+type Backend interface {
+	// Deploy deploys the EndorsementVerifier and a per-TMS TokenState clone for spec.TMS, seeding the
+	// endorser set, threshold, graphHiding mode and public parameters (version 0), and returns the
+	// deployed addresses.
+	Deploy(spec DeploySpec) (Deployment, error)
+
+	// UpdatePublicParams seeds or updates the on-chain public parameters for the TMS, the value the
+	// driver reads back via getPublicParameters / getPublicParamsVersion.
+	UpdatePublicParams(tms TMSRef, ppRaw []byte) error
+}

--- a/x/token/services/network/evm/nwo/doc.go
+++ b/x/token/services/network/evm/nwo/doc.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package nwo is the EVM network driver's own integration-network support: the seam a test harness
+// uses to stand up the driver's on-chain backend (deploy the contracts, seed and update public
+// parameters) so the token integration suites can run against an EVM backend by switching topology.
+//
+// It lives inside the evm module, not in a consumer's integration tree, because the module is
+// developed as if it lived in a different repo (design §15.6, working rule R7): its integration
+// surface ships with it. That is why this package depends only on evm-module types and never on the
+// panurus integration module (the dependency runs the other way, integration requires this module).
+//
+// The layering mirrors fabricx: the backend's own repo (FSC for fabricx, this module for evm) ships
+// the platform, and a consumer's NWO framework adds a thin adapter over it. So a panurus adapter
+// (integration/nwo/token/evm) implements the token-layer Backend by delegating to the Backend defined
+// here; that adapter lands with the concrete backend and the go.mod require+replace (Week 6), which
+// is why it is not part of this skeleton.
+//
+// # The contract (backend.go)
+//
+//   - Backend is the driver-owned surface a test harness drives: Deploy stands up a TMS's contracts
+//     (EndorsementVerifier + a per-TMS TokenState clone, seeding PP v0 + endorser set + threshold +
+//     graphHiding) and returns the addresses a node's evm config points at; UpdatePublicParams seeds
+//     or updates the on-chain public parameters.
+//   - How the node itself is stood up (Besu in dev mode vs the fabricx+EVM gateway container) is the
+//     concrete backend's concern, layered on top; this package fixes only the driver-owned shape both
+//     backends share.
+//
+// # The split (issue #1989)
+//
+//   - Besu backend: the primary/acceptance backend, implemented with the Week-6 integration milestone.
+//   - fabricx+EVM gateway backend: booting the gateway node and its topology.
+//
+// Both implement this same Backend, so the fungible dlog test bodies run unchanged on either by
+// selecting the backend. The deployed config must carry the token.tms.<id>.services.network.evm.*
+// block the driver reads, including the endorser Ethereum-address to FSC identity registry, threshold
+// and allowlist (design §6.1/§10).
+package nwo


### PR DESCRIPTION
The driver-owned seam for standing up an EVM backend in the token integration network, so the fungible suites run against an EVM backend by switching topology. Pushing it first (as discussed on #1989) so both EVM backends build against a fixed contract.

Moved into the evm module's own `nwo` folder per review: the module is developed as if it lived in a separate repo, so its integration surface ships with it and depends only on evm-module types.

What's here:

- a `Backend` interface: `Deploy` stands up a TMS's contracts (EndorsementVerifier + a per-TMS TokenState clone, seeding PP v0 + endorser set + threshold + graphHiding) and returns the addresses a node's config points at; `UpdatePublicParams` seeds the on-chain params.
- the supporting types (`DeploySpec`, `Deployment`, `TMSRef`), all evm-native.

No node bootstrap here. Besu (mine, Week 6) and the fabricx+EVM gateway (#1989) both implement this same Backend. The thin panurus adapter that plugs it into the token NWO framework lands with the concrete backend and the go.mod require+replace.