### PR TITLE
feat(evm): network methods, submission and finality

### DIFF
--- a/x/token/services/network/evm/abi/abi.go
+++ b/x/token/services/network/evm/abi/abi.go
@@ -119,3 +119,51 @@ func readWordAsLength(word []byte, what string) (int, error) {
 
 // maxInt is the largest value of the platform int, used to bound-check ABI lengths before conversion.
 const maxInt = int(^uint(0) >> 1)
+
+// DecodeBytes32 decodes a single bytes32 return value.
+func DecodeBytes32(ret []byte) ([32]byte, error) {
+	var out [32]byte
+	if len(ret) < wordLength {
+		return out, errors.Errorf("abi: bytes32 return too short: %d bytes", len(ret))
+	}
+	copy(out[:], ret[:wordLength])
+
+	return out, nil
+}
+
+// DecodeBoolArray decodes a bool[] return value: a head word holding the offset to the tail, then at
+// the tail a length word followed by one word per element (zero is false, anything else true).
+func DecodeBoolArray(ret []byte) ([]bool, error) {
+	if len(ret) < wordLength {
+		return nil, errors.Errorf("abi: bool array return too short for offset word: %d bytes", len(ret))
+	}
+	offset, err := readWordAsLength(ret[:wordLength], "offset")
+	if err != nil {
+		return nil, err
+	}
+	if offset > len(ret)-wordLength {
+		return nil, errors.Errorf("abi: bool array offset %d out of bounds (len %d)", offset, len(ret))
+	}
+	length, err := readWordAsLength(ret[offset:offset+wordLength], "length")
+	if err != nil {
+		return nil, err
+	}
+	body := ret[offset+wordLength:]
+	if length > len(body)/wordLength {
+		return nil, errors.Errorf("abi: bool array length %d exceeds the %d available words", length, len(body)/wordLength)
+	}
+
+	out := make([]bool, length)
+	for i := range length {
+		word := body[i*wordLength : (i+1)*wordLength]
+		for _, b := range word {
+			if b != 0 {
+				out[i] = true
+
+				break
+			}
+		}
+	}
+
+	return out, nil
+}

--- a/x/token/services/network/evm/driver.go
+++ b/x/token/services/network/evm/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/config"
 	"github.com/LFDT-Panurus/panurus/token/services/logging"
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
 )
 
 var logger = logging.MustGetLogger()
@@ -20,12 +21,14 @@ var logger = logging.MustGetLogger()
 // i.e. token.tms.<tms-id>.services.network.evm. Its presence marks a TMS as an EVM network.
 const EVMConfigKey = "services.network.evm"
 
-// networkResolver decides whether a (network, channel) pair is served by the EVM driver. It is a
-// small seam over the configuration so the driver's routing can be unit-tested without a full
-// config service.
+// networkResolver decides whether a (network, channel) pair is served by the EVM driver, and yields
+// that network's configuration. It is a small seam over the configuration service so the driver's
+// routing can be unit-tested without a full config service.
 type networkResolver interface {
 	// IsEVMNetwork reports whether the given network/channel has an EVM network configuration.
 	IsEVMNetwork(network, channel string) bool
+	// ConfigFor returns the EVM configuration for the given network/channel.
+	ConfigFor(network, channel string) (*Config, error)
 }
 
 // Driver is the EVM network driver factory. It implements driver.Driver: the network provider calls
@@ -46,13 +49,26 @@ func NewDriver(configService *config.Service) driver.Driver {
 
 // New returns an EVM Network for the given network/channel, or an error if that network is not
 // configured for EVM (so the network provider falls through to the next registered driver).
+//
+// The endorsement service and the submitter are supplied by the SDK wiring, which owns the key
+// material and the FSC view manager they need; a Network built here can serve queries and assemble
+// approvals once they are injected.
 func (d *Driver) New(network, channel string) (driver.Network, error) {
 	if !d.resolver.IsEVMNetwork(network, channel) {
 		return nil, errors.Errorf("evm: no evm network configuration for [%s:%s]", network, channel)
 	}
 	logger.Debugf("creating evm network [%s:%s]", network, channel)
 
-	return newNetwork(network), nil
+	config, err := d.resolver.ConfigFor(network, channel)
+	if err != nil {
+		return nil, err
+	}
+	evmClient, err := client.NewJSONRPCClient(config.Endpoint, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "evm: failed to create a client for [%s:%s]", network, channel)
+	}
+
+	return NewNetwork(network, config, evmClient, nil, nil)
 }
 
 // configNetworkResolver resolves EVM networks from the token-sdk configuration.
@@ -77,4 +93,22 @@ func (r *configNetworkResolver) IsEVMNetwork(network, channel string) bool {
 	}
 
 	return false
+}
+
+// ConfigFor loads and validates the EVM configuration of the first TMS declaring it for the given
+// network/channel. Every TMS on one EVM network shares the endpoint and chain, so the first match is
+// the network's configuration.
+func (r *configNetworkResolver) ConfigFor(network, channel string) (*Config, error) {
+	configs, err := r.cs.Configurations()
+	if err != nil {
+		return nil, errors.Wrapf(err, "evm: failed to load token-sdk configurations for [%s:%s]", network, channel)
+	}
+	for _, c := range configs {
+		id := c.ID()
+		if id.Network == network && id.Channel == channel && c.IsSet(EVMConfigKey) {
+			return LoadConfig(c)
+		}
+	}
+
+	return nil, errors.Errorf("evm: no evm network configuration for [%s:%s]", network, channel)
 }

--- a/x/token/services/network/evm/driver_test.go
+++ b/x/token/services/network/evm/driver_test.go
@@ -9,17 +9,29 @@ package evm
 import (
 	"testing"
 
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeResolver reports a fixed set of (network|channel) pairs as EVM networks.
+// fakeResolver reports a fixed set of (network|channel) pairs as EVM networks and yields a minimal
+// valid configuration for them.
 type fakeResolver struct {
 	evm map[string]bool
 }
 
 func (f fakeResolver) IsEVMNetwork(network, channel string) bool {
 	return f.evm[network+"|"+channel]
+}
+
+func (f fakeResolver) ConfigFor(network, channel string) (*Config, error) {
+	if !f.IsEVMNetwork(network, channel) {
+		return nil, errors.Errorf("no evm configuration for [%s:%s]", network, channel)
+	}
+	c := validConfig()
+	c.applyDefaults()
+
+	return c, c.Validate()
 }
 
 func TestDriverNewRouting(t *testing.T) {
@@ -41,15 +53,17 @@ func TestDriverNewRouting(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNetworkStubNotImplemented documents that the skeleton's behavioural methods are wired to the
-// interface but not yet implemented, so a mis-registration surfaces as a clear error rather than a
-// nil-pointer panic.
-func TestNetworkStubNotImplemented(t *testing.T) {
-	n := newNetwork("evm-net")
+// TestNetworkDeferredSurface documents the methods that land with the finality manager: they are
+// wired to the interface and return a clear error rather than panicking.
+func TestNetworkDeferredSurface(t *testing.T) {
+	n := testNetwork(t, nil, nil)
 
 	assert.NotNil(t, n.NewEnvelope())
-	err := n.Broadcast(t.Context(), &Envelope{})
+	_, err := n.Ledger()
 	require.ErrorIs(t, err, errNotImplemented)
-	_, err = n.Ledger()
-	assert.ErrorIs(t, err, errNotImplemented)
+	err = n.AddFinalityListener("ns", "tx", nil)
+	require.ErrorIs(t, err, errNotImplemented)
+	status, _, _, err := n.GetTransactionStatus(t.Context(), "ns", "tx")
+	require.ErrorIs(t, err, errNotImplemented)
+	assert.Equal(t, 4, status, "an unresolvable status must be Unknown (4), never the invalid zero code")
 }

--- a/x/token/services/network/evm/driver_test.go
+++ b/x/token/services/network/evm/driver_test.go
@@ -9,6 +9,9 @@ package evm
 import (
 	"testing"
 
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+
 	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,17 +56,40 @@ func TestDriverNewRouting(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestNetworkDeferredSurface documents the methods that land with the finality manager: they are
-// wired to the interface and return a clear error rather than panicking.
-func TestNetworkDeferredSurface(t *testing.T) {
-	n := testNetwork(t, nil, nil)
+// TestNetworkSurfaceIsWired checks the methods that used to be stubs now answer through the finality
+// manager rather than returning a not-implemented error.
+func TestNetworkSurfaceIsWired(t *testing.T) {
+	evm := &mock.EVMClient{}
+	// getTokenRequestHash returns the zero hash: the anchor has not been applied.
+	evm.CallReturns(make([]byte, 32), nil)
+	n := testNetwork(t, evm, nil)
 
 	assert.NotNil(t, n.NewEnvelope())
-	_, err := n.Ledger()
-	require.ErrorIs(t, err, errNotImplemented)
-	err = n.AddFinalityListener("ns", "tx", nil)
-	require.ErrorIs(t, err, errNotImplemented)
-	status, _, _, err := n.GetTransactionStatus(t.Context(), "ns", "tx")
-	require.ErrorIs(t, err, errNotImplemented)
-	assert.Equal(t, 4, status, "an unresolvable status must be Unknown (4), never the invalid zero code")
+
+	ledger, err := n.Ledger()
+	require.NoError(t, err)
+	require.NotNil(t, ledger)
+
+	// An anchor the chain has never seen is Unknown: never the invalid zero code, and never Invalid,
+	// because a reverted apply is indistinguishable from one still pending (design 7.4).
+	status, hash, _, err := n.GetTransactionStatus(t.Context(), "token", anchorHex(0x01))
+	require.NoError(t, err)
+	assert.Equal(t, driver.Unknown, status)
+	assert.Nil(t, hash)
+
+	code, err := ledger.Status(anchorHex(0x01))
+	require.NoError(t, err)
+	assert.Equal(t, driver.Unknown, code)
+}
+
+// TestNetworkRejectsMalformedTransactionID checks the anchor-shaped identifier is validated rather
+// than silently producing a wrong on-chain lookup.
+func TestNetworkRejectsMalformedTransactionID(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	_, _, _, err := n.GetTransactionStatus(t.Context(), "token", "not-a-valid-anchor")
+	require.Error(t, err)
+
+	err = n.AddFinalityListener("token", "not-a-valid-anchor", nil)
+	require.Error(t, err)
 }

--- a/x/token/services/network/evm/e2e_anvil_test.go
+++ b/x/token/services/network/evm/e2e_anvil_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"math/big"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/crypto"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/eip712"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+// This is the Week-5 gate: the whole write path exercised against a REAL EVM node rather than a mock.
+// It deploys the contracts with forge, then drives the driver's own submitter, finality manager and
+// query surface against them, so what is proven is that the pieces built in isolation actually
+// compose: the ABI encoding the node accepts, the transaction the node mines, the state the contract
+// stores, and the finality the driver reads back.
+//
+// It is skipped unless anvil and forge are installed, so the ordinary unit-test run stays hermetic.
+
+const (
+	// anvilKey1 is anvil's first well-known development account, used here as endorser and submitter.
+	anvilKey1 = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+	anvilPort = "18545"
+)
+
+// startAnvil boots a local anvil node and returns its endpoint, skipping the test if anvil is absent.
+func startAnvil(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("anvil"); err != nil {
+		t.Skip("anvil not installed; skipping the end-to-end gate")
+	}
+	if _, err := exec.LookPath("forge"); err != nil {
+		t.Skip("forge not installed; skipping the end-to-end gate")
+	}
+
+	cmd := exec.Command("anvil", "--port", anvilPort, "--silent")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	endpoint := "http://127.0.0.1:" + anvilPort
+	waitForPort(t, "127.0.0.1:"+anvilPort)
+
+	return endpoint
+}
+
+func waitForPort(t *testing.T, address string) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", address, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("anvil did not start listening on %s", address)
+}
+
+// deployContracts runs the project's own deploy script against the node and returns the TokenState
+// clone address, so the test exercises the same deployment path an operator would use.
+func deployContracts(t *testing.T, endpoint string, endorser client.Address, pp0 []byte) client.Address {
+	t.Helper()
+
+	// vm.startBroadcast() takes its sender from the CLI, so the key is passed as a flag rather than
+	// through the environment.
+	cmd := exec.Command("forge", "script", "script/Deploy.s.sol:Deploy",
+		"--rpc-url", endpoint, "--broadcast", "--json",
+		"--private-key", "0x"+anvilKey1)
+	cmd.Dir = "contracts"
+	cmd.Env = append(cmd.Environ(),
+		"EVM_ENDORSERS="+endorser.Hex(),
+		"EVM_THRESHOLD=1",
+		"EVM_PP0=0x"+hex.EncodeToString(pp0),
+		"EVM_GRAPH_HIDING=false",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "forge deploy failed: %s", out)
+
+	address := parseDeployedClone(t, string(out))
+	parsed, err := client.HexToAddress(address)
+	require.NoError(t, err)
+
+	return parsed
+}
+
+// parseDeployedClone pulls the TokenState clone address out of the deploy script's JSON output.
+func parseDeployedClone(t *testing.T, out string) string {
+	t.Helper()
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var payload struct {
+			Returns struct {
+				TokenState struct {
+					Value string `json:"value"`
+				} `json:"tokenState"`
+			} `json:"returns"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &payload); err != nil {
+			continue
+		}
+		if payload.Returns.TokenState.Value != "" {
+			return payload.Returns.TokenState.Value
+		}
+	}
+	t.Fatalf("could not find the deployed TokenState clone in the forge output:\n%s", out)
+
+	return ""
+}
+
+// TestEndToEndAgainstAnvil is the Week-5 gate: issue a token, then spend it, both through the
+// driver's real submission path, and read the results back from the chain.
+func TestEndToEndAgainstAnvil(t *testing.T) {
+	endpoint := startAnvil(t)
+
+	keyBytes, err := hex.DecodeString(anvilKey1)
+	require.NoError(t, err)
+	key := secp256k1.PrivKeyFromBytes(keyBytes)
+	signer, err := eip712.NewSignerFromBytes(keyBytes)
+	require.NoError(t, err)
+
+	pp0 := []byte("e2e-public-params")
+	tokenState := deployContracts(t, endpoint, signer.Address(), pp0)
+	t.Logf("deployed TokenState clone at %s", tokenState)
+
+	evmClient, err := client.NewJSONRPCClient(endpoint, nil)
+	require.NoError(t, err)
+
+	cfg := validConfig()
+	cfg.Endpoint = endpoint
+	cfg.Contracts.TokenState = tokenState.Hex()
+	cfg.Finality.BlockTag = client.BlockTagLatest // anvil mines instantly; there is no finalized tag
+	cfg.Finality.PollInterval = 50 * time.Millisecond
+	cfg.Finality.Timeout = 15 * time.Second
+	cfg.applyDefaults()
+	require.NoError(t, cfg.Validate())
+
+	submitter, err := NewSubmitter(evmClient, key, tokenState, big.NewInt(testChainID), cfg.Gas)
+	require.NoError(t, err)
+
+	n, err := NewNetwork("evm-net", cfg, evmClient, nil, submitter)
+	require.NoError(t, err)
+
+	// The node must be the chain we signed for.
+	_, err = n.Connect("token")
+	require.NoError(t, err, "Connect must accept a reachable node on the configured chain")
+
+	domain := eip712.Domain{ChainID: big.NewInt(testChainID), VerifyingContract: tokenState}
+
+	// --- issue -------------------------------------------------------------------------------------
+
+	issueAnchorID := n.ComputeTxID(&driver.TxID{Creator: []byte("issuer")})
+	issueAnchor, err := keys.AnchorFromTxID(issueAnchorID)
+	require.NoError(t, err)
+
+	tokenData := []byte("alice-owns-100")
+	issued := &statedelta.StateDelta{
+		Anchor: issueAnchor,
+		Outputs: []statedelta.OutputToken{{
+			TokenID:   keys.ComputeTokenID(issueAnchor, 0),
+			SNMarker:  keys.OutputSNMarker(issueAnchor, 0, tokenData),
+			TokenData: tokenData,
+		}},
+		TokenRequestHash:    sha256Of("issue-request"),
+		PublicParamsHash:    sha256Of(string(pp0)),
+		PublicParamsVersion: 0,
+	}
+	issueEnv := &Envelope{Anchor: issueAnchorID, Delta: issued, Endorsements: endorse(t, signer, domain, issued)}
+
+	require.NoError(t, n.Broadcast(t.Context(), issueEnv), "issue must be accepted on chain")
+	require.NotEmpty(t, issueEnv.EthTxHash, "Broadcast must record the transaction hash")
+	require.Equal(t, uint64(1), waitMined(t, evmClient, issueEnv.EthTxHash), "the issue must not revert")
+	t.Logf("issue applied in %s", issueEnv.EthTxHash)
+
+	// the token is queryable, and unspent
+	issuedID := &token.ID{TxId: issueAnchorID, Index: 0}
+	stored, err := n.QueryTokens(t.Context(), "token", []*token.ID{issuedID})
+	require.NoError(t, err)
+	assert.Equal(t, tokenData, stored[0], "the chain must return the token bytes the driver wrote")
+
+	spent, err := n.AreTokensSpent(t.Context(), "token", []*token.ID{issuedID}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{false}, spent, "a freshly issued token is unspent")
+
+	// finality resolves the anchor as valid, with the recorded token-request hash
+	status, trHash, _, err := n.GetTransactionStatus(t.Context(), "token", issueAnchorID)
+	require.NoError(t, err)
+	assert.Equal(t, driver.Valid, status)
+	assert.Equal(t, issued.TokenRequestHash[:], trHash)
+
+	// --- transfer ----------------------------------------------------------------------------------
+
+	spendAnchorID := n.ComputeTxID(&driver.TxID{Creator: []byte("alice")})
+	spendAnchor, err := keys.AnchorFromTxID(spendAnchorID)
+	require.NoError(t, err)
+
+	bobData := []byte("bob-owns-100")
+	transferred := &statedelta.StateDelta{
+		Anchor:    spendAnchor,
+		SpentRefs: [][32]byte{keys.OutputSNMarker(issueAnchor, 0, tokenData)},
+		Outputs: []statedelta.OutputToken{{
+			TokenID:   keys.ComputeTokenID(spendAnchor, 0),
+			SNMarker:  keys.OutputSNMarker(spendAnchor, 0, bobData),
+			TokenData: bobData,
+		}},
+		TokenRequestHash:    sha256Of("transfer-request"),
+		PublicParamsHash:    sha256Of(string(pp0)),
+		PublicParamsVersion: 0,
+	}
+	transferEnv := &Envelope{
+		Anchor:       spendAnchorID,
+		Delta:        transferred,
+		Endorsements: endorse(t, signer, domain, transferred),
+	}
+
+	require.NoError(t, n.Broadcast(t.Context(), transferEnv), "transfer must be accepted on chain")
+	require.Equal(t, uint64(1), waitMined(t, evmClient, transferEnv.EthTxHash), "the transfer must not revert")
+	t.Logf("transfer applied in %s", transferEnv.EthTxHash)
+
+	// alice's token is now spent, bob's exists
+	spent, err = n.AreTokensSpent(t.Context(), "token", []*token.ID{issuedID}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []bool{true}, spent, "the transferred input must be marked spent")
+
+	bobsToken, err := n.QueryTokens(t.Context(), "token", []*token.ID{{TxId: spendAnchorID, Index: 0}})
+	require.NoError(t, err)
+	assert.Equal(t, bobData, bobsToken[0])
+
+	// --- double spend ------------------------------------------------------------------------------
+
+	// A fully endorsed but doubly-spending transaction must be refused by the contract, which is the
+	// property the whole design rests on: endorsement authorizes, the chain still enforces.
+	doubleAnchorID := n.ComputeTxID(&driver.TxID{Creator: []byte("mallory")})
+	doubleAnchor, err := keys.AnchorFromTxID(doubleAnchorID)
+	require.NoError(t, err)
+
+	doubleSpend := &statedelta.StateDelta{
+		Anchor:              doubleAnchor,
+		SpentRefs:           [][32]byte{keys.OutputSNMarker(issueAnchor, 0, tokenData)}, // already spent
+		TokenRequestHash:    sha256Of("double-spend-request"),
+		PublicParamsHash:    sha256Of(string(pp0)),
+		PublicParamsVersion: 0,
+	}
+	doubleEnv := &Envelope{
+		Anchor:       doubleAnchorID,
+		Delta:        doubleSpend,
+		Endorsements: endorse(t, signer, domain, doubleSpend),
+	}
+
+	// The node may refuse it outright (gas estimation reverts) or mine it as a failed transaction;
+	// either way it must never be applied.
+	if err := n.Broadcast(t.Context(), doubleEnv); err == nil {
+		assert.Equal(t, uint64(0), waitMined(t, evmClient, doubleEnv.EthTxHash),
+			"a double spend must revert on chain")
+	}
+
+	status, _, _, err = n.GetTransactionStatus(t.Context(), "token", doubleAnchorID)
+	require.NoError(t, err)
+	assert.NotEqual(t, driver.Valid, status, "a double spend must never be recorded as valid")
+
+	// --- finality listener -------------------------------------------------------------------------
+
+	listener := &e2eListener{done: make(chan struct{})}
+	require.NoError(t, n.AddFinalityListener("token", issueAnchorID, listener))
+	select {
+	case <-listener.done:
+		assert.Equal(t, driver.Valid, listener.status, "an applied anchor must resolve as valid")
+	case <-time.After(10 * time.Second):
+		t.Fatal("the finality listener was never notified for an already-applied anchor")
+	}
+}
+
+// waitMined polls until the transaction is mined and returns its receipt status. Broadcast returns as
+// soon as the node accepts the transaction, so on-chain state must not be read until it is mined;
+// this is the same asynchrony the finality manager exists to handle.
+func waitMined(t *testing.T, c client.EVMClient, txHash string) uint64 {
+	t.Helper()
+	h, err := client.HexToHash(txHash)
+	require.NoError(t, err)
+
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		receipt, err := c.GetTransactionReceipt(t.Context(), h)
+		require.NoError(t, err)
+		if receipt != nil && receipt.BlockNumber != nil {
+			return receipt.Status
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("transaction %s was never mined", txHash)
+
+	return 0
+}
+
+// endorse signs the delta's EIP-712 digest, producing the quorum the contract verifies.
+func endorse(t *testing.T, signer *eip712.Signer, domain eip712.Domain, delta *statedelta.StateDelta) [][]byte {
+	t.Helper()
+	sig, err := signer.Sign(eip712.Digest(domain, delta))
+	require.NoError(t, err)
+
+	return [][]byte{sig}
+}
+
+// sha256Of is the hash the delta carries for the token request and the public parameters.
+func sha256Of(s string) [32]byte {
+	var out [32]byte
+	copy(out[:], crypto.SHA256([]byte(s)))
+
+	return out
+}
+
+type e2eListener struct {
+	done   chan struct{}
+	status int
+}
+
+func (l *e2eListener) OnStatus(_ context.Context, _ string, status int, _ string, _ []byte) {
+	l.status = status
+	close(l.done)
+}
+
+func (l *e2eListener) OnError(context.Context, string, error) {}

--- a/x/token/services/network/evm/finality/manager.go
+++ b/x/token/services/network/evm/finality/manager.go
@@ -1,0 +1,218 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/token/services/logging"
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// logger reports transient finality-resolution problems that are retried rather than surfaced.
+var logger = logging.MustGetLogger()
+
+// StateReader is the slice of the TokenState the finality manager reads. It is defined here, on the
+// consumer side, so this package does not import the driver package that constructs it.
+type StateReader interface {
+	// TokenRequestHash returns the token-request hash recorded for an anchor and whether the anchor
+	// has been applied at all.
+	TokenRequestHash(ctx context.Context, anchor [32]byte) (hash []byte, found bool, err error)
+}
+
+// Manager resolves the finality of EVM token transactions and notifies listeners.
+//
+// The chain is the only source of truth, which shapes what can be observed (design §7.1, §7.4):
+//
+//   - By eth transaction hash, the full lifecycle is visible: a receipt with status 1 is Valid,
+//     status 0 is Invalid, a known but unmined transaction is Busy, and one the node has never seen
+//     is dropped.
+//   - By anchor, only success is observable. applyStateDelta records the anchor as its last step, so
+//     a recorded anchor proves the transaction succeeded; but a failure REVERTS, leaving no trace at
+//     all, so a missing anchor is indistinguishable from one still pending. Failure is therefore
+//     reachable only through the timeout, which is why the timeout is a correctness parameter here
+//     rather than a convenience.
+//
+// A restart needs no persisted state: both resolutions re-read from the chain.
+type Manager struct {
+	client       client.EVMClient
+	state        StateReader
+	pollInterval time.Duration
+	timeout      time.Duration
+
+	mu      sync.Mutex
+	pending map[string]struct{}
+}
+
+// NewManager returns a finality manager. Non-positive intervals fall back to sane defaults so a
+// partially filled configuration cannot produce a busy loop.
+func NewManager(
+	evmClient client.EVMClient,
+	state StateReader,
+	pollInterval, timeout time.Duration,
+) *Manager {
+	if pollInterval <= 0 {
+		pollInterval = 2 * time.Second
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+
+	return &Manager{
+		client:       evmClient,
+		state:        state,
+		pollInterval: pollInterval,
+		timeout:      timeout,
+		pending:      map[string]struct{}{},
+	}
+}
+
+// StatusByTxHash resolves a transaction from its Ethereum hash, the path available to whoever
+// submitted it.
+func (m *Manager) StatusByTxHash(ctx context.Context, txHash client.Hash) (driver.ValidationCode, string, error) {
+	receipt, err := m.client.GetTransactionReceipt(ctx, txHash)
+	if err != nil {
+		return driver.Unknown, "", errors.Wrapf(err, "failed to read the receipt for [%s]", txHash)
+	}
+	if receipt != nil && receipt.BlockNumber != nil {
+		if receipt.Status == 1 {
+			return driver.Valid, "", nil
+		}
+
+		return driver.Invalid, "transaction reverted", nil
+	}
+
+	// No receipt yet: distinguish a transaction the node is holding from one it has never seen.
+	pending, found, err := m.client.IsPending(ctx, txHash)
+	if err != nil {
+		return driver.Unknown, "", errors.Wrapf(err, "failed to check whether [%s] is pending", txHash)
+	}
+	switch {
+	case found && pending:
+		return driver.Busy, "", nil
+	case found:
+		// Known but not pending and without a receipt: it is being mined right now.
+		return driver.Busy, "", nil
+	default:
+		return driver.Unknown, "transaction unknown to the node", nil
+	}
+}
+
+// StatusByAnchor resolves a transaction from its token-request anchor, the only identifier a
+// recipient has. A recorded anchor yields Valid together with the stored token-request hash; an
+// absent one yields Unknown, because a reverted apply leaves nothing behind to observe.
+func (m *Manager) StatusByAnchor(ctx context.Context, anchor [32]byte) (driver.ValidationCode, []byte, string, error) {
+	hash, found, err := m.state.TokenRequestHash(ctx, anchor)
+	if err != nil {
+		return driver.Unknown, nil, "", err
+	}
+	if found {
+		return driver.Valid, hash, "", nil
+	}
+
+	return driver.Unknown, nil, "", nil
+}
+
+// AddListener watches an anchor until it is applied or the timeout expires, then notifies listener
+// exactly once. If the anchor is already final it notifies immediately, matching the driver contract.
+//
+// Because failure is not observable by anchor, an anchor that has not appeared by the timeout is
+// reported Invalid: at that point the transaction either reverted or was never submitted, and either
+// way the caller must stop waiting for it.
+func (m *Manager) AddListener(ctx context.Context, anchor [32]byte, anchorID string, listener driver.FinalityListener) error {
+	if listener == nil {
+		return errors.New("finality: nil listener")
+	}
+
+	// Fast path: already final. A read failure here is not fatal, because the node may be briefly
+	// unavailable and failing the registration would lose the notification altogether; the watcher
+	// below retries and still resolves, at the timeout in the worst case.
+	code, hash, message, err := m.StatusByAnchor(ctx, anchor)
+	switch {
+	case err != nil:
+		logger.Debugf("finality: initial status check for [%s] failed, watching anyway: %v", anchorID, err)
+	case code == driver.Valid:
+		listener.OnStatus(ctx, anchorID, code, message, hash)
+
+		return nil
+	}
+
+	m.mu.Lock()
+	if _, watching := m.pending[anchorID]; watching {
+		m.mu.Unlock()
+
+		return errors.Errorf("finality: already watching [%s]", anchorID)
+	}
+	m.pending[anchorID] = struct{}{}
+	m.mu.Unlock()
+
+	// The watcher deliberately outlives the caller's context: a listener registered during a
+	// short-lived request must still be notified when the transaction settles, typically long after
+	// that request returns. Its lifetime is bounded by the finality timeout instead.
+	go m.watch(anchor, anchorID, once(listener)) // #nosec G118 -- detached by design, bounded by the timeout
+
+	return nil
+}
+
+// watch polls until the anchor is applied or the timeout expires. It runs detached from the caller's
+// context so a listener registered during a short-lived request still gets its notification.
+func (m *Manager) watch(anchor [32]byte, anchorID string, listener driver.FinalityListener) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+	defer func() {
+		m.mu.Lock()
+		delete(m.pending, anchorID)
+		m.mu.Unlock()
+	}()
+
+	ticker := time.NewTicker(m.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			code, hash, message, err := m.StatusByAnchor(ctx, anchor)
+			if err != nil {
+				continue // a transient read failure is not a verdict; keep polling until the timeout
+			}
+			if code == driver.Valid {
+				listener.OnStatus(ctx, anchorID, code, message, hash)
+
+				return
+			}
+		case <-ctx.Done():
+			// The anchor never appeared. A reverted apply emits nothing, so this is the only failure
+			// signal available by anchor.
+			listener.OnStatus(context.Background(), anchorID, driver.Invalid, "finality timeout", nil)
+
+			return
+		}
+	}
+}
+
+// once wraps a listener so it is notified at most one time, however the resolution is reached.
+func once(listener driver.FinalityListener) driver.FinalityListener {
+	return &onceListener{listener: listener}
+}
+
+type onceListener struct {
+	listener driver.FinalityListener
+	fired    sync.Once
+}
+
+func (o *onceListener) OnStatus(ctx context.Context, txID string, status int, message string, tokenRequestHash []byte) {
+	o.fired.Do(func() { o.listener.OnStatus(ctx, txID, status, message, tokenRequestHash) })
+}
+
+func (o *onceListener) OnError(ctx context.Context, txID string, err error) {
+	o.fired.Do(func() { o.listener.OnError(ctx, txID, err) })
+}

--- a/x/token/services/network/evm/finality/manager_test.go
+++ b/x/token/services/network/evm/finality/manager_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package finality
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+)
+
+// stubState reports whether an anchor has been applied, and what hash it recorded.
+type stubState struct {
+	mu    sync.Mutex
+	hash  []byte
+	found bool
+	err   error
+}
+
+func (s *stubState) TokenRequestHash(context.Context, [32]byte) ([]byte, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.hash, s.found, s.err
+}
+
+func (s *stubState) apply(hash []byte) {
+	s.mu.Lock()
+	s.hash, s.found = hash, true
+	s.mu.Unlock()
+}
+
+// recordingListener captures the single notification a listener is allowed to receive.
+type recordingListener struct {
+	mu       sync.Mutex
+	done     chan struct{}
+	status   int
+	message  string
+	trHash   []byte
+	notified int
+}
+
+func newRecordingListener() *recordingListener {
+	return &recordingListener{done: make(chan struct{})}
+}
+
+func (l *recordingListener) OnStatus(_ context.Context, _ string, status int, message string, trHash []byte) {
+	l.mu.Lock()
+	l.status, l.message, l.trHash = status, message, trHash
+	l.notified++
+	first := l.notified == 1
+	l.mu.Unlock()
+	if first {
+		close(l.done)
+	}
+}
+
+func (l *recordingListener) OnError(context.Context, string, error) {}
+
+func (l *recordingListener) wait(t *testing.T) {
+	t.Helper()
+	select {
+	case <-l.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("listener was never notified")
+	}
+}
+
+func anchor(low byte) [32]byte {
+	var a [32]byte
+	a[31] = low
+
+	return a
+}
+
+func fastManager(evm client.EVMClient, state StateReader, timeout time.Duration) *Manager {
+	return NewManager(evm, state, 5*time.Millisecond, timeout)
+}
+
+// --- resolution by eth transaction hash ------------------------------------------------------------
+
+// TestStatusByTxHash covers the lifecycle visible to whoever submitted the transaction (design §7.1).
+func TestStatusByTxHash(t *testing.T) {
+	blockNumber := uint64(10)
+
+	t.Run("mined and successful is Valid", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetTransactionReceiptReturns(&client.Receipt{BlockNumber: &blockNumber, Status: 1}, nil)
+
+		code, _, err := fastManager(evm, &stubState{}, time.Second).StatusByTxHash(t.Context(), client.Hash{})
+		require.NoError(t, err)
+		assert.Equal(t, driver.Valid, code)
+	})
+
+	t.Run("reverted is Invalid", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetTransactionReceiptReturns(&client.Receipt{BlockNumber: &blockNumber, Status: 0}, nil)
+
+		code, message, err := fastManager(evm, &stubState{}, time.Second).StatusByTxHash(t.Context(), client.Hash{})
+		require.NoError(t, err)
+		assert.Equal(t, driver.Invalid, code)
+		assert.NotEmpty(t, message, "a revert must carry a reason for the receipt")
+	})
+
+	t.Run("pending in the mempool is Busy", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetTransactionReceiptReturns(nil, nil)
+		evm.IsPendingReturns(true, true, nil)
+
+		code, _, err := fastManager(evm, &stubState{}, time.Second).StatusByTxHash(t.Context(), client.Hash{})
+		require.NoError(t, err)
+		assert.Equal(t, driver.Busy, code)
+	})
+
+	t.Run("unknown to the node is Unknown", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.GetTransactionReceiptReturns(nil, nil)
+		evm.IsPendingReturns(false, false, nil)
+
+		code, _, err := fastManager(evm, &stubState{}, time.Second).StatusByTxHash(t.Context(), client.Hash{})
+		require.NoError(t, err)
+		assert.Equal(t, driver.Unknown, code, "a dropped transaction must never be reported as the zero code")
+	})
+}
+
+// --- resolution by anchor --------------------------------------------------------------------------
+
+// TestStatusByAnchorSuccessIsObservable checks the recipient-side signal: a recorded anchor proves the
+// transition committed, and carries the token-request hash.
+func TestStatusByAnchorSuccessIsObservable(t *testing.T) {
+	state := &stubState{hash: []byte("tr-hash"), found: true}
+	m := fastManager(&mock.EVMClient{}, state, time.Second)
+
+	code, hash, _, err := m.StatusByAnchor(t.Context(), anchor(0x01))
+	require.NoError(t, err)
+	assert.Equal(t, driver.Valid, code)
+	assert.Equal(t, []byte("tr-hash"), hash)
+}
+
+// TestStatusByAnchorFailureIsNotObservable pins the asymmetry the design calls out (§7.4): a failed
+// apply reverts and leaves nothing on chain, so an absent anchor is Unknown, never Invalid. Reporting
+// Invalid here would make a merely-pending transaction look permanently failed.
+func TestStatusByAnchorFailureIsNotObservable(t *testing.T) {
+	m := fastManager(&mock.EVMClient{}, &stubState{found: false}, time.Second)
+
+	code, hash, _, err := m.StatusByAnchor(t.Context(), anchor(0x01))
+	require.NoError(t, err)
+	assert.Equal(t, driver.Unknown, code, "an unseen anchor is Unknown, not Invalid")
+	assert.Nil(t, hash)
+}
+
+func TestStatusByAnchorSurfacesReadFailure(t *testing.T) {
+	m := fastManager(&mock.EVMClient{}, &stubState{err: errors.New("node down")}, time.Second)
+
+	_, _, _, err := m.StatusByAnchor(t.Context(), anchor(0x01))
+	require.Error(t, err)
+}
+
+// --- listeners --------------------------------------------------------------------------------------
+
+// TestAddListenerNotifiesImmediatelyWhenFinal checks the driver contract: a transaction that is
+// already final must notify without waiting for a poll.
+func TestAddListenerNotifiesImmediatelyWhenFinal(t *testing.T) {
+	state := &stubState{hash: []byte("tr-hash"), found: true}
+	m := fastManager(&mock.EVMClient{}, state, time.Second)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	listener.wait(t)
+	assert.Equal(t, driver.Valid, listener.status)
+	assert.Equal(t, []byte("tr-hash"), listener.trHash)
+}
+
+// TestAddListenerNotifiesOnceApplied checks the polling path: the listener fires when the anchor
+// appears on chain.
+func TestAddListenerNotifiesOnceApplied(t *testing.T) {
+	state := &stubState{}
+	m := fastManager(&mock.EVMClient{}, state, 3*time.Second)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	state.apply([]byte("tr-hash"))
+
+	listener.wait(t)
+	assert.Equal(t, driver.Valid, listener.status)
+	assert.Equal(t, []byte("tr-hash"), listener.trHash)
+}
+
+// TestAddListenerTimesOutAsInvalid is the only failure signal available by anchor: nothing appeared
+// before the timeout, so the caller must stop waiting.
+func TestAddListenerTimesOutAsInvalid(t *testing.T) {
+	m := fastManager(&mock.EVMClient{}, &stubState{}, 50*time.Millisecond)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	listener.wait(t)
+	assert.Equal(t, driver.Invalid, listener.status)
+	assert.Contains(t, listener.message, "timeout")
+}
+
+// TestListenerNotifiedExactlyOnce checks the exactly-once contract, which matters because the driver
+// removes a listener when it fires.
+func TestListenerNotifiedExactlyOnce(t *testing.T) {
+	state := &stubState{}
+	m := fastManager(&mock.EVMClient{}, state, 200*time.Millisecond)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	state.apply([]byte("tr-hash"))
+	listener.wait(t)
+
+	// Give the watcher room to (incorrectly) fire again on a later tick or the timeout.
+	time.Sleep(300 * time.Millisecond)
+
+	listener.mu.Lock()
+	defer listener.mu.Unlock()
+	assert.Equal(t, 1, listener.notified, "a listener must be notified exactly once")
+}
+
+// TestAddListenerRejectsDuplicateWatch checks the manager does not spawn two watchers for one anchor.
+func TestAddListenerRejectsDuplicateWatch(t *testing.T) {
+	m := fastManager(&mock.EVMClient{}, &stubState{}, time.Second)
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", newRecordingListener()))
+	err := m.AddListener(t.Context(), anchor(0x01), "anchor-1", newRecordingListener())
+	require.Error(t, err)
+}
+
+func TestAddListenerRejectsNil(t *testing.T) {
+	m := fastManager(&mock.EVMClient{}, &stubState{}, time.Second)
+	require.Error(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", nil))
+}
+
+// TestTransientReadFailureDoesNotResolve checks that a flaky node does not produce a verdict: the
+// manager keeps polling rather than reporting a status it cannot support.
+func TestTransientReadFailureDoesNotResolve(t *testing.T) {
+	state := &stubState{err: errors.New("temporarily unavailable")}
+	m := fastManager(&mock.EVMClient{}, state, 100*time.Millisecond)
+	listener := newRecordingListener()
+
+	require.NoError(t, m.AddListener(t.Context(), anchor(0x01), "anchor-1", listener))
+	listener.wait(t)
+	assert.Equal(t, driver.Invalid, listener.status, "a persistent read failure resolves only at the timeout")
+}

--- a/x/token/services/network/evm/ledger.go
+++ b/x/token/services/network/evm/ledger.go
@@ -24,6 +24,7 @@ const (
 	areTokensSpentMethod      = "areTokensSpent(bytes32[])" // #nosec G101 -- ABI method signature
 	getPublicParametersMethod = "getPublicParameters()"     // #nosec G101 -- ABI method signature
 	getTransferMetadataMethod = "getTransferMetadata(bytes32)"
+	getTokenRequestHashMethod = "getTokenRequestHash(bytes32)"
 )
 
 // contractReader performs the driver's read-only calls against a TMS's TokenState clone. It is the
@@ -115,6 +116,26 @@ func (r *contractReader) transferMetadata(ctx context.Context, key [32]byte) ([]
 	}
 
 	return abi.DecodeBytes(raw)
+}
+
+// TokenRequestHash returns the token-request hash recorded for an anchor, and whether the anchor has
+// been applied at all. The contract records it as the last step of applyStateDelta and a failed apply
+// reverts the whole transaction, so a recorded hash proves the transition was committed. It satisfies
+// the finality manager's StateReader.
+func (r *contractReader) TokenRequestHash(ctx context.Context, anchor [32]byte) ([]byte, bool, error) {
+	raw, err := r.client.Call(ctx, r.tokenState, abi.EncodeBytes32Call(getTokenRequestHashMethod, anchor), r.blockTag)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "getTokenRequestHash failed")
+	}
+	hash, err := abi.DecodeBytes32(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	if hash == ([32]byte{}) {
+		return nil, false, nil
+	}
+
+	return hash[:], true, nil
 }
 
 // tokenIDOf resolves an SDK token id to its addressable on-chain id, the same derivation the

--- a/x/token/services/network/evm/ledger.go
+++ b/x/token/services/network/evm/ledger.go
@@ -1,0 +1,129 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"context"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
+)
+
+// TokenState read methods the driver calls. The signatures are canonical ABI forms; their selectors
+// are what the contract dispatches on.
+const (
+	getTokenMethod            = "getToken(bytes32)"         // #nosec G101 -- ABI method signature
+	areTokensSpentMethod      = "areTokensSpent(bytes32[])" // #nosec G101 -- ABI method signature
+	getPublicParametersMethod = "getPublicParameters()"     // #nosec G101 -- ABI method signature
+	getTransferMetadataMethod = "getTransferMetadata(bytes32)"
+)
+
+// contractReader performs the driver's read-only calls against a TMS's TokenState clone. It is the
+// shared plumbing behind the query methods on Network: resolve a token id, call, decode.
+type contractReader struct {
+	client     client.EVMClient
+	tokenState client.Address
+	blockTag   string
+}
+
+func newContractReader(evmClient client.EVMClient, tokenState client.Address, blockTag string) *contractReader {
+	if blockTag == "" {
+		blockTag = client.BlockTagFinalized
+	}
+
+	return &contractReader{client: evmClient, tokenState: tokenState, blockTag: blockTag}
+}
+
+// tokenData returns the stored bytes of a token, or empty if it does not exist.
+func (r *contractReader) tokenData(ctx context.Context, id *token.ID) ([]byte, error) {
+	if id == nil {
+		return nil, errors.New("nil token id")
+	}
+	tokenID, err := tokenIDOf(id)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := r.client.Call(ctx, r.tokenState, abi.EncodeBytes32Call(getTokenMethod, tokenID), r.blockTag)
+	if err != nil {
+		return nil, errors.Wrapf(err, "getToken failed for [%s:%d]", id.TxId, id.Index)
+	}
+
+	return abi.DecodeBytes(raw)
+}
+
+// spent reports, for each token id, whether it has been spent. It calls the contract's batch method
+// so a wallet checking many tokens costs one round trip.
+//
+// The contract resolves spent status through the content-bound marker recorded when the output was
+// created (design §5.3), so the caller does not need the token's bytes, only its id.
+func (r *contractReader) spent(ctx context.Context, ids []*token.ID) ([]bool, error) {
+	tokenIDs := make([][32]byte, len(ids))
+	for i, id := range ids {
+		if id == nil {
+			return nil, errors.Errorf("nil token id at index %d", i)
+		}
+		tokenID, err := tokenIDOf(id)
+		if err != nil {
+			return nil, err
+		}
+		tokenIDs[i] = tokenID
+	}
+
+	raw, err := r.client.Call(
+		ctx,
+		r.tokenState,
+		abi.EncodeCall(areTokensSpentMethod, abi.Bytes32Array(tokenIDs)),
+		r.blockTag,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "areTokensSpent failed")
+	}
+	out, err := abi.DecodeBoolArray(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) != len(ids) {
+		return nil, errors.Errorf("areTokensSpent returned %d results for %d ids", len(out), len(ids))
+	}
+
+	return out, nil
+}
+
+// publicParameters returns the public parameters currently stored on chain.
+func (r *contractReader) publicParameters(ctx context.Context) ([]byte, error) {
+	raw, err := r.client.Call(ctx, r.tokenState, abi.MethodID(getPublicParametersMethod), r.blockTag)
+	if err != nil {
+		return nil, errors.Wrap(err, "getPublicParameters failed")
+	}
+
+	return abi.DecodeBytes(raw)
+}
+
+// transferMetadata returns the value stored for a transfer metadata key, or empty if unset.
+func (r *contractReader) transferMetadata(ctx context.Context, key [32]byte) ([]byte, error) {
+	raw, err := r.client.Call(ctx, r.tokenState, abi.EncodeBytes32Call(getTransferMetadataMethod, key), r.blockTag)
+	if err != nil {
+		return nil, errors.Wrap(err, "getTransferMetadata failed")
+	}
+
+	return abi.DecodeBytes(raw)
+}
+
+// tokenIDOf resolves an SDK token id to its addressable on-chain id, the same derivation the
+// translator and the contract use.
+func tokenIDOf(id *token.ID) ([32]byte, error) {
+	anchor, err := keys.AnchorFromTxID(id.TxId)
+	if err != nil {
+		return [32]byte{}, errors.Wrapf(err, "invalid token anchor [%s]", id.TxId)
+	}
+
+	return keys.ComputeTokenID(anchor, id.Index), nil
+}

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -16,23 +16,65 @@ import (
 	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
 
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/endorsement"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
 )
 
-// errNotImplemented is returned by the Network methods that are not wired up yet. The skeleton
-// exists so registration and routing can be validated before the behaviour lands (Phases 3-6).
+// errNotImplemented marks the surface that lands with the finality manager.
 var errNotImplemented = errors.New("evm: not implemented")
 
-// Network is the EVM implementation of driver.Network. In Phase 1.2 every behavioural method is a
-// stub returning errNotImplemented; the real implementations are filled in from Phase 3 onwards.
+// EndorsementService is the endorsement entry point the driver drives to collect a quorum. It is
+// satisfied by *endorsement.Service and narrowed here so the network can be tested with a stub.
+type EndorsementService interface {
+	// Endorse collects a quorum of endorsements for the request and returns the assembled result.
+	Endorse(context view.Context, req *endorsement.EndorseRequest) (*endorsement.Result, error)
+}
+
+// Network is the EVM implementation of driver.Network for one network. It owns the pieces a token
+// transaction travels through: the endorsement service that authorizes a delta, the submitter that
+// puts it on chain, and the contract reader that answers queries.
 type Network struct {
-	name string
+	name        string
+	config      *Config
+	client      client.EVMClient
+	endorsement EndorsementService
+	submitter   *Submitter
+	reader      *contractReader
+	tokenState  client.Address
 }
 
 // Compile-time assertion that Network satisfies the driver contract.
 var _ driver.Network = (*Network)(nil)
 
-func newNetwork(name string) *Network {
-	return &Network{name: name}
+// NewNetwork assembles an EVM Network from its already-resolved collaborators.
+func NewNetwork(
+	name string,
+	config *Config,
+	evmClient client.EVMClient,
+	endorsementService EndorsementService,
+	submitter *Submitter,
+) (*Network, error) {
+	if config == nil {
+		return nil, errors.New("evm network: nil configuration")
+	}
+	if evmClient == nil {
+		return nil, errors.New("evm network: nil evm client")
+	}
+	tokenState, err := config.TokenStateAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Network{
+		name:        name,
+		config:      config,
+		client:      evmClient,
+		endorsement: endorsementService,
+		submitter:   submitter,
+		reader:      newContractReader(evmClient, tokenState, config.Finality.BlockTag),
+		tokenState:  tokenState,
+	}, nil
 }
 
 // Name returns the identifier of the network.
@@ -41,24 +83,49 @@ func (n *Network) Name() string { return n.name }
 // Channel returns the empty string: EVM has no channel concept.
 func (n *Network) Channel() string { return "" }
 
-// Normalize fills default service options for the EVM network.
+// Normalize fills default service options for the EVM network: this network and the empty channel.
 func (n *Network) Normalize(opt *token2.ServiceOptions) (*token2.ServiceOptions, error) {
-	return nil, errNotImplemented
+	if opt == nil {
+		return nil, errors.New("evm network: nil service options")
+	}
+	if len(opt.Network) == 0 {
+		opt.Network = n.name
+	}
+	if len(opt.Channel) != 0 && opt.Channel != n.Channel() {
+		return nil, errors.Errorf("evm network has no channels, got [%s]", opt.Channel)
+	}
+	opt.Channel = n.Channel()
+
+	return opt, nil
 }
 
-// Connect initializes namespace-scoped services for the EVM network.
+// Connect validates that the configured backend is reachable and is the chain the driver signs for,
+// then returns the service options that bind a TMS to this network. Checking here means a
+// misconfigured endpoint or chain id fails at startup rather than at the first transaction.
 func (n *Network) Connect(ns string) ([]token2.ServiceOption, error) {
-	return nil, errNotImplemented
-}
+	ctx := context.Background()
+	chainID, err := n.client.ChainID(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "evm network: node at [%s] is not reachable", n.config.Endpoint)
+	}
+	if chainID.Cmp(n.config.ChainIDBig()) != 0 {
+		return nil, errors.Errorf("evm network: node reports chain id %s, configuration says %d",
+			chainID, n.config.ChainID)
+	}
 
-// Broadcast submits a signed transaction envelope to the EVM node.
-func (n *Network) Broadcast(ctx context.Context, blob any) error {
-	return errNotImplemented
+	return []token2.ServiceOption{
+		token2.WithNetwork(n.name),
+		token2.WithChannel(n.Channel()),
+		token2.WithNamespace(ns),
+	}, nil
 }
 
 // NewEnvelope returns a new, empty EVM envelope.
 func (n *Network) NewEnvelope() driver.Envelope { return &Envelope{} }
 
+// RequestApproval collects a quorum of endorsements over the token request and returns the envelope
+// carrying the endorsed delta. It does not touch the chain: the transaction is assembled and sent by
+// Broadcast, so a request that fails to gather a quorum costs no gas.
 func (n *Network) RequestApproval(
 	context view.Context,
 	tms *token2.ManagementService,
@@ -67,49 +134,192 @@ func (n *Network) RequestApproval(
 	txID driver.TxID,
 	metadata driver.TransientMap,
 ) (driver.Envelope, error) {
-	return nil, errNotImplemented
+	if n.endorsement == nil {
+		return nil, errors.New("evm network: no endorsement service configured")
+	}
+	if tms == nil {
+		return nil, errors.New("evm network: nil token management service")
+	}
+
+	anchor := n.ComputeTxID(&txID)
+	result, err := n.endorsement.Endorse(context, &endorsement.EndorseRequest{
+		TokenRequest: requestRaw,
+		TMSID:        tms.ID(),
+		Anchor:       anchor,
+		Metadata:     metadata,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to collect endorsements for [%s]", anchor)
+	}
+
+	return &Envelope{
+		Anchor:       anchor,
+		Delta:        result.Delta,
+		Endorsements: result.Endorsements,
+	}, nil
 }
 
-// ComputeTxID computes the deterministic token-request anchor for the transaction.
-func (n *Network) ComputeTxID(id *driver.TxID) string { return "" }
+// Broadcast assembles the endorsed envelope into a signed transaction, sends it, and records the
+// resulting raw transaction and hash back into the envelope so the caller can follow its finality.
+func (n *Network) Broadcast(ctx context.Context, blob any) error {
+	env, ok := blob.(*Envelope)
+	if !ok {
+		return errors.Errorf("evm network: expected *Envelope, got [%T]", blob)
+	}
+	if n.submitter == nil {
+		return errors.New("evm network: no submitter configured")
+	}
+	if env.Delta == nil {
+		return errors.Errorf("evm network: envelope [%s] carries no state delta", env.Anchor)
+	}
 
-func (n *Network) SetupPublicParams(context view.Context, tmsID token2.TMSID, publicParamsRaw []byte, signer view.Identity, txID driver.TxID) (driver.Envelope, error) {
-	// TODO implement me
-	panic("implement me")
+	rawTx, txHash, err := n.submitter.Submit(ctx, env.Delta, env.Endorsements)
+	if err != nil {
+		return errors.Wrapf(err, "failed to broadcast [%s]", env.Anchor)
+	}
+	env.RawTx = rawTx
+	env.EthTxHash = txHash.Hex()
+
+	return nil
 }
 
-// FetchPublicParameters retrieves the public parameters from the TokenState contract.
+// ComputeTxID returns the token-request anchor for the transaction.
+//
+// It MUTATES id: when the nonce is empty it generates a fresh random one and writes it back, which is
+// the contract FSC and the Fabric driver implement and the ttx layer relies on. A read-only
+// implementation would derive the same anchor for every transaction of a creator, and the second one
+// submitted would revert as an already-processed anchor (design §5.3).
+func (n *Network) ComputeTxID(id *driver.TxID) string {
+	if id == nil {
+		return ""
+	}
+	if len(id.Nonce) == 0 {
+		nonce, err := generateNonce()
+		if err != nil {
+			// Matching FSC, which panics here: without a nonce there is no safe anchor to return, and
+			// a randomness failure is not something a caller can act on.
+			panic(err)
+		}
+		id.Nonce = nonce
+	}
+
+	return computeAnchor(id.Nonce, id.Creator)
+}
+
+// SetupPublicParams collects endorsements for a public-parameters update. The endorsers translate the
+// setup request into a setup delta, so the flow matches RequestApproval; it exists separately because
+// it takes a TMSID rather than a management service, which is what makes first-time setup of a
+// namespace with no public parameters possible.
+func (n *Network) SetupPublicParams(
+	context view.Context,
+	tmsID token2.TMSID,
+	publicParamsRaw []byte,
+	signer view.Identity,
+	txID driver.TxID,
+) (driver.Envelope, error) {
+	if n.endorsement == nil {
+		return nil, errors.New("evm network: no endorsement service configured")
+	}
+
+	anchor := n.ComputeTxID(&txID)
+	result, err := n.endorsement.Endorse(context, &endorsement.EndorseRequest{
+		TokenRequest: publicParamsRaw,
+		TMSID:        tmsID,
+		Anchor:       anchor,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to collect endorsements for public parameters [%s]", anchor)
+	}
+
+	return &Envelope{
+		Anchor:       anchor,
+		Delta:        result.Delta,
+		Endorsements: result.Endorsements,
+	}, nil
+}
+
+// FetchPublicParameters retrieves the public parameters currently stored in the TokenState contract.
 func (n *Network) FetchPublicParameters(namespace string) ([]byte, error) {
-	return nil, errNotImplemented
+	return n.reader.publicParameters(context.Background())
 }
 
-// QueryTokens reads token data for the given IDs from the TokenState contract.
+// QueryTokens reads the stored bytes of the given tokens. A token that does not exist on chain is an
+// error rather than an empty entry, because the caller asked for tokens it believes exist and a
+// silent gap would read as a valid empty token.
 func (n *Network) QueryTokens(ctx context.Context, namespace string, ids []*token.ID) ([][]byte, error) {
-	return nil, errNotImplemented
+	out := make([][]byte, len(ids))
+	for i, id := range ids {
+		data, err := n.reader.tokenData(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) == 0 {
+			return nil, errors.Errorf("token [%s:%d] does not exist", id.TxId, id.Index)
+		}
+		out[i] = data
+	}
+
+	return out, nil
 }
 
-// AreTokensSpent checks the spent status of the given tokens on-chain.
-func (n *Network) AreTokensSpent(ctx context.Context, namespace string, tokenIDs []*token.ID, meta []string) ([]bool, error) {
-	return nil, errNotImplemented
+// AreTokensSpent checks the spent status of the given tokens, aligned with the input. It resolves
+// through the content-bound marker recorded at creation, so only the ids are needed.
+func (n *Network) AreTokensSpent(
+	ctx context.Context,
+	namespace string,
+	tokenIDs []*token.ID,
+	meta []string,
+) ([]bool, error) {
+	if len(tokenIDs) == 0 {
+		return nil, nil
+	}
+
+	return n.reader.spent(ctx, tokenIDs)
 }
 
-// LocalMembership returns the local membership service for EVM identities.
+// LookupTransferMetadataKey reads a transfer metadata value from the TokenState contract, polling
+// until it appears or the timeout expires. The value is written when the transaction carrying it is
+// applied, so a caller may legitimately ask before it exists.
+func (n *Network) LookupTransferMetadataKey(namespace string, key string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	metadataKey := keys.TransferMetadataKey(key)
+	ticker := time.NewTicker(n.config.Finality.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		value, err := n.reader.transferMetadata(ctx, metadataKey)
+		if err != nil {
+			return nil, err
+		}
+		if len(value) != 0 {
+			return value, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, errors.Errorf("transfer metadata key [%s] not found within %s", key, timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+// LocalMembership returns the local membership service for EVM identities. It lands with the driver
+// wiring.
 func (n *Network) LocalMembership() driver.LocalMembership { return nil }
 
-// AddFinalityListener registers a listener for the finality of a transaction.
+// AddFinalityListener registers a listener for the finality of a transaction. It lands with the
+// finality manager.
 func (n *Network) AddFinalityListener(namespace string, txID string, listener driver.FinalityListener) error {
 	return errNotImplemented
 }
 
-// GetTransactionStatus returns the validation status and token-request hash of a transaction.
+// GetTransactionStatus returns the validation status and token-request hash of a transaction. It
+// lands with the finality manager.
 func (n *Network) GetTransactionStatus(ctx context.Context, namespace, txID string) (int, []byte, string, error) {
-	return 0, nil, "", errNotImplemented
+	return driver.Unknown, nil, "", errNotImplemented
 }
 
-// LookupTransferMetadataKey reads transfer metadata from the TokenState contract.
-func (n *Network) LookupTransferMetadataKey(namespace string, key string, timeout time.Duration) ([]byte, error) {
-	return nil, errNotImplemented
-}
-
-// Ledger returns the read-only EVM ledger adapter.
+// Ledger returns the read-only EVM ledger adapter. It lands with the finality manager, whose status
+// resolution it shares.
 func (n *Network) Ledger() (driver.Ledger, error) { return nil, errNotImplemented }

--- a/x/token/services/network/evm/network.go
+++ b/x/token/services/network/evm/network.go
@@ -8,6 +8,9 @@ package evm
 
 import (
 	"context"
+	"encoding/hex"
+	"strconv"
+	"strings"
 	"time"
 
 	token2 "github.com/LFDT-Panurus/panurus/token"
@@ -18,11 +21,9 @@ import (
 	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
 	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
 	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/endorsement"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/finality"
 	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
 )
-
-// errNotImplemented marks the surface that lands with the finality manager.
-var errNotImplemented = errors.New("evm: not implemented")
 
 // EndorsementService is the endorsement entry point the driver drives to collect a quorum. It is
 // satisfied by *endorsement.Service and narrowed here so the network can be tested with a stub.
@@ -41,6 +42,7 @@ type Network struct {
 	endorsement EndorsementService
 	submitter   *Submitter
 	reader      *contractReader
+	finality    *finality.Manager
 	tokenState  client.Address
 }
 
@@ -66,13 +68,16 @@ func NewNetwork(
 		return nil, err
 	}
 
+	reader := newContractReader(evmClient, tokenState, config.Finality.BlockTag)
+
 	return &Network{
 		name:        name,
 		config:      config,
 		client:      evmClient,
 		endorsement: endorsementService,
 		submitter:   submitter,
-		reader:      newContractReader(evmClient, tokenState, config.Finality.BlockTag),
+		reader:      reader,
+		finality:    finality.NewManager(evmClient, reader, config.Finality.PollInterval, config.Finality.Timeout),
 		tokenState:  tokenState,
 	}, nil
 }
@@ -304,22 +309,102 @@ func (n *Network) LookupTransferMetadataKey(namespace string, key string, timeou
 	}
 }
 
-// LocalMembership returns the local membership service for EVM identities. It lands with the driver
-// wiring.
+// LocalMembership returns the local membership service for EVM identities. It is supplied by the SDK
+// wiring, which owns the node's identities.
 func (n *Network) LocalMembership() driver.LocalMembership { return nil }
 
-// AddFinalityListener registers a listener for the finality of a transaction. It lands with the
-// finality manager.
+// AddFinalityListener registers a listener for the finality of the transaction identified by its
+// anchor. If the transaction is already final the listener is notified immediately; otherwise it is
+// notified once, when the anchor appears on chain or the finality timeout expires.
 func (n *Network) AddFinalityListener(namespace string, txID string, listener driver.FinalityListener) error {
-	return errNotImplemented
+	anchor, err := keys.AnchorFromTxID(txID)
+	if err != nil {
+		return errors.Wrapf(err, "evm network: invalid transaction id [%s]", txID)
+	}
+
+	return n.finality.AddListener(context.Background(), anchor, txID, listener)
 }
 
-// GetTransactionStatus returns the validation status and token-request hash of a transaction. It
-// lands with the finality manager.
+// GetTransactionStatus returns the validation status and token-request hash of a transaction,
+// identified by its anchor.
+//
+// Only success is observable by anchor: the contract records the anchor as the last step of a
+// successful apply, while a failure reverts and leaves nothing behind. An unrecorded anchor is
+// therefore Unknown, not Invalid; resolving it as failed is the finality timeout's job (design §7.4).
 func (n *Network) GetTransactionStatus(ctx context.Context, namespace, txID string) (int, []byte, string, error) {
-	return driver.Unknown, nil, "", errNotImplemented
+	anchor, err := keys.AnchorFromTxID(txID)
+	if err != nil {
+		return driver.Unknown, nil, "", errors.Wrapf(err, "evm network: invalid transaction id [%s]", txID)
+	}
+
+	return n.finality.StatusByAnchor(ctx, anchor)
 }
 
-// Ledger returns the read-only EVM ledger adapter. It lands with the finality manager, whose status
-// resolution it shares.
-func (n *Network) Ledger() (driver.Ledger, error) { return nil, errNotImplemented }
+// Ledger returns the read-only ledger view, which answers the validation status of a transaction.
+func (n *Network) Ledger() (driver.Ledger, error) { return &ledgerView{network: n}, nil }
+
+// ledgerView adapts the network to the driver's Ledger contract.
+type ledgerView struct {
+	network *Network
+}
+
+// Status returns the validation code of the transaction with the given anchor.
+func (l *ledgerView) Status(id string) (driver.ValidationCode, error) {
+	code, _, _, err := l.network.GetTransactionStatus(context.Background(), "", id)
+	if err != nil {
+		return driver.Unknown, err
+	}
+
+	return code, nil
+}
+
+// GetTransactionStatus returns the status and token-request hash of a transaction by anchor.
+func (l *ledgerView) GetTransactionStatus(
+	ctx context.Context,
+	namespace, txID string,
+) (int, []byte, string, error) {
+	return l.network.GetTransactionStatus(ctx, namespace, txID)
+}
+
+// GetStates returns the raw token bytes stored at each key, where a key is a token id in the
+// hex-anchor:index form the driver addresses tokens by. A key with no state yields a nil entry.
+func (l *ledgerView) GetStates(ctx context.Context, namespace string, keys ...string) ([][]byte, error) {
+	out := make([][]byte, len(keys))
+	for i, k := range keys {
+		id, err := parseTokenKey(k)
+		if err != nil {
+			return nil, err
+		}
+		data, err := l.network.reader.tokenData(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if len(data) != 0 {
+			out[i] = data
+		}
+	}
+
+	return out, nil
+}
+
+// TransferMetadataKey derives the on-chain key of a transfer metadata sub-key. It is pure derivation
+// and says nothing about whether the key exists.
+func (l *ledgerView) TransferMetadataKey(k string) (string, error) {
+	key := keys.TransferMetadataKey(k)
+
+	return hex.EncodeToString(key[:]), nil
+}
+
+// parseTokenKey parses a "<hex-anchor>:<index>" token key.
+func parseTokenKey(k string) (*token.ID, error) {
+	sep := strings.LastIndex(k, ":")
+	if sep < 0 {
+		return nil, errors.Errorf("evm ledger: malformed token key [%s], want <anchor>:<index>", k)
+	}
+	index, err := strconv.ParseUint(k[sep+1:], 10, 64)
+	if err != nil {
+		return nil, errors.Wrapf(err, "evm ledger: malformed token key [%s]", k)
+	}
+
+	return &token.ID{TxId: k[:sep], Index: index}, nil
+}

--- a/x/token/services/network/evm/network_test.go
+++ b/x/token/services/network/evm/network_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"time"
+
+	token2 "github.com/LFDT-Panurus/panurus/token"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/hyperledger-labs/fabric-smart-client/platform/view/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/token/token"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/endorsement"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+const (
+	testTokenState = "0x5FbDB2315678afecb367f032d93F642f64180aa3" // #nosec G101 -- contract address, not a credential
+	testChainID    = 31337
+)
+
+// validConfig returns a minimal configuration that passes validation, for tests that need a Network
+// rather than a specific configuration document.
+func validConfig() *Config {
+	return &Config{
+		Endpoint:  "http://localhost:8545",
+		ChainID:   testChainID,
+		Contracts: ContractsConfig{TokenState: testTokenState},
+		Endorsement: EndorsementConfig{
+			Threshold: 1,
+			Endorsers: []EndorserBinding{
+				{Address: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", FSCIdentity: "endorser-1"},
+			},
+		},
+	}
+}
+
+// testNetwork builds a Network over the given client and endorsement service; nil values are replaced
+// with empty stubs so callers only supply what their test exercises.
+func testNetwork(t *testing.T, evmClient client.EVMClient, endorser EndorsementService) *Network {
+	t.Helper()
+	if evmClient == nil {
+		evmClient = &mock.EVMClient{}
+	}
+	c := validConfig()
+	c.applyDefaults()
+	require.NoError(t, c.Validate())
+
+	n, err := NewNetwork("evm-net", c, evmClient, endorser, nil)
+	require.NoError(t, err)
+
+	return n
+}
+
+// anchorHex returns a valid 32-byte anchor in the hex form a token.ID carries.
+func anchorHex(low byte) string {
+	var a [32]byte
+	a[31] = low
+
+	return hex.EncodeToString(a[:])
+}
+
+// abiBytes encodes b as an ABI dynamic bytes return value, the shape a getToken call returns.
+func abiBytes(b []byte) []byte {
+	out := make([]byte, 64)
+	out[31] = 0x20
+	binary.BigEndian.PutUint64(out[56:64], uint64(len(b)))
+	out = append(out, b...)
+	if pad := (32 - len(b)%32) % 32; pad != 0 {
+		out = append(out, make([]byte, pad)...)
+	}
+
+	return out
+}
+
+// abiBoolArray encodes flags as an ABI bool[] return value.
+func abiBoolArray(flags []bool) []byte {
+	out := make([]byte, 64)
+	out[31] = 0x20
+	binary.BigEndian.PutUint64(out[56:64], uint64(len(flags)))
+	for _, f := range flags {
+		word := make([]byte, 32)
+		if f {
+			word[31] = 1
+		}
+		out = append(out, word...)
+	}
+
+	return out
+}
+
+// stubEndorser returns a fixed endorsement result, or an error.
+type stubEndorser struct {
+	result *endorsement.Result
+	err    error
+	seen   *endorsement.EndorseRequest
+}
+
+func (s *stubEndorser) Endorse(_ view.Context, req *endorsement.EndorseRequest) (*endorsement.Result, error) {
+	s.seen = req
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.result, nil
+}
+
+// --- Normalize / Connect -------------------------------------------------------------------------
+
+func TestNormalize(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	t.Run("fills the network and clears the channel", func(t *testing.T) {
+		opt, err := n.Normalize(&token2.ServiceOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "evm-net", opt.Network)
+		assert.Empty(t, opt.Channel)
+	})
+
+	t.Run("rejects a channel, since evm has none", func(t *testing.T) {
+		_, err := n.Normalize(&token2.ServiceOptions{Channel: "ch0"})
+		require.Error(t, err)
+	})
+
+	t.Run("rejects nil options", func(t *testing.T) {
+		_, err := n.Normalize(nil)
+		require.Error(t, err)
+	})
+}
+
+// TestConnectVerifiesChain checks the startup guard: a node on a different chain than configured must
+// fail here rather than at the first transaction, where it would surface as a rejected signature.
+func TestConnectVerifiesChain(t *testing.T) {
+	t.Run("matching chain id connects", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.ChainIDReturns(bigInt(testChainID), nil)
+		n := testNetwork(t, evm, nil)
+
+		opts, err := n.Connect("token")
+		require.NoError(t, err)
+		assert.Len(t, opts, 3)
+	})
+
+	t.Run("mismatched chain id is refused", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.ChainIDReturns(bigInt(1), nil)
+		n := testNetwork(t, evm, nil)
+
+		_, err := n.Connect("token")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chain id")
+	})
+
+	t.Run("unreachable node is refused", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.ChainIDReturns(nil, errors.New("dial tcp: connection refused"))
+		n := testNetwork(t, evm, nil)
+
+		_, err := n.Connect("token")
+		require.Error(t, err)
+	})
+}
+
+// --- RequestApproval -----------------------------------------------------------------------------
+
+// TestRequestApprovalDoesNotTouchTheChain checks the separation the design relies on: collecting
+// endorsements is free, and only Broadcast spends gas. A request that cannot gather a quorum must
+// never have sent anything.
+func TestRequestApprovalDoesNotTouchTheChain(t *testing.T) {
+	evm := &mock.EVMClient{}
+	stub := &stubEndorser{err: errors.New("no quorum")}
+	n := testNetwork(t, evm, stub)
+
+	_, err := n.RequestApproval(nil, &token2.ManagementService{}, []byte("request"), nil, driverTxID(), nil)
+	require.Error(t, err)
+	assert.Zero(t, evm.SendRawTransactionCallCount(), "a failed approval must not broadcast")
+}
+
+func TestRequestApprovalWithoutEndorsementService(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+	_, err := n.RequestApproval(nil, &token2.ManagementService{}, []byte("request"), nil, driverTxID(), nil)
+	require.Error(t, err)
+}
+
+// --- Broadcast -----------------------------------------------------------------------------------
+
+func TestBroadcastRejectsBadInput(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	t.Run("wrong blob type", func(t *testing.T) {
+		require.Error(t, n.Broadcast(t.Context(), "not an envelope"))
+	})
+
+	t.Run("no submitter configured", func(t *testing.T) {
+		err := n.Broadcast(t.Context(), &Envelope{Anchor: "a", Delta: &statedelta.StateDelta{}})
+		require.Error(t, err)
+	})
+
+	t.Run("envelope without a delta", func(t *testing.T) {
+		err := n.Broadcast(t.Context(), &Envelope{Anchor: "a"})
+		require.Error(t, err)
+	})
+}
+
+// --- queries -------------------------------------------------------------------------------------
+
+func TestQueryTokens(t *testing.T) {
+	t.Run("returns the stored bytes", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(abiBytes([]byte("token-bytes")), nil)
+		n := testNetwork(t, evm, nil)
+
+		out, err := n.QueryTokens(t.Context(), "token", []*token.ID{{TxId: anchorHex(0x01), Index: 0}})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, []byte("token-bytes"), out[0])
+	})
+
+	t.Run("a missing token is an error, not an empty entry", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(abiBytes(nil), nil)
+		n := testNetwork(t, evm, nil)
+
+		_, err := n.QueryTokens(t.Context(), "token", []*token.ID{{TxId: anchorHex(0x01), Index: 0}})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not exist")
+	})
+
+	t.Run("the call targets the token's addressable id", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(abiBytes([]byte("x")), nil)
+		n := testNetwork(t, evm, nil)
+
+		txID := anchorHex(0xB1)
+		_, err := n.QueryTokens(t.Context(), "token", []*token.ID{{TxId: txID, Index: 3}})
+		require.NoError(t, err)
+
+		_, to, data, tag := evm.CallArgsForCall(0)
+		assert.Equal(t, n.tokenState, to)
+		assert.Equal(t, client.BlockTagFinalized, tag)
+
+		anchor, err := keys.AnchorFromTxID(txID)
+		require.NoError(t, err)
+		expected := keys.ComputeTokenID(anchor, 3)
+		assert.Equal(t, expected[:], data[4:], "the call must address the computed token id")
+	})
+}
+
+func TestAreTokensSpent(t *testing.T) {
+	t.Run("returns aligned flags", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(abiBoolArray([]bool{true, false}), nil)
+		n := testNetwork(t, evm, nil)
+
+		out, err := n.AreTokensSpent(t.Context(), "token", []*token.ID{
+			{TxId: anchorHex(0x01), Index: 0},
+			{TxId: anchorHex(0x02), Index: 1},
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []bool{true, false}, out)
+	})
+
+	t.Run("an empty request needs no call", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		n := testNetwork(t, evm, nil)
+
+		out, err := n.AreTokensSpent(t.Context(), "token", nil, nil)
+		require.NoError(t, err)
+		assert.Empty(t, out)
+		assert.Zero(t, evm.CallCallCount())
+	})
+
+	t.Run("a length mismatch from the contract is an error", func(t *testing.T) {
+		evm := &mock.EVMClient{}
+		evm.CallReturns(abiBoolArray([]bool{true}), nil)
+		n := testNetwork(t, evm, nil)
+
+		_, err := n.AreTokensSpent(t.Context(), "token", []*token.ID{
+			{TxId: anchorHex(0x01), Index: 0},
+			{TxId: anchorHex(0x02), Index: 1},
+		}, nil)
+		require.Error(t, err)
+	})
+}
+
+func TestFetchPublicParameters(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(abiBytes([]byte("public-params")), nil)
+	n := testNetwork(t, evm, nil)
+
+	out, err := n.FetchPublicParameters("token")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("public-params"), out)
+}
+
+// TestLookupTransferMetadataKeyTimesOut checks the polling contract: the value is written when the
+// carrying transaction is applied, so a caller may ask before it exists and must get a timeout rather
+// than a false empty answer.
+func TestLookupTransferMetadataKeyTimesOut(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(abiBytes(nil), nil) // never appears
+	n := testNetwork(t, evm, nil)
+	n.config.Finality.PollInterval = 10 * time.Millisecond
+
+	_, err := n.LookupTransferMetadataKey("token", "key", 50*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestLookupTransferMetadataKeyFound(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.CallReturns(abiBytes([]byte("value")), nil)
+	n := testNetwork(t, evm, nil)
+
+	out, err := n.LookupTransferMetadataKey("token", "key", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("value"), out)
+}
+
+// bigInt is a small helper for chain ids in tests.
+func bigInt(v int64) *big.Int { return big.NewInt(v) }
+
+// driverTxID returns a TxID with a creator and an empty nonce, the shape callers pass in.
+func driverTxID() driver.TxID {
+	return driver.TxID{Creator: []byte("alice")}
+}

--- a/x/token/services/network/evm/nonce.go
+++ b/x/token/services/network/evm/nonce.go
@@ -1,0 +1,79 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+)
+
+// NonceManager hands out the submitter account's Ethereum transaction nonces. Ethereum requires them
+// to be strictly sequential per account, so concurrent broadcasts must not read the same value: the
+// manager serializes allocation and tracks the next nonce locally rather than asking the node each
+// time, which would hand the same nonce to two callers racing between the query and the send.
+//
+// The chain is the source of truth, so there is nothing to persist. On a fresh start (or after a
+// restart) the first allocation recovers from eth_getTransactionCount at the pending tag, which
+// already accounts for transactions still in the mempool. That makes a node restart transparent, at
+// the cost of one round trip.
+type NonceManager struct {
+	client    client.EVMClient
+	submitter client.Address
+
+	mu          sync.Mutex
+	next        uint64
+	initialized bool
+}
+
+// NewNonceManager returns a manager for the submitter account.
+func NewNonceManager(evmClient client.EVMClient, submitter client.Address) *NonceManager {
+	return &NonceManager{client: evmClient, submitter: submitter}
+}
+
+// Next returns the nonce to use for the next transaction and advances the counter. The caller owns
+// the returned nonce: if it does not end up broadcasting, it should Reset so the sequence does not
+// develop a gap that stalls every later transaction.
+func (n *NonceManager) Next(ctx context.Context) (uint64, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if !n.initialized {
+		pending, err := n.client.PendingNonceAt(ctx, n.submitter)
+		if err != nil {
+			return 0, errors.Wrapf(err, "failed to recover the nonce for submitter [%s]", n.submitter)
+		}
+		n.next = pending
+		n.initialized = true
+	}
+
+	nonce := n.next
+	n.next++
+
+	return nonce, nil
+}
+
+// Reset drops the cached counter so the next allocation re-reads from the node. It is the recovery
+// path for a failed broadcast: rather than guess whether the node saw the transaction, re-derive the
+// sequence from the pending nonce, which is authoritative.
+func (n *NonceManager) Reset() {
+	n.mu.Lock()
+	n.initialized = false
+	n.mu.Unlock()
+}
+
+// Cached returns the next nonce the manager would hand out and whether it has been initialized,
+// without contacting the node. It exists for diagnostics and tests.
+func (n *NonceManager) Cached() (uint64, bool) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	return n.next, n.initialized
+}

--- a/x/token/services/network/evm/nonce_test.go
+++ b/x/token/services/network/evm/nonce_test.go
@@ -92,9 +92,7 @@ func TestNonceConcurrentAllocationIsUnique(t *testing.T) {
 		got = make(map[uint64]struct{}, callers)
 	)
 	for range callers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			nonce, err := n.Next(t.Context())
 			if err != nil {
 				return
@@ -102,7 +100,7 @@ func TestNonceConcurrentAllocationIsUnique(t *testing.T) {
 			mu.Lock()
 			got[nonce] = struct{}{}
 			mu.Unlock()
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/x/token/services/network/evm/nonce_test.go
+++ b/x/token/services/network/evm/nonce_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+)
+
+// TestNonceRecoversFromChain is the restart story: the manager holds no persisted state, so the first
+// allocation after a start re-derives the sequence from the node's pending nonce.
+func TestNonceRecoversFromChain(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(42, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	got, err := n.Next(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), got, "the first nonce must come from the chain, not from zero")
+}
+
+// TestNonceIsSequentialWithoutRefetching checks the manager does not ask the node for every
+// transaction: doing so would hand the same nonce to two callers racing between the query and the
+// send.
+func TestNonceIsSequentialWithoutRefetching(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(7, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	for want := uint64(7); want < 12; want++ {
+		got, err := n.Next(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+	assert.Equal(t, 1, evm.PendingNonceAtCallCount(), "the node is consulted once, not per transaction")
+}
+
+// TestNonceResetReRecovers checks the failed-broadcast path: after a reset the sequence is
+// re-derived from the node, which is authoritative about what it has actually seen.
+func TestNonceResetReRecovers(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturnsOnCall(0, 5, nil)
+	evm.PendingNonceAtReturnsOnCall(1, 9, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	first, err := n.Next(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), first)
+
+	n.Reset()
+
+	second, err := n.Next(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(9), second, "after a reset the nonce must come from the node again")
+	assert.Equal(t, 2, evm.PendingNonceAtCallCount())
+}
+
+func TestNonceSurfacesRecoveryFailure(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(0, errors.New("node unavailable"))
+	n := NewNonceManager(evm, client.Address{})
+
+	_, err := n.Next(t.Context())
+	require.Error(t, err)
+
+	_, initialized := n.Cached()
+	assert.False(t, initialized, "a failed recovery must not leave the manager initialized")
+}
+
+// TestNonceConcurrentAllocationIsUnique is the property Ethereum requires: every concurrent caller
+// must get a distinct nonce, or all but one transaction is rejected.
+func TestNonceConcurrentAllocationIsUnique(t *testing.T) {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(100, nil)
+	n := NewNonceManager(evm, client.Address{})
+
+	const callers = 50
+	var (
+		wg  sync.WaitGroup
+		mu  sync.Mutex
+		got = make(map[uint64]struct{}, callers)
+	)
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			nonce, err := n.Next(t.Context())
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			got[nonce] = struct{}{}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, got, callers, "every concurrent caller must receive a distinct nonce")
+}

--- a/x/token/services/network/evm/submitter.go
+++ b/x/token/services/network/evm/submitter.go
@@ -1,0 +1,164 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"context"
+	"math"
+	"math/big"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/eip712"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+// Submitter turns an endorsed StateDelta into a signed Ethereum transaction and sends it. It owns the
+// submitter key, the nonce sequence and the gas policy, which are the three things that make a
+// transaction acceptable to the node (design §8).
+//
+// It is deliberately separate from endorsement: the endorsers authorize *what* is applied, the
+// submitter only decides *how* it reaches the chain (nonce, gas, fees). Paying for a transaction
+// grants no authority over its contents, which the contract verifies independently.
+type Submitter struct {
+	client     client.EVMClient
+	key        *secp256k1.PrivateKey
+	address    client.Address
+	tokenState client.Address
+	chainID    *big.Int
+	gas        GasConfig
+	nonces     *NonceManager
+}
+
+// NewSubmitter assembles a Submitter for one TMS.
+func NewSubmitter(
+	evmClient client.EVMClient,
+	key *secp256k1.PrivateKey,
+	tokenState client.Address,
+	chainID *big.Int,
+	gas GasConfig,
+) (*Submitter, error) {
+	if evmClient == nil {
+		return nil, errors.New("submitter: nil evm client")
+	}
+	if key == nil {
+		return nil, errors.New("submitter: nil signing key")
+	}
+	if chainID == nil || chainID.Sign() <= 0 {
+		return nil, errors.New("submitter: chain id must be set and positive")
+	}
+	address := eip712.PubKeyToAddress(key.PubKey())
+
+	return &Submitter{
+		client:     evmClient,
+		key:        key,
+		address:    address,
+		tokenState: tokenState,
+		chainID:    chainID,
+		gas:        gas,
+		nonces:     NewNonceManager(evmClient, address),
+	}, nil
+}
+
+// Address returns the submitter's Ethereum account, the one that pays for gas.
+func (s *Submitter) Address() client.Address { return s.address }
+
+// Submit encodes applyStateDelta(delta, endorsements), signs it and broadcasts it, returning the raw
+// transaction and its hash. On any failure after a nonce was allocated it resets the sequence, so a
+// transaction that never reached the node does not leave a gap that would stall every later one.
+func (s *Submitter) Submit(
+	ctx context.Context,
+	delta *statedelta.StateDelta,
+	endorsements [][]byte,
+) (rawTx []byte, txHash client.Hash, err error) {
+	if delta == nil {
+		return nil, client.Hash{}, errors.New("submitter: nil state delta")
+	}
+	if len(endorsements) == 0 {
+		return nil, client.Hash{}, errors.New("submitter: no endorsements to submit")
+	}
+
+	data := abi.EncodeApplyStateDelta(delta, endorsements)
+
+	nonce, err := s.nonces.Next(ctx)
+	if err != nil {
+		return nil, client.Hash{}, err
+	}
+	defer func() {
+		if err != nil {
+			// The nonce was allocated but never consumed on chain; re-derive the sequence.
+			s.nonces.Reset()
+		}
+	}()
+
+	gasLimit, err := s.gasLimit(ctx, data)
+	if err != nil {
+		return nil, client.Hash{}, err
+	}
+	fees, err := s.client.SuggestGasFees(ctx)
+	if err != nil {
+		return nil, client.Hash{}, errors.Wrap(err, "submitter: failed to get gas fees")
+	}
+
+	tx := &client.DynamicFeeTx{
+		ChainID:              s.chainID,
+		Nonce:                nonce,
+		MaxPriorityFeePerGas: fees.MaxPriorityFeePerGas,
+		MaxFeePerGas:         fees.MaxFeePerGas,
+		Gas:                  gasLimit,
+		To:                   &s.tokenState,
+		Value:                big.NewInt(0), // applyStateDelta is not payable
+		Data:                 data,
+	}
+
+	rawTx, err = client.SignTx(tx, s.key)
+	if err != nil {
+		return nil, client.Hash{}, errors.Wrap(err, "submitter: failed to sign the transaction")
+	}
+	txHash, err = s.client.SendRawTransaction(ctx, rawTx)
+	if err != nil {
+		return nil, client.Hash{}, errors.Wrap(err, "submitter: failed to broadcast the transaction")
+	}
+
+	return rawTx, txHash, nil
+}
+
+// gasLimit resolves the gas limit for a call, either from configuration or by asking the node and
+// applying the configured safety margin (state can change between estimation and execution, so the
+// bare estimate is not enough).
+func (s *Submitter) gasLimit(ctx context.Context, data []byte) (uint64, error) {
+	if s.gas.Strategy == GasStrategyFixed {
+		if s.gas.Limit == 0 {
+			return 0, errors.New("submitter: fixed gas strategy with no limit configured")
+		}
+
+		return s.gas.Limit, nil
+	}
+
+	estimate, err := s.client.EstimateGas(ctx, client.CallMsg{
+		From: &s.address,
+		To:   &s.tokenState,
+		Data: data,
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "submitter: failed to estimate gas")
+	}
+
+	multiplier := s.gas.Multiplier
+	if multiplier < 1 {
+		multiplier = DefaultGasMultiplier
+	}
+	scaled := math.Ceil(float64(estimate) * multiplier)
+	if scaled > math.MaxInt64 {
+		return 0, errors.Errorf("submitter: gas estimate %v overflows", scaled)
+	}
+
+	return uint64(scaled), nil
+}

--- a/x/token/services/network/evm/submitter_test.go
+++ b/x/token/services/network/evm/submitter_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/abi"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/client/mock"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/statedelta"
+)
+
+// testKey returns the well-known secp256k1 test key with the given low byte.
+func testKey(low byte) *secp256k1.PrivateKey {
+	raw := make([]byte, 32)
+	raw[31] = low
+
+	return secp256k1.PrivKeyFromBytes(raw)
+}
+
+func testDelta() *statedelta.StateDelta {
+	var anchor, hash [32]byte
+	anchor[31] = 0xA1
+	hash[31] = 0x0F
+
+	return &statedelta.StateDelta{
+		Anchor:              anchor,
+		TokenRequestHash:    hash,
+		PublicParamsHash:    hash,
+		PublicParamsVersion: 1,
+	}
+}
+
+// readySubmitterClient returns a mock node that answers everything a successful submit needs.
+func readySubmitterClient() *mock.EVMClient {
+	evm := &mock.EVMClient{}
+	evm.PendingNonceAtReturns(3, nil)
+	evm.EstimateGasReturns(100_000, nil)
+	evm.SuggestGasFeesReturns(client.GasFees{
+		MaxFeePerGas:         big.NewInt(20_000_000_000),
+		MaxPriorityFeePerGas: big.NewInt(1_000_000_000),
+	}, nil)
+	evm.SendRawTransactionReturns(client.Hash{}, nil)
+
+	return evm
+}
+
+func testSubmitter(t *testing.T, evm client.EVMClient, gas GasConfig) *Submitter {
+	t.Helper()
+	tokenState, err := client.HexToAddress(testTokenState)
+	require.NoError(t, err)
+	s, err := NewSubmitter(evm, testKey(1), tokenState, big.NewInt(testChainID), gas)
+	require.NoError(t, err)
+
+	return s
+}
+
+func estimateGas() GasConfig {
+	return GasConfig{Strategy: GasStrategyEstimate, Multiplier: DefaultGasMultiplier}
+}
+
+// TestSubmitSendsSignedApplyStateDelta checks the whole write path: the endorsed delta is encoded as
+// an applyStateDelta call, signed, and sent to the TokenState.
+func TestSubmitSendsSignedApplyStateDelta(t *testing.T) {
+	evm := readySubmitterClient()
+	s := testSubmitter(t, evm, estimateGas())
+	endorsements := [][]byte{make([]byte, 65)}
+
+	rawTx, _, err := s.Submit(t.Context(), testDelta(), endorsements)
+	require.NoError(t, err)
+	require.NotEmpty(t, rawTx)
+
+	require.Equal(t, 1, evm.SendRawTransactionCallCount())
+	_, sent := evm.SendRawTransactionArgsForCall(0)
+	assert.Equal(t, rawTx, sent)
+	assert.Equal(t, client.TxTypeDynamicFee, rawTx[0], "the driver sends type-2 transactions")
+
+	// the gas estimation must have been for the same calldata that gets signed
+	_, msg := evm.EstimateGasArgsForCall(0)
+	assert.Equal(t, abi.EncodeApplyStateDelta(testDelta(), endorsements), msg.Data)
+	require.NotNil(t, msg.To)
+	assert.Equal(t, s.tokenState, *msg.To)
+}
+
+// TestSubmitAppliesGasMultiplier checks the safety margin: state can change between estimation and
+// execution, so the bare estimate is not enough.
+func TestSubmitAppliesGasMultiplier(t *testing.T) {
+	evm := readySubmitterClient()
+	evm.EstimateGasReturns(100_000, nil)
+	s := testSubmitter(t, evm, GasConfig{Strategy: GasStrategyEstimate, Multiplier: 1.5})
+
+	limit, err := s.gasLimit(t.Context(), []byte{0x01})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(150_000), limit)
+}
+
+func TestSubmitFixedGasStrategy(t *testing.T) {
+	evm := readySubmitterClient()
+	s := testSubmitter(t, evm, GasConfig{Strategy: GasStrategyFixed, Limit: 250_000})
+
+	limit, err := s.gasLimit(t.Context(), []byte{0x01})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(250_000), limit)
+	assert.Zero(t, evm.EstimateGasCallCount(), "a fixed limit must not consult the node")
+}
+
+// TestSubmitResetsNonceOnFailure is the production trap: a nonce allocated for a transaction that
+// never reached the node would leave a gap, and every later transaction would sit unmineable behind
+// it. A failed submit must put the sequence back under the node's authority.
+func TestSubmitResetsNonceOnFailure(t *testing.T) {
+	evm := readySubmitterClient()
+	evm.SendRawTransactionReturns(client.Hash{}, errors.New("broadcast rejected"))
+	s := testSubmitter(t, evm, estimateGas())
+
+	_, _, err := s.Submit(t.Context(), testDelta(), [][]byte{make([]byte, 65)})
+	require.Error(t, err)
+
+	_, initialized := s.nonces.Cached()
+	assert.False(t, initialized, "a failed broadcast must reset the nonce sequence")
+}
+
+func TestSubmitRejectsIncompleteInput(t *testing.T) {
+	s := testSubmitter(t, readySubmitterClient(), estimateGas())
+
+	t.Run("nil delta", func(t *testing.T) {
+		_, _, err := s.Submit(t.Context(), nil, [][]byte{make([]byte, 65)})
+		require.Error(t, err)
+	})
+
+	t.Run("no endorsements", func(t *testing.T) {
+		_, _, err := s.Submit(t.Context(), testDelta(), nil)
+		require.Error(t, err, "an unendorsed delta must never be broadcast")
+	})
+}
+
+func TestNewSubmitterValidates(t *testing.T) {
+	tokenState, err := client.HexToAddress(testTokenState)
+	require.NoError(t, err)
+
+	t.Run("nil client", func(t *testing.T) {
+		_, err := NewSubmitter(nil, testKey(1), tokenState, big.NewInt(1), estimateGas())
+		require.Error(t, err)
+	})
+
+	t.Run("nil key", func(t *testing.T) {
+		_, err := NewSubmitter(&mock.EVMClient{}, nil, tokenState, big.NewInt(1), estimateGas())
+		require.Error(t, err)
+	})
+
+	t.Run("missing chain id", func(t *testing.T) {
+		_, err := NewSubmitter(&mock.EVMClient{}, testKey(1), tokenState, nil, estimateGas())
+		require.Error(t, err, "an unset chain id would allow cross-chain replay")
+	})
+}
+
+// TestSubmitterAddressMatchesKey checks the submitter reports the account that actually pays, derived
+// from its own key.
+func TestSubmitterAddressMatchesKey(t *testing.T) {
+	s := testSubmitter(t, readySubmitterClient(), estimateGas())
+	assert.Equal(t, "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", s.Address().Hex())
+}

--- a/x/token/services/network/evm/txid.go
+++ b/x/token/services/network/evm/txid.go
@@ -1,0 +1,53 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+
+	"github.com/hyperledger-labs/fabric-smart-client/pkg/utils/errors"
+
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/crypto"
+)
+
+// NonceLength is the size of a generated token-request nonce, matching the 24 bytes FSC generates.
+const NonceLength = 24
+
+// computeAnchor derives the token-request anchor from a nonce and a creator identity:
+// SHA-256(len(nonce) ‖ nonce ‖ creator), hex encoded (design §5.3).
+//
+// The nonce is length prefixed rather than plainly concatenated, which is a deliberate deviation from
+// Fabric's protoutil.ComputeTxID (it appends the two directly). Plain concatenation is ambiguous: a
+// different split of the same bytes between nonce and creator yields the same anchor, and since the
+// anchor is the contract's replay key, a collision would make a legitimate transaction revert as
+// AnchorAlreadyProcessed. Nothing requires byte-parity with Fabric here, because the anchor is
+// produced and consumed only by this driver, so the safer derivation is used.
+//
+// The result is hex of exactly 32 bytes, so keys.AnchorFromTxID decodes it back.
+func computeAnchor(nonce, creator []byte) string {
+	var prefix [4]byte
+	binary.BigEndian.PutUint32(prefix[:], uint32(len(nonce))) // #nosec G115 -- a nonce is never 4 GiB
+
+	buf := make([]byte, 0, len(prefix)+len(nonce)+len(creator))
+	buf = append(buf, prefix[:]...)
+	buf = append(buf, nonce...)
+	buf = append(buf, creator...)
+
+	return hex.EncodeToString(crypto.SHA256(buf))
+}
+
+// generateNonce returns a fresh cryptographically random nonce.
+func generateNonce() ([]byte, error) {
+	nonce := make([]byte, NonceLength)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, errors.Wrap(err, "failed to generate a token-request nonce")
+	}
+
+	return nonce, nil
+}

--- a/x/token/services/network/evm/txid_test.go
+++ b/x/token/services/network/evm/txid_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package evm
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LFDT-Panurus/panurus/token/services/network/driver"
+	"github.com/LFDT-Panurus/panurus/x/token/services/network/evm/keys"
+)
+
+// TestComputeTxIDGeneratesAndWritesBackNonce is the critical mutating contract (design §5.3): callers
+// pass a TxID with an empty nonce and rely on the driver to fill it in. A read-only implementation
+// would derive the same anchor for every transaction of a creator, and the second one submitted would
+// revert on chain as an already-processed anchor.
+func TestComputeTxIDGeneratesAndWritesBackNonce(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	id := &driver.TxID{Creator: []byte("alice")}
+	anchor := n.ComputeTxID(id)
+
+	require.NotEmpty(t, anchor)
+	require.Len(t, id.Nonce, NonceLength, "the generated nonce must be written back into the caller's struct")
+	assert.NotEqual(t, make([]byte, NonceLength), id.Nonce, "the nonce must not be all zeros")
+
+	// Recomputing with the now-populated id must reproduce the same anchor.
+	assert.Equal(t, anchor, n.ComputeTxID(id), "a populated nonce must be respected, not regenerated")
+}
+
+// TestComputeTxIDDistinctPerTransaction is the property the on-chain replay guard depends on: two
+// transactions from the same creator must get different anchors.
+func TestComputeTxIDDistinctPerTransaction(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	seen := make(map[string]struct{}, 50)
+	for range 50 {
+		anchor := n.ComputeTxID(&driver.TxID{Creator: []byte("alice")})
+		_, dup := seen[anchor]
+		require.False(t, dup, "anchors must be unique per transaction")
+		seen[anchor] = struct{}{}
+	}
+}
+
+// TestComputeTxIDRoundTripsToAnchor checks the anchor is exactly what keys.AnchorFromTxID decodes,
+// since the translator and the contract address state by that 32-byte value.
+func TestComputeTxIDRoundTripsToAnchor(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	id := &driver.TxID{Creator: []byte("alice")}
+	anchor := n.ComputeTxID(id)
+
+	decoded, err := keys.AnchorFromTxID(anchor)
+	require.NoError(t, err, "the anchor must decode as a 32-byte value")
+	assert.Len(t, decoded, keys.AnchorLength)
+
+	raw, err := hex.DecodeString(anchor)
+	require.NoError(t, err)
+	assert.Equal(t, raw, decoded[:])
+}
+
+// TestComputeTxIDIsDeterministic pins the derivation: the same nonce and creator always yield the
+// same anchor.
+func TestComputeTxIDIsDeterministic(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	nonce := bytes.Repeat([]byte{0xAB}, NonceLength)
+	first := n.ComputeTxID(&driver.TxID{Nonce: nonce, Creator: []byte("alice")})
+	second := n.ComputeTxID(&driver.TxID{Nonce: nonce, Creator: []byte("alice")})
+	assert.Equal(t, first, second)
+}
+
+// TestComputeTxIDGoldenVector pins the exact derivation, so a change to the hash input (which would
+// silently move every anchor, and with it every token id) cannot pass unnoticed.
+func TestComputeTxIDGoldenVector(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	anchor := n.ComputeTxID(&driver.TxID{
+		Nonce:   bytes.Repeat([]byte{0x01}, NonceLength),
+		Creator: []byte("creator"),
+	})
+	assert.Equal(t, "51cce1270715341f3cf0e9e2dde8913c7f0484c64a46c00b332d6befb1761ffa", anchor)
+	assert.Len(t, anchor, 64, "an anchor is hex of 32 bytes")
+}
+
+// TestComputeTxIDLengthPrefixPreventsAmbiguity checks the reason the nonce is length prefixed rather
+// than plainly concatenated (design §5.3): without it, a different split of the same bytes between
+// nonce and creator would collide, and since the anchor is the contract's replay key a collision
+// makes a legitimate transaction revert.
+func TestComputeTxIDLengthPrefixPreventsAmbiguity(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+
+	// "ab"+"c" and "a"+"bc" concatenate to the same bytes but must not share an anchor.
+	first := n.ComputeTxID(&driver.TxID{Nonce: []byte("ab"), Creator: []byte("c")})
+	second := n.ComputeTxID(&driver.TxID{Nonce: []byte("a"), Creator: []byte("bc")})
+	assert.NotEqual(t, first, second, "the nonce/creator split must be unambiguous")
+}
+
+func TestComputeTxIDNilIsEmpty(t *testing.T) {
+	n := testNetwork(t, nil, nil)
+	assert.Empty(t, n.ComputeTxID(nil))
+}
+
+func TestGenerateNonce(t *testing.T) {
+	first, err := generateNonce()
+	require.NoError(t, err)
+	require.Len(t, first, NonceLength)
+
+	second, err := generateNonce()
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second, "nonces must be random")
+}


### PR DESCRIPTION
Builds on the client and codec from the last PR to make the driver actually work end to end.

- the network methods: RequestApproval collects a quorum and returns the endorsed delta without touching the chain, so a request that fails to reach one costs no gas, and Broadcast encodes applyStateDelta, signs it and sends it. Plus the queries (tokens, spent status, public parameters, transfer metadata).
- ComputeTxID, the nonce manager and the submitter.
- the finality baseline, and Ledger/GetTransactionStatus/AddFinalityListener on top of it.

Two things worth calling out:

ComputeTxID mutates the TxID it is given. Callers pass an empty nonce and rely on the driver to fill it in, which is what FSC and the fabric driver do. Without it every transaction from a creator derives the same anchor and the second one ever submitted reverts as already processed, so it passes a single transaction demo and deadlocks in production.

Finality can only observe success by anchor. The contract records the anchor as the last step of a successful apply, and a failure reverts and leaves nothing behind, so an anchor that has not appeared is Unknown rather than Invalid. The timeout is the only failure signal a recipient gets, which makes it a correctness parameter rather than a convenience.

There is an end to end test that deploys the contracts on a local node and drives the real submission path: issue, transfer, double spend refused, and finality read back. It skips when anvil and forge are absent so the normal test run stays hermetic. Writing it caught two things, that the deploy script needs an explicit sender, and that Broadcast returns before the transaction is mined, so the test now waits and asserts the receipt status rather than just that the node accepted it.

Still open, and going with the wiring: LocalMembership, the DI that injects the endorsement service and submitter, and the endorser's validation record.
