### PR TITLE
CSP prover folding optimization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,10 @@ jobs:
           dlog-fabric-t12,
           dlog-fabric-t13,
 #          dlog-fabric-t14,
+          # Single job: covers the CSP range-proof prover/verifier end-to-end. The
+          # libp2p/replicas variants run identical CSP code, so they would only add
+          # network spin-up time without adding coverage.
+          dlogcsp-fabric-t1-websocket,
           fabricx-dlog-t1-websocket,
           fabricx-dlog-t1-libp2p,
           fabricx-dlog-t1-replicas,

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -179,6 +179,24 @@ To run the `dlog-fabric-t1` test:
 make integration-tests-dlog-fabric-t1
 ```
 
+### CSP Range-Proof Suite
+
+The DLOG driver supports two range-proof backends: the default BulletProof
+(`rp.RangeProofType`) and the Compressed Sigma Protocol (`rp.CSPRangeProofType`). The
+regular `dlog-fabric-*` fungible suite exercises the BulletProof path. The parallel
+`dlogcsp` suite (`integration/token/fungible/dlogcsp/`) is a verbatim mirror that stands
+up the same fungible topology with CSP range proofs instead, so the CSP prover/verifier is
+covered end-to-end.
+
+```bash
+make integration-tests-dlogcsp-fabric-t1
+```
+
+CSP is selected at the topology level: set `common.TMSOpts.CSP = true` (which applies
+`zkatdlognoghv1.WithCSP` to the TMS). The public-parameters generator then builds the PP
+via `setup.WithVersionAndProofType(..., rp.CSPRangeProofType)` instead of the default
+`setup.WithVersion`.
+
 ### Enabling the Token Platform Without a TMS
 
 By default, an FSC node only gets `token: enabled: true` written into its generated

--- a/fungible.mk
+++ b/fungible.mk
@@ -116,6 +116,26 @@ integration-tests-dlog-fabric-t14:
 integration-tests-dlog-fabric:
 	cd ./integration/token/fungible/dlog; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --label-filter="$(TEST_FILTER)" .
 
+.PHONY: integration-tests-dlogcsp-fabric-t1
+integration-tests-dlogcsp-fabric-t1:
+	make integration-tests-dlogcsp-fabric TEST_FILTER="T1"
+
+.PHONY: integration-tests-dlogcsp-fabric-t1-websocket
+integration-tests-dlogcsp-fabric-t1-websocket:
+	make integration-tests-dlogcsp-fabric TEST_FILTER="T1 && websocket"
+
+.PHONY: integration-tests-dlogcsp-fabric-t1-libp2p
+integration-tests-dlogcsp-fabric-t1-libp2p:
+	make integration-tests-dlogcsp-fabric TEST_FILTER="T1 && libp2p"
+
+.PHONY: integration-tests-dlogcsp-fabric-t1-replicas
+integration-tests-dlogcsp-fabric-t1-replicas:
+	make integration-tests-dlogcsp-fabric TEST_FILTER="T1 && replicas"
+
+.PHONY: integration-tests-dlogcsp-fabric
+integration-tests-dlogcsp-fabric:
+	cd ./integration/token/fungible/dlogcsp; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) --label-filter="$(TEST_FILTER)" .
+
 .PHONY: integration-tests-fabtoken-dlog-fabric
 integration-tests-fabtoken-dlog-fabric:
 	cd ./integration/token/fungible/mixed; export FAB_BINS=$(FAB_BINS); ginkgo $(GINKGO_TEST_OPTS) .

--- a/integration/nwo/token/generators/crypto/zkatdlognoghv1/gen.go
+++ b/integration/nwo/token/generators/crypto/zkatdlognoghv1/gen.go
@@ -53,6 +53,23 @@ func IsAries(tms *topology.TMS) bool {
 	return false
 }
 
+// WithCSP notifies the backend to generate public parameters that use the
+// Compressed Sigma Protocol (CSP) range-proof backend instead of the default
+// BulletProof.
+func WithCSP(tms *topology.TMS) {
+	tms.BackendParams["rangeproof.csp"] = true
+}
+
+// IsCSP returns true if this TMS requires CSP range proofs.
+func IsCSP(tms *topology.TMS) bool {
+	cspBoxed, ok := tms.BackendParams["rangeproof.csp"]
+	if ok {
+		return cspBoxed.(bool)
+	}
+
+	return false
+}
+
 var logger = logging.MustGetLogger()
 
 type CryptoMaterialGenerator struct {

--- a/integration/nwo/token/generators/pp/zkatdlognoghv1/gen.go
+++ b/integration/nwo/token/generators/pp/zkatdlognoghv1/gen.go
@@ -16,6 +16,7 @@ import (
 	math3 "github.com/IBM/mathlib"
 	"github.com/LFDT-Panurus/panurus/integration/nwo/token/generators/crypto/zkatdlognoghv1"
 	"github.com/LFDT-Panurus/panurus/integration/nwo/token/topology"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/setup"
 	"github.com/LFDT-Panurus/panurus/token/driver"
 	"github.com/LFDT-Panurus/panurus/token/services/identity"
@@ -71,7 +72,11 @@ func (d *DLogPublicParamsGenerator) Generate(tms *topology.TMS, wallets *topolog
 			return nil, err
 		}
 	}
-	pp, err := setup.WithVersion(bits, ipkBytes, curveID, d.DriverVersion)
+	proofType := rp.RangeProofType
+	if zkatdlognoghv1.IsCSP(tms) {
+		proofType = rp.CSPRangeProofType
+	}
+	pp, err := setup.WithVersionAndProofType(bits, ipkBytes, curveID, d.DriverVersion, proofType)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/ports.go
+++ b/integration/ports.go
@@ -71,6 +71,7 @@ const (
 	ZKATDLogFungible
 	ZKATDLogFungibleStress
 	ZKATDLogFungibleHSM
+	ZKATDLogFungibleCSP
 
 	FabTokenFungible
 

--- a/integration/token/common/topology.go
+++ b/integration/token/common/topology.go
@@ -25,6 +25,9 @@ type TMSOpts struct {
 	TokenSDKDriver      string
 	PublicParamsGenArgs []string
 	Aries               bool
+	// CSP, when true, generates DLog public parameters that use the Compressed
+	// Sigma Protocol (CSP) range-proof backend instead of the default BulletProof.
+	CSP bool
 }
 
 type Opts struct {
@@ -59,6 +62,9 @@ func SetDefaultParams(tms *topology.TMS, opts TMSOpts) {
 	case zkatdlognoghv1.DriverIdentifier:
 		if opts.Aries {
 			zkatdlognoghv1.WithAries(tms)
+		}
+		if opts.CSP {
+			zkatdlognoghv1.WithCSP(tms)
 		}
 	case fabtokenv1.DriverIdentifier:
 		// no nothig

--- a/integration/token/fungible/dlogcsp/dlog_suite_test.go
+++ b/integration/token/fungible/dlogcsp/dlog_suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dlogcsp
+
+import (
+	"testing"
+
+	"github.com/LFDT-Panurus/panurus/integration"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EndToEnd Fungible (DLOG, CSP range proofs) Suite")
+}
+
+func StartPortDlog() int {
+	return integration.ZKATDLogFungibleCSP.StartPortForNode()
+}

--- a/integration/token/fungible/dlogcsp/dlog_test.go
+++ b/integration/token/fungible/dlogcsp/dlog_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright IBM Corp All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dlogcsp
+
+import (
+	integration2 "github.com/LFDT-Panurus/panurus/integration"
+	"github.com/LFDT-Panurus/panurus/integration/nwo/token/generators/crypto/zkatdlognoghv1"
+	token2 "github.com/LFDT-Panurus/panurus/integration/token"
+	"github.com/LFDT-Panurus/panurus/integration/token/common"
+	"github.com/LFDT-Panurus/panurus/integration/token/common/sdk/fdlog"
+	"github.com/LFDT-Panurus/panurus/integration/token/fungible"
+	"github.com/LFDT-Panurus/panurus/integration/token/fungible/topology"
+	"github.com/hyperledger-labs/fabric-smart-client/integration/nwo/fsc"
+	nodepkg "github.com/hyperledger-labs/fabric-smart-client/pkg/node"
+	. "github.com/onsi/ginkgo/v2"
+)
+
+const None = 0
+const (
+	Aries = 1 << iota
+	AuditorAsIssuer
+	NoAuditor
+	HSM
+	WebEnabled
+	WithEndorsers
+)
+
+var _ = Describe("EndToEnd", func() {
+	for _, t := range integration2.AllTestTypes {
+		Describe("T1 Fungible with Auditor ne Issuer", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T1"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+		})
+
+		Describe("Extras with websockets", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries|WebEnabled, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("Update public params (new auditor and issuer)", Label("T2"), func() {
+				fungible.TestPublicParamsUpdate(
+					ts.II,
+					"newAuditor",
+					fungible.PrepareUpdatedPublicParams(ts.II, "newAuditor", "newIssuer", "default", false),
+					"default",
+					false,
+					selector,
+					false,
+				)
+			})
+			It("Update public params (append new auditor and issuer)", Label("T2.1"), func() {
+				fungible.TestPublicParamsUpdate(
+					ts.II,
+					"newAuditor",
+					fungible.PrepareUpdatedPublicParams(ts.II, "newAuditor", "newIssuer", "default", true),
+					"default",
+					false,
+					selector,
+					true,
+				)
+			})
+			It("Test Identity Revocation", Label("T3"), func() { fungible.TestRevokeIdentity(ts.II, "auditor", selector) })
+			It("Test Remote Wallet (GRPC)", Label("T4"), func() { fungible.TestRemoteOwnerWallet(ts.II, "auditor", selector, false) })
+			It("Test Remote Wallet (WebSocket)", Label("T5"), func() { fungible.TestRemoteOwnerWallet(ts.II, "auditor", selector, true) })
+		})
+
+		Describe("Fungible with Auditor = Issuer", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries|AuditorAsIssuer, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T6"), func() { fungible.TestAll(ts.II, "issuer", nil, true, selector) })
+			It("Update public params", Label("T7"), func() {
+				fungible.TestPublicParamsUpdate(
+					ts.II,
+					"newIssuer",
+					fungible.PrepareUpdatedPublicParams(ts.II, "newIssuer", "newIssuer", "default", false),
+					"default",
+					true,
+					selector,
+					false,
+				)
+			})
+		})
+
+		Describe("Fungible with Auditor ne Issuer + Fabric CA", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, None, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T8"), func() { fungible.TestAll(ts.II, "auditor", nil, false, selector) })
+		})
+
+		Describe("Malicious Transactions", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries|NoAuditor, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("Malicious Transactions", Label("T9"), func() { fungible.TestMaliciousTransactions(ts.II, selector) })
+		})
+
+		Describe("Fungible with Auditor ne Issuer and Endorsers", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries|WithEndorsers, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T10"), func() { fungible.TestAll(ts.II, "auditor", nil, true, selector) })
+		})
+
+		Describe("Multisig", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T12"), func() { fungible.TestMultiSig(ts.II, selector) })
+		})
+
+		Describe("PolicyIdentity", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("OR and AND succeeded", Label("T14"), func() {
+				fungible.TestPolicyOR(ts.II, selector)
+				fungible.TestPolicyAND(ts.II, selector)
+			})
+		})
+
+		Describe("Redeem to yourself", t.Label, func() {
+			ts, selector := newTestSuite(t.CommType, Aries, t.ReplicationFactor, "", "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("Test redeem", Label("T13"), func() { fungible.TestRedeem(ts.II, selector, "default") })
+		})
+
+	}
+
+	for _, tokenSelector := range integration2.TokenSelectors {
+		Describe("TokenSelector Test", integration2.WebSocketNoReplication.Label, Label(tokenSelector), func() {
+			ts, replicaSelector := newTestSuite(integration2.WebSocketNoReplication.CommType, Aries, integration2.WebSocketNoReplication.ReplicationFactor, tokenSelector, "alice", "bob", "charlie")
+			BeforeEach(ts.Setup)
+			AfterEach(ts.TearDown)
+			It("succeeded", Label("T11"), func() { fungible.TestSelector(ts.II, "auditor", replicaSelector) })
+		})
+	}
+})
+
+func newTestSuite(commType fsc.P2PCommunicationType, mask int, factor int, tokenSelector string, names ...string) (*token2.TestSuite, *token2.ReplicaSelector) {
+	opts, selector := token2.NewReplicationOptions(factor, names...)
+	ts := token2.NewTestSuite(StartPortDlog, topology.Topology(
+		common.Opts{
+			Backend:             "fabric",
+			CommType:            commType,
+			DefaultTMSOpts:      common.TMSOpts{TokenSDKDriver: zkatdlognoghv1.DriverIdentifier, Aries: mask&Aries > 0, CSP: true},
+			NoAuditor:           mask&NoAuditor > 0,
+			AuditorAsIssuer:     mask&AuditorAsIssuer > 0,
+			HSM:                 mask&HSM > 0,
+			WebEnabled:          mask&WebEnabled > 0,
+			SDKs:                []nodepkg.SDK{&fdlog.SDK{}},
+			Monitoring:          false,
+			ReplicationOpts:     opts,
+			FSCBasedEndorsement: mask&WithEndorsers > 0,
+			FSCLogSpec:          "info",
+			TokenSelector:       tokenSelector,
+		},
+	))
+
+	return ts, selector
+}

--- a/integration/token/fungible/topology/topology.go
+++ b/integration/token/fungible/topology/topology.go
@@ -258,6 +258,9 @@ func Topology(opts common.Opts) []api.Topology {
 		if tmsOpts.Aries {
 			zkatdlognoghv1.WithAries(tms)
 		}
+		if tmsOpts.CSP {
+			zkatdlognoghv1.WithCSP(tms)
+		}
 		tms.SetTokenGenPublicParams(tmsOpts.PublicParamsGenArgs...)
 		if !opts.NoAuditor {
 			tms.AddAuditor(auditor)

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp.go
@@ -81,6 +81,16 @@ type prover struct {
 	Curve          *mathlib.Curve // Curve identifier
 	witness        []*mathlib.Zr  // opening for the commitment
 
+	// realLen is an optional hint: the number of leading "real" entries, i.e. the
+	// prefix [0, realLen) of Generators/LinearForm/witness before the caller's
+	// power-of-two padding. When rp.go builds the statement it pads the tail
+	// [realLen, 2^NumberOfRounds) with witness=0, LinearForm=0 and Generators=GenG1.
+	// A valid hint (0 < realLen < N and realLen > N/2) lets Prove() take a faster
+	// round-0 path that skips the zero terms and collapses the duplicated GenG1
+	// generators. The result is byte-identical to the full path, so the proof and
+	// transcript are unchanged. Zero (the default) disables the optimization.
+	realLen uint64
+
 	TranscriptHeader []byte
 }
 
@@ -145,17 +155,55 @@ func (p *prover) Prove() (*Proof, error) {
 	for i := range p.NumberOfRounds {
 		n := len(generators) / 2
 
-		// Cross-commitments via MSM:
-		//   left[i]  = MSM(gen_L, wit_R)   gen_L = generators[:n], wit_R = witness[n:]
-		//   right[i] = MSM(gen_R, wit_L)   gen_R = generators[n:], wit_L = witness[:n]
-		left[i] = smallMSM(p.Curve, generators[:n], witness[n:])
-		right[i] = smallMSM(p.Curve, generators[n:], witness[:n])
+		// Fast round-0 path: rp.go pads the tail [realLen, N) with witness=0,
+		// LinearForm=0 and Generators=GenG1, and realLen > N/2 so the whole
+		// padding lies in the second half. Only round 0 sees this structure (the
+		// fold densifies everything afterwards). nzR is the count of "real"
+		// columns whose right-half partner is not padding. The results below are
+		// value-identical to the full path — zero terms vanish and the duplicated
+		// GenG1 generators collapse by distributivity — so the transcript and the
+		// emitted proof are unchanged.
+		fastRound0 := i == 0 && p.realLen > uint64(n) && p.realLen < uint64(len(generators))
+		nzR := n
+		if fastRound0 {
+			nzR = int(p.realLen) - n // #nosec G115 -- 0 < realLen-n < n by the guard above
+		}
 
-		// Cross scalar products via ModAddMul (scalar-field MSM):
-		//   vLeft[i]  = ⟨f_L, wit_R⟩
-		//   vRight[i] = ⟨f_R, wit_L⟩
-		vLeft[i] = math.InnerProduct(linearForm[:n], witness[n:], p.Curve)
-		vRight[i] = math.InnerProduct(linearForm[n:], witness[:n], p.Curve)
+		if fastRound0 {
+			// left = MSM(gen_L, wit_R): wit_R is zero beyond nzR.
+			left[i] = smallMSM(p.Curve, generators[:nzR], witness[n:n+nzR])
+
+			// right = MSM(gen_R, wit_L): the gen_R tail is a run of GenG1, so
+			//   right = MSM(gen_R[:nzR], wit_L[:nzR]) + (Σ_{j≥nzR} wit_L[j])·GenG1.
+			tailSum := p.Curve.NewZrFromInt(0)
+			for j := nzR; j < n; j++ {
+				tailSum = p.Curve.ModAdd(tailSum, witness[j], p.Curve.GroupOrder)
+			}
+			rPoints := make([]*mathlib.G1, 0, nzR+1)
+			rScalars := make([]*mathlib.Zr, 0, nzR+1)
+			rPoints = append(rPoints, generators[n:n+nzR]...)
+			rScalars = append(rScalars, witness[:nzR]...)
+			rPoints = append(rPoints, p.Curve.GenG1)
+			rScalars = append(rScalars, tailSum)
+			right[i] = smallMSM(p.Curve, rPoints, rScalars)
+
+			// vLeft = ⟨f_L, wit_R⟩: wit_R zero beyond nzR.
+			// vRight = ⟨f_R, wit_L⟩: f_R zero beyond nzR.
+			vLeft[i] = math.InnerProduct(linearForm[:nzR], witness[n:n+nzR], p.Curve)
+			vRight[i] = math.InnerProduct(linearForm[n:n+nzR], witness[:nzR], p.Curve)
+		} else {
+			// Cross-commitments via MSM:
+			//   left[i]  = MSM(gen_L, wit_R)   gen_L = generators[:n], wit_R = witness[n:]
+			//   right[i] = MSM(gen_R, wit_L)   gen_R = generators[n:], wit_L = witness[:n]
+			left[i] = smallMSM(p.Curve, generators[:n], witness[n:])
+			right[i] = smallMSM(p.Curve, generators[n:], witness[:n])
+
+			// Cross scalar products via ModAddMul (scalar-field MSM):
+			//   vLeft[i]  = ⟨f_L, wit_R⟩
+			//   vRight[i] = ⟨f_R, wit_L⟩
+			vLeft[i] = math.InnerProduct(linearForm[:n], witness[n:], p.Curve)
+			vRight[i] = math.InnerProduct(linearForm[n:], witness[:n], p.Curve)
+		}
 
 		// Absorb cross terms into transcript, then squeeze challenge.
 		tr.Absorb(left[i].Bytes())
@@ -171,23 +219,39 @@ func (p *prover) Prove() (*Proof, error) {
 		// Fold generators:  gen'[j] = gen_L[j] + c · gen_R[j]
 		// Fold linear form: f'[j]   = f_L[j]   + c · f_R[j]
 		// Fold witness:     w'[j]   = c · w_L[j] + w_R[j]
+		//
+		// For the padded tail (j ≥ nzR, only in the fast round-0 path) the
+		// right-half partners are gen_R=GenG1, f_R=0, w_R=0, so the fold reduces
+		// to gen'[j]=gen_L[j]+c·GenG1 (a shared point-add), f'[j]=f_L[j] (a no-op)
+		// and w'[j]=c·w_L[j] (a single mul).
+		var cG *mathlib.G1
+		if fastRound0 {
+			cG = p.Curve.GenG1.Mul(c) // the single shared c·GenG1
+		}
 		for j := range n {
-			// gen'[j] = 1·gen_L[j] + c·gen_R[j], zero allocations
-			generators[j].Mul2InPlace(one, generators[n+j], c)
+			if j < nzR {
+				// gen'[j] = 1·gen_L[j] + c·gen_R[j], zero allocations
+				generators[j].Mul2InPlace(one, generators[n+j], c)
 
-			p.Curve.ModAddMul2InPlace(
-				linearForm[j],
-				one, linearForm[j],
-				c, linearForm[n+j],
-				p.Curve.GroupOrder,
-			)
+				p.Curve.ModAddMul2InPlace(
+					linearForm[j],
+					one, linearForm[j],
+					c, linearForm[n+j],
+					p.Curve.GroupOrder,
+				)
 
-			p.Curve.ModAddMul2InPlace(
-				witness[j],
-				c, witness[j],
-				witness[n+j], one,
-				p.Curve.GroupOrder,
-			)
+				p.Curve.ModAddMul2InPlace(
+					witness[j],
+					c, witness[j],
+					witness[n+j], one,
+					p.Curve.GroupOrder,
+				)
+			} else {
+				// Padded tail (fast round 0 only).
+				generators[j].Add(cG)                                                // gen'[j] = gen_L[j] + c·GenG1
+				p.Curve.ModMulInPlace(witness[j], c, witness[j], p.Curve.GroupOrder) // w'[j] = c·w_L[j]
+				// linearForm'[j] = f_L[j] + c·0 = f_L[j]: unchanged, no-op.
+			}
 		}
 
 		generators = generators[:n]

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/csp_test.go
@@ -332,3 +332,52 @@ func TestCSP_TranscriptHeaderMismatch(t *testing.T) {
 		})
 	}
 }
+
+// TestRound0FastPathMatchesFull verifies that the round-0 padding optimization
+// (realLen hint) is value-preserving: for the same padded statement, the proof
+// produced with the hint is byte-identical to the one produced without it, and
+// both verify. This is the core safety property — identical proofs imply an
+// identical Fiat-Shamir transcript, so soundness is unaffected.
+func TestRound0FastPathMatchesFull(t *testing.T) {
+	curves := []math.CurveID{math.BN254, math.BLS12_381_BBS_GURVY}
+	// (rounds, m) chosen to cover: the token cases (n=32/64), a case with no
+	// padding (m==N), and a case where m is only just above N/2.
+	cases := []struct {
+		rounds uint64
+		m      int
+	}{
+		{7, 68},  // n=32 -> N=128
+		{8, 132}, // n=64 -> N=256
+		{6, 64},  // m==N: no padding, fast path must be a no-op
+		{6, 33},  // m just above N/2=32
+		{6, 63},  // m just below N
+		{4, 9},   // small: N=16, m just above 8
+	}
+
+	for _, curveID := range curves {
+		curve := math.Curves[curveID]
+		for _, tc := range cases {
+			t.Run(fmt.Sprintf("curve=%d/rounds=%d/m=%d", curveID, tc.rounds, tc.m), func(t *testing.T) {
+				pi := buildPaddedInstance(curve, tc.rounds, tc.m)
+
+				full, err := pi.prover().Prove() // realLen=0 -> full path
+				require.NoError(t, err)
+				fast, err := pi.proverHinted().Prove() // realLen=m -> fast path
+				require.NoError(t, err)
+
+				// Byte-identical cross-terms across all rounds.
+				require.Len(t, fast.Left, len(full.Left))
+				for i := range full.Left {
+					require.Equal(t, full.Left[i].Bytes(), fast.Left[i].Bytes(), "Left[%d]", i)
+					require.Equal(t, full.Right[i].Bytes(), fast.Right[i].Bytes(), "Right[%d]", i)
+					require.Equal(t, full.VLeft[i].Bytes(), fast.VLeft[i].Bytes(), "VLeft[%d]", i)
+					require.Equal(t, full.VRight[i].Bytes(), fast.VRight[i].Bytes(), "VRight[%d]", i)
+				}
+
+				// Both proofs must verify against the same statement.
+				require.NoError(t, pi.verifier().Verify(full))
+				require.NoError(t, pi.verifier().Verify(fast))
+			})
+		}
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package csp
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	math "github.com/IBM/mathlib"
+	math2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/math"
+)
+
+// paddedInstance mirrors rp.go's CSP input layout: the first m entries are
+// "real" (random), and the tail [m,N) is padded exactly as rp.go does —
+// witness=0, linearForm=0, generators=GenG1 (a single duplicated generator).
+type paddedInstance struct {
+	curve      *math.Curve
+	rounds     uint64
+	N          int
+	m          int // real length = 2n+4
+	generators []*math.G1
+	witness    []*math.Zr
+	linearForm []*math.Zr
+}
+
+func buildPaddedInstance(curve *math.Curve, rounds uint64, m int) *paddedInstance {
+	N := 1 << rounds
+	rand, _ := curve.Rand()
+	gen := make([]*math.G1, N)
+	wit := make([]*math.Zr, N)
+	lf := make([]*math.Zr, N)
+	for i := range N {
+		if i < m {
+			gen[i] = curve.HashToG1([]byte("g-" + strconv.Itoa(i)))
+			wit[i] = curve.NewRandomZr(rand)
+			lf[i] = curve.NewRandomZr(rand)
+		} else {
+			gen[i] = curve.GenG1 // duplicated non-zero generator (as in rp.go)
+			wit[i] = curve.NewZrFromInt(0)
+			lf[i] = curve.NewZrFromInt(0)
+		}
+	}
+	return &paddedInstance{curve: curve, rounds: rounds, N: N, m: m, generators: gen, witness: wit, linearForm: lf}
+}
+
+func (pi *paddedInstance) prover() *prover { return pi.proverRealLen(0) }
+
+func (pi *paddedInstance) proverHinted() *prover { return pi.proverRealLen(uint64(pi.m)) }
+
+// proverRealLen builds a CSP prover for this instance; realLen=0 disables the
+// round-0 fast path (baseline), realLen=m enables it.
+func (pi *paddedInstance) proverRealLen(realLen uint64) *prover {
+	com := pi.curve.MultiScalarMul(pi.generators, pi.witness)
+	value := math2.InnerProduct(pi.linearForm, pi.witness, pi.curve)
+	p := &prover{
+		Commitment:     com,
+		Generators:     pi.generators,
+		LinearForm:     pi.linearForm,
+		Value:          value,
+		NumberOfRounds: pi.rounds,
+		Curve:          pi.curve,
+		witness:        pi.witness,
+		realLen:        realLen,
+	}
+	return p.WithTranscriptHeader([]byte("bench"))
+}
+
+func (pi *paddedInstance) verifier() *verifier {
+	com := pi.curve.MultiScalarMul(pi.generators, pi.witness)
+	value := math2.InnerProduct(pi.linearForm, pi.witness, pi.curve)
+	v := &verifier{
+		Commitment:     com,
+		Generators:     pi.generators,
+		LinearForm:     pi.linearForm,
+		Value:          value,
+		NumberOfRounds: pi.rounds,
+		Curve:          pi.curve,
+	}
+	return v.WithTranscriptHeader([]byte("bench"))
+}
+
+// bitCases maps a range bit-length n to (rounds, m) where m=2n+4 and
+// N=2^rounds is the next power of two >= m.
+type bitCase struct {
+	name   string
+	rounds uint64
+	m      int
+}
+
+func bitCases() []bitCase {
+	return []bitCase{
+		{"n32", 7, 68},  // 2*32+4=68  -> N=128
+		{"n64", 8, 132}, // 2*64+4=132 -> N=256
+	}
+}
+
+var benchCurves = []struct {
+	name string
+	id   math.CurveID
+}{
+	{"BN254", math.BN254},
+	{"BLS12_381", math.BLS12_381_BBS_GURVY},
+}
+
+// BenchmarkCSPProve measures the CSP prover on a realistic padded input (the
+// path production takes: the round-0 fast path enabled via the realLen hint),
+// per curve and bit-length. To re-derive the optimization's speedup, swap
+// pi.proverHinted() for pi.prover() (realLen=0 disables the fast path).
+func BenchmarkCSPProve(b *testing.B) {
+	for _, c := range benchCurves {
+		curve := math.Curves[c.id]
+		for _, bc := range bitCases() {
+			pi := buildPaddedInstance(curve, bc.rounds, bc.m)
+			b.Run(c.name+"/"+bc.name, func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					if _, err := pi.proverHinted().Prove(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkRangeProofProve measures the full CSP range-proof generation (Lagrange
+// linear-form construction + the CSP engine, which carries the round-0 fast path
+// via rp.go's realLen hint). This is the "one level up" prover harness — the
+// counterpart to BenchmarkRangeProofVerify. Toggle rp.go's `realLen` line to get
+// a before/after at this level.
+func BenchmarkRangeProofProve(b *testing.B) {
+	cases := []struct {
+		n     uint64
+		value int64
+	}{
+		{32, 1 << 15},
+		{64, 1_000_000_000_000_000},
+	}
+	for _, c := range benchCurves {
+		curve := math.Curves[c.id]
+		for _, tc := range cases {
+			setup, err := newRPSetup(curve, tc.n, tc.value)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Run(fmt.Sprintf("%s/n=%d", c.name, tc.n), func(b *testing.B) {
+				b.ReportAllocs()
+				for range b.N {
+					if _, err := setup.prover.Prove(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
@@ -51,7 +51,9 @@ func buildPaddedInstance(curve *math.Curve, rounds uint64, m int) *paddedInstanc
 
 func (pi *paddedInstance) prover() *prover { return pi.proverRealLen(0) }
 
-func (pi *paddedInstance) proverHinted() *prover { return pi.proverRealLen(uint64(int64(pi.m))) }
+func (pi *paddedInstance) proverHinted() *prover {
+	return pi.proverRealLen(uint64(pi.m)) //nolint:gosec // m is always non-negative
+}
 
 // proverRealLen builds a CSP prover for this instance; realLen=0 disables the
 // round-0 fast path (baseline), realLen=m enables it.

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/padding_bench_test.go
@@ -45,12 +45,13 @@ func buildPaddedInstance(curve *math.Curve, rounds uint64, m int) *paddedInstanc
 			lf[i] = curve.NewZrFromInt(0)
 		}
 	}
+
 	return &paddedInstance{curve: curve, rounds: rounds, N: N, m: m, generators: gen, witness: wit, linearForm: lf}
 }
 
 func (pi *paddedInstance) prover() *prover { return pi.proverRealLen(0) }
 
-func (pi *paddedInstance) proverHinted() *prover { return pi.proverRealLen(uint64(pi.m)) }
+func (pi *paddedInstance) proverHinted() *prover { return pi.proverRealLen(uint64(int64(pi.m))) }
 
 // proverRealLen builds a CSP prover for this instance; realLen=0 disables the
 // round-0 fast path (baseline), realLen=m enables it.
@@ -67,6 +68,7 @@ func (pi *paddedInstance) proverRealLen(realLen uint64) *prover {
 		witness:        pi.witness,
 		realLen:        realLen,
 	}
+
 	return p.WithTranscriptHeader([]byte("bench"))
 }
 
@@ -81,6 +83,7 @@ func (pi *paddedInstance) verifier() *verifier {
 		NumberOfRounds: pi.rounds,
 		Curve:          pi.curve,
 	}
+
 	return v.WithTranscriptHeader([]byte("bench"))
 }
 

--- a/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
+++ b/token/core/zkatdlog/nogh/v1/crypto/rp/csp/rp.go
@@ -427,7 +427,10 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 		lf = append(lf, math.Zero(rp.Curve))
 	}
 
-	// Non-ZK CSP proof for the blinded statement.
+	// Non-ZK CSP proof for the blinded statement. realLen marks the real prefix
+	// (before the power-of-two padding appended above): its tail [witSize, paddedSize)
+	// has witness=0, LinearForm=0 and Generators=GenG1, which the prover exploits in
+	// its round-0 fast path.
 	cspP := &prover{
 		Commitment:     witComm,
 		Generators:     gExt,
@@ -436,6 +439,7 @@ func (rp *rangeProver) Prove() (*RangeProof, error) {
 		NumberOfRounds: cspRounds,
 		Curve:          rp.Curve,
 		witness:        wit,
+		realLen:        witSize,
 	}
 	cspProof, err := cspP.WithTranscriptHeader(rp.TranscriptHeader).Prove()
 	if err != nil {

--- a/token/core/zkatdlog/nogh/v1/issue/issuer_test.go
+++ b/token/core/zkatdlog/nogh/v1/issue/issuer_test.go
@@ -12,6 +12,7 @@ import (
 
 	math "github.com/IBM/mathlib"
 	math2 "github.com/LFDT-Panurus/panurus/token/core/common/crypto/math"
+	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/benchmark"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/crypto/rp"
 	issue2 "github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/issue"
 	"github.com/LFDT-Panurus/panurus/token/core/zkatdlog/nogh/v1/issue/mock"
@@ -84,7 +85,9 @@ func TestIssuer(t *testing.T) {
 }
 
 // BenchmarkIssuer measures the cost of creating ZK-issue actions under
-// different parameter sets provided by the benchmark helper.
+// different parameter sets provided by the benchmark helper. The range-proof
+// backend is selected with -proof_type (1/bulletproof/bf, or 2/csp); CSP
+// exercises the round-0 prover optimization.
 func BenchmarkIssuer(b *testing.B) {
 	bits, err := benchmark2.Bits(32, 64)
 	require.NoError(b, err)
@@ -92,10 +95,11 @@ func BenchmarkIssuer(b *testing.B) {
 	outputs, err := benchmark2.NumOutputs(1, 2, 3)
 	require.NoError(b, err)
 	testCases := benchmark2.GenerateCases(bits, curves, nil, outputs, nil)
+	proofType := benchmark.ProofType()
 
 	for _, tc := range testCases {
 		b.Run(tc.Name, func(b *testing.B) {
-			env := newBenchmarkIssuerEnv(b, b.N, tc.BenchmarkCase)
+			env := newBenchmarkIssuerEnv(b, b.N, tc.BenchmarkCase, proofType)
 
 			// Optional: Reset timer if you had expensive setup code above
 			b.ResetTimer()
@@ -214,11 +218,15 @@ type benchmarkIssuerEnv struct {
 }
 
 // newBenchmarkIssuerEnv creates n prepared issuer environments using the
-// provided benchmark case parameters.
-func newBenchmarkIssuerEnv(b *testing.B, n int, benchmarkCase *benchmark2.Case) *benchmarkIssuerEnv {
+// provided benchmark case parameters and range-proof backend.
+func newBenchmarkIssuerEnv(b *testing.B, n int, benchmarkCase *benchmark2.Case, proofType rp.ProofType) *benchmarkIssuerEnv {
 	b.Helper()
 	envs := make([]*issuerEnv, n)
-	pp := setup(b, benchmarkCase.Bits, benchmarkCase.CurveID)
+	setupFn := setup
+	if proofType == rp.CSPRangeProofType {
+		setupFn = setupCSP
+	}
+	pp := setupFn(b, benchmarkCase.Bits, benchmarkCase.CurveID)
 	for i := range envs {
 		envs[i] = newIssuerEnv(pp, benchmarkCase.NumOutputs)
 	}

--- a/token/core/zkatdlog/nogh/v1/setup/setup.go
+++ b/token/core/zkatdlog/nogh/v1/setup/setup.go
@@ -301,13 +301,19 @@ func Setup(bitLength uint64, idemixIssuerPK []byte, curveID mathlib.CurveID) (*P
 
 // WithVersion is like Setup with the additional possibility to specify the version number
 func WithVersion(bitLength uint64, idemixIssuerPK []byte, curveID mathlib.CurveID, version driver.TokenDriverVersion) (*PublicParams, error) {
+	return WithVersionAndProofType(bitLength, idemixIssuerPK, curveID, version, rp.RangeProofType)
+}
+
+// WithVersionAndProofType is like WithVersion but also lets the caller choose the
+// range-proof backend (rp.RangeProofType for BulletProof, rp.CSPRangeProofType for CSP).
+func WithVersionAndProofType(bitLength uint64, idemixIssuerPK []byte, curveID mathlib.CurveID, version driver.TokenDriverVersion, proofType rp.ProofType) (*PublicParams, error) {
 	return NewWith(SetupParams{
 		DriverName:     DLogNoGHDriverName,
 		DriverVersion:  version,
 		BitLength:      bitLength,
 		IdemixIssuerPK: idemixIssuerPK,
 		CurveID:        curveID,
-		ProofType:      rp.RangeProofType,
+		ProofType:      proofType,
 	})
 }
 


### PR DESCRIPTION
Improve performance of first folding step in proof generation by exploiting structure of vectors of generators, witness and coeffs of linear form. 

**Comments for the reviewers on failing CI checks (not related to algorithmic code):**
1. It turned out there was no itest for csp which cause coverage CI fail. 
I therefore added a csp itest and the necessary supporting code to the branch, which 
increased the file count.

   @adecaro please take a look at least at the itest related changed files in:
   - .github/workflows/...
   - docs/development/...
   - integration/...
   - token/core/zkatdlog/nogh/v1/setup/setup.go
   - fungible.mk

2. After including the new csp itest, the CI fails with for "Tests / utest (unit-tests-race) (pull_request)", but Claude said this is not a real failure but is expected when comparing a fork to the main trunk (**the CI tries to post the results table as a PR comment but GitHub deliberately hands fork PRs a read-only GITHUB_TOKEN**).