### PR TITLE
feat(evm): JSON-RPC client, transaction signing, ABI write codec and config

### DIFF
--- a/x/token/services/network/evm/abi/encode.go
+++ b/x/token/services/network/evm/abi/encode.go
@@ -1,0 +1,196 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package abi
+
+import (
+	"encoding/binary"
+	"math/big"
+)
+
+// The write side of the codec: enough ABI encoding to call applyStateDelta, whose argument is a
+// struct with nested dynamic members (bytes32[], a struct array carrying bytes, bytes[]) plus a
+// second bytes[] argument. That is the only write the driver makes, but it exercises the trickiest
+// part of the ABI: the head/tail layout, where every dynamic value contributes a 32-byte offset in
+// the head and its payload in the tail, recursively.
+//
+// The encoder is expressed as a tiny value model (each value knows whether it is dynamic and how to
+// encode its head and tail) so nesting composes correctly instead of being hand-unrolled per shape.
+
+// Value is an ABI-encodable value.
+type Value interface {
+	// isDynamic reports whether the value is encoded as an offset in the head plus a payload in the
+	// tail (dynamic), or inline in the head (static).
+	isDynamic() bool
+	// encode returns the value's own encoding: the inline word for a static value, the payload for a
+	// dynamic one.
+	encode() []byte
+}
+
+// --- static values -------------------------------------------------------------------------------
+
+type wordValue [32]byte
+
+func (wordValue) isDynamic() bool { return false }
+
+func (v wordValue) encode() []byte {
+	out := make([]byte, wordLength)
+	copy(out, v[:])
+
+	return out
+}
+
+// Bytes32 encodes a bytes32, stored left-aligned as-is.
+func Bytes32(b [32]byte) Value { return wordValue(b) }
+
+// Uint64 encodes a uint64 as a right-aligned 32-byte word (the ABI widens all integers to a word).
+func Uint64(x uint64) Value {
+	var w wordValue
+	binary.BigEndian.PutUint64(w[wordLength-8:], x)
+
+	return w
+}
+
+// Uint256 encodes a non-negative big.Int as a right-aligned 32-byte word.
+func Uint256(x *big.Int) Value {
+	var w wordValue
+	if x != nil {
+		b := x.Bytes()
+		if len(b) > wordLength {
+			b = b[len(b)-wordLength:]
+		}
+		copy(w[wordLength-len(b):], b)
+	}
+
+	return w
+}
+
+// Bool encodes a bool as a 32-byte word (0 or 1).
+func Bool(b bool) Value {
+	var w wordValue
+	if b {
+		w[wordLength-1] = 1
+	}
+
+	return w
+}
+
+// --- dynamic values ------------------------------------------------------------------------------
+
+type bytesValue []byte
+
+func (bytesValue) isDynamic() bool { return true }
+
+// encode lays out a dynamic bytes payload: a length word followed by the data, right-padded to a
+// multiple of 32 bytes.
+func (v bytesValue) encode() []byte {
+	out := make([]byte, 0, wordLength+len(v)+wordLength)
+	out = append(out, lengthWord(len(v))...)
+	out = append(out, v...)
+	if pad := (wordLength - len(v)%wordLength) % wordLength; pad != 0 {
+		out = append(out, make([]byte, pad)...)
+	}
+
+	return out
+}
+
+// Bytes encodes a dynamic byte string.
+func Bytes(b []byte) Value { return bytesValue(b) }
+
+type arrayValue []Value
+
+func (arrayValue) isDynamic() bool { return true }
+
+// encode lays out a dynamic array: a length word followed by the head/tail encoding of its elements.
+func (v arrayValue) encode() []byte {
+	return append(lengthWord(len(v)), encodeValues(v)...)
+}
+
+// Array encodes a dynamic array (T[]) of the given elements.
+func Array(elems ...Value) Value { return arrayValue(elems) }
+
+// Bytes32Array encodes a bytes32[].
+func Bytes32Array(items [][32]byte) Value {
+	elems := make([]Value, len(items))
+	for i := range items {
+		elems[i] = Bytes32(items[i])
+	}
+
+	return arrayValue(elems)
+}
+
+// BytesArray encodes a bytes[].
+func BytesArray(items [][]byte) Value {
+	elems := make([]Value, len(items))
+	for i := range items {
+		elems[i] = Bytes(items[i])
+	}
+
+	return arrayValue(elems)
+}
+
+type tupleValue []Value
+
+// isDynamic reports whether the tuple contains any dynamic member; a tuple is dynamic iff one of its
+// members is, which is what decides whether it is inlined or referenced by offset.
+func (v tupleValue) isDynamic() bool {
+	for _, f := range v {
+		if f.isDynamic() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (v tupleValue) encode() []byte { return encodeValues(v) }
+
+// Tuple encodes a struct with the given fields, in declaration order.
+func Tuple(fields ...Value) Value { return tupleValue(fields) }
+
+// --- layout --------------------------------------------------------------------------------------
+
+// encodeValues lays out a sequence of values in ABI head/tail form: static values inline in the head,
+// dynamic values as an offset word in the head (measured from the start of the sequence) with the
+// payload appended to the tail.
+func encodeValues(values []Value) []byte {
+	headSize := 0
+	for _, v := range values {
+		if v.isDynamic() {
+			headSize += wordLength
+		} else {
+			headSize += len(v.encode())
+		}
+	}
+
+	head := make([]byte, 0, headSize)
+	var tail []byte
+	for _, v := range values {
+		if v.isDynamic() {
+			head = append(head, lengthWord(headSize+len(tail))...)
+			tail = append(tail, v.encode()...)
+
+			continue
+		}
+		head = append(head, v.encode()...)
+	}
+
+	return append(head, tail...)
+}
+
+// EncodeCall returns the calldata for a method: its 4-byte selector followed by the ABI encoding of
+// the arguments. The signature must be the canonical form (see MethodID).
+func EncodeCall(signature string, args ...Value) []byte {
+	return append(MethodID(signature), encodeValues(args)...)
+}
+
+// lengthWord encodes a non-negative length or offset as a 32-byte word.
+func lengthWord(n int) []byte {
+	w := make([]byte, wordLength)
+	binary.BigEndian.PutUint64(w[wordLength-8:], uint64(n)) // #nosec G115 -- n is a non-negative length
+
+	return w
+}

--- a/x/token/services/network/evm/abi/encode_test.go
+++ b/x/token/services/network/evm/abi/encode_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package abi
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+func word(v byte) [32]byte {
+	var a [32]byte
+	a[31] = v
+
+	return a
+}
+
+// goldenDelta is the delta pinned by TestEncodeApplyStateDeltaGoldenVector. It deliberately covers
+// the shapes that make the head/tail layout non-trivial: several dynamic arrays, a struct array whose
+// elements carry dynamic bytes, and an output whose data spans more than one word (so the tail
+// padding matters).
+func goldenDelta() *statedelta.StateDelta {
+	return &statedelta.StateDelta{
+		Anchor:    word(0xA1),
+		SpentRefs: [][32]byte{word(0x11), word(0x22)},
+		Outputs: []statedelta.OutputToken{
+			{TokenID: word(0x31), SNMarker: word(0x32), TokenData: []byte("out-0")},
+			{TokenID: word(0x41), SNMarker: word(0x42), TokenData: []byte("second-output-longer-than-one-word-to-test-padding")},
+		},
+		MetadataKeys:        [][32]byte{word(0x51)},
+		MetadataVals:        [][]byte{[]byte("meta-0")},
+		TokenRequestHash:    word(0x61),
+		PublicParamsHash:    word(0x71),
+		PublicParamsVersion: 3,
+	}
+}
+
+func goldenSignatures() [][]byte {
+	a := make([]byte, 65)
+	a[64] = 27
+	b := make([]byte, 65)
+	b[64] = 28
+
+	return [][]byte{a, b}
+}
+
+// TestApplyStateDeltaSelector pins the selector against the compiled contract ABI. The canonical
+// signature must match what the contract dispatches on, or every call reverts as an unknown method.
+func TestApplyStateDeltaSelector(t *testing.T) {
+	// Verified with `cast sig` against the signature taken from the compiled TokenState ABI.
+	assert.Equal(t, "e7920565", hex.EncodeToString(MethodID(ApplyStateDeltaMethod)))
+}
+
+// TestEncodeApplyStateDeltaGoldenVector is the Phase-B gate: the calldata must match, byte for byte,
+// a vector independently decoded with foundry's `cast decode-calldata`, which round-tripped every
+// field (anchor, both spent refs, both outputs including the multi-word one, metadata, hashes,
+// version, isSetup, and both signatures). That pins the ABI head/tail layout for nested dynamic
+// types, which is the part most easily got wrong.
+func TestEncodeApplyStateDeltaGoldenVector(t *testing.T) {
+	want :=
+		"e792056500000000000000000000000000000000000000000000000000000000" +
+			"0000004000000000000000000000000000000000000000000000000000000000" +
+			"0000048000000000000000000000000000000000000000000000000000000000" +
+			"000000a100000000000000000000000000000000000000000000000000000000" +
+			"0000014000000000000000000000000000000000000000000000000000000000" +
+			"000001a000000000000000000000000000000000000000000000000000000000" +
+			"0000036000000000000000000000000000000000000000000000000000000000" +
+			"000003a000000000000000000000000000000000000000000000000000000000" +
+			"0000006100000000000000000000000000000000000000000000000000000000" +
+			"0000007100000000000000000000000000000000000000000000000000000000" +
+			"0000000300000000000000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000042000000000000000000000000000000000000000000000000000000000" +
+			"0000000200000000000000000000000000000000000000000000000000000000" +
+			"0000001100000000000000000000000000000000000000000000000000000000" +
+			"0000002200000000000000000000000000000000000000000000000000000000" +
+			"0000000200000000000000000000000000000000000000000000000000000000" +
+			"0000004000000000000000000000000000000000000000000000000000000000" +
+			"000000e000000000000000000000000000000000000000000000000000000000" +
+			"0000003100000000000000000000000000000000000000000000000000000000" +
+			"0000003200000000000000000000000000000000000000000000000000000000" +
+			"0000006000000000000000000000000000000000000000000000000000000000" +
+			"000000056f75742d300000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000004100000000000000000000000000000000000000000000000000000000" +
+			"0000004200000000000000000000000000000000000000000000000000000000" +
+			"0000006000000000000000000000000000000000000000000000000000000000" +
+			"000000327365636f6e642d6f75747075742d6c6f6e6765722d7468616e2d6f6e" +
+			"652d776f72642d746f2d746573742d70616464696e6700000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000000100000000000000000000000000000000000000000000000000000000" +
+			"0000005100000000000000000000000000000000000000000000000000000000" +
+			"0000000100000000000000000000000000000000000000000000000000000000" +
+			"0000002000000000000000000000000000000000000000000000000000000000" +
+			"000000066d6574612d3000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000000200000000000000000000000000000000000000000000000000000000" +
+			"0000004000000000000000000000000000000000000000000000000000000000" +
+			"000000c000000000000000000000000000000000000000000000000000000000" +
+			"0000004100000000000000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"000000001b000000000000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"0000004100000000000000000000000000000000000000000000000000000000" +
+			"0000000000000000000000000000000000000000000000000000000000000000" +
+			"000000001c000000000000000000000000000000000000000000000000000000" +
+			"00000000"
+
+	got := EncodeApplyStateDelta(goldenDelta(), goldenSignatures())
+	assert.Equal(t, want, hex.EncodeToString(got))
+}
+
+// TestEncodeApplyStateDeltaSetupShape covers the other delta the driver sends: a public-parameters
+// update, with empty arrays and non-empty setup parameters.
+func TestEncodeApplyStateDeltaSetupShape(t *testing.T) {
+	delta := &statedelta.StateDelta{
+		Anchor:              word(0x77),
+		TokenRequestHash:    word(0x88),
+		PublicParamsHash:    word(0x99),
+		PublicParamsVersion: 4,
+		IsSetup:             true,
+		SetupParameters:     []byte("pp-v4"),
+	}
+	got := EncodeApplyStateDelta(delta, goldenSignatures())
+
+	require.Greater(t, len(got), selectorLength)
+	assert.Equal(t, MethodID(ApplyStateDeltaMethod), got[:selectorLength])
+	// the encoding is word aligned after the selector
+	assert.Zero(t, (len(got)-selectorLength)%wordLength)
+}
+
+// TestEncodeIsDeterministic checks the encoder has no map iteration or other nondeterminism: the
+// same delta must always produce the same calldata, since the endorsers signed those exact bytes.
+func TestEncodeIsDeterministic(t *testing.T) {
+	first := EncodeApplyStateDelta(goldenDelta(), goldenSignatures())
+	for range 5 {
+		assert.Equal(t, first, EncodeApplyStateDelta(goldenDelta(), goldenSignatures()))
+	}
+}
+
+// TestEncodeFieldsAreCovered checks each delta field actually reaches the calldata: changing any one
+// of them changes the encoding.
+func TestEncodeFieldsAreCovered(t *testing.T) {
+	base := hex.EncodeToString(EncodeApplyStateDelta(goldenDelta(), goldenSignatures()))
+
+	mutations := map[string]func(*statedelta.StateDelta){
+		"anchor":       func(d *statedelta.StateDelta) { d.Anchor = word(0xFF) },
+		"spent refs":   func(d *statedelta.StateDelta) { d.SpentRefs = [][32]byte{word(0xFF)} },
+		"outputs":      func(d *statedelta.StateDelta) { d.Outputs = nil },
+		"output data":  func(d *statedelta.StateDelta) { d.Outputs[0].TokenData = []byte("changed") },
+		"metadata key": func(d *statedelta.StateDelta) { d.MetadataKeys = [][32]byte{word(0xFF)} },
+		"metadata val": func(d *statedelta.StateDelta) { d.MetadataVals = [][]byte{[]byte("changed")} },
+		"tr hash":      func(d *statedelta.StateDelta) { d.TokenRequestHash = word(0xFF) },
+		"pp hash":      func(d *statedelta.StateDelta) { d.PublicParamsHash = word(0xFF) },
+		"pp version":   func(d *statedelta.StateDelta) { d.PublicParamsVersion = 99 },
+		"is setup":     func(d *statedelta.StateDelta) { d.IsSetup = true },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			d := goldenDelta()
+			mutate(d)
+			assert.NotEqual(t, base, hex.EncodeToString(EncodeApplyStateDelta(d, goldenSignatures())),
+				"%s must be covered by the encoding", name)
+		})
+	}
+}
+
+// TestEncodeSignaturesAreCovered checks the signature bundle reaches the calldata.
+func TestEncodeSignaturesAreCovered(t *testing.T) {
+	base := EncodeApplyStateDelta(goldenDelta(), goldenSignatures())
+	fewer := EncodeApplyStateDelta(goldenDelta(), goldenSignatures()[:1])
+	assert.NotEqual(t, base, fewer)
+
+	none := EncodeApplyStateDelta(goldenDelta(), nil)
+	assert.NotEqual(t, base, none)
+}
+
+// --- value encoder unit tests --------------------------------------------------------------------
+
+func TestStaticValues(t *testing.T) {
+	assert.Equal(t, "00000000000000000000000000000000000000000000000000000000000000ff",
+		hex.EncodeToString(Uint64(255).encode()))
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000001",
+		hex.EncodeToString(Bool(true).encode()))
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000",
+		hex.EncodeToString(Bool(false).encode()))
+	assert.Equal(t, "00000000000000000000000000000000000000000000000000000000000004d2",
+		hex.EncodeToString(Uint256(big.NewInt(1234)).encode()))
+	assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000",
+		hex.EncodeToString(Uint256(nil).encode()), "a nil big.Int encodes as zero")
+
+	for _, v := range []Value{Uint64(1), Bool(true), Uint256(big.NewInt(1)), Bytes32(word(1))} {
+		assert.False(t, v.isDynamic())
+	}
+}
+
+// TestBytesPadding checks dynamic bytes are length prefixed and right padded to a word boundary.
+func TestBytesPadding(t *testing.T) {
+	cases := map[string]int{
+		"":                                 32,      // just the length word
+		"a":                                32 + 32, // length + one padded word
+		"exactly thirty two bytes of data": 32 + 32, // 32 bytes fills one word exactly, no padding
+		"this payload is definitely longer than thirty two bytes": 32 + 64,
+	}
+	for in, wantLen := range cases {
+		require.Len(t, []byte("exactly thirty two bytes of data"), 32, "fixture must really be 32 bytes")
+		assert.Len(t, Bytes([]byte(in)).encode(), wantLen, "payload %q (%d bytes)", in, len(in))
+	}
+}
+
+// TestTupleDynamicity checks a tuple is dynamic exactly when one of its members is, which decides
+// whether it is inlined or referenced by offset.
+func TestTupleDynamicity(t *testing.T) {
+	assert.False(t, Tuple(Bytes32(word(1)), Uint64(2)).isDynamic(), "all static members")
+	assert.True(t, Tuple(Bytes32(word(1)), Bytes([]byte("x"))).isDynamic(), "one dynamic member")
+	assert.True(t, Array().isDynamic(), "arrays are always dynamic")
+	assert.True(t, Bytes(nil).isDynamic(), "bytes are always dynamic")
+}
+
+// TestEmptyArraysEncodeAsLengthZero checks the empty cases the setup delta relies on.
+func TestEmptyArraysEncodeAsLengthZero(t *testing.T) {
+	zero := "0000000000000000000000000000000000000000000000000000000000000000"
+	assert.Equal(t, zero, hex.EncodeToString(Bytes32Array(nil).encode()))
+	assert.Equal(t, zero, hex.EncodeToString(BytesArray(nil).encode()))
+	assert.Equal(t, zero, hex.EncodeToString(Array().encode()))
+}

--- a/x/token/services/network/evm/abi/statedelta.go
+++ b/x/token/services/network/evm/abi/statedelta.go
@@ -1,0 +1,53 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package abi
+
+import (
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+// ApplyStateDeltaMethod is the canonical ABI signature of the TokenState write the driver makes. It
+// is the flattened form of applyStateDelta(StateDelta calldata, bytes[] calldata): structs become
+// parenthesized tuples, in declaration order. Taken from the compiled contract ABI, so the selector
+// (0xe7920565) matches what the contract dispatches on; the field order matches StateDelta.sol and
+// the EIP-712 type, and must stay in lockstep with both.
+const ApplyStateDeltaMethod = "applyStateDelta(" +
+	"(bytes32,bytes32[],(bytes32,bytes32,bytes)[],bytes32[],bytes[],bytes32,bytes32,uint64,bool,bytes)," +
+	"bytes[])"
+
+// EncodeApplyStateDelta returns the calldata for applyStateDelta(delta, signatures): the endorsed
+// state transition plus the endorser signatures the contract verifies against the delta's EIP-712
+// digest.
+//
+// The field order below mirrors the Solidity struct exactly. It is the same order the EIP-712
+// hashStruct uses, which is what makes the signatures the endorsers produced verify against the
+// delta encoded here.
+func EncodeApplyStateDelta(delta *statedelta.StateDelta, signatures [][]byte) []byte {
+	return EncodeCall(ApplyStateDeltaMethod, StateDeltaValue(delta), BytesArray(signatures))
+}
+
+// StateDeltaValue converts a StateDelta into its ABI tuple value.
+func StateDeltaValue(delta *statedelta.StateDelta) Value {
+	outputs := make([]Value, len(delta.Outputs))
+	for i, o := range delta.Outputs {
+		// OutputToken(bytes32 tokenID, bytes32 snMarker, bytes tokenData)
+		outputs[i] = Tuple(Bytes32(o.TokenID), Bytes32(o.SNMarker), Bytes(o.TokenData))
+	}
+
+	return Tuple(
+		Bytes32(delta.Anchor),
+		Bytes32Array(delta.SpentRefs),
+		Array(outputs...),
+		Bytes32Array(delta.MetadataKeys),
+		BytesArray(delta.MetadataVals),
+		Bytes32(delta.TokenRequestHash),
+		Bytes32(delta.PublicParamsHash),
+		Uint64(delta.PublicParamsVersion),
+		Bool(delta.IsSetup),
+		Bytes(delta.SetupParameters),
+	)
+}

--- a/x/token/services/network/evm/client/evmclient.go
+++ b/x/token/services/network/evm/client/evmclient.go
@@ -13,6 +13,21 @@ import (
 
 //go:generate counterfeiter -o mock/evmclient.go -fake-name EVMClient . EVMClient
 
+// Block tags for state-reading calls. They live here, in the package every other one depends on, so
+// there is a single source of truth: the driver, the endorsers' validation ledger and the version
+// keeper must all read at the same tag, or they would validate against different views of the chain.
+const (
+	// BlockTagFinalized is the PoS finalized tag, the default everywhere: reading at it removes reorg
+	// handling from v1 (design §7.2).
+	BlockTagFinalized = "finalized"
+	// BlockTagSafe is the weaker "safe head" tag, available for deployments that accept reorg risk in
+	// exchange for lower latency.
+	BlockTagSafe = "safe"
+	// BlockTagLatest is the chain head; it offers no reorg protection and is intended for local
+	// development against an instant-mining node.
+	BlockTagLatest = "latest"
+)
+
 // Receipt is the subset of an Ethereum transaction receipt the driver needs.
 type Receipt struct {
 	TxHash      Hash

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -1,0 +1,437 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+)
+
+// DefaultRequestTimeout bounds a single JSON-RPC round trip when the caller's context has no
+// deadline of its own.
+const DefaultRequestTimeout = 30 * time.Second
+
+// JSONRPCClient is the EVMClient implementation over HTTP JSON-RPC. It speaks plain eth_* methods,
+// so it works against any standard node (Besu is the acceptance backend, anvil the inner loop, and
+// an fabric-x-evm gateway is just another endpoint).
+//
+// It is deliberately dependency-free: the requests and the hex-quantity encoding the Ethereum JSON-RPC
+// spec mandates are handled here rather than pulled from go-ethereum, whose license is a hard blocker
+// (design §9, §15.6).
+type JSONRPCClient struct {
+	endpoint string
+	http     *http.Client
+	// id is the JSON-RPC request counter, incremented atomically so concurrent calls never reuse an id.
+	id atomic.Uint64
+}
+
+// Compile-time assertion that the client satisfies the frozen interface.
+var _ EVMClient = (*JSONRPCClient)(nil)
+
+// NewJSONRPCClient returns a client for the node at endpoint. A nil httpClient uses a default one
+// with DefaultRequestTimeout.
+func NewJSONRPCClient(endpoint string, httpClient *http.Client) (*JSONRPCClient, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return nil, errors.New("evm client: empty endpoint")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: DefaultRequestTimeout}
+	}
+
+	return &JSONRPCClient{endpoint: endpoint, http: httpClient}, nil
+}
+
+// ChainID returns the chain id reported by the node.
+func (c *JSONRPCClient) ChainID(ctx context.Context) (*big.Int, error) {
+	var out string
+	if err := c.call(ctx, "eth_chainId", &out); err != nil {
+		return nil, err
+	}
+
+	return parseHexBig(out)
+}
+
+// Ping checks the node is reachable by asking for its chain id.
+func (c *JSONRPCClient) Ping(ctx context.Context) error {
+	_, err := c.ChainID(ctx)
+
+	return err
+}
+
+// Call performs a read-only contract call at the given block tag.
+func (c *JSONRPCClient) Call(ctx context.Context, to Address, data []byte, blockTag string) ([]byte, error) {
+	if blockTag == "" {
+		blockTag = "finalized"
+	}
+	arg := map[string]any{"to": to.Hex(), "data": encodeHexBytes(data)}
+	var out string
+	if err := c.call(ctx, "eth_call", &out, arg, blockTag); err != nil {
+		return nil, err
+	}
+
+	return decodeHexBytes(out)
+}
+
+// GetLogs returns the logs matching the filter.
+func (c *JSONRPCClient) GetLogs(ctx context.Context, q LogFilter) ([]Log, error) {
+	topics := make([]any, 0, len(q.Topics))
+	for _, position := range q.Topics {
+		if len(position) == 0 {
+			topics = append(topics, nil) // matches any value at this position
+
+			continue
+		}
+		values := make([]string, 0, len(position))
+		for _, t := range position {
+			values = append(values, t.Hex())
+		}
+		topics = append(topics, values)
+	}
+	arg := map[string]any{
+		"address":   q.Address.Hex(),
+		"fromBlock": encodeHexUint(q.FromBlock),
+		"toBlock":   encodeHexUint(q.ToBlock),
+	}
+	if len(topics) != 0 {
+		arg["topics"] = topics
+	}
+
+	var raw []jsonLog
+	if err := c.call(ctx, "eth_getLogs", &raw, arg); err != nil {
+		return nil, err
+	}
+	out := make([]Log, 0, len(raw))
+	for i := range raw {
+		l, err := raw[i].toLog()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+
+	return out, nil
+}
+
+// PendingNonceAt returns the next nonce for account, including pending transactions.
+func (c *JSONRPCClient) PendingNonceAt(ctx context.Context, account Address) (uint64, error) {
+	var out string
+	if err := c.call(ctx, "eth_getTransactionCount", &out, account.Hex(), "pending"); err != nil {
+		return 0, err
+	}
+
+	return parseHexUint(out)
+}
+
+// EstimateGas estimates the gas needed to execute msg.
+func (c *JSONRPCClient) EstimateGas(ctx context.Context, msg CallMsg) (uint64, error) {
+	arg := map[string]any{}
+	if msg.From != nil {
+		arg["from"] = msg.From.Hex()
+	}
+	if msg.To != nil {
+		arg["to"] = msg.To.Hex()
+	}
+	if len(msg.Data) != 0 {
+		arg["data"] = encodeHexBytes(msg.Data)
+	}
+	if msg.Value != nil {
+		arg["value"] = encodeHexBig(msg.Value)
+	}
+
+	var out string
+	if err := c.call(ctx, "eth_estimateGas", &out, arg); err != nil {
+		return 0, err
+	}
+
+	return parseHexUint(out)
+}
+
+// SuggestGasFees returns the node's suggested EIP-1559 fees: the priority tip it reports, and a max
+// fee of baseFee*2 + tip, the customary headroom that keeps a transaction includable across a few
+// blocks of base-fee growth.
+func (c *JSONRPCClient) SuggestGasFees(ctx context.Context) (GasFees, error) {
+	var tipHex string
+	if err := c.call(ctx, "eth_maxPriorityFeePerGas", &tipHex); err != nil {
+		return GasFees{}, err
+	}
+	tip, err := parseHexBig(tipHex)
+	if err != nil {
+		return GasFees{}, err
+	}
+
+	var head struct {
+		BaseFeePerGas string `json:"baseFeePerGas"`
+	}
+	if err := c.call(ctx, "eth_getBlockByNumber", &head, "latest", false); err != nil {
+		return GasFees{}, err
+	}
+	baseFee := new(big.Int)
+	if head.BaseFeePerGas != "" {
+		if baseFee, err = parseHexBig(head.BaseFeePerGas); err != nil {
+			return GasFees{}, err
+		}
+	}
+
+	maxFee := new(big.Int).Add(new(big.Int).Mul(baseFee, big.NewInt(2)), tip)
+
+	return GasFees{MaxFeePerGas: maxFee, MaxPriorityFeePerGas: tip}, nil
+}
+
+// SendRawTransaction submits a signed, RLP-encoded transaction and returns its hash.
+func (c *JSONRPCClient) SendRawTransaction(ctx context.Context, rawTx []byte) (Hash, error) {
+	var out string
+	if err := c.call(ctx, "eth_sendRawTransaction", &out, encodeHexBytes(rawTx)); err != nil {
+		return Hash{}, err
+	}
+
+	return HexToHash(out)
+}
+
+// GetTransactionReceipt returns the receipt for txHash, or (nil, nil) if it is not yet mined.
+func (c *JSONRPCClient) GetTransactionReceipt(ctx context.Context, txHash Hash) (*Receipt, error) {
+	var raw *jsonReceipt
+	if err := c.call(ctx, "eth_getTransactionReceipt", &raw, txHash.Hex()); err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, nil // not mined yet
+	}
+
+	return raw.toReceipt()
+}
+
+// IsPending reports whether txHash is still pending. found is false when the node does not know the
+// transaction at all (dropped or never seen), which the finality resolver uses to distinguish
+// "pending" from "dropped" (design §7.1).
+func (c *JSONRPCClient) IsPending(ctx context.Context, txHash Hash) (bool, bool, error) {
+	var tx *struct {
+		BlockNumber *string `json:"blockNumber"`
+	}
+	if err := c.call(ctx, "eth_getTransactionByHash", &tx, txHash.Hex()); err != nil {
+		return false, false, err
+	}
+	if tx == nil {
+		return false, false, nil // unknown to the node
+	}
+
+	// A null blockNumber means the node holds it in the mempool but it is not mined.
+	return tx.BlockNumber == nil, true, nil
+}
+
+// --- JSON-RPC plumbing ---------------------------------------------------------------------------
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      uint64 `json:"id"`
+	Method  string `json:"method"`
+	Params  []any  `json:"params"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *rpcError) Error() string {
+	return "json-rpc error " + strconv.Itoa(e.Code) + ": " + e.Message
+}
+
+type rpcResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+// call performs one JSON-RPC request and unmarshals the result into out. A JSON-RPC error response
+// is returned as an *rpcError so callers can classify by code.
+func (c *JSONRPCClient) call(ctx context.Context, method string, out any, params ...any) error {
+	if params == nil {
+		params = []any{}
+	}
+	body, err := json.Marshal(&rpcRequest{JSONRPC: "2.0", ID: c.id.Add(1), Method: method, Params: params})
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal %s request", method)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrapf(err, "failed to build %s request", method)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return errors.Wrapf(err, "%s call failed", method)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("%s call returned http %d", method, resp.StatusCode)
+	}
+
+	var rpcResp rpcResponse
+	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
+		return errors.Wrapf(err, "failed to decode %s response", method)
+	}
+	if rpcResp.Error != nil {
+		return errors.Wrapf(rpcResp.Error, "%s failed", method)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(rpcResp.Result, out); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal %s result", method)
+	}
+
+	return nil
+}
+
+// --- wire types ----------------------------------------------------------------------------------
+
+type jsonLog struct {
+	Address     string   `json:"address"`
+	Topics      []string `json:"topics"`
+	Data        string   `json:"data"`
+	TxHash      string   `json:"transactionHash"`
+	BlockNumber string   `json:"blockNumber"`
+}
+
+func (j *jsonLog) toLog() (Log, error) {
+	addr, err := HexToAddress(j.Address)
+	if err != nil {
+		return Log{}, errors.Wrap(err, "invalid log address")
+	}
+	topics := make([]Hash, 0, len(j.Topics))
+	for _, t := range j.Topics {
+		h, err := HexToHash(t)
+		if err != nil {
+			return Log{}, errors.Wrap(err, "invalid log topic")
+		}
+		topics = append(topics, h)
+	}
+	data, err := decodeHexBytes(j.Data)
+	if err != nil {
+		return Log{}, errors.Wrap(err, "invalid log data")
+	}
+	txHash, err := HexToHash(j.TxHash)
+	if err != nil {
+		return Log{}, errors.Wrap(err, "invalid log transaction hash")
+	}
+	blockNumber, err := parseHexUint(j.BlockNumber)
+	if err != nil {
+		return Log{}, errors.Wrap(err, "invalid log block number")
+	}
+
+	return Log{Address: addr, Topics: topics, Data: data, TxHash: txHash, BlockNumber: blockNumber}, nil
+}
+
+type jsonReceipt struct {
+	TxHash      string    `json:"transactionHash"`
+	BlockNumber *string   `json:"blockNumber"`
+	Status      string    `json:"status"`
+	Logs        []jsonLog `json:"logs"`
+}
+
+func (j *jsonReceipt) toReceipt() (*Receipt, error) {
+	txHash, err := HexToHash(j.TxHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid receipt transaction hash")
+	}
+	status, err := parseHexUint(j.Status)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid receipt status")
+	}
+	out := &Receipt{TxHash: txHash, Status: status}
+	if j.BlockNumber != nil {
+		bn, err := parseHexUint(*j.BlockNumber)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid receipt block number")
+		}
+		out.BlockNumber = &bn
+	}
+	for i := range j.Logs {
+		l, err := j.Logs[i].toLog()
+		if err != nil {
+			return nil, err
+		}
+		out.Logs = append(out.Logs, l)
+	}
+
+	return out, nil
+}
+
+// --- hex quantities ------------------------------------------------------------------------------
+
+// encodeHexUint encodes a number as a minimal 0x-prefixed hex quantity, the JSON-RPC convention.
+func encodeHexUint(x uint64) string {
+	return "0x" + strconv.FormatUint(x, 16)
+}
+
+// encodeHexBig encodes a big.Int as a minimal 0x-prefixed hex quantity.
+func encodeHexBig(x *big.Int) string {
+	if x == nil {
+		return "0x0"
+	}
+
+	return "0x" + x.Text(16)
+}
+
+// encodeHexBytes encodes a byte slice as 0x-prefixed hex data.
+func encodeHexBytes(b []byte) string {
+	return "0x" + hex.EncodeToString(b)
+}
+
+// decodeHexBytes decodes 0x-prefixed hex data, tolerating an empty or bare "0x" value.
+func decodeHexBytes(s string) ([]byte, error) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	if s == "" {
+		return nil, nil
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid hex data [%s]", s)
+	}
+
+	return b, nil
+}
+
+// parseHexUint parses a 0x-prefixed hex quantity into a uint64.
+func parseHexUint(s string) (uint64, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	if trimmed == "" {
+		return 0, errors.Errorf("empty hex quantity")
+	}
+	v, err := strconv.ParseUint(trimmed, 16, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "invalid hex quantity [%s]", s)
+	}
+
+	return v, nil
+}
+
+// parseHexBig parses a 0x-prefixed hex quantity into a big.Int.
+func parseHexBig(s string) (*big.Int, error) {
+	trimmed := strings.TrimPrefix(strings.TrimSpace(s), "0x")
+	if trimmed == "" {
+		return nil, errors.Errorf("empty hex quantity")
+	}
+	v, ok := new(big.Int).SetString(trimmed, 16)
+	if !ok {
+		return nil, errors.Errorf("invalid hex quantity [%s]", s)
+	}
+
+	return v, nil
+}

--- a/x/token/services/network/evm/client/jsonrpc.go
+++ b/x/token/services/network/evm/client/jsonrpc.go
@@ -75,7 +75,7 @@ func (c *JSONRPCClient) Ping(ctx context.Context) error {
 // Call performs a read-only contract call at the given block tag.
 func (c *JSONRPCClient) Call(ctx context.Context, to Address, data []byte, blockTag string) ([]byte, error) {
 	if blockTag == "" {
-		blockTag = "finalized"
+		blockTag = BlockTagFinalized
 	}
 	arg := map[string]any{"to": to.Hex(), "data": encodeHexBytes(data)}
 	var out string

--- a/x/token/services/network/evm/client/jsonrpc_test.go
+++ b/x/token/services/network/evm/client/jsonrpc_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rpcCall captures one request the client made, so tests can assert the method and params on the
+// wire (the JSON-RPC contract with the node), not just the decoded return value.
+type rpcCall struct {
+	Method string
+	Params []any
+}
+
+// newTestServer starts a JSON-RPC server whose handler returns, for each method, the raw JSON given
+// in results. It records every request for later assertions.
+func newTestServer(t *testing.T, results map[string]string) (*JSONRPCClient, *[]rpcCall) {
+	t.Helper()
+	var calls []rpcCall
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     uint64 `json:"id"`
+			Method string `json:"method"`
+			Params []any  `json:"params"`
+		}
+		// assert, not require: this runs on the server goroutine, where FailNow would not stop the test.
+		if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&req)) {
+			w.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+		calls = append(calls, rpcCall{Method: req.Method, Params: req.Params})
+
+		result, ok := results[req.Method]
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}`))
+
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":` + result + `}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	// #nosec G107 -- httptest local test server URL
+	c, err := NewJSONRPCClient(srv.URL, srv.Client())
+	require.NoError(t, err)
+
+	return c, &calls
+}
+
+func TestNewJSONRPCClientRejectsEmptyEndpoint(t *testing.T) {
+	_, err := NewJSONRPCClient("", nil)
+	require.Error(t, err)
+	_, err = NewJSONRPCClient("   ", nil)
+	require.Error(t, err)
+}
+
+func TestChainIDAndPing(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{"eth_chainId": `"0x7a69"`})
+
+	got, err := c.ChainID(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(31337), got)
+	require.NotEmpty(t, *calls)
+	assert.Equal(t, "eth_chainId", (*calls)[0].Method)
+
+	require.NoError(t, c.Ping(context.Background()))
+}
+
+func TestCallEncodesTargetAndBlockTag(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{"eth_call": `"0x1234"`})
+
+	to, err := HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+	out, err := c.Call(context.Background(), to, []byte{0xab, 0xcd}, "finalized")
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x12, 0x34}, out)
+
+	require.Len(t, *calls, 1)
+	assert.Equal(t, "eth_call", (*calls)[0].Method)
+	require.Len(t, (*calls)[0].Params, 2)
+	arg, ok := (*calls)[0].Params[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, to.Hex(), arg["to"])
+	assert.Equal(t, "0xabcd", arg["data"])
+	assert.Equal(t, "finalized", (*calls)[0].Params[1], "the block tag must be sent as given")
+}
+
+func TestCallDefaultsToFinalized(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{"eth_call": `"0x"`})
+
+	_, err := c.Call(context.Background(), Address{}, nil, "")
+	require.NoError(t, err)
+	require.Len(t, *calls, 1)
+	assert.Equal(t, "finalized", (*calls)[0].Params[1], "an empty tag must default to finalized")
+}
+
+func TestCallSurfacesRPCError(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{}) // every method returns a JSON-RPC error
+
+	_, err := c.Call(context.Background(), Address{}, nil, "latest")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "method not found")
+}
+
+func TestPendingNonceAt(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{"eth_getTransactionCount": `"0x2a"`})
+
+	got, err := c.PendingNonceAt(context.Background(), Address{})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), got)
+	require.Len(t, *calls, 1)
+	assert.Equal(t, "pending", (*calls)[0].Params[1], "the nonce must include pending transactions")
+}
+
+func TestEstimateGas(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{"eth_estimateGas": `"0x5208"`})
+
+	to, err := HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+	got, err := c.EstimateGas(context.Background(), CallMsg{To: &to, Data: []byte{0x01}})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21000), got)
+}
+
+// TestSuggestGasFees checks the EIP-1559 fee derivation: the tip comes from the node, and the max
+// fee leaves headroom for base-fee growth (baseFee*2 + tip).
+func TestSuggestGasFees(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_maxPriorityFeePerGas": `"0x3b9aca00"`,            // 1 gwei
+		"eth_getBlockByNumber":     `{"baseFeePerGas":"0x7"}`, // 7 wei
+	})
+
+	fees, err := c.SuggestGasFees(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(1_000_000_000), fees.MaxPriorityFeePerGas)
+	assert.Equal(t, big.NewInt(2*7+1_000_000_000), fees.MaxFeePerGas)
+}
+
+// TestSuggestGasFeesPreLondon covers a node whose head block reports no base fee.
+func TestSuggestGasFeesPreLondon(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_maxPriorityFeePerGas": `"0x1"`,
+		"eth_getBlockByNumber":     `{}`,
+	})
+
+	fees, err := c.SuggestGasFees(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, big.NewInt(1), fees.MaxFeePerGas, "with no base fee the max fee is just the tip")
+}
+
+func TestSendRawTransaction(t *testing.T) {
+	const txHash = "0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa"
+	c, calls := newTestServer(t, map[string]string{"eth_sendRawTransaction": `"` + txHash + `"`})
+
+	got, err := c.SendRawTransaction(context.Background(), []byte{0x02, 0xff})
+	require.NoError(t, err)
+	assert.Equal(t, txHash, got.Hex())
+	require.Len(t, *calls, 1)
+	assert.Equal(t, "0x02ff", (*calls)[0].Params[0], "the raw transaction must be sent as hex data")
+}
+
+func TestGetTransactionReceiptMined(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_getTransactionReceipt": `{
+			"transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa",
+			"blockNumber":"0x10",
+			"status":"0x1",
+			"logs":[{
+				"address":"0x5FbDB2315678afecb367f032d93F642f64180aa3",
+				"topics":["0x1111111111111111111111111111111111111111111111111111111111111111"],
+				"data":"0xbeef",
+				"transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa",
+				"blockNumber":"0x10"
+			}]
+		}`,
+	})
+
+	got, err := c.GetTransactionReceipt(context.Background(), Hash{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uint64(1), got.Status)
+	require.NotNil(t, got.BlockNumber)
+	assert.Equal(t, uint64(16), *got.BlockNumber)
+	require.Len(t, got.Logs, 1)
+	assert.Equal(t, []byte{0xbe, 0xef}, got.Logs[0].Data)
+	require.Len(t, got.Logs[0].Topics, 1)
+}
+
+// TestGetTransactionReceiptNotMined checks the (nil, nil) contract the finality layer relies on.
+func TestGetTransactionReceiptNotMined(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{"eth_getTransactionReceipt": `null`})
+
+	got, err := c.GetTransactionReceipt(context.Background(), Hash{})
+	require.NoError(t, err)
+	assert.Nil(t, got, "an unmined transaction is (nil, nil), not an error")
+}
+
+func TestGetTransactionReceiptReverted(t *testing.T) {
+	c, _ := newTestServer(t, map[string]string{
+		"eth_getTransactionReceipt": `{
+			"transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa",
+			"blockNumber":"0x10","status":"0x0","logs":[]
+		}`,
+	})
+
+	got, err := c.GetTransactionReceipt(context.Background(), Hash{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uint64(0), got.Status, "a reverted transaction reports status 0")
+}
+
+// TestIsPending covers the three states the finality resolver distinguishes (design §7.1).
+func TestIsPending(t *testing.T) {
+	t.Run("pending: known but unmined", func(t *testing.T) {
+		c, _ := newTestServer(t, map[string]string{"eth_getTransactionByHash": `{"blockNumber":null}`})
+		pending, found, err := c.IsPending(context.Background(), Hash{})
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.True(t, pending)
+	})
+
+	t.Run("mined: has a block number", func(t *testing.T) {
+		c, _ := newTestServer(t, map[string]string{"eth_getTransactionByHash": `{"blockNumber":"0x10"}`})
+		pending, found, err := c.IsPending(context.Background(), Hash{})
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.False(t, pending)
+	})
+
+	t.Run("dropped: unknown to the node", func(t *testing.T) {
+		c, _ := newTestServer(t, map[string]string{"eth_getTransactionByHash": `null`})
+		pending, found, err := c.IsPending(context.Background(), Hash{})
+		require.NoError(t, err)
+		assert.False(t, found, "an unknown transaction must report found=false so it can be treated as dropped")
+		assert.False(t, pending)
+	})
+}
+
+func TestGetLogs(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{
+		"eth_getLogs": `[{
+			"address":"0x5FbDB2315678afecb367f032d93F642f64180aa3",
+			"topics":["0x1111111111111111111111111111111111111111111111111111111111111111"],
+			"data":"0x","transactionHash":"0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa",
+			"blockNumber":"0x2"
+		}]`,
+	})
+
+	addr, err := HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+	topic, err := HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+
+	logs, err := c.GetLogs(context.Background(), LogFilter{
+		Address: addr, FromBlock: 1, ToBlock: 100, Topics: [][]Hash{{topic}},
+	})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, addr, logs[0].Address)
+	assert.Equal(t, uint64(2), logs[0].BlockNumber)
+
+	require.Len(t, *calls, 1)
+	arg, ok := (*calls)[0].Params[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "0x1", arg["fromBlock"])
+	assert.Equal(t, "0x64", arg["toBlock"])
+}
+
+// TestGetLogsWildcardTopic checks that an empty inner slice becomes a null (match-any) position,
+// which is the eth_getLogs convention.
+func TestGetLogsWildcardTopic(t *testing.T) {
+	c, calls := newTestServer(t, map[string]string{"eth_getLogs": `[]`})
+
+	topic, err := HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+	_, err = c.GetLogs(context.Background(), LogFilter{Topics: [][]Hash{{topic}, {}}})
+	require.NoError(t, err)
+
+	arg, ok := (*calls)[0].Params[0].(map[string]any)
+	require.True(t, ok)
+	topics, ok := arg["topics"].([]any)
+	require.True(t, ok)
+	require.Len(t, topics, 2)
+	assert.Nil(t, topics[1], "an empty position must serialize as null to match any value")
+}
+
+func TestHexHelpers(t *testing.T) {
+	t.Run("uint round trip", func(t *testing.T) {
+		for _, v := range []uint64{0, 1, 42, 21000, 1 << 40} {
+			got, err := parseHexUint(encodeHexUint(v))
+			require.NoError(t, err)
+			assert.Equal(t, v, got)
+		}
+	})
+
+	t.Run("big round trip", func(t *testing.T) {
+		// Compared with Cmp, not Equal: a parsed zero and big.NewInt(0) are numerically equal but
+		// differ in internal representation (nil vs empty nat).
+		for _, v := range []int64{0, 1, 1_000_000_000} {
+			got, err := parseHexBig(encodeHexBig(big.NewInt(v)))
+			require.NoError(t, err)
+			assert.Zero(t, got.Cmp(big.NewInt(v)), "round trip of %d", v)
+		}
+	})
+
+	t.Run("bytes round trip", func(t *testing.T) {
+		got, err := decodeHexBytes(encodeHexBytes([]byte{0xde, 0xad}))
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0xde, 0xad}, got)
+	})
+
+	t.Run("empty data decodes to nil", func(t *testing.T) {
+		for _, s := range []string{"0x", "", "  "} {
+			got, err := decodeHexBytes(s)
+			require.NoError(t, err)
+			assert.Empty(t, got)
+		}
+	})
+
+	t.Run("malformed values are errors", func(t *testing.T) {
+		_, err := parseHexUint("0x")
+		require.Error(t, err)
+		_, err = parseHexUint("0xzz")
+		require.Error(t, err)
+		_, err = parseHexBig("0x")
+		require.Error(t, err)
+		_, err = decodeHexBytes("0xodd")
+		require.Error(t, err)
+	})
+}

--- a/x/token/services/network/evm/client/rlp.go
+++ b/x/token/services/network/evm/client/rlp.go
@@ -1,0 +1,95 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"math/big"
+)
+
+// Minimal RLP encoder, enough for EIP-1559 (type-2) transaction encoding. RLP is only needed on the
+// write path (building the raw transaction to broadcast); nothing in the driver decodes RLP, so this
+// is deliberately encode-only.
+//
+// It is hand-rolled because go-ethereum's license is a hard blocker for the project (design §9,
+// §15.6). The encoding follows the Ethereum yellow paper: a byte string under 56 bytes is prefixed
+// with 0x80+len, longer strings with 0xb7+lenOfLen followed by the big-endian length; lists use
+// 0xc0/0xf7 the same way. A single byte below 0x80 encodes as itself.
+
+const (
+	// rlpStringShortBase is the prefix for a byte string shorter than 56 bytes.
+	rlpStringShortBase = 0x80
+	// rlpStringLongBase is the prefix for a byte string of 56 bytes or more.
+	rlpStringLongBase = 0xb7
+	// rlpListShortBase is the prefix for a list whose payload is shorter than 56 bytes.
+	rlpListShortBase = 0xc0
+	// rlpListLongBase is the prefix for a list whose payload is 56 bytes or more.
+	rlpListLongBase = 0xf7
+	// rlpShortLimit is the payload-length boundary between the short and long forms.
+	rlpShortLimit = 56
+)
+
+// rlpString encodes a byte string.
+func rlpString(b []byte) []byte {
+	// A single byte in [0x00, 0x7f] is its own encoding.
+	if len(b) == 1 && b[0] < rlpStringShortBase {
+		return []byte{b[0]}
+	}
+
+	return append(rlpLengthPrefix(len(b), rlpStringShortBase, rlpStringLongBase), b...)
+}
+
+// rlpList encodes an already-encoded concatenation of items as a list.
+func rlpList(payload []byte) []byte {
+	return append(rlpLengthPrefix(len(payload), rlpListShortBase, rlpListLongBase), payload...)
+}
+
+// rlpUint encodes an integer as a minimal big-endian byte string: zero encodes as the empty string
+// (0x80), and leading zero bytes are never emitted. This canonical form is what the signature and
+// the transaction hash are computed over, so a non-minimal encoding would produce a different hash
+// and a transaction the node rejects.
+func rlpUint(x uint64) []byte {
+	return rlpString(minimalBytes(x))
+}
+
+// rlpBigInt encodes a non-negative big.Int as a minimal big-endian byte string. A nil or zero value
+// encodes as the empty string, matching rlpUint(0).
+func rlpBigInt(x *big.Int) []byte {
+	if x == nil || x.Sign() == 0 {
+		return rlpString(nil)
+	}
+
+	return rlpString(x.Bytes())
+}
+
+// rlpLengthPrefix returns the length prefix for a payload of the given size, using shortBase for
+// payloads under 56 bytes and longBase (plus the big-endian length) for larger ones.
+func rlpLengthPrefix(length int, shortBase, longBase byte) []byte {
+	if length < rlpShortLimit {
+		return []byte{shortBase + byte(length)} // #nosec G115 -- length < 56, fits in a byte
+	}
+	lenBytes := minimalBytes(uint64(length)) // #nosec G115 -- length is non-negative
+	out := make([]byte, 0, 1+len(lenBytes))
+	out = append(out, longBase+byte(len(lenBytes))) // #nosec G115 -- at most 8 length bytes
+
+	return append(out, lenBytes...)
+}
+
+// minimalBytes returns x as big-endian bytes with no leading zeros; zero returns an empty slice.
+func minimalBytes(x uint64) []byte {
+	if x == 0 {
+		return nil
+	}
+	var buf [8]byte
+	i := len(buf)
+	for x > 0 {
+		i--
+		buf[i] = byte(x) // #nosec G115 -- truncation to the low byte is intended
+		x >>= 8
+	}
+
+	return buf[i:]
+}

--- a/x/token/services/network/evm/client/rlp_test.go
+++ b/x/token/services/network/evm/client/rlp_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRLPStringVectors pins the encoder against the canonical examples from the Ethereum yellow
+// paper / RLP spec, so a wrong prefix or length form cannot pass unnoticed.
+func TestRLPStringVectors(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"empty string", nil, "80"},
+		{"single zero byte", []byte{0x00}, "00"},
+		{"single low byte", []byte{0x7f}, "7f"},
+		{"single byte at boundary", []byte{0x80}, "8180"},
+		{"dog", []byte("dog"), "83646f67"},
+		{"55 bytes uses short form", bytes.Repeat([]byte{0x61}, 55), "b7" + strings.Repeat("61", 55)},
+		{"56 bytes uses long form", bytes.Repeat([]byte{0x61}, 56), "b838" + strings.Repeat("61", 56)},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hex.EncodeToString(rlpString(tt.in)))
+		})
+	}
+}
+
+func TestRLPListVectors(t *testing.T) {
+	// ["cat","dog"] = 0xc8 0x83 c a t 0x83 d o g
+	payload := append(rlpString([]byte("cat")), rlpString([]byte("dog"))...)
+	assert.Equal(t, "c88363617483646f67", hex.EncodeToString(rlpList(payload)))
+
+	// the empty list
+	assert.Equal(t, "c0", hex.EncodeToString(rlpList(nil)))
+}
+
+// TestRLPUintIsMinimal checks the canonical integer form: no leading zeros, and zero encodes as the
+// empty string. A non-minimal encoding would change the signing hash and the node would reject the
+// transaction.
+func TestRLPUintIsMinimal(t *testing.T) {
+	cases := map[uint64]string{
+		0:          "80",
+		1:          "01",
+		127:        "7f",
+		128:        "8180",
+		256:        "820100",
+		1024:       "820400",
+		16_777_216: "8401000000",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, hex.EncodeToString(rlpUint(in)), "rlpUint(%d)", in)
+	}
+}
+
+func TestRLPBigIntMatchesUint(t *testing.T) {
+	for _, v := range []uint64{0, 1, 127, 128, 256, 1 << 32} {
+		assert.Equal(t,
+			hex.EncodeToString(rlpUint(v)),
+			hex.EncodeToString(rlpBigInt(new(big.Int).SetUint64(v))),
+			"big and uint encodings must agree for %d", v)
+	}
+	// nil is treated as zero
+	assert.Equal(t, "80", hex.EncodeToString(rlpBigInt(nil)))
+}
+
+func TestMinimalBytes(t *testing.T) {
+	require.Empty(t, minimalBytes(0))
+	assert.Equal(t, []byte{0x01}, minimalBytes(1))
+	assert.Equal(t, []byte{0x01, 0x00}, minimalBytes(256))
+	assert.Equal(t, []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, minimalBytes(^uint64(0)))
+}

--- a/x/token/services/network/evm/client/tx.go
+++ b/x/token/services/network/evm/client/tx.go
@@ -1,0 +1,135 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"math/big"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/crypto"
+)
+
+// TxTypeDynamicFee is the EIP-2718 type byte of an EIP-1559 (dynamic-fee) transaction. The driver
+// only ever sends type-2 transactions: they are the current standard and are supported by Besu and
+// every modern node (design §8).
+const TxTypeDynamicFee byte = 0x02
+
+// signatureLength is the length of the compact secp256k1 signature decred returns: {v, r, s}.
+const signatureLength = 65
+
+// DynamicFeeTx is an unsigned EIP-1559 transaction. The driver builds one per `applyStateDelta`
+// call: To is the TokenState clone, Data the ABI-encoded call, Value always zero (the contract is
+// not payable).
+//
+// Fees follow EIP-1559: MaxFeePerGas caps the total the sender pays per gas, MaxPriorityFeePerGas
+// the tip to the proposer. Both come from the node's suggestion, adjusted by the configured gas
+// strategy.
+type DynamicFeeTx struct {
+	ChainID              *big.Int
+	Nonce                uint64
+	MaxPriorityFeePerGas *big.Int
+	MaxFeePerGas         *big.Int
+	Gas                  uint64
+	To                   *Address // nil means contract creation; the driver always sets it
+	Value                *big.Int
+	Data                 []byte
+	// AccessList is always empty for the driver's calls. It is part of the signed payload, so it is
+	// encoded (as an empty list) rather than omitted.
+}
+
+// SigningHash returns the hash the sender signs: keccak256(0x02 || rlp([chainId, nonce,
+// maxPriorityFeePerGas, maxFeePerGas, gas, to, value, data, accessList])) per EIP-1559. The field
+// order is normative; changing it produces a valid-looking but unusable transaction.
+func (t *DynamicFeeTx) SigningHash() [32]byte {
+	return crypto.Keccak256Hash(append([]byte{TxTypeDynamicFee}, rlpList(t.payload())...))
+}
+
+// payload encodes the nine signed fields as the concatenation of their RLP encodings.
+func (t *DynamicFeeTx) payload() []byte {
+	var buf []byte
+	buf = append(buf, rlpBigInt(t.ChainID)...)
+	buf = append(buf, rlpUint(t.Nonce)...)
+	buf = append(buf, rlpBigInt(t.MaxPriorityFeePerGas)...)
+	buf = append(buf, rlpBigInt(t.MaxFeePerGas)...)
+	buf = append(buf, rlpUint(t.Gas)...)
+	buf = append(buf, rlpString(t.toBytes())...)
+	buf = append(buf, rlpBigInt(t.Value)...)
+	buf = append(buf, rlpString(t.Data)...)
+	// empty access list
+	buf = append(buf, rlpList(nil)...)
+
+	return buf
+}
+
+// toBytes returns the recipient address bytes, or an empty slice for contract creation.
+func (t *DynamicFeeTx) toBytes() []byte {
+	if t.To == nil {
+		return nil
+	}
+
+	return t.To.Bytes()
+}
+
+// SignTx signs the transaction with the submitter's secp256k1 key and returns the raw, broadcastable
+// transaction: 0x02 || rlp([...signed fields, yParity, r, s]).
+//
+// Signature format differs from the endorsement signatures (design §8): a typed transaction carries
+// yParity as 0 or 1, NOT the legacy v of 27/28, and r and s are encoded as minimal big-endian RLP
+// integers rather than fixed 32-byte words. s is normalized to the lower half of the group order
+// (EIP-2); decred already produces canonical signatures, and this asserts it rather than assuming.
+func SignTx(tx *DynamicFeeTx, key *secp256k1.PrivateKey) ([]byte, error) {
+	if tx == nil {
+		return nil, errors.New("nil transaction")
+	}
+	if key == nil {
+		return nil, errors.New("nil signing key")
+	}
+	if tx.ChainID == nil || tx.ChainID.Sign() <= 0 {
+		return nil, errors.New("transaction chain id must be set and positive")
+	}
+
+	hash := tx.SigningHash()
+	// SignCompact returns {v, r, s} with v = 27 + recovery id, the same layout the endorsement
+	// signer reorders; here the recovery id is carried as yParity instead.
+	compact := ecdsa.SignCompact(key, hash[:], false)
+	if len(compact) != signatureLength {
+		return nil, errors.Errorf("unexpected compact signature length %d", len(compact))
+	}
+
+	yParity := compact[0] - 27
+	if yParity > 1 {
+		return nil, errors.Errorf("unexpected recovery id %d", yParity)
+	}
+	r := new(big.Int).SetBytes(compact[1:33])
+	s := new(big.Int).SetBytes(compact[33:65])
+	if s.Cmp(secp256k1HalfOrder) > 0 {
+		return nil, errors.New("signing produced a non-canonical (high-s) signature")
+	}
+
+	var buf []byte
+	buf = append(buf, tx.payload()...)
+	buf = append(buf, rlpUint(uint64(yParity))...)
+	buf = append(buf, rlpBigInt(r)...)
+	buf = append(buf, rlpBigInt(s)...)
+
+	return append([]byte{TxTypeDynamicFee}, rlpList(buf)...), nil
+}
+
+// TxHash returns the hash of a raw, signed transaction: keccak256 over the full encoded bytes
+// (including the type byte). This is the hash the node reports and the driver tracks for finality.
+func TxHash(rawTx []byte) Hash {
+	return crypto.Keccak256Hash(rawTx)
+}
+
+// secp256k1HalfOrder is N/2, the upper bound for a canonical (non-malleable) s value (EIP-2).
+var secp256k1HalfOrder = new(big.Int).SetBytes([]byte{
+	0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+	0x5d, 0x57, 0x6e, 0x73, 0x57, 0xa4, 0x50, 0x1d, 0xdf, 0xe9, 0x2f, 0x46, 0x68, 0x1b, 0x20, 0xa0,
+})

--- a/x/token/services/network/evm/client/tx_test.go
+++ b/x/token/services/network/evm/client/tx_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKey returns the well-known secp256k1 test key with the given low byte; key 1 is the
+// address 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf, reproducible with any Ethereum tooling.
+func testKey(low byte) *secp256k1.PrivateKey {
+	raw := make([]byte, 32)
+	raw[31] = low
+
+	return secp256k1.PrivKeyFromBytes(raw)
+}
+
+// goldenTx is the transaction pinned by TestSignTxGoldenVector. Keep it in sync with the committed
+// expectations below; both were produced by this code and independently decoded with
+// `cast decode-transaction`, which recovered the expected signer.
+func goldenTx(t *testing.T) *DynamicFeeTx {
+	t.Helper()
+	to, err := HexToAddress("0x5FbDB2315678afecb367f032d93F642f64180aa3")
+	require.NoError(t, err)
+
+	return &DynamicFeeTx{
+		ChainID:              big.NewInt(31337),
+		Nonce:                7,
+		MaxPriorityFeePerGas: big.NewInt(1_000_000_000),
+		MaxFeePerGas:         big.NewInt(20_000_000_000),
+		Gas:                  100_000,
+		To:                   &to,
+		Value:                big.NewInt(0),
+		Data:                 []byte{0xde, 0xad, 0xbe, 0xef},
+	}
+}
+
+// TestSignTxGoldenVector is the Phase-A gate: a signed EIP-1559 transaction must match, byte for
+// byte, a vector independently validated with foundry's `cast decode-transaction`, which recovered
+// signer 0x7e5f4552091a69125d5dfcb7b8c2659029395bdf (the address of test key 1) and reported the same
+// transaction hash. Since the recovered signer depends on every encoded byte, this pins the whole
+// chain: RLP field order and minimality, the type prefix, the signing hash, and the yParity/r/s
+// signature encoding.
+func TestSignTxGoldenVector(t *testing.T) {
+	const (
+		wantSigningHash = "6569407866fe8e08fd874689c6d85c060753957cf6784ed1278d62756223c174"
+		wantRawTx       = "02f872827a6907843b9aca008504a817c800830186a0945fbdb2315678afecb367f032d93f642f64180aa3" +
+			"8084deadbeefc080a0c082262bf546fb58f63a42598eb821d9f47e05e56780fceb478e4526141356b9" +
+			"a0096827805bd69e284b1ab5e4d5a9719a859439a570722c1f77ab9aa2f52b645a"
+		wantTxHash = "0x853f272fffc6efc284fc16a254decca742d2347e05703e501c59968f78f81ffa"
+	)
+
+	tx := goldenTx(t)
+	h := tx.SigningHash()
+	assert.Equal(t, wantSigningHash, hex.EncodeToString(h[:]), "signing hash diverges from the golden vector")
+
+	rawTx, err := SignTx(tx, testKey(1))
+	require.NoError(t, err)
+	assert.Equal(t, wantRawTx, hex.EncodeToString(rawTx), "raw transaction diverges from the golden vector")
+	assert.Equal(t, wantTxHash, TxHash(rawTx).Hex())
+}
+
+// TestSignTxIsDeterministic pins RFC 6979 determinism: the same key and transaction always produce
+// the same raw bytes, which is what makes the golden vector reproducible.
+func TestSignTxIsDeterministic(t *testing.T) {
+	first, err := SignTx(goldenTx(t), testKey(1))
+	require.NoError(t, err)
+	second, err := SignTx(goldenTx(t), testKey(1))
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+// TestSignTxTypePrefix checks the EIP-2718 envelope: a typed transaction starts with its type byte.
+func TestSignTxTypePrefix(t *testing.T) {
+	rawTx, err := SignTx(goldenTx(t), testKey(1))
+	require.NoError(t, err)
+	require.NotEmpty(t, rawTx)
+	assert.Equal(t, TxTypeDynamicFee, rawTx[0])
+}
+
+// TestSignTxDistinctInputsDiverge checks that fields actually enter the signed payload: changing any
+// one of them changes the signing hash (and so the raw transaction).
+func TestSignTxDistinctInputsDiverge(t *testing.T) {
+	base := goldenTx(t).SigningHash()
+
+	mutations := map[string]func(*DynamicFeeTx){
+		"nonce":    func(tx *DynamicFeeTx) { tx.Nonce++ },
+		"chain id": func(tx *DynamicFeeTx) { tx.ChainID = big.NewInt(1) },
+		"gas":      func(tx *DynamicFeeTx) { tx.Gas++ },
+		"max fee":  func(tx *DynamicFeeTx) { tx.MaxFeePerGas = big.NewInt(1) },
+		"tip":      func(tx *DynamicFeeTx) { tx.MaxPriorityFeePerGas = big.NewInt(1) },
+		"value":    func(tx *DynamicFeeTx) { tx.Value = big.NewInt(1) },
+		"data":     func(tx *DynamicFeeTx) { tx.Data = []byte{0x01} },
+		"to":       func(tx *DynamicFeeTx) { addr := Address{}; tx.To = &addr },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			tx := goldenTx(t)
+			mutate(tx)
+			assert.NotEqual(t, base, tx.SigningHash(), "%s must be covered by the signing hash", name)
+		})
+	}
+}
+
+// TestSignTxDifferentKeysDiffer checks the signature depends on the key.
+func TestSignTxDifferentKeysDiffer(t *testing.T) {
+	one, err := SignTx(goldenTx(t), testKey(1))
+	require.NoError(t, err)
+	two, err := SignTx(goldenTx(t), testKey(2))
+	require.NoError(t, err)
+	assert.NotEqual(t, one, two)
+}
+
+func TestSignTxRejectsInvalidInput(t *testing.T) {
+	t.Run("nil transaction", func(t *testing.T) {
+		_, err := SignTx(nil, testKey(1))
+		require.Error(t, err)
+	})
+
+	t.Run("nil key", func(t *testing.T) {
+		_, err := SignTx(goldenTx(t), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("missing chain id", func(t *testing.T) {
+		tx := goldenTx(t)
+		tx.ChainID = nil
+		_, err := SignTx(tx, testKey(1))
+		require.Error(t, err, "an unset chain id would allow cross-chain replay")
+	})
+
+	t.Run("zero chain id", func(t *testing.T) {
+		tx := goldenTx(t)
+		tx.ChainID = big.NewInt(0)
+		_, err := SignTx(tx, testKey(1))
+		require.Error(t, err)
+	})
+}
+
+// TestSignTxContractCreation checks a nil recipient encodes as the empty string (contract creation)
+// rather than a zero address; the driver always sets To, but the encoding must still be correct.
+func TestSignTxContractCreation(t *testing.T) {
+	tx := goldenTx(t)
+	tx.To = nil
+	rawTx, err := SignTx(tx, testKey(1))
+	require.NoError(t, err)
+	require.NotEmpty(t, rawTx)
+
+	zero := Address{}
+	withZero := goldenTx(t)
+	withZero.To = &zero
+	assert.NotEqual(t, tx.SigningHash(), withZero.SigningHash(),
+		"contract creation must not encode like a call to the zero address")
+}

--- a/x/token/services/network/evm/config.go
+++ b/x/token/services/network/evm/config.go
@@ -1,0 +1,277 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// Configuration defaults. They are applied at load time so a minimal config (endpoint, chain id,
+// contracts, endorsement) is enough to run, and every unset knob has a documented, safe value.
+const (
+	// DefaultBlockTag is the block tag state reads use: the PoS finalized tag, which removes reorg
+	// handling from v1 (design §7.2). It aliases the canonical value in the client package.
+	DefaultBlockTag = client.BlockTagFinalized
+	// DefaultPollInterval is how often finality polls a transaction's status.
+	DefaultPollInterval = 2 * time.Second
+	// DefaultFinalityTimeout bounds how long a transaction is awaited before it is treated as failed.
+	DefaultFinalityTimeout = 5 * time.Minute
+	// DefaultGasMultiplier scales the node's gas estimate to absorb small state changes between
+	// estimation and execution.
+	DefaultGasMultiplier = 1.2
+	// DefaultGasStrategy estimates gas per transaction rather than using a fixed limit.
+	DefaultGasStrategy = GasStrategyEstimate
+)
+
+// Gas strategies.
+const (
+	// GasStrategyEstimate asks the node to estimate gas and scales it by Multiplier.
+	GasStrategyEstimate = "estimate"
+	// GasStrategyFixed uses Limit for every transaction.
+	GasStrategyFixed = "fixed"
+)
+
+// Config is the EVM network configuration for one TMS, read from
+// token.tms.<tms-id>.services.network.evm (design §10).
+type Config struct {
+	// Endpoint is the node's JSON-RPC URL.
+	Endpoint string `yaml:"endpoint"`
+	// ChainID is the chain the driver signs for; it is checked against the node at startup so a
+	// misconfiguration surfaces immediately rather than as rejected transactions.
+	ChainID int64 `yaml:"chainID"`
+
+	Contracts   ContractsConfig   `yaml:"contracts"`
+	Finality    FinalityConfig    `yaml:"finality"`
+	Gas         GasConfig         `yaml:"gas"`
+	Endorser    EndorserConfig    `yaml:"endorser"`
+	Submitter   SubmitterConfig   `yaml:"submitter"`
+	Endorsement EndorsementConfig `yaml:"endorsement"`
+}
+
+// ContractsConfig holds the deployed contract addresses for the TMS.
+type ContractsConfig struct {
+	// TokenState is this TMS's TokenState clone; it also anchors the EIP-712 domain.
+	TokenState string `yaml:"tokenState"`
+	// EndorsementVerifier is the verifier the TokenState calls; optional in config, since the
+	// TokenState holds the authoritative reference.
+	EndorsementVerifier string `yaml:"endorsementVerifier"`
+}
+
+// FinalityConfig controls how transaction finality is observed.
+type FinalityConfig struct {
+	// BlockTag is the tag state is read at (finalized or safe).
+	BlockTag string `yaml:"blockTag"`
+	// PollInterval is the delay between status polls.
+	PollInterval time.Duration `yaml:"pollInterval"`
+	// Timeout bounds how long a transaction is awaited. It is also a recipient's only failure signal:
+	// a failed apply reverts and emits no log, so "no event by the timeout" is what makes it Invalid
+	// (design §7.4).
+	Timeout time.Duration `yaml:"timeout"`
+}
+
+// GasConfig controls gas limit selection.
+type GasConfig struct {
+	// Strategy is estimate or fixed.
+	Strategy string `yaml:"strategy"`
+	// Multiplier scales the node's estimate when Strategy is estimate.
+	Multiplier float64 `yaml:"multiplier"`
+	// Limit is the gas limit used when Strategy is fixed.
+	Limit uint64 `yaml:"limit"`
+}
+
+// EndorserConfig describes this node's endorser identity, present only if the node endorses.
+type EndorserConfig struct {
+	// Enabled marks this node as an endorser.
+	Enabled bool `yaml:"enabled"`
+	// Keystore is the path to this endorser's secp256k1 key material.
+	Keystore string `yaml:"keystore"`
+	// Address is the endorser's Ethereum address, as registered in the EndorsementVerifier.
+	Address string `yaml:"address"`
+	// FSCIdentity is the endorser's FSC identity, used to route endorsement requests.
+	FSCIdentity string `yaml:"fscIdentity"`
+}
+
+// SubmitterConfig describes the account that signs and pays for transactions.
+type SubmitterConfig struct {
+	// Keystore is the path to the submitter's secp256k1 key material.
+	Keystore string `yaml:"keystore"`
+	// Address is the submitter's Ethereum address.
+	Address string `yaml:"address"`
+}
+
+// EndorsementConfig is the endorsement policy: the quorum, who may ask for endorsement, and the
+// endorser set with the address to FSC identity binding the initiator routes on (design §6.1).
+type EndorsementConfig struct {
+	// Threshold is the number of distinct endorser signatures a transaction needs. It must match the
+	// threshold the EndorsementVerifier was constructed with.
+	Threshold uint `yaml:"threshold"`
+	// Allowlist is the FSC identities permitted to request endorsement. Empty means the policy is
+	// resolved from the TMS network's nodes at wiring time.
+	Allowlist []string `yaml:"allowlist"`
+	// Endorsers binds each endorser's Ethereum address to its FSC identity.
+	Endorsers []EndorserBinding `yaml:"endorsers"`
+}
+
+// EndorserBinding is one endorser's address and FSC identity.
+type EndorserBinding struct {
+	Address     string `yaml:"address"`
+	FSCIdentity string `yaml:"fscIdentity"`
+}
+
+// LoadConfig reads the EVM configuration from the TMS configuration, applies defaults, and validates
+// it. It fails fast: a bad configuration is a startup error (design §13), never a surprise at the
+// first transaction.
+func LoadConfig(configuration Configuration) (*Config, error) {
+	var c Config
+	if err := configuration.UnmarshalKey(EVMConfigKey, &c); err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal evm configuration under [%s]", EVMConfigKey)
+	}
+	c.applyDefaults()
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+// Configuration is the slice of the SDK's configuration service this package needs.
+type Configuration interface {
+	// IsSet reports whether a key is defined.
+	IsSet(key string) bool
+	// UnmarshalKey decodes the value at key into rawVal.
+	UnmarshalKey(key string, rawVal any) error
+}
+
+// applyDefaults fills unset optional fields.
+func (c *Config) applyDefaults() {
+	if c.Finality.BlockTag == "" {
+		c.Finality.BlockTag = DefaultBlockTag
+	}
+	if c.Finality.PollInterval <= 0 {
+		c.Finality.PollInterval = DefaultPollInterval
+	}
+	if c.Finality.Timeout <= 0 {
+		c.Finality.Timeout = DefaultFinalityTimeout
+	}
+	if c.Gas.Strategy == "" {
+		c.Gas.Strategy = DefaultGasStrategy
+	}
+	if c.Gas.Multiplier <= 0 {
+		c.Gas.Multiplier = DefaultGasMultiplier
+	}
+}
+
+// Validate checks the configuration is internally consistent and usable.
+func (c *Config) Validate() error {
+	if c.Endpoint == "" {
+		return errors.New("evm config: endpoint is required")
+	}
+	if c.ChainID <= 0 {
+		return errors.Errorf("evm config: chainID must be positive, got %d", c.ChainID)
+	}
+	if _, err := c.TokenStateAddress(); err != nil {
+		return err
+	}
+	if c.Contracts.EndorsementVerifier != "" {
+		if _, err := client.HexToAddress(c.Contracts.EndorsementVerifier); err != nil {
+			return errors.Wrap(err, "evm config: invalid endorsementVerifier address")
+		}
+	}
+	switch c.Finality.BlockTag {
+	case client.BlockTagFinalized, client.BlockTagSafe, client.BlockTagLatest:
+	default:
+		return errors.Errorf("evm config: unsupported finality blockTag [%s]", c.Finality.BlockTag)
+	}
+	if err := c.validateGas(); err != nil {
+		return err
+	}
+
+	return c.validateEndorsement()
+}
+
+func (c *Config) validateGas() error {
+	switch c.Gas.Strategy {
+	case GasStrategyEstimate:
+		if c.Gas.Multiplier < 1 {
+			return errors.Errorf("evm config: gas multiplier must be at least 1, got %v", c.Gas.Multiplier)
+		}
+	case GasStrategyFixed:
+		if c.Gas.Limit == 0 {
+			return errors.New("evm config: gas limit is required when strategy is fixed")
+		}
+	default:
+		return errors.Errorf("evm config: unsupported gas strategy [%s]", c.Gas.Strategy)
+	}
+
+	return nil
+}
+
+// validateEndorsement enforces the quorum invariants: a positive threshold no larger than the
+// endorser set, and every endorser carrying both an address and an FSC identity (one without the
+// other cannot be routed to or recovered from, design §6.1). Duplicate addresses are rejected because
+// the contract counts distinct signers, so a duplicate would inflate an apparent quorum.
+func (c *Config) validateEndorsement() error {
+	e := c.Endorsement
+	if len(e.Endorsers) == 0 {
+		return errors.New("evm config: no endorsers configured")
+	}
+	if e.Threshold == 0 {
+		return errors.New("evm config: endorsement threshold must be positive")
+	}
+	if int(e.Threshold) > len(e.Endorsers) {
+		return errors.Errorf("evm config: endorsement threshold %d exceeds the %d configured endorsers",
+			e.Threshold, len(e.Endorsers))
+	}
+
+	seen := make(map[client.Address]struct{}, len(e.Endorsers))
+	for i, b := range e.Endorsers {
+		if b.FSCIdentity == "" {
+			return errors.Errorf("evm config: endorser %d has no fscIdentity", i)
+		}
+		addr, err := client.HexToAddress(b.Address)
+		if err != nil {
+			return errors.Wrapf(err, "evm config: endorser %d has an invalid address", i)
+		}
+		if _, dup := seen[addr]; dup {
+			return errors.Errorf("evm config: duplicate endorser address [%s]", b.Address)
+		}
+		seen[addr] = struct{}{}
+	}
+
+	if c.Endorser.Enabled {
+		if c.Endorser.Address == "" {
+			return errors.New("evm config: endorser.address is required when endorser.enabled is set")
+		}
+		if _, err := client.HexToAddress(c.Endorser.Address); err != nil {
+			return errors.Wrap(err, "evm config: invalid endorser address")
+		}
+	}
+
+	return nil
+}
+
+// TokenStateAddress returns the configured TokenState clone address.
+func (c *Config) TokenStateAddress() (client.Address, error) {
+	if c.Contracts.TokenState == "" {
+		return client.Address{}, errors.New("evm config: contracts.tokenState is required")
+	}
+	addr, err := client.HexToAddress(c.Contracts.TokenState)
+	if err != nil {
+		return client.Address{}, errors.Wrap(err, "evm config: invalid tokenState address")
+	}
+
+	return addr, nil
+}
+
+// ChainIDBig returns the chain id as a big.Int, the form the EIP-712 domain and transaction signing
+// need.
+func (c *Config) ChainIDBig() *big.Int { return big.NewInt(c.ChainID) }

--- a/x/token/services/network/evm/config_test.go
+++ b/x/token/services/network/evm/config_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// yamlConfiguration is a Configuration backed by a real YAML document, so the tests exercise the
+// actual decoding path (tags, nested blocks, durations) rather than a hand-built struct.
+type yamlConfiguration struct {
+	root map[string]any
+}
+
+func newYAMLConfiguration(t *testing.T, doc string) *yamlConfiguration {
+	t.Helper()
+	var root map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &root))
+
+	return &yamlConfiguration{root: root}
+}
+
+// lookup walks a dotted key path.
+func (c *yamlConfiguration) lookup(key string) (any, bool) {
+	current := any(c.root)
+	for _, part := range splitKey(key) {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+func (c *yamlConfiguration) IsSet(key string) bool {
+	_, ok := c.lookup(key)
+
+	return ok
+}
+
+func (c *yamlConfiguration) UnmarshalKey(key string, rawVal any) error {
+	v, ok := c.lookup(key)
+	if !ok {
+		return nil // absent key leaves the target zero, matching the SDK's behaviour
+	}
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	return yaml.Unmarshal(raw, rawVal)
+}
+
+func splitKey(key string) []string {
+	var out []string
+	start := 0
+	for i := range len(key) {
+		if key[i] == '.' {
+			out = append(out, key[start:i])
+			start = i + 1
+		}
+	}
+
+	return append(out, key[start:])
+}
+
+const fullConfigYAML = `
+services:
+  network:
+    evm:
+      endpoint: http://localhost:8545
+      chainID: 31337
+      contracts:
+        tokenState: "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+        endorsementVerifier: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+      finality:
+        blockTag: finalized
+        pollInterval: 2s
+        timeout: 5m
+      gas:
+        strategy: estimate
+        multiplier: 1.5
+      endorser:
+        enabled: true
+        keystore: /keys/endorser
+        address: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+        fscIdentity: alice
+      submitter:
+        keystore: /keys/submitter
+        address: "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf"
+      endorsement:
+        threshold: 2
+        allowlist: [alice, bob]
+        endorsers:
+          - address: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+            fscIdentity: alice
+          - address: "0x2b5ad5c4795c026514f8317c7a215e218dccd6cf"
+            fscIdentity: bob
+`
+
+func TestLoadConfigFullDocument(t *testing.T) {
+	c, err := LoadConfig(newYAMLConfiguration(t, fullConfigYAML))
+	require.NoError(t, err)
+
+	assert.Equal(t, "http://localhost:8545", c.Endpoint)
+	assert.Equal(t, int64(31337), c.ChainID)
+	assert.Equal(t, int64(31337), c.ChainIDBig().Int64())
+	assert.Equal(t, "finalized", c.Finality.BlockTag)
+	assert.Equal(t, 2*time.Second, c.Finality.PollInterval)
+	assert.Equal(t, 5*time.Minute, c.Finality.Timeout)
+	assert.InEpsilon(t, 1.5, c.Gas.Multiplier, 1e-9)
+	assert.True(t, c.Endorser.Enabled)
+	assert.Equal(t, uint(2), c.Endorsement.Threshold)
+	require.Len(t, c.Endorsement.Endorsers, 2)
+	assert.Equal(t, "alice", c.Endorsement.Endorsers[0].FSCIdentity)
+	assert.Equal(t, []string{"alice", "bob"}, c.Endorsement.Allowlist)
+
+	addr, err := c.TokenStateAddress()
+	require.NoError(t, err)
+	assert.Equal(t, "0x5fbdb2315678afecb367f032d93f642f64180aa3", addr.Hex())
+}
+
+// minimalConfigYAML omits every optional block, so the defaults must make it usable.
+const minimalConfigYAML = `
+services:
+  network:
+    evm:
+      endpoint: http://localhost:8545
+      chainID: 1337
+      contracts:
+        tokenState: "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+      endorsement:
+        threshold: 1
+        endorsers:
+          - address: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+            fscIdentity: alice
+`
+
+func TestLoadConfigAppliesDefaults(t *testing.T) {
+	c, err := LoadConfig(newYAMLConfiguration(t, minimalConfigYAML))
+	require.NoError(t, err)
+
+	assert.Equal(t, DefaultBlockTag, c.Finality.BlockTag)
+	assert.Equal(t, DefaultPollInterval, c.Finality.PollInterval)
+	assert.Equal(t, DefaultFinalityTimeout, c.Finality.Timeout)
+	assert.Equal(t, DefaultGasStrategy, c.Gas.Strategy)
+	assert.InEpsilon(t, DefaultGasMultiplier, c.Gas.Multiplier, 1e-9)
+}
+
+// TestConfigKeyIsSetOnRealYAML settles the Week-1 review question: whether IsSet on the parent key
+// (services.network.evm) actually distinguishes an EVM TMS from a non-EVM one, since that is what
+// Driver.New routes on. It is checked here against real YAML, with both a leaf and the parent key.
+func TestConfigKeyIsSetOnRealYAML(t *testing.T) {
+	evmTMS := newYAMLConfiguration(t, fullConfigYAML)
+	assert.True(t, evmTMS.IsSet(EVMConfigKey), "an evm TMS must be detected by the parent key")
+	assert.True(t, evmTMS.IsSet(EVMConfigKey+".endpoint"), "and by a leaf key")
+
+	fabricTMS := newYAMLConfiguration(t, `
+services:
+  network:
+    fabric:
+      channel: testchannel
+`)
+	assert.False(t, fabricTMS.IsSet(EVMConfigKey), "a non-evm TMS must not be detected")
+	assert.False(t, fabricTMS.IsSet(EVMConfigKey+".endpoint"))
+}
+
+func TestConfigValidationRejectsBadDocuments(t *testing.T) {
+	base := func() *Config {
+		c, err := LoadConfig(newYAMLConfiguration(t, fullConfigYAML))
+		require.NoError(t, err)
+
+		return c
+	}
+
+	cases := map[string]func(*Config){
+		"empty endpoint":          func(c *Config) { c.Endpoint = "" },
+		"zero chain id":           func(c *Config) { c.ChainID = 0 },
+		"negative chain id":       func(c *Config) { c.ChainID = -1 },
+		"missing token state":     func(c *Config) { c.Contracts.TokenState = "" },
+		"malformed token state":   func(c *Config) { c.Contracts.TokenState = "0xdeadbeef" },
+		"malformed verifier":      func(c *Config) { c.Contracts.EndorsementVerifier = "not-an-address" },
+		"unsupported block tag":   func(c *Config) { c.Finality.BlockTag = "pending" },
+		"unknown gas strategy":    func(c *Config) { c.Gas.Strategy = "guess" },
+		"multiplier below one":    func(c *Config) { c.Gas.Multiplier = 0.5 },
+		"fixed gas without limit": func(c *Config) { c.Gas.Strategy = GasStrategyFixed; c.Gas.Limit = 0 },
+		"no endorsers":            func(c *Config) { c.Endorsement.Endorsers = nil },
+		"zero threshold":          func(c *Config) { c.Endorsement.Threshold = 0 },
+		"threshold above set": func(c *Config) {
+			c.Endorsement.Threshold = uint(len(c.Endorsement.Endorsers)) + 1
+		},
+		"endorser without identity": func(c *Config) { c.Endorsement.Endorsers[0].FSCIdentity = "" },
+		"endorser with bad address": func(c *Config) { c.Endorsement.Endorsers[0].Address = "0x1234" },
+		"duplicate endorser address": func(c *Config) {
+			c.Endorsement.Endorsers[1].Address = c.Endorsement.Endorsers[0].Address
+		},
+		"enabled endorser without address": func(c *Config) { c.Endorser.Address = "" },
+		"enabled endorser bad address":     func(c *Config) { c.Endorser.Address = "nope" },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := base()
+			mutate(c)
+			require.Error(t, c.Validate())
+		})
+	}
+}
+
+// TestFixedGasStrategyIsValid checks the fixed strategy is accepted when a limit is set.
+func TestFixedGasStrategyIsValid(t *testing.T) {
+	c, err := LoadConfig(newYAMLConfiguration(t, fullConfigYAML))
+	require.NoError(t, err)
+	c.Gas.Strategy = GasStrategyFixed
+	c.Gas.Limit = 500_000
+	require.NoError(t, c.Validate())
+}
+
+// TestThresholdEqualToSetSizeIsValid checks the boundary: an N-of-N policy is legitimate.
+func TestThresholdEqualToSetSizeIsValid(t *testing.T) {
+	c, err := LoadConfig(newYAMLConfiguration(t, fullConfigYAML))
+	require.NoError(t, err)
+	c.Endorsement.Threshold = uint(len(c.Endorsement.Endorsers))
+	require.NoError(t, c.Validate())
+}

--- a/x/token/services/network/evm/endorsement/ledger.go
+++ b/x/token/services/network/evm/endorsement/ledger.go
@@ -40,9 +40,10 @@ type Ledger struct {
 	blockTag   string
 }
 
-// DefaultBlockTag is the block tag the ledger reads at when none is configured: the PoS finalized
-// tag, which removes reorg handling from validation (design §7.2).
-const DefaultBlockTag = "finalized"
+// DefaultBlockTag is the block tag the ledger reads at when none is configured. It aliases the
+// canonical value in the client package so the endorsers' ledger, the version keeper and the driver
+// can never drift onto different views of the chain.
+const DefaultBlockTag = client.BlockTagFinalized
 
 // NewLedger returns a Ledger reading the TokenState contract through the EVM client. An empty
 // blockTag defaults to DefaultBlockTag.

--- a/x/token/services/network/evm/go.mod
+++ b/x/token/services/network/evm/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.54.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -108,7 +109,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/x/token/services/network/evm/pp/versionkeeper.go
+++ b/x/token/services/network/evm/pp/versionkeeper.go
@@ -1,0 +1,98 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pp
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// getPublicParamsVersionMethod is the canonical ABI signature of the TokenState read the keeper
+// syncs from.
+const getPublicParamsVersionMethod = "getPublicParamsVersion()"
+
+// VersionKeeper tracks the public-parameters version of one TMS. Endorsers refuse to sign a
+// StateDelta whose version does not match, and the contract rejects one that does not match its own
+// at apply time, so this is the driver's cached view of that value (design §3.5, §6.2).
+//
+// The on-chain convention: initialize sets version 0, and each endorsed setup delta increments it.
+// The keeper mirrors that, and is safe for concurrent use because the driver reads it from every
+// endorsement while a public-parameters update may be syncing.
+type VersionKeeper struct {
+	client     client.EVMClient
+	tokenState client.Address
+	blockTag   string
+
+	mu          sync.RWMutex
+	version     uint64
+	initialized bool
+}
+
+// NewVersionKeeper returns a keeper reading the TokenState clone at the given block tag. An empty
+// blockTag defaults to client.BlockTagFinalized. The keeper starts uninitialized: the first Sync
+// populates it.
+func NewVersionKeeper(evmClient client.EVMClient, tokenState client.Address, blockTag string) *VersionKeeper {
+	if blockTag == "" {
+		blockTag = client.BlockTagFinalized
+	}
+
+	return &VersionKeeper{client: evmClient, tokenState: tokenState, blockTag: blockTag}
+}
+
+// Sync reads the current version from the contract and caches it.
+func (k *VersionKeeper) Sync(ctx context.Context) (uint64, error) {
+	raw, err := k.client.Call(ctx, k.tokenState, abi.MethodID(getPublicParamsVersionMethod), k.blockTag)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to read the public parameters version")
+	}
+	version, err := abi.DecodeUint64(raw)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to decode the public parameters version")
+	}
+
+	k.mu.Lock()
+	k.version = version
+	k.initialized = true
+	k.mu.Unlock()
+
+	return version, nil
+}
+
+// GetVersion returns the cached version, syncing once if it has never been read. Callers on the
+// endorsement path use this rather than Sync so a steady state costs no round trip.
+func (k *VersionKeeper) GetVersion(ctx context.Context) (uint64, error) {
+	k.mu.RLock()
+	version, initialized := k.version, k.initialized
+	k.mu.RUnlock()
+	if initialized {
+		return version, nil
+	}
+
+	return k.Sync(ctx)
+}
+
+// Cached returns the cached version and whether it has been populated, without ever calling the
+// node. It is for callers that must not block, such as diagnostics.
+func (k *VersionKeeper) Cached() (uint64, bool) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	return k.version, k.initialized
+}
+
+// Invalidate drops the cached value so the next GetVersion re-reads from the contract. The driver
+// calls it after applying a public-parameters update, whose whole point is that the version moved.
+func (k *VersionKeeper) Invalidate() {
+	k.mu.Lock()
+	k.initialized = false
+	k.mu.Unlock()
+}

--- a/x/token/services/network/evm/pp/versionkeeper_test.go
+++ b/x/token/services/network/evm/pp/versionkeeper_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pp
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+)
+
+// uint64Return encodes v as the ABI return value of a uint64 method.
+func uint64Return(v uint64) []byte {
+	out := make([]byte, 32)
+	binary.BigEndian.PutUint64(out[24:], v)
+
+	return out
+}
+
+func testAddress(low byte) client.Address {
+	var a client.Address
+	a[client.AddressLength-1] = low
+
+	return a
+}
+
+func TestSyncReadsAndCaches(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(uint64Return(3), nil)
+
+	k := NewVersionKeeper(evm, testAddress(0xAA), "")
+	got, err := k.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), got)
+
+	cached, ok := k.Cached()
+	assert.True(t, ok)
+	assert.Equal(t, uint64(3), cached)
+
+	// the call must target the TokenState with the getPublicParamsVersion selector, at the block tag
+	require.Equal(t, 1, evm.CallCallCount())
+	_, to, data, tag := evm.CallArgsForCall(0)
+	assert.Equal(t, testAddress(0xAA), to)
+	assert.Equal(t, "finalized", tag, "an empty block tag must default to finalized")
+	assert.Equal(t, abi.MethodID("getPublicParamsVersion()"), data)
+}
+
+// TestGetVersionSyncsOnceThenServesCache is the property the endorsement path depends on: a steady
+// state costs no round trip.
+func TestGetVersionSyncsOnceThenServesCache(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(uint64Return(7), nil)
+	k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
+
+	for range 5 {
+		got, err := k.GetVersion(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, uint64(7), got)
+	}
+	assert.Equal(t, 1, evm.CallCallCount(), "only the first read may hit the node")
+}
+
+// TestInvalidateForcesResync covers the public-parameters update path: after an update the cached
+// version is stale by definition, so the next read must go back to the contract.
+func TestInvalidateForcesResync(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturnsOnCall(0, uint64Return(1), nil)
+	evm.CallReturnsOnCall(1, uint64Return(2), nil)
+	k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
+
+	first, err := k.GetVersion(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), first)
+
+	k.Invalidate()
+	second, err := k.GetVersion(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), second, "after an update the keeper must observe the bumped version")
+	assert.Equal(t, 2, evm.CallCallCount())
+}
+
+func TestCachedBeforeAnySync(t *testing.T) {
+	k := NewVersionKeeper(&mock.EVMClient{}, testAddress(0xAA), "finalized")
+	version, ok := k.Cached()
+	assert.False(t, ok, "the keeper starts uninitialized")
+	assert.Zero(t, version)
+}
+
+func TestSyncSurfacesErrors(t *testing.T) {
+	t.Run("call failure", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(nil, assert.AnError)
+		k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
+		_, err := k.Sync(context.Background())
+		require.Error(t, err)
+
+		_, ok := k.Cached()
+		assert.False(t, ok, "a failed sync must not mark the keeper initialized")
+	})
+
+	t.Run("undecodable result", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns([]byte{0x01}, nil) // too short for a uint64 word
+		k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
+		_, err := k.Sync(context.Background())
+		require.Error(t, err)
+	})
+}
+
+// TestConcurrentAccess exercises the keeper the way the driver uses it: many endorsements reading
+// while an update re-syncs. Run under -race, this is what proves the locking is right.
+func TestConcurrentAccess(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(uint64Return(5), nil)
+	k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := k.GetVersion(context.Background())
+			assert.NoError(t, err)
+			k.Cached()
+		}()
+	}
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			k.Invalidate()
+			_, err := k.Sync(context.Background())
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	version, ok := k.Cached()
+	assert.True(t, ok)
+	assert.Equal(t, uint64(5), version)
+}

--- a/x/token/services/network/evm/pp/versionkeeper_test.go
+++ b/x/token/services/network/evm/pp/versionkeeper_test.go
@@ -125,26 +125,38 @@ func TestConcurrentAccess(t *testing.T) {
 	evm.CallReturns(uint64Return(5), nil)
 	k := NewVersionKeeper(evm, testAddress(0xAA), "finalized")
 
-	var wg sync.WaitGroup
+	// Failures are collected rather than asserted inside the goroutines: a failed assertion there
+	// would call FailNow off the test goroutine, which is not allowed.
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+	record := func(err error) {
+		if err == nil {
+			return
+		}
+		mu.Lock()
+		errs = append(errs, err)
+		mu.Unlock()
+	}
+
 	for range 16 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			_, err := k.GetVersion(context.Background())
-			assert.NoError(t, err)
+			record(err)
 			k.Cached()
-		}()
+		})
 	}
 	for range 4 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			k.Invalidate()
 			_, err := k.Sync(context.Background())
-			assert.NoError(t, err)
-		}()
+			record(err)
+		})
 	}
 	wg.Wait()
+	require.Empty(t, errs, "concurrent access must not fail")
 
 	version, ok := k.Cached()
 	assert.True(t, ok)


### PR DESCRIPTION
The plumbing the driver needs before it can talk to a node. Splitting this out from the network methods so it stays reviewable, the rest follows in the next PR.

- a JSON-RPC EVMClient over plain eth_* methods, so it works against any standard node
- a minimal RLP encoder and EIP-1559 transaction assembly and signing
- the ABI write side: a small value model that handles the head/tail layout for nested dynamic types, and the applyStateDelta encoder on top of it
- the evm config block with defaults and validation
- a version keeper that caches the on-chain public parameters version

RLP and the transaction signing are hand-rolled on decred/secp256k1 rather than go-ethereum, same as the rest of the driver.

Two things are pinned to golden vectors that were verified with cast, not just against my own code:

- the signed transaction, which cast decodes to the expected signer, so the field order, minimal integer encoding, signing hash and yParity/r/s encoding are all covered
- the applyStateDelta calldata, which cast round-trips field by field including a multi-word output, so the ABI offsets are covered

The selector comes from the compiled contract ABI rather than being written by hand. Config also settles an open question from week 1: whether IsSet on the parent key really distinguishes an evm TMS. It does, checked against real yaml with both an evm and a non-evm TMS.

One small cleanup: "finalized" was about to exist as two separate constants and a couple of literals, so the block tags now live in one place. The endorsers' ledger, the version keeper and the driver have to read at the same tag or they would validate against different views of the chain.
