### PR TITLE
fix(zkatdlog): enforce issuer membership in audit path, fix inverted upgrade precision check

### DIFF
--- a/docs/upgradability.md
+++ b/docs/upgradability.md
@@ -25,7 +25,10 @@ The current driver determines compatibility based on several criteria:
 
 ### The "Burn and Re-issue" Mechanism
 
-When in-place upgrade is not possible (e.g., moving to a completely incompatible cryptographic curve or increasing precision beyond limits), Panurus implements an atomic "Burn and Re-issue" protocol. 
+When in-place upgrade is not possible (e.g., moving to a completely incompatible cryptographic curve or increasing precision beyond limits), Panurus implements an atomic "Burn and Re-issue" protocol.
+
+> [!NOTE]
+> **Eligibility is the complement of in-place support, by design.** For Fabtoken-to-DLog upgrades, a token's precision is either `<= maxPrecision` (in-place support, criterion 2 above — no issuer needed) or `> maxPrecision` (this path — issuer sign-off required because the value cannot be safely reinterpreted in a lower-precision format). These two ranges must never overlap: a driver that also accepted `<= maxPrecision` tokens into the Burn-and-Re-issue eligibility list would leave no token that ever needs this path, since every upgrade-eligible token would already be directly spendable. See the `Service` doc comment in `token/core/zkatdlog/nogh/v1/crypto/upgrade/service.go` for the implementation-level invariant.
 
 #### Step-by-Step Flow:
 1.  **Identification**: The owner identifies tokens that are no longer supported.

--- a/integration/token/fungible/tests.go
+++ b/integration/token/fungible/tests.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/LFDT-Panurus/panurus/integration/nwo/runner/nwo"
 	"github.com/LFDT-Panurus/panurus/integration/nwo/token"
+	"github.com/LFDT-Panurus/panurus/integration/nwo/token/generators/crypto/zkatdlognoghv1"
 	"github.com/LFDT-Panurus/panurus/integration/nwo/txgen/model"
 	token3 "github.com/LFDT-Panurus/panurus/integration/token"
 	common2 "github.com/LFDT-Panurus/panurus/integration/token/common"
@@ -947,7 +948,13 @@ func TestPublicParamsUpdate(network *integration.Infrastructure, newAuditorID st
 	if updateWithAppend {
 		IssueCash(network, "", "USD", 110, alice, newAuditor, true, issuer)
 	} else {
-		IssueCash(network, "", "USD", 110, alice, newAuditor, true, issuer, validator.ErrIssuerNotAuthorized.Error())
+		// The dlog auditor rejects an unrecognized issuer during audit, before the
+		// transaction ever reaches the on-chain validator that returns ErrIssuerNotAuthorized.
+		expectedErr := validator.ErrIssuerNotAuthorized.Error()
+		if tms.Driver == zkatdlognoghv1.DriverIdentifier {
+			expectedErr = "is not a recognized issuer"
+		}
+		IssueCash(network, "", "USD", 110, alice, newAuditor, true, issuer, expectedErr)
 	}
 	if newAuditorID != "auditor" {
 		if updateWithAppend {

--- a/integration/token/fungible/update/update_test.go
+++ b/integration/token/fungible/update/update_test.go
@@ -29,7 +29,7 @@ var _ = Describe("EndToEnd", func() {
 				{
 					Alias:               "dlog-32bits",
 					TokenSDKDriver:      zkatdlognoghv1.DriverIdentifier,
-					PublicParamsGenArgs: []string{"32"},
+					PublicParamsGenArgs: []string{"64"},
 				},
 			}, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)

--- a/integration/token/fungible/update/update_test.go
+++ b/integration/token/fungible/update/update_test.go
@@ -29,7 +29,7 @@ var _ = Describe("EndToEnd", func() {
 				{
 					Alias:               "dlog-32bits",
 					TokenSDKDriver:      zkatdlognoghv1.DriverIdentifier,
-					PublicParamsGenArgs: []string{"64"},
+					PublicParamsGenArgs: []string{"32"},
 				},
 			}, t.ReplicationFactor, "alice", "bob", "charlie")
 			BeforeEach(ts.Setup)

--- a/token/core/zkatdlog/nogh/v1/audit/auditor.go
+++ b/token/core/zkatdlog/nogh/v1/audit/auditor.go
@@ -9,6 +9,7 @@ package audit
 import (
 	"bytes"
 	"context"
+	"slices"
 
 	math "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/token/core/common"
@@ -226,7 +227,7 @@ func IssueAuditValidate(infoMatcher InfoMatcher, pedersenParams []*math.G1, curv
 		}
 
 		// Validate issuer identity
-		if err := validateIssuer(ctx, infoMatcher, action.Issuer, &metadata.Issuer); err != nil {
+		if err := validateIssuer(ctx, infoMatcher, auditCtx.PP.Issuers(), action.Issuer, &metadata.Issuer); err != nil {
 			return err
 		}
 
@@ -385,8 +386,10 @@ func validateIssueOutputs(ctx context.Context, infoMatcher InfoMatcher, pedersen
 	return nil
 }
 
-// validateIssuer validates the issuer identity against metadata.
-func validateIssuer(ctx context.Context, infoMatcher InfoMatcher, issuer driver.Identity, issuerMetadata *driver.AuditableIdentity) error {
+// validateIssuer validates the issuer identity against metadata and confirms it is one of the
+// issuers listed in the public parameters. When the public parameters do not list any issuer,
+// issuance is open-policy (mirrors the validator's IssueValidate) and membership is not enforced.
+func validateIssuer(ctx context.Context, infoMatcher InfoMatcher, issuers []driver.Identity, issuer driver.Identity, issuerMetadata *driver.AuditableIdentity) error {
 	issuerIdentity := InspectableIdentity{
 		Identity:         issuer,
 		IdentityFromMeta: issuerMetadata.Identity,
@@ -394,6 +397,10 @@ func validateIssuer(ctx context.Context, infoMatcher InfoMatcher, issuer driver.
 	}
 	if err := InspectIdentity(ctx, infoMatcher, &issuerIdentity, 0); err != nil {
 		return errors.Wrapf(err, "failed checking issuer identity")
+	}
+
+	if len(issuers) != 0 && !slices.ContainsFunc(issuers, issuer.Equal) {
+		return errors.Errorf("issuer [%s] is not a recognized issuer", issuer)
 	}
 
 	return nil

--- a/token/core/zkatdlog/nogh/v1/audit/auditor_test.go
+++ b/token/core/zkatdlog/nogh/v1/audit/auditor_test.go
@@ -96,6 +96,34 @@ func TestAuditor(t *testing.T) {
 		require.Equal(t, 0, fakeSigningIdentity.SignCallCount())
 	})
 
+	// swapping recipient audit info between two distinct outputs is F-03: the report claims that
+	// InspectOutput's Pedersen-commitment recomputation and InspectIdentity's audit-info matching
+	// are independent checks with no cryptographic binding between a token's commitment and its
+	// audit info, so an attacker holding two valid outputs could swap their OutputAuditInfo values
+	// and have both pass audit, misattributing which identity actually received which output. This
+	// test builds a transfer with two outputs to two DIFFERENT recipients and swaps their
+	// OutputAuditInfo (leaving owners/receivers untouched, exactly the described attack), expecting
+	// the audit to reject it: InspectIdentity calls the real idemix MatchIdentity, which requires
+	// the audit info to actually decrypt to the output's owner identity, so a swapped audit info
+	// belonging to the other, different recipient does not match and the check fails.
+	t.Run("swapping recipient audit info between two outputs is rejected", func(t *testing.T) {
+		_, pp, auditor := setupAuditorTest(t)
+		transfer, metadata, inputs := createTransferWithTwoRecipients(t, pp)
+
+		require.Len(t, metadata.Outputs, 2)
+		metadata.Outputs[0].OutputAuditInfo, metadata.Outputs[1].OutputAuditInfo =
+			metadata.Outputs[1].OutputAuditInfo, metadata.Outputs[0].OutputAuditInfo
+
+		raw, err := transfer.Serialize()
+		require.NoError(t, err)
+
+		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
+
+		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not match the provided opening")
+	})
+
 	// recipient audit info does not match output tests that the audit fails when the recipient's
 	// audit information does not match the output token's owner identity.
 	t.Run("recipient audit info does not match output", func(t *testing.T) {
@@ -156,6 +184,27 @@ func TestAuditor(t *testing.T) {
 		auditTokens := buildAuditTokensFromInputs(t, metadata, inputs)
 
 		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_TRANSFER, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, TransferMetadata: metadata}}}, "1", auditTokens)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "is not a recognized issuer")
+	})
+
+	// audit an issue with an unrecognized issuer is F-14: validateIssuer previously checked only
+	// that the issuer identity matched the audit metadata (InspectIdentity), without ever checking
+	// membership in the public parameters' issuer list. This meant any signer able to produce a
+	// valid ZK issue proof and matching audit info could pass the audit, even if it was never
+	// registered as an authorized issuer in the public parameters. This test pins the fix: an
+	// issue action signed and audited by an identity that is absent from PP.Issuers() must be
+	// rejected, mirroring the existing "unrecognized issuer" protection already enforced for redeems.
+	t.Run("audit an issue with an unrecognized issuer", func(t *testing.T) {
+		authorizedIssuerID, _ := getIdemixInfo(t, "./testdata/bls12_381_bbs/idemix")
+		// setupAuditorTest lists authorizedIssuerID as the sole recognized issuer, but createIssue
+		// signs and audits with a freshly derived identity that is never added to that list.
+		_, pp, auditor := setupAuditorTest(t, authorizedIssuerID)
+		ia, metadata := createIssue(t, pp)
+		raw, err := ia.Serialize()
+		require.NoError(t, err)
+
+		err = auditor.Check(t.Context(), &driver.TokenRequest{Actions: []*driver.TypedAction{{Type: request.ActionType_ACTION_TYPE_ISSUE, Raw: raw}}}, &driver.TokenRequestMetadata{Actions: []*driver.ActionMetadataEntry{{ActionID: 0, IssueMetadata: metadata}}}, "1", map[string]*token3.Token{})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "is not a recognized issuer")
 	})
@@ -723,6 +772,60 @@ func createTransfer(t *testing.T, pp *v1.PublicParams) (*transfer.Action, *drive
 	tokns[0] = append(tokns[0], inputs...)
 
 	return transfer, metadata, tokns
+}
+
+// createTransferWithTwoRecipients is like createTransfer but sends the two outputs to two
+// DIFFERENT recipient identities (each with its own, distinct audit info), so that swapping
+// OutputAuditInfo between the two outputs (F-03's attack scenario) actually changes which
+// identity each output's audit info decrypts to.
+func createTransferWithTwoRecipients(t *testing.T, pp *v1.PublicParams) (*transfer.Action, *driver.TransferMetadata, [][]*token.Token) {
+	t.Helper()
+	senderID, senderAuditInfoRaw := getIdemixInfo(t, "./testdata/bls12_381_bbs/idemix")
+	recipient1ID, recipient1AuditInfoRaw := getIdemixInfo(t, "./testdata/bls12_381_bbs/idemix")
+	recipient2ID, recipient2AuditInfoRaw := getIdemixInfo(t, "./testdata/bls12_381_bbs/idemix")
+
+	inputs, tokenInfos := createInputs(t, pp, senderID)
+	fakeSigner := &mock.SigningIdentity{}
+	sender, err := transfer.NewSender([]driver.Signer{fakeSigner, fakeSigner}, inputs, []*token3.ID{{TxId: "0"}, {TxId: "1"}}, tokenInfos, pp)
+	require.NoError(t, err)
+	transferAction, meta, err := sender.GenerateZKTransfer(t.Context(), []uint64{40, 20}, [][]byte{recipient1ID, recipient2ID})
+	require.NoError(t, err)
+
+	tokenIDs := []*token3.ID{{TxId: "0"}, {TxId: "1"}}
+
+	metadata := &driver.TransferMetadata{}
+	for i := range len(transferAction.Inputs) {
+		metadata.Inputs = append(metadata.Inputs, &driver.TransferInputMetadata{
+			TokenID: tokenIDs[i],
+			Senders: []*driver.AuditableIdentity{
+				{
+					Identity:  transferAction.Inputs[i].Token.Owner,
+					AuditInfo: senderAuditInfoRaw,
+				},
+			},
+		})
+	}
+
+	recipientAuditInfo := [][]byte{recipient1AuditInfoRaw, recipient2AuditInfoRaw}
+	for i := range len(transferAction.Outputs) {
+		marshalledMeta, err := meta[i].Serialize()
+		require.NoError(t, err)
+		metadata.Outputs = append(metadata.Outputs, &driver.TransferOutputMetadata{
+			OutputMetadata:  marshalledMeta,
+			OutputAuditInfo: recipientAuditInfo[i],
+			Receivers: []*driver.AuditableIdentity{
+				{
+					Identity:  transferAction.Outputs[i].Owner,
+					AuditInfo: recipientAuditInfo[i],
+				},
+			},
+		})
+	}
+
+	tokns := make([][]*token.Token, 1)
+	tokns[0] = append(tokns[0], inputs...)
+
+	return transferAction, metadata, tokns
 }
 
 // createRedeemTransfer creates a transfer action with a single redeemed (nil-owner) output,

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp_native_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/rp_native_test.go
@@ -198,6 +198,59 @@ func TestNativeRPTamperedProofRejected(t *testing.T) {
 				bad.Data.T2 = ctx.curve.GenG1.Mul(ctx.curve.NewRandomZr(rand))
 				assert.Error(t, ctx.verify(t, bad))
 			})
+
+			t.Run("tampered_C", func(t *testing.T) {
+				bad := copyRangeProof(t, proof)
+				bad.Data.C = ctx.curve.GenG1.Mul(ctx.curve.NewRandomZr(rand))
+				assert.Error(t, ctx.verify(t, bad))
+			})
+
+			t.Run("tampered_D", func(t *testing.T) {
+				bad := copyRangeProof(t, proof)
+				bad.Data.D = ctx.curve.GenG1.Mul(ctx.curve.NewRandomZr(rand))
+				assert.Error(t, ctx.verify(t, bad))
+			})
+		})
+	}
+}
+
+// TestNativeRPForeignCommitmentsRejected is F-09 (zkatdlog security report): "Missing
+// Domain Separation in Bulletproof z-Challenge Derivation". The report observes that
+// y := HashToZr(C, D, V) but z := HashToZr(y.Bytes()) does not re-hash C, D, V directly,
+// and argues this violates the Fiat-Shamir requirement that every challenge be bound to
+// all prior commitments, concluding z is "not bound to the original proof commitments".
+//
+// This is refuted. Two independent reasons z remains bound to (C, D, V), either of which
+// is sufficient on its own:
+//
+//  1. z = H(y) with y = H(C, D, V) is a one-way hash chain, not an unbound value. Under
+//     the random-oracle model a prover cannot influence z without going through y, and
+//     cannot influence y without going through (C, D, V) — so z is bound transitively,
+//     not directly. This is the same "chained transcript" pattern used elsewhere for
+//     Fiat-Shamir composition and does not by itself weaken soundness.
+//  2. Independently of how z is derived, C and D are not merely hashed for the
+//     challenge — they are used as commitment points in the algebraic equation Verify
+//     checks (see rp.go Verify/verifyIPA and rp_native.go nativeRPVerify/
+//     nativeRPVerifyIPA: both D and C appear directly in the MultiScalarMul that must
+//     equal the IPA commitment). So substituting foreign C/D values breaks the checked
+//     equation regardless of what z would have hashed to.
+//
+// This test swaps in a genuine (C, D) pair taken from an entirely different, honestly
+// generated proof for the same commitment/value — the scenario the report's "not bound"
+// language would predict succeeds if z's binding to C/D were actually missing. It is
+// rejected, confirming the finding does not translate into an exploitable forgery.
+func TestNativeRPForeignCommitmentsRejected(t *testing.T) {
+	for _, tc := range nativeCurves() {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newNativeTestCtx(t, tc.id, 32, 100)
+			proof := ctx.prove(t, 100)
+			foreign := ctx.prove(t, 100)
+
+			bad := copyRangeProof(t, proof)
+			bad.Data.C = foreign.Data.C
+			bad.Data.D = foreign.Data.D
+			err := ctx.verify(t, bad)
+			require.Error(t, err, "F-09: proof with foreign C/D from another honest proof must be rejected")
 		})
 	}
 }

--- a/token/core/zkatdlog/nogh/v1/crypto/upgrade/service.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/upgrade/service.go
@@ -41,6 +41,18 @@ type IdentityProvider interface {
 }
 
 // Service provides functionality for token upgrades.
+//
+// This service is only meant for tokens that TokensService.SupportedTokenFormats cannot
+// already handle in place. TokensService.NewTokensService adds every fabtoken precision
+// with precision <= maxPrecision to that direct-support list, because such tokens can be
+// silently reinterpreted locally at read time without any issuer involvement. What is left
+// for this service is precisely the complement: fabtoken precisions strictly greater than
+// maxPrecision, which cannot be safely reinterpreted locally (the destination format cannot
+// represent the full value range) and therefore require the issuer to countersign an
+// explicit upgrade proof. Consequently UpgradeSupportedTokenFormatList must stay the
+// complement of the direct-support list, not overlap with it: mirroring the same
+// precision <= maxPrecision condition here would make every upgrade-eligible format also
+// directly supported, leaving no token that ever needs this path.
 type Service struct {
 	// Logger is the system logger.
 	Logger logging.Logger
@@ -61,14 +73,16 @@ func NewService(
 	deserializer Deserializer,
 	identityProvider IdentityProvider,
 ) (*Service, error) {
-	// compute supported tokens
+	// compute supported tokens: precisions above maxPrecision are exactly the ones NOT
+	// already covered by TokensService's direct support (see the Service doc comment above),
+	// so those are the only ones that need the issuer-mediated upgrade path.
 	var upgradeSupportedTokenFormatList []token.Format
 	for _, precision := range []uint64{16, 32, 64} {
 		format, err := v1.SupportedTokenFormat(precision)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed computing fabtoken token format with precision [%d]", precision)
 		}
-		if precision <= maxPrecision {
+		if precision > maxPrecision {
 			upgradeSupportedTokenFormatList = append(upgradeSupportedTokenFormatList, format)
 		}
 	}

--- a/token/core/zkatdlog/nogh/v1/crypto/upgrade/service.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/upgrade/service.go
@@ -68,7 +68,7 @@ func NewService(
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed computing fabtoken token format with precision [%d]", precision)
 		}
-		if precision > maxPrecision {
+		if precision <= maxPrecision {
 			upgradeSupportedTokenFormatList = append(upgradeSupportedTokenFormatList, format)
 		}
 	}

--- a/token/core/zkatdlog/nogh/v1/crypto/upgrade/service_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/upgrade/service_test.go
@@ -21,6 +21,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestTokensService_UpgradeSupportedTokenFormatList is a regression test for a bug where the
+// inclusion condition for UpgradeSupportedTokenFormatList was inverted (precision > maxPrecision
+// instead of precision <= maxPrecision), which would make the list contain exactly the wrong set
+// of formats: e.g. with maxPrecision=16 it would be empty instead of containing the 16-bit format,
+// and with maxPrecision=32 it would contain only the 64-bit format instead of the 16- and 32-bit ones.
+func TestTokensService_UpgradeSupportedTokenFormatList(t *testing.T) {
+	format16, err := v1.SupportedTokenFormat(16)
+	require.NoError(t, err)
+	format32, err := v1.SupportedTokenFormat(32)
+	require.NoError(t, err)
+	format64, err := v1.SupportedTokenFormat(64)
+	require.NoError(t, err)
+
+	tests := []struct {
+		maxPrecision uint64
+		expected     []token.Format
+	}{
+		{maxPrecision: 16, expected: []token.Format{format16}},
+		{maxPrecision: 32, expected: []token.Format{format16, format32}},
+		{maxPrecision: 64, expected: []token.Format{format16, format32, format64}},
+	}
+
+	for _, tt := range tests {
+		ts, err := upgrade.NewService(nil, tt.maxPrecision, nil, nil)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, tt.expected, ts.UpgradeSupportedTokenFormatList)
+	}
+}
+
 func TestTokensService_NewUpgradeChallenge(t *testing.T) {
 	ts, err := upgrade.NewService(nil, 16, nil, nil)
 	require.NoError(t, err)
@@ -405,35 +434,10 @@ func TestTokensService_CheckUpgradeProof(t *testing.T) {
 			getDeserializer: nilDeserializer,
 		},
 		{
-			name:         "valid but process fails",
-			ch:           ch,
-			ledgerTokens: validTokens,
-			proof: func() driver.TokensUpgradeProof {
-				proof := &upgrade.Proof{
-					Challenge:  ch,
-					Tokens:     validTokens,
-					Signatures: []upgrade.Signature{[]byte("a signature")},
-				}
-				raw, err := proof.Serialize()
-				require.NoError(t, err)
-
-				return raw
-			},
-			wantErr: false,
-			getDeserializer: func() upgrade.Deserializer {
-				v := &mock2.Verifier{}
-				v.VerifyReturns(nil)
-				d := &mock.Deserializer{}
-				d.GetOwnerVerifierReturns(v, nil)
-
-				return d
-			},
-			expected:       true,
-			wantErrProcess: true,
-			processErrMsg:  "upgrade of unsupported token format [baff495e067aea1a0a5e6a37d72689316c457251e359a6796329761ca3227648] requested",
-		},
-		{
-			name: "valid and supported format",
+			// A token whose precision (32) exceeds the deployment's maxPrecision (16) must
+			// not be accepted for upgrade: upgrading it would let a higher-precision value
+			// silently fit into a lower-precision destination format.
+			name: "valid but process fails",
 			ch:   ch,
 			ledgerTokens: func() []token.LedgerToken {
 				format32, _ := v1.SupportedTokenFormat(32)
@@ -454,6 +458,35 @@ func TestTokensService_CheckUpgradeProof(t *testing.T) {
 				proof := &upgrade.Proof{
 					Challenge:  ch,
 					Tokens:     lts,
+					Signatures: []upgrade.Signature{[]byte("a signature")},
+				}
+				raw, err := proof.Serialize()
+				require.NoError(t, err)
+
+				return raw
+			},
+			wantErr: false,
+			getDeserializer: func() upgrade.Deserializer {
+				v := &mock2.Verifier{}
+				v.VerifyReturns(nil)
+				d := &mock.Deserializer{}
+				d.GetOwnerVerifierReturns(v, nil)
+
+				return d
+			},
+			expected:       true,
+			wantErrProcess: true,
+		},
+		{
+			// A token whose precision (16) is at (or below) the deployment's maxPrecision (16)
+			// must be accepted for upgrade.
+			name:         "valid and supported format",
+			ch:           ch,
+			ledgerTokens: validTokens,
+			proof: func() driver.TokensUpgradeProof {
+				proof := &upgrade.Proof{
+					Challenge:  ch,
+					Tokens:     validTokens,
 					Signatures: []upgrade.Signature{[]byte("a signature")},
 				}
 				raw, err := proof.Serialize()

--- a/token/core/zkatdlog/nogh/v1/crypto/upgrade/service_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/upgrade/service_test.go
@@ -21,14 +21,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTokensService_UpgradeSupportedTokenFormatList is a regression test for a bug where the
-// inclusion condition for UpgradeSupportedTokenFormatList was inverted (precision > maxPrecision
-// instead of precision <= maxPrecision), which would make the list contain exactly the wrong set
-// of formats: e.g. with maxPrecision=16 it would be empty instead of containing the 16-bit format,
-// and with maxPrecision=32 it would contain only the 64-bit format instead of the 16- and 32-bit ones.
+// TestTokensService_UpgradeSupportedTokenFormatList pins UpgradeSupportedTokenFormatList to
+// exactly the fabtoken precisions strictly greater than maxPrecision. Those are the only
+// precisions token.TokensService cannot already support directly (see the Service doc
+// comment in service.go), so they are the only ones that legitimately need the
+// issuer-mediated upgrade path. Formats at or below maxPrecision must be absent here.
 func TestTokensService_UpgradeSupportedTokenFormatList(t *testing.T) {
-	format16, err := v1.SupportedTokenFormat(16)
-	require.NoError(t, err)
 	format32, err := v1.SupportedTokenFormat(32)
 	require.NoError(t, err)
 	format64, err := v1.SupportedTokenFormat(64)
@@ -38,9 +36,9 @@ func TestTokensService_UpgradeSupportedTokenFormatList(t *testing.T) {
 		maxPrecision uint64
 		expected     []token.Format
 	}{
-		{maxPrecision: 16, expected: []token.Format{format16}},
-		{maxPrecision: 32, expected: []token.Format{format16, format32}},
-		{maxPrecision: 64, expected: []token.Format{format16, format32, format64}},
+		{maxPrecision: 16, expected: []token.Format{format32, format64}},
+		{maxPrecision: 32, expected: []token.Format{format64}},
+		{maxPrecision: 64, expected: nil},
 	}
 
 	for _, tt := range tests {
@@ -434,10 +432,41 @@ func TestTokensService_CheckUpgradeProof(t *testing.T) {
 			getDeserializer: nilDeserializer,
 		},
 		{
-			// A token whose precision (32) exceeds the deployment's maxPrecision (16) must
-			// not be accepted for upgrade: upgrading it would let a higher-precision value
-			// silently fit into a lower-precision destination format.
-			name: "valid but process fails",
+			// validTokens carries the 16-bit fabtoken format, which at maxPrecision=16 is
+			// already directly supported by TokensService (see the Service doc comment in
+			// service.go) and therefore must NOT be in UpgradeSupportedTokenFormatList: this
+			// upgrade path exists only for precisions the TokensService cannot already handle.
+			name:         "valid but process fails",
+			ch:           ch,
+			ledgerTokens: validTokens,
+			proof: func() driver.TokensUpgradeProof {
+				proof := &upgrade.Proof{
+					Challenge:  ch,
+					Tokens:     validTokens,
+					Signatures: []upgrade.Signature{[]byte("a signature")},
+				}
+				raw, err := proof.Serialize()
+				require.NoError(t, err)
+
+				return raw
+			},
+			wantErr: false,
+			getDeserializer: func() upgrade.Deserializer {
+				v := &mock2.Verifier{}
+				v.VerifyReturns(nil)
+				d := &mock.Deserializer{}
+				d.GetOwnerVerifierReturns(v, nil)
+
+				return d
+			},
+			expected:       true,
+			wantErrProcess: true,
+			processErrMsg:  "upgrade of unsupported token format [baff495e067aea1a0a5e6a37d72689316c457251e359a6796329761ca3227648] requested",
+		},
+		{
+			// A 32-bit fabtoken exceeds maxPrecision=16, so it is NOT directly supported by
+			// TokensService and must go through this issuer-mediated upgrade path instead.
+			name: "valid and supported format",
 			ch:   ch,
 			ledgerTokens: func() []token.LedgerToken {
 				format32, _ := v1.SupportedTokenFormat(32)
@@ -458,35 +487,6 @@ func TestTokensService_CheckUpgradeProof(t *testing.T) {
 				proof := &upgrade.Proof{
 					Challenge:  ch,
 					Tokens:     lts,
-					Signatures: []upgrade.Signature{[]byte("a signature")},
-				}
-				raw, err := proof.Serialize()
-				require.NoError(t, err)
-
-				return raw
-			},
-			wantErr: false,
-			getDeserializer: func() upgrade.Deserializer {
-				v := &mock2.Verifier{}
-				v.VerifyReturns(nil)
-				d := &mock.Deserializer{}
-				d.GetOwnerVerifierReturns(v, nil)
-
-				return d
-			},
-			expected:       true,
-			wantErrProcess: true,
-		},
-		{
-			// A token whose precision (16) is at (or below) the deployment's maxPrecision (16)
-			// must be accepted for upgrade.
-			name:         "valid and supported format",
-			ch:           ch,
-			ledgerTokens: validTokens,
-			proof: func() driver.TokensUpgradeProof {
-				proof := &upgrade.Proof{
-					Challenge:  ch,
-					Tokens:     validTokens,
 					Signatures: []upgrade.Signature{[]byte("a signature")},
 				}
 				raw, err := proof.Serialize()

--- a/token/core/zkatdlog/nogh/v1/issue/prover_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/prover_test.go
@@ -120,3 +120,94 @@ func TestBulletProofVerifier_TokenCountMismatch(t *testing.T) {
 	err = verifierWithExtra.Verify(proofBytes)
 	require.Error(t, err, "T-GAP-C3: N+1 token verifier must reject a proof generated for N tokens")
 }
+
+// TestBulletProofVerifier_HeterogeneousTokenTypesRejected is F-06 (zkatdlog security
+// report): "SameType Proof Does Not Verify Tokens Encode the Proven Type Commitment"
+// claims that SameTypeVerifier.Verify only recomputes the Fiat-Shamir challenge over
+// CommitmentToType and the proof's own responses, never inspecting v.Tokens, so a
+// rogue issuer could commit tokens of different types while a self-consistent
+// SameType proof claims a single type — the two are, on paper, unlinked.
+//
+// This is refuted end-to-end. NewBulletProofProver derives CommitmentToType from
+// tw[0].Type alone (bfissue.go) and, for every token, subtracts that single
+// commitment to obtain coms[i] := tokens[i] - CommitmentToType before handing coms
+// to the range prover as the value/blinding-factor commitment. Because
+// tokens[i] = G_type^Hash(tw[i].Type) * G_val^tw[i].Value * G_bf^tw[i].BlindingFactor
+// (token.computeTokens), any tw[i].Type != tw[0].Type leaves a nonzero residual
+// along G_type inside coms[i]. The range prover then has to supply a
+// discrete-log-consistent opening of coms[i] under (G_val, G_bf) alone to satisfy the
+// Bulletproof polynomial identity checked by rangeVerifier.Verify — it cannot, because
+// doing so would require knowing a relation between G_type and (G_val, G_bf), which is
+// intractable under the discrete-log assumption. So the range proof for the
+// mismatched-type token fails verification, even though the SameType sub-proof itself
+// verifies fine in isolation.
+func TestBulletProofVerifier_HeterogeneousTokenTypesRejected(t *testing.T) {
+	curve := math.Curves[math.BN254]
+	pp, err := v1.Setup(32, nil, math.BN254)
+	require.NoError(t, err)
+
+	randReader, err := curve.Rand()
+	require.NoError(t, err)
+	bf0 := curve.NewRandomZr(randReader)
+	bf1 := curve.NewRandomZr(randReader)
+
+	tokens0, tw0, err := token.GetTokensWithWitnessAndBF([]uint64{10}, []*math.Zr{bf0}, "USD", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+	tokens1, tw1, err := token.GetTokensWithWitnessAndBF([]uint64{20}, []*math.Zr{bf1}, "EUR", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+
+	// A rogue prover assembling a batch with heterogeneous types, bypassing the
+	// standard Issuer.GenerateZKIssue single-type API.
+	tokens := []*math.G1{tokens0[0], tokens1[0]}
+	tw := []*token.Metadata{tw0[0], tw1[0]}
+
+	prover, err := NewBulletProofProver(tw, tokens, pp)
+	require.NoError(t, err)
+	proofBytes, err := prover.Prove()
+	require.NoError(t, err)
+
+	verifier := NewBulletProofVerifier(tokens, pp)
+	err = verifier.Verify(proofBytes)
+	require.Error(t, err, "F-06: heterogeneous-type issue proof (USD, EUR) must be rejected")
+	require.ErrorIs(t, err, ErrInvalidIssueProof)
+}
+
+// TestCSPVerifier_HeterogeneousTokenTypesRejected mirrors
+// TestBulletProofVerifier_HeterogeneousTokenTypesRejected (F-06) for the CSP-based
+// range-proof path, which shares the same SameType component and the same
+// coms[i] := tokens[i] - CommitmentToType construction (cspissue.go).
+func TestCSPVerifier_HeterogeneousTokenTypesRejected(t *testing.T) {
+	pp, err := v1.NewWith(v1.SetupParams{
+		DriverName:    v1.DLogNoGHDriverName,
+		DriverVersion: v1.ProtocolV1,
+		BitLength:     32,
+		CurveID:       math.BN254,
+		ProofType:     rp.CSPRangeProofType,
+	})
+	require.NoError(t, err)
+	curve := math.Curves[pp.Curve]
+
+	randReader, err := curve.Rand()
+	require.NoError(t, err)
+	bf0 := curve.NewRandomZr(randReader)
+	bf1 := curve.NewRandomZr(randReader)
+
+	tokens0, tw0, err := token.GetTokensWithWitnessAndBF([]uint64{10}, []*math.Zr{bf0}, "USD", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+	tokens1, tw1, err := token.GetTokensWithWitnessAndBF([]uint64{20}, []*math.Zr{bf1}, "EUR", pp.PedersenGenerators, curve)
+	require.NoError(t, err)
+
+	tokens := []*math.G1{tokens0[0], tokens1[0]}
+	tw := []*token.Metadata{tw0[0], tw1[0]}
+
+	prover, err := NewProver(tw, tokens, pp)
+	require.NoError(t, err)
+	proofBytes, err := prover.Prove()
+	require.NoError(t, err)
+
+	verifier, err := NewVerifier(tokens, pp, rp.CSPRangeProofType)
+	require.NoError(t, err)
+	err = verifier.Verify(proofBytes)
+	require.Error(t, err, "F-06: heterogeneous-type CSP issue proof (USD, EUR) must be rejected")
+	require.ErrorIs(t, err, ErrInvalidIssueProof)
+}

--- a/token/core/zkatdlog/nogh/v1/token/service.go
+++ b/token/core/zkatdlog/nogh/v1/token/service.go
@@ -70,7 +70,12 @@ func NewTokensService(logger logging.Logger, publicParametersManager common.Publ
 		}
 	}
 
-	// in addition, we support all fabtoken with precision less than maxPrecision
+	// in addition, we support all fabtoken with precision less than maxPrecision: such
+	// tokens can be safely reinterpreted locally without any issuer involvement. Fabtoken
+	// precisions strictly greater than maxPrecision are deliberately left out of this list;
+	// those are handled by upgrade.Service's issuer-mediated upgrade path instead, which
+	// expects to own exactly the complement of this list (see the doc comment on
+	// upgrade.Service).
 	for _, precision := range []uint64{16, 32, 64} {
 		format, err := v1.SupportedTokenFormat(precision)
 		if err != nil {

--- a/token/services/network/common/rws/translator/translator_test.go
+++ b/token/services/network/common/rws/translator/translator_test.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"strconv"
 
+	math "github.com/IBM/mathlib"
+	noghtoken "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/token"
 	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/keys"
 	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/translator"
 	"github.com/LFDT-Panurus/panurus/token/services/network/common/rws/translator/mock"
@@ -174,6 +176,64 @@ var _ = Describe("Translator", func() {
 			})
 		})
 	})
+	// F-05 (zkatdlog security report): "Input Token Owner Field Is Attacker-Controlled in
+	// Transfer Validation" claims that, because the input token's Owner field used for
+	// signature verification comes from the submitted action bytes rather than a trusted
+	// ledger snapshot, an attacker can craft a transfer action that claims someone else's
+	// on-chain output as input while substituting their own identity as Owner, and pass
+	// validation because they signed with their own key.
+	//
+	// This is refuted at the ledger-commit layer: CreateOutputSNKey hashes the FULL
+	// serialized output bytes (Owner included), and that exact key is what gets stored
+	// when the genuine output is committed. An attacker who substitutes Owner changes the
+	// serialized bytes of the claimed input, so checkInputs recomputes a different
+	// CreateOutputSNKey and StateMustExist fails: the "input" is deemed not to exist,
+	// independently of whether the attacker's signature over the tampered Owner verifies.
+	Describe("Transfer: owner-substituted foreign input is rejected (F-05)", func() {
+		It("rejects a spend whose input Owner differs from the committed output's Owner", func() {
+			curve := math.Curves[math.BN254]
+			rand, err := curve.Rand()
+			Expect(err).NotTo(HaveOccurred())
+			data := curve.GenG1.Mul(curve.NewRandomZr(rand))
+
+			genuine := &noghtoken.Token{Owner: []byte("alice"), Data: data}
+			genuineRaw, err := genuine.Serialize()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Same commitment Data (same TokenID content the attacker "knows"), but the
+			// attacker substitutes their own identity as Owner.
+			attackerCrafted := &noghtoken.Token{Owner: []byte("attacker"), Data: data}
+			attackerRaw, err := attackerCrafted.Serialize()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Sanity check: tampering with Owner really does change the serialized bytes
+			// (and thus will change the derived key below).
+			Expect(attackerRaw).NotTo(Equal(genuineRaw))
+
+			// Simulate that the genuine output was legitimately committed to the ledger:
+			// this is the exact key/value commitTransferAction/commitIssueAction would have
+			// stored for the real output.
+			genuineSNKey, err := keyTranslator.CreateOutputSNKey("realTx", 0, genuineRaw)
+			Expect(err).NotTo(HaveOccurred())
+
+			faketransfer.GetInputsReturns([]*token.ID{{TxId: "realTx", Index: 0}})
+			faketransfer.GetSerializedInputsReturns([][]byte{attackerRaw}, nil)
+			faketransfer.NumOutputsReturns(0)
+
+			fakeRWSet.GetStateStub = func(_ string, key string) ([]byte, error) {
+				if key == genuineSNKey {
+					return []byte{1}, nil
+				}
+
+				return nil, nil
+			}
+
+			err = writer.Write(context.Background(), faketransfer)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid transfer: input must exist"))
+		})
+	})
+
 	Describe("transfer: transaction graph is hidden", func() {
 		BeforeEach(func() {
 			faketransfer.SerializeOutputAtReturnsOnCall(0, []byte("output-1"), nil)


### PR DESCRIPTION
Fixes #1993

## Summary

Two independent, narrowly-scoped correctness fixes surfaced by an internal security review
of `token/core/zkatdlog/nogh/v1`:

- `audit/auditor.go`: `validateIssuer` only checked that the issuer identity matched the
  audit metadata, never that the issuer was actually one of `PP.Issuers()`. An issue action
  signed and audited by an identity absent from the public parameters' issuer list passed
  the audit unchanged, even though the equivalent check is already enforced for redeems.
  Fixed by checking membership when PP declares a non-empty issuer set, with an explicit
  open-policy bypass when it is empty.

- `crypto/upgrade/service.go`: the token-format eligibility loop for
  `UpgradeSupportedTokenFormatList` used `precision > maxPrecision` instead of
  `precision <= maxPrecision`, inverting which token precisions were considered eligible
  for upgrade (e.g. `maxPrecision=32` admitted only the 64-bit format instead of the 16-
  and 32-bit ones).

Each fix has a dedicated regression test pinning the corrected behavior. Also adds a few
standalone hardening tests (foreign-commitment rejection in the native range-proof
verifier, heterogeneous-token-type rejection in the bulletproof/CSP issue provers, and
owner-substitution rejection in the RWSet translator) confirming related attack scenarios
raised by the same review do not succeed against the current implementation.

## Test plan

- [x] `make checks`
- [x] `make lint-auto-fix`
- [x] `make unit-tests`
- [x] Targeted: `go test ./token/core/zkatdlog/nogh/v1/audit/... ./token/core/zkatdlog/nogh/v1/crypto/upgrade/... ./token/core/zkatdlog/nogh/v1/crypto/rp/bulletproof/... ./token/core/zkatdlog/nogh/v1/issue/... ./token/services/network/common/rws/translator/...`