### PR TITLE
fix(ci): skip tidy-check in nightly FSC update workflow

### DIFF
--- a/.github/workflows/nightly-fsc.yml
+++ b/.github/workflows/nightly-fsc.yml
@@ -33,7 +33,7 @@ jobs:
         run: make install-tools
 
       - name: Run checks
-        run: make checks
+        run: make checks-no-tidy
 
       - name: Run linter
         run: make lint

--- a/checks.mk
+++ b/checks.mk
@@ -1,6 +1,12 @@
 .PHONY: checks
 checks: licensecheck gofmt goimports govet gofix misspell ineffassign staticcheck protos-lint buf-format tidy-check
 
+.PHONY: checks-no-tidy
+# same as 'checks' but without tidy-check; for use after a workflow step that
+# already rewrote go.mod/go.sum to a new dependency version and ran 'make tidy'
+# itself, where tidy-check's git-diff-against-HEAD heuristic would always fail
+checks-no-tidy: licensecheck gofmt goimports govet gofix misspell ineffassign staticcheck protos-lint buf-format
+
 .PHONY: licensecheck
 licensecheck:
 	@echo Running license check


### PR DESCRIPTION
## Summary
- `tidy-check` flags any uncommitted `go.mod`/`go.sum` change as untidy by diffing against git HEAD. The nightly FSC bump workflow deliberately rewrites those files to a new `fabric-smart-client` version (and already runs `make tidy` itself via `update-dep`) before `make checks` runs, so the git-diff heuristic fails unconditionally on every nightly run even though the modules are genuinely tidy.
- Add a `checks-no-tidy` target to `checks.mk` (same check list as `checks`, minus `tidy-check`) and switch `nightly-fsc.yml`'s "Run checks" step to use it. `tidy-check` and the regular `checks` target are unchanged for normal PR/local usage.

Fixes #2003

## Test plan
- [x] `make checks-no-tidy` exits 0 and skips the tidy-check section entirely
- [x] `make checks` still exits 0 and prints "✓ All Go modules are tidy." (no regression for normal usage)
- [x] `make lint-auto-fix` — 0 issues in every module