### PR TITLE
fix(lookup): isolate per-namespace failures in queryByID

### DIFF
--- a/docs/services/network-fabric.md
+++ b/docs/services/network-fabric.md
@@ -350,6 +350,13 @@ The setup listener watches for changes to a specific ledger key that stores publ
 
 The same delivery-based mechanism is reused by the [lookup service](../../token/services/network/fabric/lookup/deliveryllm.go) to detect transfer action metadata writes: it derives the transfer action metadata key prefix from [`KeyTranslator.TransferActionMetadataKeyPrefix`](../../token/services/network/common/rws/translator/rwset.go) and prefix-matches rwset writes against it, without needing to know each write's specific subkey ahead of time.
 
+When resolving a batch of keys, the lookup service groups them by namespace and issues one
+`QueryStates` chaincode call per namespace
+([`deliveryqs.go`](../../token/services/network/fabric/lookup/deliveryqs.go)). Each namespace is
+resolved independently: if its query cannot be built, does not reach the chaincode, or returns a
+response that cannot be decoded, only that namespace falls back to the block scan. The keys of the
+other namespaces in the same batch are still resolved and delivered.
+
 ## State Queries
 
 The Fabric implementation provides efficient state querying through the chaincode:

--- a/token/services/network/fabric/lookup/deliveryllm.go
+++ b/token/services/network/fabric/lookup/deliveryllm.go
@@ -129,7 +129,8 @@ func (p *deliveryBasedLLMProvider) NewManager(network, channel string) (Listener
 		},
 		&DeliveryScanQueryByID{
 			Delivery: ch.Delivery(),
-			Channel:  ch,
+			Querier:  &ChannelStateQuerier{Channel: ch},
+			Vault:    ch.Vault(),
 		},
 		p.tracerProvider.Tracer("finality_listener_manager", tracing.WithMetricsOpts(tracing.MetricsOpts{})),
 		p.newMapper(network, channel),

--- a/token/services/network/fabric/lookup/deliveryqs.go
+++ b/token/services/network/fabric/lookup/deliveryqs.go
@@ -25,9 +25,37 @@ const (
 	FirstBlock       = 1
 )
 
+// stateQuerier is the subset of the Fabric channel used to ask the token chaincode for the
+// current value of a set of state keys in a single namespace.
+type stateQuerier interface {
+	QueryStates(ns driver.Namespace, arg []byte) ([]byte, error)
+}
+
+// rwsetInspector is the subset of the Fabric vault used to read the writes of a scanned
+// transaction.
+type rwsetInspector interface {
+	InspectRWSet(ctx context.Context, rwset []byte, namespaces ...driver.Namespace) (*fabric.RWSet, error)
+}
+
+// blockScanner is the subset of the Fabric delivery service used to scan blocks.
+type blockScanner interface {
+	ScanFromBlock(ctx context.Context, block uint64, callback fabric.DeliveryCallback) error
+}
+
+// ChannelStateQuerier queries the token chaincode of a namespace over a Fabric channel.
+type ChannelStateQuerier struct {
+	Channel *fabric.Channel
+}
+
+// QueryStates invokes QueryStates on the token chaincode deployed under ns.
+func (c *ChannelStateQuerier) QueryStates(ns driver.Namespace, arg []byte) ([]byte, error) {
+	return c.Channel.Chaincode(ns).Query(QueryStates, arg).Query()
+}
+
 type DeliveryScanQueryByID struct {
-	Delivery *fabric.Delivery
-	Channel  *fabric.Channel
+	Delivery blockScanner
+	Querier  stateQuerier
+	Vault    rwsetInspector
 }
 
 func (q *DeliveryScanQueryByID) QueryByID(ctx context.Context, startingBlock driver.BlockNum, evicted map[driver.PKey][]events.ListenerEntry[KeyInfo]) (<-chan []KeyInfo, error) {
@@ -59,27 +87,32 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.PKe
 	// for each namespace, have a call to the token chaincode
 	startDelivery := false
 	for ns, keys := range keysByNS {
+		// A failure here concerns this namespace only. Leave its keys in keysByNS and keySet and
+		// fall back to the block scan, rather than returning and dropping every other namespace
+		// in the batch along with it (see #1990, and #1426 for the same fix on the finality path).
 		arg, err := json.Marshal(keys)
 		if err != nil {
-			logger.Errorf("failed marshalling args for query by ids [%v]: [%s]", keys, err)
+			logger.Errorf("failed marshalling args for query by ids [%v]: [%s], falling back to block scan", keys, err)
+			startDelivery = true
 
-			return
+			continue
 		}
 
 		logger.DebugfContext(ctx, "querying chaincode [%s] for the states of ids [%v]", ns, keys)
-		chaincode := q.Channel.Chaincode(ns)
-		res, err := chaincode.Query(QueryStates, arg).Query()
+		res, err := q.Querier.QueryStates(ns, arg)
 		if err != nil {
-			logger.Errorf("failed querying by ids [%v]: [%s]", keys, err)
+			logger.Errorf("failed querying by ids [%v]: [%s], falling back to block scan", keys, err)
+			startDelivery = true
 
-			return
+			continue
 		}
 		values := make([][]byte, 0, len(keys))
 		err = json.Unmarshal(res, &values)
 		if err != nil {
-			logger.Errorf("failed unmarshalling results for query by ids [%v]: [%s]", keys, err)
+			logger.Errorf("failed unmarshalling results for query by ids [%v]: [%s], falling back to block scan", keys, err)
+			startDelivery = true
 
-			return
+			continue
 		}
 		found := make([]KeyInfo, 0, len(values))
 		var notFound []string
@@ -114,7 +147,7 @@ func (q *DeliveryScanQueryByID) queryByID(ctx context.Context, keys []driver.PKe
 	logger.DebugfContext(ctx, "start scanning blocks starting from [%d], looking for remaining keys [%s]", startingBlock, keySet)
 
 	// start delivery for the future
-	v := q.Channel.Vault()
+	v := q.Vault
 	err := q.Delivery.ScanFromBlock(
 		ctx,
 		startingBlock,

--- a/token/services/network/fabric/lookup/deliveryqs_test.go
+++ b/token/services/network/fabric/lookup/deliveryqs_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lookup_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/fabric/lookup"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/common/driver"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/fabric/core/generic/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- minimal fakes ---
+
+// fakeEntry is a listener entry that only needs to report the namespace its key belongs to,
+// which is all queryByID reads from the evicted map.
+type fakeEntry struct {
+	ns driver.Namespace
+}
+
+func (f *fakeEntry) Namespace() driver.Namespace                      { return f.ns }
+func (f *fakeEntry) OnStatus(context.Context, lookup.KeyInfo)         {}
+func (f *fakeEntry) Equals(events.ListenerEntry[lookup.KeyInfo]) bool { return false }
+
+type querierResult struct {
+	raw []byte
+	err error
+}
+
+type fakeQuerier struct {
+	results map[driver.Namespace]querierResult
+	queried []driver.Namespace
+}
+
+func (f *fakeQuerier) QueryStates(ns driver.Namespace, _ []byte) ([]byte, error) {
+	f.queried = append(f.queried, ns)
+	r, ok := f.results[ns]
+	if !ok {
+		return nil, errors.New("no stub for namespace " + ns)
+	}
+
+	return r.raw, r.err
+}
+
+type fakeScanner struct {
+	called     bool
+	startBlock uint64
+}
+
+func (f *fakeScanner) ScanFromBlock(_ context.Context, block uint64, _ fabric.DeliveryCallback) error {
+	f.called = true
+	f.startBlock = block
+
+	return nil
+}
+
+// fakeVault is only reached from inside the scan callback, which these tests never invoke.
+type fakeVault struct{}
+
+func (fakeVault) InspectRWSet(context.Context, []byte, ...driver.Namespace) (*fabric.RWSet, error) {
+	return nil, errors.New("InspectRWSet not expected in these tests")
+}
+
+// --- helpers ---
+
+// evictedFor builds the evicted map queryByID expects, one key per namespace so that the
+// order of the chaincode response is unambiguous.
+func evictedFor(byNS map[driver.Namespace]driver.PKey) map[driver.PKey][]events.ListenerEntry[lookup.KeyInfo] {
+	m := make(map[driver.PKey][]events.ListenerEntry[lookup.KeyInfo], len(byNS))
+	for ns, key := range byNS {
+		m[key] = []events.ListenerEntry[lookup.KeyInfo]{&fakeEntry{ns: ns}}
+	}
+
+	return m
+}
+
+// values marshals a chaincode QueryStates response.
+func values(t *testing.T, vals ...[]byte) []byte {
+	t.Helper()
+	raw, err := json.Marshal(vals)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func drain(ch <-chan []lookup.KeyInfo) []lookup.KeyInfo {
+	var all []lookup.KeyInfo
+	for batch := range ch {
+		all = append(all, batch...)
+	}
+
+	return all
+}
+
+func newQuery(querier *fakeQuerier, scanner *fakeScanner) *lookup.DeliveryScanQueryByID {
+	return &lookup.DeliveryScanQueryByID{
+		Delivery: scanner,
+		Querier:  querier,
+		Vault:    fakeVault{},
+	}
+}
+
+// --- tests ---
+
+// When every namespace resolves, all keys are delivered and no block scan is needed.
+func TestQueryByID_AllNamespacesResolve(t *testing.T) {
+	querier := &fakeQuerier{results: map[driver.Namespace]querierResult{
+		"ns1": {raw: values(t, []byte("v1"))},
+		"ns2": {raw: values(t, []byte("v2"))},
+	}}
+	scanner := &fakeScanner{}
+
+	ch, err := newQuery(querier, scanner).QueryByID(t.Context(), 100, evictedFor(map[driver.Namespace]driver.PKey{
+		"ns1": "k1",
+		"ns2": "k2",
+	}))
+	require.NoError(t, err)
+
+	got := drain(ch)
+	require.Len(t, got, 2)
+	assert.ElementsMatch(t, []lookup.KeyInfo{
+		{Namespace: "ns1", Key: "k1", Value: []byte("v1")},
+		{Namespace: "ns2", Key: "k2", Value: []byte("v2")},
+	}, got)
+	assert.False(t, scanner.called, "no block scan should start when every key resolves")
+}
+
+// Regression test for #1990. A namespace whose chaincode query fails must not take the rest
+// of the batch down with it, and must fall back to the block scan.
+func TestQueryByID_FailingNamespaceDoesNotDropOthers(t *testing.T) {
+	querier := &fakeQuerier{results: map[driver.Namespace]querierResult{
+		"bad":  {err: errors.New("chaincode unreachable")},
+		"good": {raw: values(t, []byte("v"))},
+	}}
+	scanner := &fakeScanner{}
+
+	ch, err := newQuery(querier, scanner).QueryByID(t.Context(), 100, evictedFor(map[driver.Namespace]driver.PKey{
+		"bad":  "kbad",
+		"good": "kgood",
+	}))
+	require.NoError(t, err)
+
+	got := drain(ch)
+	assert.Equal(t, []lookup.KeyInfo{{Namespace: "good", Key: "kgood", Value: []byte("v")}}, got,
+		"the healthy namespace must still be delivered")
+	assert.Len(t, querier.queried, 2, "both namespaces must be attempted")
+	assert.True(t, scanner.called, "the failed namespace must fall back to the block scan")
+	assert.Equal(t, uint64(90), scanner.startBlock)
+}
+
+// A malformed chaincode response is isolated to its own namespace, same as a query error.
+func TestQueryByID_MalformedResponseDoesNotDropOthers(t *testing.T) {
+	querier := &fakeQuerier{results: map[driver.Namespace]querierResult{
+		"bad":  {raw: []byte("not json")},
+		"good": {raw: values(t, []byte("v"))},
+	}}
+	scanner := &fakeScanner{}
+
+	ch, err := newQuery(querier, scanner).QueryByID(t.Context(), 100, evictedFor(map[driver.Namespace]driver.PKey{
+		"bad":  "kbad",
+		"good": "kgood",
+	}))
+	require.NoError(t, err)
+
+	got := drain(ch)
+	assert.Equal(t, []lookup.KeyInfo{{Namespace: "good", Key: "kgood", Value: []byte("v")}}, got)
+	assert.True(t, scanner.called, "the malformed namespace must fall back to the block scan")
+}
+
+// A key the chaincode reports as absent still triggers the scan, which is the pre-existing
+// behaviour this change must not disturb.
+func TestQueryByID_MissingValueTriggersScan(t *testing.T) {
+	querier := &fakeQuerier{results: map[driver.Namespace]querierResult{
+		"ns1": {raw: values(t, []byte{})},
+	}}
+	scanner := &fakeScanner{}
+
+	ch, err := newQuery(querier, scanner).QueryByID(t.Context(), 100, evictedFor(map[driver.Namespace]driver.PKey{
+		"ns1": "k1",
+	}))
+	require.NoError(t, err)
+
+	assert.Empty(t, drain(ch))
+	assert.True(t, scanner.called)
+}


### PR DESCRIPTION
Closes #1990.

`queryByID` queries the token chaincode once per namespace. If one of those queries failed, it
returned from the whole function, and since there is a `defer close(ch)` that dropped every
other namespace in the batch along with it. `startDelivery` also stayed false, so the block scan
never ran, and listeners on all those keys just never fired.

Now a failure only skips its own namespace. Its keys stay in `keysByNS` and `keySet` so the scan
picks them up, and the healthy namespaces still deliver. Same fix #1426 made on the finality path.

The type held a concrete `*fabric.Delivery` and `*fabric.Channel`, so it was not testable at all.
Pulled out three small interfaces plus a `ChannelStateQuerier` adapter that leaves the existing
chaincode call as it was. `deliveryllm.go` is the only construction site.

Four tests, and I checked they fail without the fix. One caveat worth knowing: the "other
namespaces still delivered" assertion only fails some of the time against the old code, because
map order decides whether the good namespace ran before the bad one returned. The "scan must
start" assertion fails every time, so that is the one really pinning the regression.

Not in here: the starting block is `max(FirstBlock, lastBlock-NumberPastBlocks)` with both
operands unsigned, so a low `lastBlock` underflows instead of clamping to `FirstBlock`. Same line
sits in `finality/deliveryqs.go`. Happy to open a separate issue for it.
