### PR TITLE
Benchmark Github Actions

### DIFF
--- a/.github/workflows/token-validation-benchmark.yml
+++ b/.github/workflows/token-validation-benchmark.yml
@@ -1,0 +1,216 @@
+name: Token Validation Benchmark
+
+# Runs the token-validation benchmarks on both the PR branch and its base
+# branch, then posts a comment on the PR with the percentage differences.
+#
+# Run locally with act (https://github.com/nektos/act):
+#   1. Create an event payload describing the PR to benchmark. base.sha/head.sha
+#      must be commits that exist locally; number is only used for the comment.
+#        cat > /tmp/pr-event.json <<'JSON'
+#        {
+#          "pull_request": {
+#            "number": 1,
+#            "base": { "sha": "<base-commit-sha>" },
+#            "head": { "sha": "<pr-commit-sha>" }
+#          }
+#        }
+#        JSON
+#   2. Run one variant at a time so the two gRPC jobs never share port 8099
+#      (act puts all matrix jobs on the host network; real CI isolates them):
+#        act pull_request \
+#          -W .github/workflows/token-validation-benchmark.yml \
+#          -e /tmp/pr-event.json \
+#          --matrix variant:ipa \
+#          --artifact-server-path /tmp/act-artifacts
+#   3. The final `gh pr comment` step needs a real token/PR; expect it to fail
+#      locally. Inspect the generated report in the compare job's logs instead,
+#      or add `--matrix ...` and run only the `benchmark` job with `-j benchmark`.
+#   If a run is interrupted, clear leftover containers before retrying:
+#        docker rm -f $(docker ps -aq --filter ancestor=catthehacker/ubuntu:act-latest)
+on:
+  pull_request:
+  workflow_dispatch:
+  
+# Needed so the compare job can post a comment on the PR.
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  # -mod=mod lets `go test` update go.mod/go.sum in the ephemeral CI checkout.
+  GOFLAGS: -mod=mod
+  MODULE_DIR: cmd/token_validation_service
+  GO_MOD_FILE: cmd/token_validation_service/go.mod
+  OUTPUT_DIR: bench
+  # go test knobs. Kept modest so the PR feedback loop stays reasonable; raise
+  # COUNT for more statistically stable comparisons.
+  BENCHTIME: 10s
+  COUNT: 5
+  # -cpu is set at run time to the number of CPUs the runner actually has
+  # (nproc), rather than a fixed 16/32 that may exceed the runner and skew
+  # results. NUM_CONN is the gRPC client connection sweep, unrelated to -cpu.
+  NUM_CONN: 4
+  # -testRoot values selecting the crypto variant. Each variant now names its
+  # testdata explicitly rather than relying on a compiled-in default.
+  CSP_TEST_ROOT: -testRoot=../../token/core/zkatdlog/nogh/v1/regression/testdata/zero/csp/32-BLS12_381_BBS_GURVY
+  IPA_TEST_ROOT: -testRoot=../../token/core/zkatdlog/nogh/v1/regression/testdata/zero/32-BLS12_381_BBS_GURVY
+  # GOGC for the benchmark runs. A high value suppresses GC during the short
+  # benchtime windows so measurements aren't perturbed by collection pauses.
+  GOGC: 10000
+  # Percentage change treated as noise by the compare step. Deltas smaller than
+  # this (or whose base/PR sample ranges overlap) are reported as neutral (➖).
+  DELTA: 1
+
+jobs:
+  # Job 1: benchmark BOTH branches on the SAME runner, interleaved.
+  #
+  # The matrix is the cross product of:
+  #   * variant  - the crypto backend (ipa is the default, csp adds -testRoot)
+  #   * bench     - which benchmark to run and the flags unique to it
+  #
+  # giving (2 variants x 2 benchmarks) = 4 runs. Crucially, `ref` (pr vs base)
+  # is NOT a matrix dimension: each job checks out both the PR head and the base
+  # commit and benchmarks them on the one runner, sample-by-sample interleaved.
+  # This is deliberate — GitHub-hosted runners sit on heterogeneous host CPUs
+  # with noisy neighbors, so benchmarking pr and base on two different VMs made
+  # the reported delta a measure of hardware variance (±10-25%) rather than of
+  # the diff. Same-runner + interleaving cancels both host-to-host variance and
+  # within-runner drift, so the ratio reflects the code change.
+  #
+  # Because the two runs on a runner are sequential (not parallel), the fixed
+  # gRPC server port never collides.
+  benchmark:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [ipa, csp]
+        bench:
+          # Per-benchmark flags are assembled in the run step (below) because
+          # the ${{ env }} context is not available inside a matrix.
+          - id: local
+            name: BenchmarkLocalTokenValidation
+            file_prefix: local-token-validation
+          - id: grpc
+            name: BenchmarkAPIGRPC
+            file_prefix: api-grpc
+    env:
+      # The _pr_ / _base_ tag in the filename is how the compare job groups
+      # results back into the two branches.
+      BASE_FILE: ${{ matrix.bench.file_prefix }}-${{ matrix.variant }}_base_.txt
+      PR_FILE: ${{ matrix.bench.file_prefix }}-${{ matrix.variant }}_pr_.txt
+    steps:
+      - name: Checkout base (${{ github.event.pull_request.base.sha }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Checkout pr (${{ github.event.pull_request.head.sha }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: pr/${{ env.GO_MOD_FILE }}
+          cache-dependency-path: "**/*.sum"
+
+      - name: Run ${{ matrix.bench.name }} (${{ matrix.variant }}, base vs pr interleaved)
+        run: |
+          set -o pipefail
+          mkdir -p "$GITHUB_WORKSPACE/$OUTPUT_DIR"
+
+          # Use exactly the CPUs the runner has, so -cpu never exceeds the
+          # available parallelism (which would oversubscribe and add noise).
+          cpu=$(nproc)
+
+          # Flags unique to each benchmark:
+          #   local - in-process validation, no server, -cpu = runner CPUs.
+          #   grpc  - full gRPC API path, -cpu = runner CPUs, sweep client conns.
+          case "${{ matrix.bench.id }}" in
+            local) bench_flags="-run ^$ -cpu=$cpu" ;;
+            grpc)  bench_flags="-cpu=$cpu -numConn=$NUM_CONN" ;;
+          esac
+
+          # Each variant selects its crypto testdata explicitly.
+          case "${{ matrix.variant }}" in
+            ipa) test_root="$IPA_TEST_ROOT" ;;
+            csp) test_root="$CSP_TEST_ROOT" ;;
+          esac
+
+          base_out="$GITHUB_WORKSPACE/$OUTPUT_DIR/$BASE_FILE"
+          pr_out="$GITHUB_WORKSPACE/$OUTPUT_DIR/$PR_FILE"
+          : > "$base_out"
+          : > "$pr_out"
+
+          # Run one sample of base, then one of pr, and repeat COUNT times.
+          # Interleaving (base,pr,base,pr,...) cancels slow drift on the runner
+          # in addition to the host-to-host variance the same-runner design
+          # already removes. Each file ends up with COUNT benchmark lines, which
+          # is shape-identical to `go test -count=COUNT` for the parser.
+          run_one() {
+            # $1 = checkout dir, $2 = output file to append to
+            ( cd "$1/$MODULE_DIR" && go test \
+                -bench=${{ matrix.bench.name }} \
+                -benchtime="$BENCHTIME" \
+                -count=1 \
+                $bench_flags \
+                $test_root \
+            ) | tee -a "$2"
+          }
+
+          for i in $(seq 1 "$COUNT"); do
+            echo "=== sample $i/$COUNT: base ==="
+            run_one base "$base_out"
+            echo "=== sample $i/$COUNT: pr ==="
+            run_one pr "$pr_out"
+          done
+
+      - name: Upload raw benchmark output
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-raw-${{ matrix.bench.id }}-${{ matrix.variant }}
+          path: |
+            ${{ env.OUTPUT_DIR }}/${{ env.BASE_FILE }}
+            ${{ env.OUTPUT_DIR }}/${{ env.PR_FILE }}
+          if-no-files-found: error
+
+  # Job 2: pair PR-vs-base results and post the percentage differences.
+  compare:
+    needs: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download raw benchmark outputs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: benchmark-raw-*
+          path: ${{ env.OUTPUT_DIR }}
+          merge-multiple: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install parser dependencies
+        run: pip install pandas
+
+      - name: Build comparison report
+        run: |
+          python cmd/benchmarking/compare_benchmarks.py \
+            --input-dir "$OUTPUT_DIR" \
+            --base-tag '_base_' \
+            --pr-tag '_pr_' \
+            --delta "$DELTA" \
+            --output comment.md
+
+      - name: Post comparison comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "${{ github.event.pull_request.number }}" --body-file comment.md

--- a/cmd/benchmarking/bench_parse.py
+++ b/cmd/benchmarking/bench_parse.py
@@ -1,0 +1,91 @@
+"""Lightweight parser for `go test -bench` text output.
+
+This module holds only the pure-parsing logic so it can be imported without
+pulling in plotting/UI dependencies (plotly, streamlit). Both the plotting
+tool (``plotly_plot_node.py``) and the PR comparison tool
+(``compare_benchmarks.py``) import :func:`simple_parser` from here, keeping a
+single source of truth for how a benchmark line is turned into a row.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def _is_number(s: str) -> bool:
+    """Return True if ``s`` parses as a float."""
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _split_workers(name: str) -> tuple[str, int]:
+    """Split a trailing ``-N`` worker count off a name, defaulting to 1."""
+    base, sep, tail = name.rpartition("-")
+    if sep and tail.isdigit():
+        return base, int(tail)
+    return name, 1
+
+
+def simple_parser(path: Path) -> pd.DataFrame:
+    """Parse a ``go test -bench`` output file into a tidy DataFrame.
+
+    Each ``Benchmark...`` line becomes one row: the benchmark name, its
+    ``key=value`` sub-parameters, the trailing ``-N`` worker count, the
+    iteration count, and every ``<value> <metric-name>`` metric pair
+    (e.g. ``ns/op``, ``TPS``). A ``tps`` column and a Little's-Law
+    ``avg (ms)`` column are derived when the inputs are present.
+    """
+    rows = []
+    for ln in path.read_text().splitlines():
+        if not ln.startswith("Benchmark"):
+            continue
+        first, *cols = ln.split()
+        if not cols:
+            continue
+
+        bench_name, *params = first.split("/")
+        if params:
+            last_param, workers = _split_workers(params[-1])
+            row: dict[str, Any] = {"bench": bench_name, "workers": workers}
+            for p in [*params[:-1], last_param]:
+                if "=" in p:
+                    k, v = p.split("=", 1)
+                    row[k] = v
+        else:
+            bench_name, workers = _split_workers(bench_name)
+            row = {"bench": bench_name, "workers": workers}
+
+        row["iterations"] = int(cols.pop(0))
+
+        # Each metric is a value followed by its (multi-word) name.
+        i = 0
+        while i < len(cols):
+            j = i + 1
+            while j < len(cols) and not _is_number(cols[j]):
+                j += 1
+            row[" ".join(cols[i + 1:j])] = float(cols[i])
+            i = j
+
+        rows.append(row)
+
+    df = pd.DataFrame(rows)
+    if df.empty:
+        return df
+
+    if "TPS" in df.columns:
+        df = df.rename(columns={"TPS": "tps"})
+    for col in [c for c in df.columns if c.startswith("ns/op") and "(" in c]:
+        label = col.split("(")[1].rstrip(")")
+        df[f"{label} (ms)"] = df[col] / 1e6
+        df = df.drop(columns=[col])
+
+    if 'tps' in df.columns and 'workers' in df.columns:
+        # Little's Law (latency = concurrency / throughput)
+        # concurrency = workers, tps is in seconds (so X 1000 to get ms)
+        df['avg (ms)'] = df['workers'] * 1000 / df['tps']
+
+    return df

--- a/cmd/benchmarking/compare_benchmarks.py
+++ b/cmd/benchmarking/compare_benchmarks.py
@@ -1,0 +1,240 @@
+"""Compare two sets of benchmark outputs and emit a Markdown report.
+
+Given a directory of ``go test -bench`` output files split into a *base* group
+(the target branch, e.g. ``main``) and a *PR* group, this pairs each benchmark
+row across the two groups and reports the percentage change in latency
+(``ns/op``) and throughput (``TPS``). The result is written as a Markdown table
+suitable for posting as a pull-request comment.
+
+Files are assigned to a group by a substring match on their name:
+``--base-tag`` marks base-branch files, ``--pr-tag`` marks PR-branch files.
+
+Example
+-------
+    python compare_benchmarks.py \
+        --input-dir bench \
+        --base-tag _base_ --pr-tag _pr_ \
+        --output comment.md
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from bench_parse import simple_parser
+
+# Measurement/derived columns produced by the parser. These vary run-to-run
+# and must never be part of a row's identity key — only the benchmark's input
+# parameters (the ``key=value`` sub-tests) identify a row.
+_MEASUREMENT_COLS = {"iterations", "ns/op", "tps", "avg (ms)"}
+# Only throughput (TPS) is reported. ns/op is still parsed (and excluded from
+# row identity via _MEASUREMENT_COLS) but intentionally not shown in the table.
+_METRIC_COLS = ("tps",)
+
+# How each metric trends: for throughput (TPS) higher is better. Used only to
+# pick the emoji, never the number.
+_LOWER_IS_BETTER = {"tps": False}
+
+
+# Crypto variants recognised in filenames (e.g. ``...-ipa_base_.txt``). The
+# variant is not present in the benchmark line itself, so it is carried as a
+# column and made part of a row's identity — otherwise ipa and csp rows for the
+# same benchmark would collide.
+_VARIANTS = ("ipa", "csp")
+
+_DEFAULT_DELTA = 1.0
+
+
+def _variant_of(name: str) -> str:
+    """Extract the crypto variant from a benchmark filename, or 'unknown'."""
+    for v in _VARIANTS:
+        if f"-{v}_" in name:
+            return v
+    return "unknown"
+
+
+def _row_key(row: pd.Series, param_cols: list[str]) -> tuple:
+    """Build a hashable identity for a benchmark row from its parameters.
+
+    Missing parameters (``NaN`` after concatenating benchmarks with different
+    parameter sets) are normalised to ``None`` so that two rows describing the
+    same benchmark compare equal — ``NaN != NaN`` would otherwise break pairing.
+    """
+    def norm(v):
+        return None if pd.isna(v) else v
+
+    return (row["variant"], row["bench"], row["workers"],
+            *(norm(row.get(c)) for c in param_cols))
+
+
+def _load_group(input_dir: Path, tag: str) -> pd.DataFrame:
+    """Parse and concatenate every file in ``input_dir`` whose name contains ``tag``.
+
+    Each row is tagged with the crypto ``variant`` parsed from its filename.
+    """
+    frames = []
+    for f in sorted(input_dir.glob("*.txt")):
+        if tag not in f.name:
+            continue
+        df = simple_parser(f)
+        if df.empty:
+            continue
+        df["variant"] = _variant_of(f.name)
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def _pct(base: float, new: float) -> float:
+    """Percentage change from ``base`` to ``new`` (0 when base is 0)."""
+    if base == 0:
+        return 0.0
+    return (new - base) / base * 100.0
+
+
+def _ranges_overlap(base_samples: list, pr_samples: list) -> bool:
+    """True if the base and PR sample ranges overlap (change not distinguishable).
+
+    Even measured on the same runner, benchmarks jitter sample-to-sample. If the
+    two branches' observed [min, max] ranges overlap, the delta cannot be told
+    apart from that jitter, so it should not be reported as a real change. With
+    fewer than two usable samples on either side there is no range to compare, so
+    we conservatively treat it as overlapping (not significant).
+    """
+    if len(base_samples) < 2 or len(pr_samples) < 2:
+        return True
+    return min(base_samples) <= max(pr_samples) and min(pr_samples) <= max(base_samples)
+
+
+def _emoji(metric: str, pct: float, base_samples: list, pr_samples: list, delta: float = _DEFAULT_DELTA) -> str:
+    """Pick an indicator for a change, given whether lower is better.
+
+    Returns the neutral marker when the change is within the ±1% noise band or
+    when the base/PR sample ranges overlap (i.e. the delta is not statistically
+    distinguishable from run-to-run jitter).
+    """
+    if abs(pct) < delta:  # treat sub-1% as noise
+        return "➖"
+    if _ranges_overlap(base_samples, pr_samples):
+        return "➖"
+    improved = (pct < 0) == _LOWER_IS_BETTER[metric]
+    return "🟢" if improved else "🔴"
+
+
+def build_report(base: pd.DataFrame, pr: pd.DataFrame, delta: float = _DEFAULT_DELTA) -> str:
+    """Render the Markdown comparison table for two parsed benchmark groups."""
+    if base.empty or pr.empty:
+        missing = "base" if base.empty else "PR"
+        return f"⚠️ No benchmark results found for the **{missing}** branch."
+
+    # Parameter columns identify a row: everything except variant/bench/workers,
+    # the measurements, and any derived latency column (``... (ms)``).
+    non_param = {"variant", "bench", "workers", *_MEASUREMENT_COLS}
+    param_cols = sorted(
+        c for c in set(base.columns) | set(pr.columns)
+        if c not in non_param and not c.endswith("(ms)")
+    )
+
+    # With ``go test -count=N`` each benchmark line appears N times. Average the
+    # metrics per identity key so the comparison reflects the mean, not whichever
+    # repeat happened to be parsed last.
+    def by_key(df: pd.DataFrame) -> dict:
+        acc: dict = {}
+        for _, r in df.iterrows():
+            acc.setdefault(_row_key(r, param_cols), []).append(r)
+        out = {}
+        for key, rows in acc.items():
+            agg = rows[0].copy()
+            for metric in _METRIC_COLS:
+                vals = [r.get(metric)
+                        for r in rows if not pd.isna(r.get(metric))]
+                agg[metric] = sum(vals) / len(vals) if vals else float("nan")
+                # Retain the raw per-count samples so the significance guard in
+                # ``_emoji`` can compare the base/PR ranges, not just the means.
+                # A plain string key avoids pandas treating a tuple as a
+                # multi-index label on the Series.
+                agg[f"_samples_{metric}"] = vals
+            out[key] = agg
+        return out
+
+    base_by_key = by_key(base)
+    pr_by_key = by_key(pr)
+
+    lines = [
+        "## 📊 Token Validation Benchmark",
+        "",
+        (
+            "Comparison of this PR against the base branch. "
+            f"🟢 improvement · 🔴 regression · ➖ within ±{delta}% noise."
+        ),
+        "",
+        "| Variant | Benchmark | Params | Workers | TPS (base → PR) | Δ TPS |",
+        "|---|---|---|---|---|---|",
+    ]
+
+    for key in sorted(pr_by_key.keys() & base_by_key.keys(), key=lambda k: tuple(map(str, k))):
+        b, p = base_by_key[key], pr_by_key[key]
+        variant, bench, workers, *param_vals = key
+        params = ", ".join(
+            f"{c}={v}" for c, v in zip(param_cols, param_vals) if v is not None
+        ) or "—"
+
+        cells = [variant, bench, params, str(workers)]
+        for metric in _METRIC_COLS:
+            bv, pv = b.get(metric), p.get(metric)
+            if pd.isna(bv) or pd.isna(pv):
+                cells += ["n/a", "n/a"]
+                continue
+            pct = _pct(bv, pv)
+            base_samples = b.get(f"_samples_{metric}", [])
+            pr_samples = p.get(f"_samples_{metric}", [])
+            cells.append(f"{bv:,.0f} → {pv:,.0f}")
+            cells.append(
+                f"{_emoji(metric, pct, base_samples, pr_samples)} {pct:+.1f}%")
+        lines.append("| " + " | ".join(cells) + " |")
+
+    only_pr = pr_by_key.keys() - base_by_key.keys()
+    only_base = base_by_key.keys() - pr_by_key.keys()
+    if only_pr:
+        lines += ["",
+                  f"> ℹ️ {len(only_pr)} benchmark(s) present only on the PR branch (new)."]
+    if only_base:
+        lines += ["",
+                  f"> ℹ️ {len(only_base)} benchmark(s) present only on the base branch (removed/renamed)."]
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", type=Path, required=True,
+                        help="Directory containing base and PR .txt outputs")
+    parser.add_argument("--base-tag", default="_base_",
+                        help="Filename substring marking base-branch files")
+    parser.add_argument("--delta", type=float, default=_DEFAULT_DELTA,
+                        help="Percent for comparison that is neglected, default: 1")
+    parser.add_argument("--pr-tag", default="_pr_",
+                        help="Filename substring marking PR-branch files")
+    parser.add_argument("--output", type=Path, default=Path("comment.md"),
+                        help="Where to write the Markdown report")
+    args = parser.parse_args()
+
+    if not args.input_dir.exists():
+        raise FileNotFoundError(args.input_dir)
+    if not (0 <= args.delta <= 100):
+        raise ValueError("Delta must be between 1 and 100")
+
+    base = _load_group(args.input_dir, args.base_tag)
+    pr = _load_group(args.input_dir, args.pr_tag)
+    report = build_report(base, pr, delta=args.delta)
+
+    args.output.write_text(report)
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmd/benchmarking/plotly_plot_node.py
+++ b/cmd/benchmarking/plotly_plot_node.py
@@ -4,82 +4,21 @@ from pathlib import Path
 from typing import Any
 import pandas as pd
 import plotly.express as px
+import plotly.io as pio
 import streamlit as st
+
+# Parsing logic lives in a dependency-free module so it can be reused by the
+# PR benchmark-comparison tool without importing plotly/streamlit.
+from bench_parse import simple_parser
+
 st.set_page_config(
-    layout="wide", page_icon=":chart_with_upwards_trend:", page_title="TPS Degradation", initial_sidebar_state="collapsed")
+    layout="wide", page_icon=":chart_with_upwards_trend:",
+    page_title="TPS Degradation", initial_sidebar_state="collapsed")
 
 IGNORE_COLS = {"bench", "workers", "tps",
                "iterations", "ns/op", "B/op", "allocs/op"}
 DEFAULT_BENCH_DIR = "bench"
-
-
-def _is_number(s: str) -> bool:
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
-
-
-def simple_parser(path: Path) -> pd.DataFrame:
-    rows = []
-    for ln in path.read_text().splitlines():
-        if not ln.startswith("Benchmark"):
-            continue
-        first, *cols = ln.split()
-        if not cols:
-            continue
-
-        bench_name, *params = first.split("/")
-        if params:
-            parts = params[-1].rsplit("-", 1)
-            if len(parts) == 2 and parts[1].isdigit():
-                last_param, workers = parts[0], int(parts[1])
-            else:
-                last_param, workers = params[-1], 1
-            row: dict[str, Any] = {"bench": bench_name, "workers": workers}
-            for p in [*params[:-1], last_param]:
-                if "=" in p:
-                    k, v = p.split("=", 1)
-                    row[k] = v
-        else:
-            parts = bench_name.rsplit("-", 1)
-            if len(parts) == 2 and parts[1].isdigit():
-                bench_name, workers = parts[0], int(parts[1])
-            else:
-                workers = 1
-            row = {"bench": bench_name, "workers": workers}
-
-        row["iterations"] = int(cols.pop(0))
-
-        i = 0
-        while i < len(cols):
-            pval = cols[i]
-            j = i + 1
-            while j < len(cols) and not _is_number(cols[j]):
-                j += 1
-            pname = " ".join(cols[i + 1:j])
-            row[pname] = float(pval)
-            i = j
-
-        rows.append(row)
-
-    df = pd.DataFrame(rows)
-    if df.empty:
-        return df
-
-    if "TPS" in df.columns:
-        df = df.rename(columns={"TPS": "tps"})
-    for col in [c for c in df.columns if c.startswith("ns/op") and "(" in c]:
-        label = col.split("(")[1].rstrip(")")
-        df[f"{label} (ms)"] = df[col] / 1e6
-        df = df.drop(columns=[col])
-
-    if 'tps' in df.columns and 'workers' in df.columns:
-        # Little's Law (latency = concurrency / throughput)
-        df['avg (ms)'] = df['workers'] * 1000 / df['tps']
-
-    return df
+SHAPES = ['circle', 'square', 'diamond', 'cross', 'hexagon', 'star']
 
 
 # --- STRUCTURED PARALLEL LOG PARSER ---
@@ -90,22 +29,9 @@ PARALLEL_THROUGHPUT_RE = re.compile(r'Pure Throughput\s+([\d.]+)/s')
 PARALLEL_LATENCY_RE = re.compile(
     r'(Min|P50 \(Median\)|Average|P95|P99\.9|P99|P5|Max)\s+'
     r'([\d.]+(?:ms|[n\xb5\xc2]+s|s))')
+WORKERS_RE = re.compile(r'^Workers\s+(\d+)')
 
-
-def _parse_ms(s: str) -> float:
-    m = re.match(r'([\d.]+)(.*)', s)
-    val, unit = float(m.group(1)), m.group(2)  # type: ignore
-    if unit == 'ms':
-        return val
-    if unit == 'ns':
-        return val / 1e6
-    if unit == 's':
-        return val * 1e3
-    if '\xb5' in unit or 'µ' in unit:
-        return val / 1e3
-    raise ValueError(f"unknown unit: {unit}")
-
-
+# Latency keys we keep, mapped from log label -> column name.
 LATENCY_KEYS = {
     'P50 (Median)': 'p50 (ms)',
     'P5': 'p5 (ms)',
@@ -113,58 +39,55 @@ LATENCY_KEYS = {
     'P99': 'p99 (ms)',
 }
 DISPLAY_LATENCY = {'avg (ms)', 'p50 (ms)', 'p95 (ms)'}
-WORKERS_RE = re.compile(r'^Workers\s+(\d+)')
+
+# Multipliers to convert a latency unit into milliseconds.
+_MS_PER_UNIT = {'ms': 1, 'ns': 1e-6, 's': 1e3}
+
+
+def _parse_ms(s: str) -> float:
+    m = re.match(r'([\d.]+)(.*)', s)
+    val, unit = float(m.group(1)), m.group(2)  # type: ignore
+    if '\xb5' in unit or 'µ' in unit:
+        return val / 1e3
+    if unit in _MS_PER_UNIT:
+        return val * _MS_PER_UNIT[unit]
+    raise ValueError(f"unknown unit: {unit}")
+
+
+def _parse_setup(params_raw: str) -> dict:
+    """Extract ``k=v`` pairs from a ``Setup(#key_val,_...)`` fragment."""
+    setup = {}
+    m = re.search(r'Setup\((.+?)\)', params_raw)
+    for token in (m.group(1).split(',_') if m else []):
+        token = token.strip('_').lstrip('#')
+        if '_' in token:
+            k, v = token.split('_', 1)
+            setup[k] = v
+    return setup
 
 
 def parse_parallel_log(path: Path, default_bench: str | None = None) -> pd.DataFrame:
     text = ANSI_ESCAPE_RE.sub('', path.read_text())
+    has_run_lines = bool(PARALLEL_RUN_RE.search(text))
     rows: list[dict] = []
     current: dict = {}
-    has_run_lines = bool(PARALLEL_RUN_RE.search(text))
 
-    for line in text.splitlines():
-        line = line.strip()
-
-        m = PARALLEL_RUN_RE.match(line)
-        if m:
+    for line in (ln.strip() for ln in text.splitlines()):
+        if m := PARALLEL_RUN_RE.match(line):
             if current:
                 rows.append(current)
-            bench, params_raw, workers = m.group(
-                1), m.group(2), int(m.group(3))
-            current = {'bench': bench, 'workers': workers}
-            setup_m = re.search(r'Setup\((.+?)\)', params_raw)
-            if setup_m:
-                for token in setup_m.group(1).split(',_'):
-                    token = token.strip('_').lstrip('#')
-                    if '_' in token:
-                        k, v = token.split('_', 1)
-                        current[k] = v
-            continue
-
-        if not has_run_lines:
-            m = WORKERS_RE.match(line)
-            if m:
-                workers = int(m.group(1))
-                if current:
-                    rows.append(current)
-                current = {
-                    'bench': default_bench or path.stem,
-                    'workers': workers,
-                }
-                continue
-
-        m = PARALLEL_THROUGHPUT_RE.match(line)
-        if m:
+            current = {'bench': m.group(1), 'workers': int(m.group(3)),
+                       **_parse_setup(m.group(2))}
+        elif not has_run_lines and (m := WORKERS_RE.match(line)):
+            if current:
+                rows.append(current)
+            current = {'bench': default_bench or path.stem,
+                       'workers': int(m.group(1))}
+        elif m := PARALLEL_THROUGHPUT_RE.match(line):
             current['tps'] = float(m.group(1))
-            continue
-
-        m = PARALLEL_LATENCY_RE.match(line)
-        if m and m.group(1) in LATENCY_KEYS:
+        elif (m := PARALLEL_LATENCY_RE.match(line)) and m.group(1) in LATENCY_KEYS:
             current[LATENCY_KEYS[m.group(1)]] = _parse_ms(m.group(2))
-            continue
-
-        m = re.match(r'Total Ops\s+(\d+)', line)
-        if m:
+        elif m := re.match(r'Total Ops\s+(\d+)', line):
             current['iterations'] = int(m.group(1))
 
     if current:
@@ -179,18 +102,17 @@ def has_multi_nc(df: pd.DataFrame) -> bool:
 # --- PLOTTING ---
 
 
-def _tps_fig(df, color_col, title):
-    fig = px.line(df, x='workers', y='tps', color=color_col,
-                  symbol=color_col,
-                  markers=True, title=title,
-                  labels={'workers': 'Workers', 'tps': 'TPS', color_col: ''},
-                  symbol_sequence=SHAPES)
-    fig.update_yaxes(
-        nticks=25,
-    )
-    fig.update_layout(template='plotly_white',
-                      hovermode='x unified')
+def _style(fig):
+    fig.update_layout(template='plotly_white', hovermode='x unified')
     return fig
+
+
+def _tps_fig(df, color_col, title):
+    fig = px.line(df, x='workers', y='tps', color=color_col, symbol=color_col,
+                  markers=True, title=title, symbol_sequence=SHAPES,
+                  labels={'workers': 'Workers', 'tps': 'TPS', color_col: ''})
+    fig.update_yaxes(nticks=25)
+    return _style(fig)
 
 
 def _latency_fig(df, color_col, dash_col, title):
@@ -200,31 +122,28 @@ def _latency_fig(df, color_col, dash_col, title):
     melted = df.melt(id_vars=[color_col, 'workers'], value_vars=latency_cols,
                      var_name='percentile', value_name='latency')
     dash_map = {'avg (ms)': 'dash', 'p50 (ms)': 'solid', 'p95 (ms)': 'dot'}
-    fig = px.line(melted, x='workers', y='latency',
-                  color=color_col, line_dash=dash_col, markers=True, title=title,
-                  labels={'workers': 'Workers',
-                          'latency': 'Latency (ms)', color_col: ''},
-                  line_dash_map=dash_map)
-    fig.update_layout(template='plotly_white', hovermode='x unified')
-    return fig
+    return _style(px.line(
+        melted, x='workers', y='latency', color=color_col, line_dash=dash_col,
+        markers=True, title=title, line_dash_map=dash_map,
+        labels={'workers': 'Workers', 'latency': 'Latency (ms)', color_col: ''}))
 
 
 def _aggregate(df, group_cols):
-    numeric = [c for c in df.select_dtypes(
-        include='number').columns if c != 'workers']
-    return (df.groupby(group_cols)[numeric].mean().reset_index().sort_values('workers'))
+    numeric = [c for c in df.select_dtypes(include='number').columns
+               if c != 'workers']
+    return df.groupby(group_cols)[numeric].mean().reset_index().sort_values('workers')
 
 
 def make_figures(df):
-    param_cols = [
-        c for c in df.columns if c not in IGNORE_COLS and not c.endswith("(ms)")]
+    param_cols = [c for c in df.columns
+                  if c not in IGNORE_COLS and not c.endswith("(ms)")]
     figs = []
 
     for bench, bdf in df.groupby('bench'):
         bdf = bdf.copy()
         varying = [c for c in param_cols if c in bdf and bdf[c].nunique() > 1]
-        fixed = [c for c in param_cols if c in bdf and bdf[c].nunique()
-                 <= 1 and bdf[c].notna().any()]
+        fixed = [c for c in param_cols
+                 if c in bdf and bdf[c].nunique() <= 1 and bdf[c].notna().any()]
 
         bdf['series'] = (
             bdf[varying].astype(str).apply(
@@ -256,36 +175,36 @@ def parse_combined(dfs: dict[str, pd.DataFrame]):
     return dct
 
 
-SHAPES = ['circle', 'square', 'diamond', 'cross', 'hexagon', 'star']
+def _with_bench(dfs: dict[str, pd.DataFrame]) -> list[pd.DataFrame]:
+    """Copy each frame and set its ``bench`` column to the dict key."""
+    parts = []
+    for name, df in dfs.items():
+        df = df.copy()
+        df["bench"] = name
+        parts.append(df)
+    return parts
 
 
 def make_combined_figures(dfs, local_dfs):
-    figs = {"_All": None}
-    all_dfs = []
-    for name, d in local_dfs.items():
-        d = d.copy()
-        d["bench"] = name
-        all_dfs.append(_aggregate(d, ["bench", "workers"]))
+    figs: dict = {"_All": None}
+    all_dfs = [_aggregate(d, ["bench", "workers"])
+               for d in _with_bench(local_dfs)]
+    local_parts = _with_bench(local_dfs)
 
-    for nc, df in sorted(dfs.items(), key=lambda x: x[0]):
+    for nc, df in sorted(dfs.items()):
         agg = _aggregate(df, ["bench", "workers"])
         d = agg.copy()
         d["bench"] = d["bench"] + f" (nc={nc})"
         all_dfs.append(d)
-        local_parts = []
-        for name, ldf in local_dfs.items():
-            ldf = ldf.copy()
-            ldf['bench'] = name
-            local_parts.append(ldf)
+
         agg = _aggregate(
             pd.concat([agg, *local_parts], ignore_index=True),
-            ["bench", "workers"]
-        )
-
+            ["bench", "workers"])
         figs[nc] = _tps_fig(agg, 'bench', f'TPS (nc={nc})')
         lat = _latency_fig(agg, 'bench', 'percentile', f'Latency (nc={nc})')
         if lat:
             figs[f"{nc}_latency"] = lat
+
     figs["_All"] = _tps_fig(
         pd.concat(all_dfs, ignore_index=True), 'bench', 'TPS (All)')
     return figs
@@ -296,11 +215,12 @@ def _get_dir():
 
     with st.sidebar:
         directory = st.text_input(
-            "Directory", value=str(def_dir) if def_dir.exists() else "", key="benchdir")
+            "Directory", value=str(def_dir) if def_dir.exists() else "",
+            key="benchdir")
         os.environ["DEF_BENCH"] = directory
 
     if not directory:
-        st.info(f"Please input a Folder in the Sidebar")
+        st.info("Please input a Folder in the Sidebar")
         return None
     directory = Path(directory)
     if not directory.exists():
@@ -309,48 +229,65 @@ def _get_dir():
     return directory
 
 
+def _show(name: str, df: pd.DataFrame):
+    with st.expander(f"`{name}`"):
+        for fig in make_figures(df):
+            st.plotly_chart(fig, key=f"{name}-{fig.layout.title.text}")
+        st.dataframe(df)
+
+
+def _load(directory: Path, pattern: str, parse) -> dict[str, pd.DataFrame]:
+    out = {}
+    for path in sorted(directory.glob(pattern)):
+        df = parse(path)
+        if not df.empty:
+            _show(path.stem, df)
+            out[path.stem] = df
+    return out
+
+
 def main():
     directory = _get_dir()
     if not directory:
         return
-    single = {}
 
-    for path in sorted(directory.glob("*.log")):
-        df = parse_parallel_log(path)
-        if df.empty:
-            continue
-        with st.expander(f"`{path.stem}`"):
-            for fig in make_figures(df):
-                st.plotly_chart(fig)
-            st.dataframe(df)
-        single[path.stem] = df
-
-    all_dfs = {}
-    for path in sorted(directory.glob("*.txt")):
-        df = simple_parser(path)
-        if df.empty:
-            continue
-        all_dfs[path.stem] = df
-        with st.expander(f"`{path.stem}`"):
-            for fig in make_figures(df):
-                st.plotly_chart(fig)
-                st.dataframe(df)
+    single = _load(directory, "*.log", parse_parallel_log)
+    all_dfs = _load(directory, "*.txt", simple_parser)
 
     multi = {n: df.copy() for n, df in all_dfs.items() if has_multi_nc(df)}
-    single.update({n: df.copy()
-                   for n, df in all_dfs.items() if not has_multi_nc(df)})
+    single.update({n: df.copy() for n, df in all_dfs.items()
+                   if not has_multi_nc(df)})
 
-    dfs = parse_combined({
-        n: df for n, df in multi.items()
-    })
-
-    figs = make_combined_figures(dfs, local_dfs=single)
+    figs = make_combined_figures(parse_combined(multi), local_dfs=single)
     st.subheader("Combined TPS")
-    tabs = st.tabs(list(figs.keys()))
-    for fig, tab in zip(figs.values(), tabs):
+    for fig, tab in zip(figs.values(), st.tabs(list(figs.keys()))):
         with tab:
             st.plotly_chart(fig)
 
 
 if __name__ == "__main__":
-    main()
+    from argparse import ArgumentParser
+
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--single", action="store_true", help="Only plot single benchmark")
+    parser.add_argument("--input", type=str, default=None)
+    parser.add_argument("--output", type=str, default="out.html")
+
+    args = parser.parse_args()
+    if not args.single:
+        main()
+    else:
+        assert args.input, "Missing --input argument"
+        df = simple_parser(Path(args.input))
+        figs = make_figures(df=df)
+        print("Writing to", args.output)
+        if args.output.endswith((".svg", ".png", ".jpeg")):
+            pio.write_images(figs, args.output)
+        elif args.output.endswith(".html"):
+            for fig in figs:
+                pio.write_html(fig, args.output)
+        elif args.output.endswith(".json"):
+            df.to_json(args.output, indent=2)
+        else:
+            raise ValueError(f"Unsupported output extension: {args.output}")

--- a/docs/drivers/benchmark/token_validation_service_benchmark.md
+++ b/docs/drivers/benchmark/token_validation_service_benchmark.md
@@ -144,7 +144,7 @@ sed 's#127.0.0.1#123.456.789#g' ./out/testdata/fsc/nodes/test-node.0/client-conf
 5. Start client and tee output to file
 
 ```bash
-c-workloads=token-validation-service -cpu=1,2,4,8,16,32,48,64 -numConn=1,2,4,8 2>&1 | tee out.txt &
+GOGC=10000 go run ./client/ -benchtime=30s -count=5 -workloads=token-validation-service -cpu=1,2,4,8,16,32,48,64 -numConn=1,2,4,8 2>&1 | tee out.txt &
 ```
 
 This setup is ideal for:
@@ -159,7 +159,7 @@ This setup is ideal for:
 ```bash
 python -m venv .venv 
 source .venv/bin/activate
-pip install streamlit pandas
+pip install streamlit pandas plotly
 ```
 
 1. Place the results in `.txt` files in a folder called `bench`.


### PR DESCRIPTION
## Add a Token Validation benchmark GitHub Action for PR-vs-base comparison

Adds a CI workflow that automatically benchmarks the token validation service on every pull request and posts a comment showing how the PR's performance compares to its base branch. Also refactors the benchmark tooling to share a single parser between the plotting and comparison scripts.

What's included

New workflow — .github/workflows/token-validation-benchmark.yml
- Triggers on pull_request.
- benchmark job: runs a matrix of 2 refs (pr, base) × 2 crypto variants (ipa, csp) × 2 benchmarks (local, gRPC) = 8 isolated runs, each on its own runner so the fixed gRPC server port (8099) never collides.
  - local → BenchmarkLocalTokenValidation (in-process, sweeps -cpu).
  - grpc → BenchmarkAPIGRPC (full gRPC API path, sweeps client connections).
  - csp variant selects the CSP crypto testdata via -testRoot; ipa is the default.
  - Raw go test -bench output is uploaded as artifacts, tagged _pr_ / _base_.
- compare job: downloads all raw outputs, pairs each benchmark row across PR and base, and posts a Markdown table of the percentage change in latency (ns/op) and throughput (TPS) as a PR comment (pull-requests: write).

New — cmd/benchmarking/bench_parse.py
- Extracts the pure go test -bench parsing logic (simple_parser) into a standalone module with no plotting/UI dependencies, so it can be imported without pulling in plotly/streamlit. Single source of truth for turning a benchmark line into a row.

New — cmd/benchmarking/compare_benchmarks.py
- Takes a directory of base/PR benchmark outputs, pairs rows by their input identity (ignoring run-to-run measurement columns), and emits a Markdown comparison report suitable for a PR comment.

Refactor — cmd/benchmarking/plotly_plot_node.py
- Now imports simple_parser from bench_parse instead of carrying its own copy.

Docs — docs/drivers/benchmark/token_validation_service_benchmark.md
- Fixes the client run command (adds GOGC=10000 go run ./client/ -benchtime=30s -count=5 …) and adds plotly to the pip install line.

Local testing

The workflow header documents how to run it locally with act, including a sample PR event payload and the need to run one matrix variant at a time (act shares the host network, unlike real CI).

Notes

- Benchmark knobs (BENCHTIME=10s, COUNT=3, CPU=16, NUM_CONN=4) are kept modest to keep PR feedback responsive; raise COUNT for more statistically stable comparisons.
- GOFLAGS: -mod=mod lets go test update go.mod/go.sum in the ephemeral checkout.