### PR TITLE
docs: trim AGENTS.md and extract integration-test debugging runbook

### DIFF
--- a/.claude/skills/debug-integration-tests/SKILL.md
+++ b/.claude/skills/debug-integration-tests/SKILL.md
@@ -1,0 +1,1 @@
+../../../docs/development/debug-integration-tests.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,18 +26,6 @@
 - `make tidy` - Synchronize Go dependencies
 - `go generate ./...` - Generate mocks
 
-## 📁 Project Structure
-```
-token/
-├── core/          # Driver implementations (fabtoken, zkatdlog)
-├── driver/        # Interface definitions (ports)
-├── services/      # High-level services (identity, network, ttx, storage)
-└── sdk/           # Public API entry points
-integration/
-├── nwo/           # Network Orchestrator for test networks
-└── token/         # Actual test suites (fungible, nft, dvp, etc.)
-```
-
 ## 🔧 Development Workflow
 
 ### 1. Setup (One-time)
@@ -82,57 +70,12 @@ make integration-tests-dlog-fabric TEST_FILTER="T1"
 - **Go module issues**: `make tidy`
 - **Mock generation failures**: `make install-tools` (ensures counterfeiter is installed)
 
-## 🔄 CI Workflow Overview
-
-To ensure your commits pass CI automatically, understand what runs:
-
-### 🔧 Pre-Merge Checks (GitHub Actions)
-All PRs and pushes to `main` trigger these workflows:
-
-1. **Checks Job** (Prerequisite):
-   - License verification
-   - Code formatting (`gofmt`, `goimports`)
-   - Static analysis (`govet`, `staticcheck`, `ineffassign`, `misspell`)
-   - *Run locally with:* `make checks`
-
-2. **Unit Testing**:
-   - Race detector enabled tests
-   - Regression tests
-   - Coverage reporting to Coveralls
-
-3. **Integration Testing** (Extensive Matrix):
-   - Fabtoken (cleartext tokens): t1-t5
-   - ZKATDLog (privacy tokens): t1-t13
-   - Fabric-X, Interop, NFT, DVP, Update tests
-   - Stress tests
-   - All with coverage reporting
-
-4. **Separate Workflows**:
-   - **golangci-lint**: Comprehensive linting (30 min timeout)
-   - **Markdown links**: Validates all doc links
-   - **CodeQL**: Security analysis (weekly + on push/PR)
-
-### 💡 Best Practices for CI Success
-- **Always run** `make checks` and `make lint-auto-fix` before committing
-- **Verify** `FAB_BINS` is set for integration test compatibility
-- **Address** all linting and static check warnings promptly
-- **Keep** dependencies updated with `make tidy`
-
 ## 🏗️ Architecture Overview
 
 ### Core Patterns
 - **Driver Pattern**: Swappable token technologies via interfaces in `token/driver`
 - **Service Pattern**: Encapsulated high-level logic in `token/services`
 - **TTX Service**: Orchestrates token transaction lifecycle (Request → Assemble → Sign → Commit)
-
-### Key Technologies
-- Go 1.24+
-- Hyperledger Fabric
-- Fabric Smart Client (FSC)
-- Idemix/zkatdlog (privacy)
-- Mathlib
-- Ginkgo (testing framework)
-- Cobra (CLI framework)
 
 ## 🧪 Testing Strategy
 
@@ -232,28 +175,10 @@ needs a `/slash-command` trigger for one, add a symlink at
   API/lint breakage until `make checks` and `make lint-auto-fix` are clean, then stops and
   waits for the user's go-ahead before pushing a branch or opening the PR — the "never push
   or open a PR without explicit go-ahead" rule above still applies to this runbook.
+- **Debugging Integration Tests**: [docs/development/debug-integration-tests.md](docs/development/debug-integration-tests.md)
+  (Claude Code: `/debug-integration-tests`). Log locations, Docker/network inspection, and
+  Ginkgo focus/skip techniques for diagnosing failing integration tests.
 
 ## 🔍 Debugging & Advanced Testing
 
-### Log Locations
-- **Integration Tests**: System temp directory (`/tmp/fsc-integration-<random>/...`)
-- **Containers**: `docker logs <container_name>`
-- **Persisted Logs**: Temporarily modify test to use `NewLocalTestSuite` (outputs to `./testdata`)
-
-### Debugging Techniques
-- **Manual Inspection**: Use `time.Sleep()` or pause loops in tests to inspect Docker state
-- **Network Preservation**: Check for `no-cleanup` option or manually comment test suite cleanup
-- **Focused Tests**: Modify `It(...)` to `FIt(...)` to focus, or `XIt(...)` to skip (never commit these changes)
-
-## 📚 Key Files & Directories
-- `Makefile`: Central control hub - read to discover targets
-- `go.mod`: Project dependencies
-- `tools/tools.go`: Tool dependencies source of truth (install with `make install-tools`)
-- `token/`: Core SDK logic
-- `integration/`: Integration tests and Network Orchestrator
-
-## 💡 Best Practices for CI Success
-Before marking a task complete:
-- **Always run** `make checks` and `make lint-auto-fix` before committing
-- **Address** all linting and static check warnings promptly
-- **Keep** dependencies updated with `make tidy`
+See [Debugging Integration Tests](docs/development/debug-integration-tests.md) (Claude Code: `/debug-integration-tests`).

--- a/docs/development/ai_agents.md
+++ b/docs/development/ai_agents.md
@@ -55,6 +55,9 @@ without re-deriving the steps each time:
   dependency across all Go modules, resolves resulting API/lint breakage until
   `make checks` is clean, then pauses for user confirmation before pushing or opening
   a PR. Also available in Claude Code as `/update-fsc`.
+- **[Debugging Integration Tests](./debug-integration-tests.md)** — log locations,
+  Docker/network inspection, and Ginkgo focus/skip techniques for diagnosing failing
+  integration tests. Also available in Claude Code as `/debug-integration-tests`.
 
 ## Issue & PR Submission
 

--- a/docs/development/debug-integration-tests.md
+++ b/docs/development/debug-integration-tests.md
@@ -10,6 +10,41 @@ This doc is the single source of truth. In Claude Code it is also exposed as the
 `/debug-integration-tests` skill via a symlink at
 `.claude/skills/debug-integration-tests/SKILL.md`.
 
+## Running Integration Tests: `TEST_FILTER` Labels
+
+`TEST_FILTER` is a Ginkgo `--label-filter` expression, and it can combine **two
+independent kinds of label** with `&&`:
+
+1. **Test-identifying labels** (`T1`, `T2`, `T2.1`, `T3`, ...) — identify the
+   scenario itself, set via `Label("T1")` on the individual `It(...)` block
+   (e.g. `integration/token/fungible/dlog/dlog_test.go`).
+2. **Infrastructure-type labels** (`websocket`, `libp2p`, `replicas`) — identify
+   the transport/replication configuration the scenario runs under, defined in
+   `integration/ports.go` (`WebSocketNoReplication`, `LibP2PNoReplication`,
+   `WebSocketWithReplication`). Suites that call `fungible.TestAll` loop over
+   `integration.AllTestTypes` and wrap every `Describe` in the matching infra
+   label, so a filter of just `T1` runs T1 once per infra type sequentially.
+
+Combine them to pin a scenario to one infrastructure type:
+
+```bash
+make integration-tests-dlog-fabric TEST_FILTER="T1 && websocket"
+make integration-tests-fabricx-dlog TEST_FILTER="T6 && libp2p"
+```
+
+`fungible.mk` and `fabricx.mk` already expose make targets for the common
+combos, e.g. `integration-tests-dlog-fabric-t1-websocket`, `-t1-libp2p`,
+`-t1-replicas` (CI uses these to run the three infra configurations as
+parallel jobs). The plain `-tN` targets (no infra suffix, e.g.
+`integration-tests-dlog-fabric-t1`) leave the infra label unset and run all
+three types sequentially.
+
+**Local default: websocket only.** Unless the user asks for `libp2p`,
+`replicas`, or "all infra types", always add `&& websocket` (or use an
+existing `-websocket` make target) when running integration tests locally.
+The other two configurations are far more expensive to set up locally and
+are already covered by CI's parallel per-infra jobs.
+
 ## Log Locations
 - **Integration Tests**: System temp directory (`/tmp/fsc-integration-<random>/...`)
 - **Containers**: `docker logs <container_name>`

--- a/docs/development/debug-integration-tests.md
+++ b/docs/development/debug-integration-tests.md
@@ -1,0 +1,25 @@
+---
+name: debug-integration-tests
+description: "Techniques for debugging Panurus integration tests — log locations, Docker/network inspection, and Ginkgo focus/skip. Trigger: /debug-integration-tests"
+trigger: /debug-integration-tests
+---
+
+# Debugging Integration Tests
+
+This doc is the single source of truth. In Claude Code it is also exposed as the
+`/debug-integration-tests` skill via a symlink at
+`.claude/skills/debug-integration-tests/SKILL.md`.
+
+## Log Locations
+- **Integration Tests**: System temp directory (`/tmp/fsc-integration-<random>/...`)
+- **Containers**: `docker logs <container_name>`
+- **Persisted Logs**: Temporarily modify test to use `NewLocalTestSuite` (outputs to `./testdata`)
+- **CI**: For a failing PR, fetch the failed jobs' logs from the most recent failed CI run
+  with `ci/scripts/get-pr-failed-logs.sh <PR_NUMBER> [REPO]` (requires `gh` authenticated).
+  It saves one cleaned, timestamp-stripped log file per failed job under
+  `pr_<PR_NUMBER>_failed_logs/`.
+
+## Debugging Techniques
+- **Manual Inspection**: Use `time.Sleep()` or pause loops in tests to inspect Docker state
+- **Network Preservation**: Check for `no-cleanup` option or manually comment test suite cleanup
+- **Focused Tests**: Modify `It(...)` to `FIt(...)` to focus, or `XIt(...)` to skip (never commit these changes)


### PR DESCRIPTION
## Summary
- Trims `AGENTS.md` by removing sections that were either redundant with linked runbooks/docs or had drifted out of date (Project Structure, CI Workflow Overview, Key Technologies, and the duplicated "Key Files & Directories" / "Best Practices for CI Success" blocks at the end of the file).
- Extracts the "Debugging & Advanced Testing" content into a standalone, agent-agnostic runbook at `docs/development/debug-integration-tests.md`, following the same pattern already used for `update-fsc.md`.
- Adds a symlink at `.claude/skills/debug-integration-tests/SKILL.md` so Claude Code exposes it as `/debug-integration-tests`, and links the new doc from both `AGENTS.md` and `docs/development/ai_agents.md`.

## Test plan
- [x] Verified no other docs reference the removed AGENTS.md sections (`grep` for "Project Structure", "CI Workflow Overview", "Key Technologies", "Key Files & Directories").
- [x] Verified the script referenced in the new runbook (`ci/scripts/get-pr-failed-logs.sh`) exists and is executable.
- [x] Confirmed the symlink resolves correctly to `docs/development/debug-integration-tests.md`.